### PR TITLE
Simplify homepage, add browse categories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,7 +220,7 @@ Defined in `src/index.css`. Always use `var(--color-*)` — never hardcode.
 - **`MIN_VOTES_FOR_RANKING` = 5** — `src/constants/app.js` — dishes below this show as "Early"
 - **`MAX_REVIEW_LENGTH` = 200** — `src/constants/app.js` — enforced client + DB constraint
 - **`MIN_VOTES_FOR_VALUE` = 8** — `src/constants/app.js` — value score eligibility
-- **Category definitions** — `src/constants/categories.js` — `BROWSE_CATEGORIES` (15 shortcuts), `MAIN_CATEGORIES`, `ALL_CATEGORIES`
+- **Category definitions** — `src/constants/categories.js` — `BROWSE_CATEGORIES` (19 shortcuts), `MAIN_CATEGORIES`, `ALL_CATEGORIES`
 - **Categories are shortcuts, NOT containers** — Browse shows 15 curated shortcuts. Search covers all dishes regardless of category.
 
 ### 4.7 localStorage Keys

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -5,6 +5,28 @@ A shared log of what each contributor worked on. Add your entries at the top.
 
 ---
 
+## 2026-02-13 - Daniel + Claude
+
+### Homepage Simplification
+- Removed emoji medals (🥇🥈🥉🏆) from Top 10 — replaced with typography-only rank numbers (red for top 3)
+- Removed bordered card wrapper around Top 10 list (border, box-shadow, inner glow)
+- Removed decorative radial gradients from SearchHero
+- Removed uppercase tracked "BROWSE BY CATEGORY" section header
+- Simplified expand/collapse to plain text (no chevron icon, no border-top)
+- Moved category scroll from separate section to inside SearchHero, under town picker
+- Category pills: removed borders, use subtle elevated background with category photos
+
+### Color Palette
+- Explored color ring palette redesign (branch `experiment/color-ring-palette-v2`)
+- Vivid Red + Bright Yellow palette tested and reverted — too primary-colored, read as cheap
+- Reverted to original Island Depths palette (Deep Rust + Warm Gold)
+- Fixed `--color-divider` from gold tint to rust tint — gold at low opacity on dark navy produced a green appearance
+
+### New Categories
+- Added fish, clams, chicken, pork to `BROWSE_CATEGORIES` (now 18 shortcuts)
+
+---
+
 ## 2026-01-22 - Daniel + Claude
 
 ### Social Features - Major Overhaul

--- a/NOTES.md
+++ b/NOTES.md
@@ -149,6 +149,10 @@ Why each item belongs in its week. Reference for next project.
 | Date | What Changed | Category |
 |------|--------------|----------|
 | Jan 17 | Category architecture: shortcuts not containers | Architecture |
+| Feb 13 | Homepage simplification: removed emoji medals, card wrapper, gradients, uppercase labels | Design |
+| Feb 13 | Categories moved to horizontal scroll under town picker | UX |
+| Feb 13 | Added fish, clams, chicken, pork to browse shortcuts (19 total) | Data |
+| Feb 13 | Divider color fix: gold→rust tint to prevent green on dark navy | Design |
 | Jan 17 | Browse reduced to 14 curated shortcuts | UX |
 | Jan 17 | Search now returns results sorted by rating | Feature |
 | Jan 16 | Added quesadilla category, fixed steak items | Data |
@@ -241,7 +245,7 @@ If it's good, it rises.
 
 **Categories are shortcuts, NOT containers.**
 
-- Browse shows ~14 curated, high-frequency categories only
+- Browse shows ~19 curated, high-frequency categories only
 - These are shortcuts to common decisions ("best X near me")
 - Browse is NOT meant to be exhaustive
 
@@ -263,9 +267,9 @@ If it's good, it rises.
 
 ---
 
-## Browse Shortcuts (14 curated)
+## Browse Shortcuts (19 curated)
 
-These appear on the Browse page as quick access:
+These appear on the Browse page and Home page category scroll:
 
 | Shortcut | Why Included |
 |----------|--------------|
@@ -282,7 +286,12 @@ These appear on the Browse page as quick access:
 | Steak | Common decision |
 | Sandwiches | Common decision |
 | Salads | Common decision |
-| Tendys | Common decision |
+| Tenders | Common decision |
+| Desserts | Common decision |
+| Fish | MV signature |
+| Clams | MV signature |
+| Chicken | Common decision |
+| Pork | Common decision |
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -173,9 +173,9 @@ Evidence: `schema.sql:1534-1776`
 
 ### Feature 1: Home / Landing
 
-**User flow:** Open app → see search bar + "Top 10" ranked dishes + category grid
+**User flow:** Open app → see search bar + town filter + category scroll + "Top 10" ranked dishes
 **Screens:** `Home.jsx`
-**Components:** `SearchHero`, `Top10Compact`, `CategoryImageCard`, `WelcomeSplash`
+**Components:** `SearchHero`, `Top10Compact`, `WelcomeSplash`
 **Hooks:** `useDishes`, `useProfile`, `useLocationContext`
 **API calls:** `dishesApi.getRankedDishes()` via `useDishes`
 **Data reads:** `get_ranked_dishes` RPC

--- a/docs/plans/2026-02-13-color-ring-palette-design.md
+++ b/docs/plans/2026-02-13-color-ring-palette-design.md
@@ -1,0 +1,97 @@
+# Color Ring Palette Redesign — Session Context
+
+> READ THIS FIRST if context was compacted. This captures the full state of the color experiment.
+
+## Status
+
+- **Branch:** `experiment/color-ring-palette-v2` (off `main`)
+- **Revert:** `git checkout main` instantly goes back to original look
+- **Project:** `/Users/danielwalsh/.local/bin/whats-good-here`
+- **Build:** Passes as of last check
+
+## What We're Doing
+
+Redesigning the color palette inspired by a book called "The Concept of Colour Concepts." The user saw a concentric ring diagram: blue (outer) → red → yellow → white (center). They want the app to feel like that progression:
+
+- **Blue (outer ring):** Background/surfaces = trust, MV/water, structural frame
+- **Red (action ring):** CTAs, vote buttons, active tabs = appetite, engagement
+- **Yellow (highlight ring):** Value badges, links, accents = highlights, notable
+- **Green (unchanged):** Rating numbers = universal "good score" signal
+- **White (center):** Text = clean readability
+
+## Key Decisions Made
+
+1. **Rating numbers STAY GREEN** — people recognize green = good score
+2. **Blue is NOT added to anything that wasn't already blue** — the user was very clear. No replacing gold links/icons with blue. Blue only shifts the SHADE of already-blue backgrounds.
+3. **Gold accents shift to yellow** — same elements, warmer/brighter shade
+4. **Red shifts shade** — same elements, slightly brighter/truer red
+5. **Backgrounds shift from teal (hue ~195) to cleaner blue (hue ~210)** — removes green tint so backgrounds match the new brighter accent colors
+
+## V1 Attempt (FAILED — reverted)
+
+On branch `experiment/color-ring-palette` (can be deleted). Replaced ALL gold rgba values across 30+ files with blue. User hated it — "you made it MORE blue!" and "everything yellow or red should have stayed but just a different shade." The mistake: bulk-replacing warm accents with cold blue.
+
+## V2 Approach (CURRENT)
+
+Only changed **2 files** + background surface shifts:
+- `src/index.css` — CSS variable values only (no component changes needed since components use vars)
+- `src/components/browse/ValueBadge.jsx` — green → yellow for "GREAT VALUE" badges
+
+## Exact CSS Variable Changes (V2)
+
+### Red (shifted shade)
+| Variable | Old | New |
+|----------|-----|-----|
+| `--color-primary` | `#C85A54` | `#D94B4B` |
+| `--color-primary-muted` | `rgba(200, 90, 84, 0.15)` | `rgba(217, 75, 75, 0.15)` |
+| `--color-primary-glow` | `rgba(200, 90, 84, 0.3)` | `rgba(217, 75, 75, 0.3)` |
+| `--color-danger` | `#C85A54` | `#D94B4B` |
+| `--glow-primary` | rust rgba | `rgba(217, 75, 75, ...)` |
+| `--focus-ring` | rust rgba | `rgba(217, 75, 75, 0.25)` |
+
+### Yellow (gold shifted to yellow)
+| Variable | Old | New |
+|----------|-----|-----|
+| `--color-accent-gold` | `#D9A765` | `#F2C94C` |
+| `--color-accent-gold-muted` | `rgba(217, 167, 101, 0.15)` | `rgba(242, 201, 76, 0.15)` |
+| `--color-link-secondary` | `#D9A765` | `#F2C94C` |
+| `--glow-gold` | `rgba(217, 167, 101, 0.2)` | `rgba(242, 201, 76, 0.2)` |
+| `--color-divider` | `rgba(217, 167, 101, 0.12)` | `rgba(242, 201, 76, 0.12)` |
+
+### Blue backgrounds (teal → cleaner blue)
+| Variable | Old | New |
+|----------|-----|-----|
+| `--color-bg` | `#0D1B22` | `#0E1621` |
+| `--color-surface` | `#0F1F2B` | `#101C28` |
+| `--color-surface-elevated` | `#162B35` | `#162636` |
+| `--color-card` | `#1A3A42` | `#1A2F42` |
+| `--color-card-hover` | `#243A43` | `#223646` |
+
+### Unchanged
+- `--color-rating: #6BB384` (green stays)
+- `--color-success: #6BB384`
+- `--color-text-primary: #F5F1E8`
+- `--color-text-secondary: #B8A99A`
+- `--color-text-tertiary: #7D7168`
+- `--color-accent-orange: #E07856`
+- All semantic status colors
+
+## Original Palette (for full revert reference)
+```css
+--color-primary: #C85A54;
+--color-accent-gold: #D9A765;
+--color-bg: #0D1B22;
+--color-surface: #0F1F2B;
+--color-surface-elevated: #162B35;
+--color-card: #1A3A42;
+--color-card-hover: #243A43;
+--color-divider: rgba(217, 167, 101, 0.12);
+```
+
+## What's Left
+
+- User needs to visually evaluate the V2 changes
+- May need tweaks to specific shades
+- The `--color-accent-orange: #E07856` hover color wasn't changed — may need adjustment to match new yellow
+- Hardcoded rgba values in ~30 component files still reference old rust `rgba(200, 90, 84, ...)` — these are low-opacity decorative effects and may need updating for full congruence, but user explicitly said NOT to bulk-change component files
+- If user approves, merge to main or keep as experiment

--- a/src/components/home/SearchHero.jsx
+++ b/src/components/home/SearchHero.jsx
@@ -2,64 +2,48 @@ import { DishSearch } from '../DishSearch'
 import { TownPicker } from '../TownPicker'
 
 /**
- * SearchHero - Hero section with value proposition and prominent search
- *
- * Design Philosophy:
- * - Clear value proposition headline
- * - Prominent search bar as primary CTA
- * - Town dropdown for filtering by MV town
+ * SearchHero - Hero section with value proposition, search, town filter, and category scroll
  */
-export function SearchHero({ town, onTownChange, loading }) {
+export function SearchHero({ town, onTownChange, loading, categoryScroll }) {
   return (
     <section
-      className="px-4 pt-8 pb-6 relative"
-      style={{
-        background: `
-          radial-gradient(ellipse 80% 60% at 50% 0%, rgba(200, 90, 84, 0.05) 0%, transparent 70%),
-          radial-gradient(ellipse 60% 50% at 50% 100%, rgba(217, 167, 101, 0.04) 0%, transparent 70%),
-          var(--color-bg)
-        `,
-      }}
+      className="pt-8 pb-5"
+      style={{ background: 'var(--color-bg)' }}
     >
-      {/* Value proposition */}
-      <div className="mb-5 text-center">
+      <div className="mb-5 text-center px-4">
         <h1
-          className="font-bold mb-1.5 leading-tight text-shadow-warm"
+          className="font-bold mb-1"
           style={{
             color: 'var(--color-text-primary)',
             fontSize: '22px',
-            letterSpacing: '-0.01em',
+            letterSpacing: '-0.02em',
           }}
         >
-          Find What's Good on the Vineyard
+          What's Good Here
         </h1>
         <p
-          className="font-medium"
           style={{
             color: 'var(--color-text-tertiary)',
             fontSize: '13px',
           }}
         >
-          Ranked by locals and people who know
+          Ranked by people who know
         </p>
       </div>
 
-      {/* Search - hero element (respects town filter) */}
-      <DishSearch loading={loading} placeholder="What's good here?" town={town} />
+      <div className="px-4">
+        <DishSearch loading={loading} placeholder="What are you craving?" town={town} />
+      </div>
 
-      {/* Town filter dropdown */}
       <div className="mt-4 text-center">
         <TownPicker town={town} onTownChange={onTownChange} />
       </div>
 
-      {/* Bottom divider */}
-      <div
-        className="absolute bottom-0 left-1/2 -translate-x-1/2 h-px"
-        style={{
-          width: '80%',
-          background: 'linear-gradient(90deg, transparent, var(--color-divider), transparent)',
-        }}
-      />
+      {categoryScroll && (
+        <div className="mt-4">
+          {categoryScroll}
+        </div>
+      )}
     </section>
   )
 }

--- a/src/components/home/Top10Compact.jsx
+++ b/src/components/home/Top10Compact.jsx
@@ -17,11 +17,10 @@ export function Top10Compact({
   town,
 }) {
   const navigate = useNavigate()
-  const [activeTab, setActiveTab] = useState('mv') // 'mv' or 'personal'
+  const [activeTab, setActiveTab] = useState('mv')
   const [expanded, setExpanded] = useState(false)
   const [prevExpanded, setPrevExpanded] = useState(false)
 
-  // Which dishes to show based on active tab
   const activeDishes = activeTab === 'personal' && showToggle
     ? personalDishes
     : dishes
@@ -31,34 +30,20 @@ export function Top10Compact({
     : activeDishes.slice(0, initialCount)
 
   const hasMore = activeDishes.length > initialCount
-
-  // Track whether we just expanded (for stagger animation)
   const justExpanded = expanded && !prevExpanded
 
   if (!dishes?.length) return null
 
   return (
-    <section
-      className="rounded-2xl p-5"
-      style={{
-        background: 'var(--color-bg)',
-        border: '1px solid var(--color-divider)',
-        boxShadow: '0 4px 16px -4px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(217, 167, 101, 0.06)',
-      }}
-    >
-      {/* Header with optional toggle */}
+    <section>
+      {/* Header */}
       {showToggle ? (
         <div role="tablist" aria-label="Top 10 list filter" className="flex gap-2 mb-4">
           <button
             role="tab"
             aria-selected={activeTab === 'mv'}
-            onClick={() => {
-              setActiveTab('mv')
-              setExpanded(false)
-            }}
-            className={`flex-1 px-3 py-2 rounded-xl text-sm font-semibold transition-all ${
-              activeTab === 'mv' ? 'shadow-md' : ''
-            }`}
+            onClick={() => { setActiveTab('mv'); setExpanded(false) }}
+            className="flex-1 px-3 py-2 rounded-xl text-sm font-semibold transition-all"
             style={{
               background: activeTab === 'mv' ? 'var(--color-primary)' : 'var(--color-surface-elevated)',
               color: activeTab === 'mv' ? 'white' : 'var(--color-text-secondary)',
@@ -69,13 +54,8 @@ export function Top10Compact({
           <button
             role="tab"
             aria-selected={activeTab === 'personal'}
-            onClick={() => {
-              setActiveTab('personal')
-              setExpanded(false)
-            }}
-            className={`flex-1 px-3 py-2 rounded-xl text-sm font-semibold transition-all ${
-              activeTab === 'personal' ? 'shadow-md' : ''
-            }`}
+            onClick={() => { setActiveTab('personal'); setExpanded(false) }}
+            className="flex-1 px-3 py-2 rounded-xl text-sm font-semibold transition-all"
             style={{
               background: activeTab === 'personal' ? 'var(--color-accent-gold)' : 'var(--color-surface-elevated)',
               color: activeTab === 'personal' ? 'var(--color-text-on-primary)' : 'var(--color-text-secondary)',
@@ -86,15 +66,13 @@ export function Top10Compact({
         </div>
       ) : (
         <h3
-          className="font-bold mb-4 pb-2.5 flex items-center gap-2"
+          className="font-bold mb-4"
           style={{
             color: 'var(--color-text-primary)',
-            borderBottom: '2px solid var(--color-accent-gold)',
             fontSize: '15px',
             letterSpacing: '-0.01em',
           }}
         >
-          <span aria-hidden="true">🏆</span>
           Top 10 {town ? `in ${town}` : 'on the Island'}
         </h3>
       )}
@@ -128,35 +106,14 @@ export function Top10Compact({
         )}
       </div>
 
-      {/* Expand/collapse button */}
+      {/* Expand/collapse */}
       {hasMore && displayedDishes.length > 0 && (
         <button
-          onClick={() => {
-            setPrevExpanded(expanded)
-            setExpanded(!expanded)
-          }}
-          className="w-full mt-3 pt-3 border-t font-semibold flex items-center justify-center gap-1 transition-opacity hover:opacity-80"
-          style={{
-            borderColor: 'var(--color-divider)',
-            color: 'var(--color-primary)',
-            fontSize: '13px',
-          }}
+          onClick={() => { setPrevExpanded(expanded); setExpanded(!expanded) }}
+          className="w-full mt-3 pt-3 text-sm font-medium transition-opacity hover:opacity-70"
+          style={{ color: 'var(--color-text-tertiary)' }}
         >
-          {expanded ? (
-            <>
-              Show less
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M5 15l7-7 7 7" />
-              </svg>
-            </>
-          ) : (
-            <>
-              Show all {activeDishes.length}
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-              </svg>
-            </>
-          )}
+          {expanded ? 'Show less' : `Show all ${activeDishes.length}`}
         </button>
       )}
     </section>
@@ -168,7 +125,6 @@ const Top10Row = memo(function Top10Row({ dish, rank, isNewlyRevealed, revealInd
   const { dish_name, restaurant_name, avg_rating, total_votes } = dish
   const isRanked = (total_votes || 0) >= MIN_VOTES_FOR_RANKING
 
-  // Build accessible label
   const accessibleLabel = isRanked
     ? `Rank ${rank}: ${dish_name} at ${restaurant_name}, rated ${avg_rating} out of 10 with ${total_votes} votes`
     : `Rank ${rank}: ${dish_name} at ${restaurant_name}, ${total_votes ? `${total_votes} vote${total_votes === 1 ? '' : 's'}` : 'new dish'}`
@@ -181,28 +137,17 @@ const Top10Row = memo(function Top10Row({ dish, rank, isNewlyRevealed, revealInd
       <button
         onClick={onClick}
         aria-label={accessibleLabel}
-        className="w-full flex items-center gap-2.5 py-2.5 px-2 rounded-lg transition-colors text-left hover:bg-[var(--color-surface-elevated)]"
+        className="w-full flex items-center gap-3 py-2.5 px-2 rounded-lg transition-colors text-left hover:bg-[var(--color-surface-elevated)]"
       >
-        {/* Rank - medals for top 3 */}
-        {rank <= 3 ? (
-          <span aria-hidden="true" className="text-base flex-shrink-0 w-6 text-center">
-            {rank === 1 && '🥇'}
-            {rank === 2 && '🥈'}
-            {rank === 3 && '🥉'}
-          </span>
-        ) : (
-          <span
-            aria-hidden="true"
-            className="w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0"
-            style={{
-              background: 'var(--color-surface)',
-              color: 'var(--color-text-tertiary)',
-              border: '1px solid rgba(217, 167, 101, 0.15)',
-            }}
-          >
-            {rank}
-          </span>
-        )}
+        {/* Rank number — typography only */}
+        <span
+          className="w-6 text-center text-sm font-bold flex-shrink-0"
+          style={{
+            color: rank <= 3 ? 'var(--color-primary)' : 'var(--color-text-tertiary)',
+          }}
+        >
+          {rank}
+        </span>
 
         {/* Info */}
         <div className="flex-1 min-w-0">
@@ -214,19 +159,14 @@ const Top10Row = memo(function Top10Row({ dish, rank, isNewlyRevealed, revealInd
           </p>
         </div>
 
-        {/* Rating or vote count */}
+        {/* Rating */}
         <div className="flex-shrink-0 text-right">
           {isRanked ? (
-            <div className="flex flex-col items-end">
-              <span className="text-sm font-bold leading-tight" style={{ color: getRatingColor(avg_rating) }}>
-                {avg_rating}
-              </span>
-              <span className="text-[10px]" style={{ color: 'var(--color-text-tertiary)' }}>
-                {total_votes} votes
-              </span>
-            </div>
+            <span className="text-sm font-bold" style={{ color: getRatingColor(avg_rating) }}>
+              {avg_rating}
+            </span>
           ) : (
-            <span className="text-[10px]" style={{ color: 'var(--color-text-tertiary)' }}>
+            <span className="text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
               {total_votes ? `${total_votes} vote${total_votes === 1 ? '' : 's'}` : 'New'}
             </span>
           )}

--- a/src/constants/categories.js
+++ b/src/constants/categories.js
@@ -19,6 +19,10 @@ export const BROWSE_CATEGORIES = [
   { id: 'taco', label: 'Tacos', emoji: '🌮' },
   { id: 'tendys', label: 'Tenders', emoji: '🍗' },
   { id: 'dessert', label: 'Desserts', emoji: '🍰' },
+  { id: 'fish', label: 'Fish', emoji: '🐟' },
+  { id: 'clams', label: 'Clams', emoji: '🐚' },
+  { id: 'chicken', label: 'Chicken', emoji: '🐔' },
+  { id: 'pork', label: 'Pork', emoji: '🐷' },
 ]
 
 // Main categories shown in category picker (singular labels)
@@ -38,6 +42,8 @@ export const MAIN_CATEGORIES = [
   { id: 'seafood', label: 'Seafood', emoji: '🦐' },
   { id: 'tendys', label: 'Tenders', emoji: '🍗' },
   { id: 'dessert', label: 'Dessert', emoji: '🍰' },
+  { id: 'fish', label: 'Fish', emoji: '🐟' },
+  { id: 'clams', label: 'Clams', emoji: '🐚' },
   { id: 'chicken', label: 'Chicken', emoji: '🐔' },
   { id: 'pork', label: 'Pork', emoji: '🐷' },
 ]
@@ -177,6 +183,8 @@ export const CATEGORY_INFO = {
   'duck': { emoji: '🦆', label: 'Duck' },
   'lamb': { emoji: '🍖', label: 'Lamb' },
   'pork': { emoji: '🐷', label: 'Pork' },
+  'fish': { emoji: '🐟', label: 'Fish' },
+  'chicken': { emoji: '🐔', label: 'Chicken' },
   'clams': { emoji: '🐚', label: 'Clams' },
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -58,7 +58,7 @@
   --color-bg: #0D1B22;                /* Deep charcoal-navy */
   --color-surface: #0F1F2B;           /* Slightly lighter */
   --color-surface-elevated: #162B35;
-  --color-divider: rgba(217, 167, 101, 0.12);  /* Warm gold tint */
+  --color-divider: rgba(200, 90, 84, 0.10);  /* Rust tint dividers */
 
   /* Cards - rich navy-teal, tropical water depth */
   --color-card: #1A3A42;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -5,9 +5,8 @@ import { useLocationContext } from '../context/LocationContext'
 import { useDishes } from '../hooks/useDishes'
 import { useProfile } from '../hooks/useProfile'
 import { MIN_VOTES_FOR_RANKING } from '../constants/app'
-import { BROWSE_CATEGORIES } from '../constants/categories'
+import { BROWSE_CATEGORIES, getCategoryNeonImage } from '../constants/categories'
 import { SearchHero, Top10Compact } from '../components/home'
-import { CategoryImageCard } from '../components/CategoryImageCard'
 
 export function Home() {
   const navigate = useNavigate()
@@ -54,23 +53,36 @@ export function Home() {
   // Whether to show the toggle (user is logged in and has preferences)
   const showPersonalToggle = user && profile?.preferred_categories?.length > 0
 
-  const [categoriesExpanded, setCategoriesExpanded] = useState(false)
-  const visibleCategories = categoriesExpanded
-    ? BROWSE_CATEGORIES
-    : BROWSE_CATEGORIES.slice(0, 6)
-
   return (
     <div className="min-h-screen" style={{ background: 'var(--color-surface)' }}>
       <h1 className="sr-only">What's Good Here - Top Ranked Dishes Near You</h1>
 
-      {/* Section 1: Hero with search */}
+      {/* Section 1: Hero with search, town filter, categories */}
       <SearchHero
         town={town}
         onTownChange={setTown}
         loading={loading}
+        categoryScroll={
+          <div
+            className="flex gap-2.5 overflow-x-auto px-4 pb-1"
+            style={{
+              scrollbarWidth: 'none',
+              msOverflowStyle: 'none',
+              WebkitOverflowScrolling: 'touch',
+            }}
+          >
+            {BROWSE_CATEGORIES.map((category) => (
+              <CategoryPill
+                key={category.id}
+                category={category}
+                onClick={() => navigate(`/browse?category=${encodeURIComponent(category.id)}`)}
+              />
+            ))}
+          </div>
+        }
       />
 
-      {/* Section 2: Top 10 Compact */}
+      {/* Section 2: Top 10 */}
       <section className="px-4 py-6">
         {loading ? (
           <Top10Skeleton />
@@ -101,67 +113,42 @@ export function Home() {
           <EmptyState onBrowse={() => navigate('/browse')} />
         )}
       </section>
-
-      {/* Section 3: Category Grid */}
-      <section
-        className="px-4 py-6"
-        style={{
-          background: 'linear-gradient(180deg, var(--color-card) 0%, var(--color-surface) 50%, var(--color-bg) 100%)',
-        }}
-      >
-        {/* Section header */}
-        <div className="mb-8 text-center">
-          {/* Decorative gold dot */}
-          <div
-            className="w-1 h-1 rounded-full mx-auto mb-3"
-            style={{ background: 'var(--color-accent-gold)' }}
-          />
-          <h2
-            className="text-[11px] font-semibold tracking-[0.2em] uppercase mb-2"
-            style={{ color: 'var(--color-text-tertiary)' }}
-          >
-            The Best By Category
-          </h2>
-          <p className="text-xs" style={{ color: 'rgba(255, 255, 255, 0.35)' }}>
-            Got another craving? Search it above.
-          </p>
-        </div>
-
-        {/* Category grid - 3 columns on mobile, 4 on desktop */}
-        <div className="grid grid-cols-3 md:grid-cols-4 gap-x-3 gap-y-8 justify-items-center max-w-2xl mx-auto">
-          {visibleCategories.map((category, index) => (
-            <div key={category.id} className="stagger-item" style={{ animationDelay: `${index * 50}ms` }}>
-              <CategoryImageCard
-                category={category}
-                onClick={() => navigate(`/browse?category=${encodeURIComponent(category.id)}`)}
-                size={72}
-              />
-            </div>
-          ))}
-        </div>
-
-        {/* Expand / collapse toggle */}
-        <div className="flex justify-center mt-6">
-          <button
-            onClick={() => setCategoriesExpanded(!categoriesExpanded)}
-            className="flex items-center gap-1.5 text-xs font-semibold tracking-wide transition-opacity hover:opacity-80"
-            style={{ color: 'var(--color-accent-gold)' }}
-          >
-            {categoriesExpanded ? 'Show fewer' : 'See all categories'}
-            <svg
-              className="w-3.5 h-3.5 transition-transform"
-              style={{ transform: categoriesExpanded ? 'rotate(180deg)' : 'none' }}
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2.5}
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-            </svg>
-          </button>
-        </div>
-      </section>
     </div>
+  )
+}
+
+function CategoryPill({ category, onClick }) {
+  const imageSrc = getCategoryNeonImage(category.id)
+  const [loaded, setLoaded] = useState(false)
+  const [imgError, setImgError] = useState(false)
+
+  return (
+    <button
+      onClick={onClick}
+      className="flex-shrink-0 flex items-center gap-2 pl-1.5 pr-3.5 py-1.5 rounded-full text-sm font-medium transition-all active:scale-[0.97]"
+      style={{
+        background: 'var(--color-surface-elevated)',
+        color: 'var(--color-text-secondary)',
+      }}
+    >
+      {imageSrc && !imgError ? (
+        <img
+          src={imageSrc}
+          alt=""
+          className="w-6 h-6 rounded-full object-cover"
+          style={{ opacity: loaded ? 1 : 0 }}
+          onLoad={() => setLoaded(true)}
+          onError={() => setImgError(true)}
+        />
+      ) : (
+        <span className="w-6 h-6 rounded-full flex items-center justify-center text-xs"
+          style={{ background: 'var(--color-surface)' }}
+        >
+          {category.emoji}
+        </span>
+      )}
+      {category.label}
+    </button>
   )
 }
 


### PR DESCRIPTION
## Summary
- **Homepage simplification:** Removed emoji medals, bordered card wrapper, decorative gradients, and uppercase section labels from the homepage. Top 10 list uses typography-only rank numbers. Category scroll moved under town picker in SearchHero.
- **Color palette:** Tested vivid red/yellow palette, reverted to original Island Depths (Deep Rust + Warm Gold). Fixed divider color variable from gold to rust tint to prevent green appearance on dark navy backgrounds.
- **New categories:** Added fish, clams, chicken, pork to browse shortcuts (19 total). Added `chicken` to `CATEGORY_INFO`, `clams` to `MAIN_CATEGORIES`.
- **Bug fix:** Added `onError` fallback on category pill images so failed loads show emoji instead of invisible gap.

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` passes (206/206)
- [ ] Visual check: homepage layout on mobile — search, town picker, category scroll, top 10 list
- [ ] Visual check: category pills with and without images
- [ ] Visual check: borders/dividers no longer appear green-tinted

🤖 Generated with [Claude Code](https://claude.com/claude-code)