### PR TITLE
Binary vote removal — Phase 2 (cleanup)

### DIFF
--- a/docs/superpowers/plans/2026-04-13-binary-vote-removal-phase-2.md
+++ b/docs/superpowers/plans/2026-04-13-binary-vote-removal-phase-2.md
@@ -1,0 +1,869 @@
+# Binary Vote Removal — Phase 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove every Phase 1 compat shim that was left behind to protect stale PWA bundles — drop `p_would_order_again` from `submit_vote_atomic`, strip `yes_votes` / `percent_worth_it` / `would_order_again` from read RPC returns and the `public_votes` view, drop the `vote_submitted` analytics dual-emit, remove the `buildReviewSnippet` boolean dependency, and wire up the existing photo-prefill UI via `dishPhotosApi.getUserPhotoForDish`.
+
+**Architecture:** Pure subtraction except for one small additive wire-up (photo prefetch in `Dish.jsx`). Two-phase DB cut from Phase 1 completes: schema removes all binary-derived returns and parameters; `votes.would_order_again` column stays for historical integrity but is never written, read, or projected going forward. Frontend stops dual-emitting analytics; analytics funnels key only on `rating_submitted`.
+
+**Tech Stack:** Supabase Postgres (plpgsql), Deno Edge Functions (TypeScript), React 19 / Vite 7, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-04-13-binary-vote-removal-phase-2-design.md` — read this before starting.
+
+**Base branch:** `feat/binary-vote-removal-phase-2` (already created; Phase 2 design spec committed as `cc78070`).
+
+---
+
+## File Structure
+
+- Create: `supabase/migrations/2026-04-13-binary-vote-removal-phase-2.sql`
+- Modify: `supabase/schema.sql`
+- Modify: `supabase/README.md`
+- Modify: `src/api/votesApi.js`
+- Modify: `src/api/votesApi.test.js`
+- Modify: `src/api/dishPhotosApi.js`
+- Modify: `src/pages/Dish.jsx`
+- Modify: `supabase/functions/seed-reviews/index.ts`
+
+Eight files, 7 tasks (+ branch setup and verification tasks). Each task produces a self-contained commit.
+
+---
+
+## Task 0: Baseline verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Confirm branch + clean state**
+
+Run:
+```bash
+cd /Users/danielwalsh/.local/bin/whats-good-here
+git branch --show-current
+git status --short | head -20
+```
+Expected: on `feat/binary-vote-removal-phase-2`, clean working tree (untracked root files unrelated to this plan are fine and expected).
+
+- [ ] **Step 2: Baseline tests + build**
+
+Run:
+```bash
+npm run test -- --run 2>&1 | tail -3
+npm run build 2>&1 | tail -3
+```
+Expected: tests 312/312 pass, build completes cleanly.
+
+---
+
+## Task 1: Write forward migration
+
+**Files:**
+- Create: `supabase/migrations/2026-04-13-binary-vote-removal-phase-2.sql`
+
+- [ ] **Step 1: Create the migration file**
+
+Write this file at `supabase/migrations/2026-04-13-binary-vote-removal-phase-2.sql`:
+
+```sql
+-- Binary Vote Removal — Phase 2
+-- Design spec: docs/superpowers/specs/2026-04-13-binary-vote-removal-phase-2-design.md
+--
+-- Drops every Phase 1 compat shim:
+--   1. submit_vote_atomic loses p_would_order_again parameter (8 → 7 args).
+--   2. Read RPCs stop returning binary-derived fields.
+--   3. public_votes view stops projecting would_order_again.
+-- The votes.would_order_again column stays in the table for historical
+-- integrity. It just stops being read, written, or projected anywhere.
+
+-- ============================================================
+-- 1. submit_vote_atomic: drop boolean param, stop writing the column
+-- ============================================================
+
+DROP FUNCTION IF EXISTS submit_vote_atomic(
+  UUID, UUID, BOOLEAN, DECIMAL, TEXT, DECIMAL, DECIMAL, TEXT
+);
+
+CREATE OR REPLACE FUNCTION submit_vote_atomic(
+  p_dish_id UUID,
+  p_user_id UUID,
+  p_rating_10 DECIMAL DEFAULT NULL,
+  p_review_text TEXT DEFAULT NULL,
+  p_purity_score DECIMAL DEFAULT NULL,
+  p_war_score DECIMAL DEFAULT NULL,
+  p_badge_hash TEXT DEFAULT NULL
+)
+RETURNS votes AS $$
+DECLARE
+  submitted_vote votes;
+BEGIN
+  IF auth.role() <> 'service_role' AND (select auth.uid()) IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'Access denied';
+  END IF;
+
+  IF p_rating_10 IS NULL THEN
+    RAISE EXCEPTION 'rating_10 is required';
+  END IF;
+
+  INSERT INTO votes (
+    dish_id,
+    user_id,
+    rating_10,
+    review_text,
+    review_created_at,
+    purity_score,
+    war_score,
+    badge_hash,
+    source
+  )
+  VALUES (
+    p_dish_id,
+    p_user_id,
+    p_rating_10,
+    p_review_text,
+    CASE WHEN p_review_text IS NOT NULL THEN NOW() ELSE NULL END,
+    p_purity_score,
+    p_war_score,
+    p_badge_hash,
+    'user'
+  )
+  ON CONFLICT (dish_id, user_id) WHERE source = 'user'
+  DO UPDATE SET
+    rating_10 = EXCLUDED.rating_10,
+    review_text = COALESCE(EXCLUDED.review_text, votes.review_text),
+    review_created_at = COALESCE(EXCLUDED.review_created_at, votes.review_created_at),
+    purity_score = COALESCE(EXCLUDED.purity_score, votes.purity_score),
+    war_score = COALESCE(EXCLUDED.war_score, votes.war_score),
+    badge_hash = COALESCE(EXCLUDED.badge_hash, votes.badge_hash)
+  RETURNING * INTO submitted_vote;
+
+  RETURN submitted_vote;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+GRANT EXECUTE ON FUNCTION submit_vote_atomic(
+  UUID, UUID, DECIMAL, TEXT, DECIMAL, DECIMAL, TEXT
+) TO authenticated;
+
+-- ============================================================
+-- 2. public_votes view: drop would_order_again column
+-- ============================================================
+
+-- Open the file supabase/schema.sql and locate the full CREATE OR REPLACE VIEW
+-- public_votes block starting at line 342 (pre-change line number). Copy its
+-- SELECT list into the CREATE OR REPLACE VIEW statement below, OMITTING the
+-- `would_order_again` column. Keep every other column and every other clause
+-- (filters, ordering, SECURITY INVOKER if present) identical.
+
+-- NOTE TO IMPLEMENTER: because public_votes' full definition is in schema.sql,
+-- grep for its current body (grep -A 40 "CREATE OR REPLACE VIEW public_votes"
+-- supabase/schema.sql) and reconstruct the CREATE OR REPLACE VIEW here with
+-- would_order_again removed from the SELECT.
+
+CREATE OR REPLACE VIEW public_votes AS
+-- <PASTE the current definition here, minus the would_order_again column>
+;
+
+-- ============================================================
+-- 3. Read RPCs: drop yes_votes, percent_worth_it, would_order_again
+-- ============================================================
+
+-- NOTE TO IMPLEMENTER: the five RPCs below live in supabase/schema.sql at
+-- approximately:
+--   get_ranked_dishes — line 737
+--   get_restaurant_dishes — line 954
+--   get_dish_variants — line 1059
+--   get_friends_votes_for_dish — line 1141
+--   get_friends_votes_for_restaurant — line 1171
+--
+-- For each: copy the full current definition from schema.sql into this
+-- migration file, then remove:
+--   - yes_votes and percent_worth_it from the RETURNS TABLE clause
+--   - any SUM(CASE WHEN v.would_order_again ...) aggregation
+--   - any ROUND((yes_votes * 100.0) / total_votes) percent computation
+--   - any would_order_again reference in SELECT or WHERE bodies
+-- Keep everything else untouched: avg_rating, total_votes, distance, ranking
+-- math, variant logic, friend-filter logic.
+--
+-- For get_friends_votes_for_dish and get_friends_votes_for_restaurant:
+-- remove would_order_again from RETURNS TABLE and from the inner SELECT.
+
+CREATE OR REPLACE FUNCTION get_ranked_dishes(...)
+-- <PASTE current definition with binary-derived fields removed>
+;
+
+CREATE OR REPLACE FUNCTION get_restaurant_dishes(...)
+-- <PASTE current definition with binary-derived fields removed>
+;
+
+CREATE OR REPLACE FUNCTION get_dish_variants(...)
+-- <PASTE current definition with binary-derived fields removed>
+;
+
+CREATE OR REPLACE FUNCTION get_friends_votes_for_dish(...)
+-- <PASTE current definition with binary-derived fields removed>
+;
+
+CREATE OR REPLACE FUNCTION get_friends_votes_for_restaurant(...)
+-- <PASTE current definition with binary-derived fields removed>
+;
+```
+
+The `<PASTE>` placeholders exist because each RPC body is 30–100 lines and the canonical version lives in `schema.sql`. Copy them verbatim, then subtract the binary fields. This avoids drift between the migration and the source of truth.
+
+- [ ] **Step 2: Fill in each placeholder from `schema.sql`**
+
+For `public_votes`:
+```bash
+grep -n -A 40 "CREATE OR REPLACE VIEW public_votes" supabase/schema.sql
+```
+Copy the view body (lines around 342). Paste into the migration. Remove the `would_order_again` column from the SELECT. Drop any trailing comma issues.
+
+For each of the five RPCs (approximate line numbers given above), run `grep -n -A 120 "CREATE OR REPLACE FUNCTION <name>" supabase/schema.sql`, copy, paste, then subtract:
+- From `RETURNS TABLE`: delete `yes_votes BIGINT,` and `percent_worth_it INT,` (and `would_order_again BOOLEAN,` in the two `get_friends_votes_*` RPCs).
+- From the SELECT / CTE / INSERT column lists: delete the aggregation that produces those fields.
+- From WHERE / GROUP BY / ORDER BY: nothing to change — these RPCs don't filter on the binary.
+
+Key line numbers in current `schema.sql` for subtraction guidance:
+- `get_ranked_dishes`: returns at lines 756-757 (`yes_votes BIGINT`, `percent_worth_it INT`); aggregations at lines 823, 877-880, 886-893.
+- `get_restaurant_dishes`: returns at lines 967-968; aggregations at lines 994, 1014, 1024, 1029.
+- `get_dish_variants`: returns at lines 1069-1070; aggregations at lines 1078, 1081-1083.
+- `get_friends_votes_for_dish`: returns at line 1149 (`would_order_again BOOLEAN`); SELECT at line 1155.
+- `get_friends_votes_for_restaurant`: returns at line 1181; SELECT at line 1188.
+
+- [ ] **Step 3: Verify the migration file is syntactically complete**
+
+No `<PASTE>` placeholders should remain. Each RPC should have a full body. Run:
+```bash
+grep -c "PASTE" supabase/migrations/2026-04-13-binary-vote-removal-phase-2.sql
+```
+Expected: `0`.
+
+- [ ] **Step 4: Commit the migration**
+
+```bash
+git add supabase/migrations/2026-04-13-binary-vote-removal-phase-2.sql
+git commit -m "feat(db): phase 2 migration — drop binary-vote compat shims
+
+Drops p_would_order_again from submit_vote_atomic. Drops yes_votes,
+percent_worth_it from get_ranked_dishes, get_restaurant_dishes,
+get_dish_variants. Drops would_order_again from friends-votes RPCs
+and public_votes view. Column stays for historical integrity."
+```
+
+---
+
+## Task 2: Sync `schema.sql`
+
+**Files:**
+- Modify: `supabase/schema.sql`
+
+Apply the exact same changes to the canonical schema file so future `schema.sql` replays don't revert Phase 2.
+
+- [ ] **Step 1: Update `submit_vote_atomic`**
+
+Open `supabase/schema.sql` around line 1715. Replace the entire `CREATE OR REPLACE FUNCTION submit_vote_atomic(...)` block (lines 1715–1785, roughly) with the post-Phase-2 body from Task 1's migration (minus the `DROP FUNCTION` — `schema.sql` uses `CREATE OR REPLACE`, so no drop needed; but note that simply CREATE OR REPLACEing over a function with a different parameter list fails in Postgres, which is why the migration does DROP+CREATE; `schema.sql` can still use CREATE OR REPLACE because it's replaying from scratch against an empty DB).
+
+Actually, for safety when replaying `schema.sql` against an existing dev/staging DB that may have the old signature, add an explicit `DROP FUNCTION IF EXISTS` above the CREATE:
+
+```sql
+DROP FUNCTION IF EXISTS submit_vote_atomic(
+  UUID, UUID, BOOLEAN, DECIMAL, TEXT, DECIMAL, DECIMAL, TEXT
+);
+
+CREATE OR REPLACE FUNCTION submit_vote_atomic(
+  p_dish_id UUID,
+  p_user_id UUID,
+  p_rating_10 DECIMAL DEFAULT NULL,
+  ...
+```
+
+Paste the new 7-arg body (same as the migration). Keep the existing trailing `GRANT EXECUTE` statement but update its signature to match (look for it in schema.sql, typically near line 2851 or colocated with other grants).
+
+- [ ] **Step 2: Update `public_votes` view**
+
+Around line 342 in `schema.sql`, find the `CREATE OR REPLACE VIEW public_votes AS` block. Remove the `would_order_again` column from its SELECT list.
+
+- [ ] **Step 3: Update each read RPC**
+
+For each of `get_ranked_dishes` (line 737), `get_restaurant_dishes` (line 954), `get_dish_variants` (line 1059), `get_friends_votes_for_dish` (line 1141), `get_friends_votes_for_restaurant` (line 1171): edit the CREATE OR REPLACE FUNCTION body in `schema.sql` to match what's in the migration file (Task 1 Step 2). The simplest operator is to copy-paste from the migration into schema.sql.
+
+- [ ] **Step 4: Verify no stale references remain**
+
+Run:
+```bash
+grep -n "p_would_order_again\|would_order_again\|yes_votes\|percent_worth_it" supabase/schema.sql
+```
+Expected output: only the `votes` table's column definition at line 82 (`would_order_again BOOLEAN,`) should remain. Every RPC reference and the view's projection should be gone.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/schema.sql
+git commit -m "chore(db): sync schema.sql with phase 2 migration"
+```
+
+---
+
+## Task 3: Drop `p_would_order_again` from `votesApi.submitVote` + kill `vote_submitted` dual-emit
+
+**Files:**
+- Modify: `src/api/votesApi.js`
+- Modify: `src/api/votesApi.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+Edit `src/api/votesApi.test.js`. Find the existing analytics-related tests in the `submitVote` suite. Replace the Phase 1 dual-emit assertions with:
+
+```javascript
+it('emits rating_submitted with clean payload (no binary fields)', async () => {
+  supabase.rpc
+    .mockResolvedValueOnce({ data: { allowed: true }, error: null })
+    .mockResolvedValueOnce({ data: { id: 'vote-1' }, error: null })
+
+  await votesApi.submitVote({
+    dishId: 'dish-1',
+    rating10: 8,
+    reviewText: 'Great!',
+  })
+
+  expect(capture).toHaveBeenCalledWith('rating_submitted', {
+    dish_id: 'dish-1',
+    rating: 8,
+    has_review: true,
+  })
+  // Phase 2: vote_submitted is gone, binary_removed property is gone
+  const allCalls = capture.mock.calls.map(c => c[0])
+  expect(allCalls).not.toContain('vote_submitted')
+})
+
+it('does not send p_would_order_again to submit_vote_atomic', async () => {
+  supabase.rpc
+    .mockResolvedValueOnce({ data: { allowed: true }, error: null })
+    .mockResolvedValueOnce({ data: { id: 'vote-1' }, error: null })
+
+  await votesApi.submitVote({
+    dishId: 'dish-1',
+    rating10: 8,
+  })
+
+  const submitCall = supabase.rpc.mock.calls.find(c => c[0] === 'submit_vote_atomic')
+  expect(submitCall).toBeTruthy()
+  expect(submitCall[1]).not.toHaveProperty('p_would_order_again')
+})
+```
+
+Delete any existing tests that assert on `vote_submitted` or on `would_order_again` being present in the RPC payload or capture call.
+
+- [ ] **Step 2: Run the tests to verify failure**
+
+Run: `npm run test -- src/api/votesApi.test.js`
+Expected: FAIL — current code still emits `vote_submitted` and still sends `p_would_order_again`.
+
+- [ ] **Step 3: Update `votesApi.js`**
+
+In `src/api/votesApi.js`, find `upsertVoteRecord` (around line 78). Update the RPC call to drop `p_would_order_again`:
+
+Before:
+```javascript
+var { data: vote, error } = await supabase.rpc('submit_vote_atomic', {
+  p_dish_id: dishId,
+  p_user_id: userId,
+  p_would_order_again: /* whatever */,  // some derivation from rating10
+  p_rating_10: rating10,
+  p_review_text: reviewText,
+  p_purity_score: purityData && purityData.purity != null ? purityData.purity : null,
+  p_war_score: jitterScore && jitterScore.score != null ? jitterScore.score : null,
+  p_badge_hash: badgeHash || null,
+})
+```
+
+After:
+```javascript
+var { data: vote, error } = await supabase.rpc('submit_vote_atomic', {
+  p_dish_id: dishId,
+  p_user_id: userId,
+  p_rating_10: rating10,
+  p_review_text: reviewText,
+  p_purity_score: purityData && purityData.purity != null ? purityData.purity : null,
+  p_war_score: jitterScore && jitterScore.score != null ? jitterScore.score : null,
+  p_badge_hash: badgeHash || null,
+})
+```
+
+Still in `upsertVoteRecord`, find the analytics block (the Phase 1 dual-emit of `vote_submitted` + `rating_submitted`). Replace it with a single emit:
+
+Before:
+```javascript
+const derivedWouldOrderAgain = rating10 != null ? rating10 >= 7.0 : null
+
+capture('vote_submitted', {
+  dish_id: dishId,
+  would_order_again: derivedWouldOrderAgain,
+  rating: rating10,
+  has_review: !!reviewText,
+  binary_removed: true,
+})
+
+capture('rating_submitted', {
+  dish_id: dishId,
+  rating: rating10,
+  has_review: !!reviewText,
+  binary_removed: true,
+})
+```
+
+After:
+```javascript
+capture('rating_submitted', {
+  dish_id: dishId,
+  rating: rating10,
+  has_review: !!reviewText,
+})
+```
+
+Also remove any `normalizeVotePayload` destructured field that referenced `wouldOrderAgain` (there shouldn't be any left from Phase 1 — confirm with a grep inside the file).
+
+- [ ] **Step 4: Run tests, verify passing**
+
+Run: `npm run test -- src/api/votesApi.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Run full suite to catch unintended fallout**
+
+Run: `npm run test -- --run 2>&1 | tail -3`
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/api/votesApi.js src/api/votesApi.test.js
+git commit -m "feat(api): phase 2 — drop p_would_order_again RPC arg and vote_submitted dual-emit"
+```
+
+---
+
+## Task 4: Add multi-photo safety to `dishPhotosApi.getUserPhotoForDish`
+
+**Files:**
+- Modify: `src/api/dishPhotosApi.js`
+
+- [ ] **Step 1: Read the current implementation**
+
+```bash
+grep -n -A 25 "getUserPhotoForDish" src/api/dishPhotosApi.js
+```
+
+Current (around line 233):
+```javascript
+async getUserPhotoForDish(dishId) {
+  try {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return null
+
+    const { data, error } = await supabase
+      .from('dish_photos')
+      .select('*')
+      .eq('dish_id', dishId)
+      .eq('user_id', user.id)
+      .maybeSingle()
+
+    if (error) throw createClassifiedError(error)
+    return data
+  } catch (error) {
+    logger.error('Error fetching user photo:', error)
+    throw error.type ? error : createClassifiedError(error)
+  }
+}
+```
+
+- [ ] **Step 2: Add ordering + limit before maybeSingle**
+
+Edit `src/api/dishPhotosApi.js` to replace the query chain with:
+
+```javascript
+const { data, error } = await supabase
+  .from('dish_photos')
+  .select('*')
+  .eq('dish_id', dishId)
+  .eq('user_id', user.id)
+  .order('created_at', { ascending: false })
+  .limit(1)
+  .maybeSingle()
+```
+
+This guards against the case where a user has uploaded multiple photos for the same dish (which `.maybeSingle()` alone would reject by throwing).
+
+- [ ] **Step 3: Build to confirm no typos**
+
+Run: `npm run build 2>&1 | tail -3`
+Expected: build passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/api/dishPhotosApi.js
+git commit -m "feat(api): multi-photo safety on getUserPhotoForDish"
+```
+
+---
+
+## Task 5: Rewrite `seed-reviews` buildReviewSnippet + insert NULL for boolean
+
+**Files:**
+- Modify: `supabase/functions/seed-reviews/index.ts`
+
+- [ ] **Step 1: Read the function around the INSERT**
+
+```bash
+grep -n -B 2 -A 30 "buildReviewSnippet\|would_order_again" supabase/functions/seed-reviews/index.ts
+```
+
+Two sites to change:
+1. `buildReviewSnippet` signature (~line 57)
+2. The caller site + the INSERT (~line 360)
+
+- [ ] **Step 2: Rewrite `buildReviewSnippet` signature**
+
+Edit `supabase/functions/seed-reviews/index.ts` around line 57. Change the function signature and its closer-selection logic:
+
+Before:
+```typescript
+function buildReviewSnippet(phrases: string[], wouldOrderAgain: boolean): string | null {
+  if (!phrases || phrases.length === 0) return null
+  // ... existing phrase-joining logic unchanged ...
+  const closers = wouldOrderAgain
+    ? [' Would definitely order again.', ' A must-try.', ' Highly recommend.']
+    : [' Probably wouldn\'t order again.', ' Not my favorite.']
+  // ... rest unchanged ...
+}
+```
+
+After:
+```typescript
+function buildReviewSnippet(phrases: string[], rating: number | null): string | null {
+  if (!phrases || phrases.length === 0) return null
+  // ... existing phrase-joining logic unchanged ...
+  const positive = rating != null && rating >= 7.0
+  const closers = positive
+    ? [' Would definitely order again.', ' A must-try.', ' Highly recommend.']
+    : [' Probably wouldn\'t order again.', ' Not my favorite.']
+  // ... rest unchanged ...
+}
+```
+
+Only the signature and the closer-selection line change. Every other line in the function stays.
+
+- [ ] **Step 3: Update the caller site + INSERT**
+
+Around line 360, replace the Phase 1 compat shim block. Before:
+
+```typescript
+// Phase 1 compat: mirror submit_vote_atomic's rating>=7.0 derivation. Phase 2 will pass NULL and drop snippet dependence.
+const wghRating = rating10
+const wouldOrderAgain = wghRating != null ? wghRating >= 7.0 : null
+
+// ... existing duplicate-avoidance check unchanged ...
+
+const reviewSnippet = buildReviewSnippet(mention.descriptive_phrases, wouldOrderAgain ?? false)
+
+const { error: insertErr } = await supabase.from('votes').insert({
+  dish_id: matched.id,
+  user_id: AI_SYSTEM_USER_ID,
+  would_order_again: wouldOrderAgain,
+  rating_10: rating10,
+  // ... rest unchanged ...
+})
+```
+
+After:
+```typescript
+// Phase 2: the votes.would_order_again column is nullable and no longer
+// surfaced anywhere. Insert NULL; the snippet builder derives its own
+// positive/negative closer from the rating.
+const wghRating = rating10
+
+// ... existing duplicate-avoidance check unchanged ...
+
+const reviewSnippet = buildReviewSnippet(mention.descriptive_phrases, wghRating)
+
+const { error: insertErr } = await supabase.from('votes').insert({
+  dish_id: matched.id,
+  user_id: AI_SYSTEM_USER_ID,
+  would_order_again: null,
+  rating_10: rating10,
+  // ... rest unchanged ...
+})
+```
+
+Delete the `const wouldOrderAgain = ...` line entirely. The `would_order_again: null` entry in the INSERT keeps explicit intent.
+
+- [ ] **Step 4: Verify no stale references**
+
+Run:
+```bash
+grep -n "wouldOrderAgain" supabase/functions/seed-reviews/index.ts
+```
+Expected: zero output. The variable is fully removed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/functions/seed-reviews/index.ts
+git commit -m "feat(seed): phase 2 — pass rating to buildReviewSnippet, insert NULL boolean
+
+Removes compat dependency on would_order_again. Snippet closer logic
+derives positive/negative directly from the rating. Votes insert writes
+NULL for the column (now stripped from all read paths)."
+```
+
+---
+
+## Task 6: Wire `existingPhotoUrl` in `Dish.jsx`
+
+**Files:**
+- Modify: `src/pages/Dish.jsx`
+
+- [ ] **Step 1: Read current prior-vote fetch**
+
+```bash
+grep -n -A 15 "getUserVoteForDish" src/pages/Dish.jsx
+```
+
+Current prior-vote fetch (approximately lines 47-57):
+```javascript
+useEffect(() => {
+  if (!user || !dishId) {
+    setPriorVote(null)
+    return
+  }
+  let cancelled = false
+  authApi.getUserVoteForDish(dishId, user.id)
+    .then((vote) => { if (!cancelled) setPriorVote(vote) })
+    .catch((err) => { logger.error('Failed to fetch prior vote:', err) })
+  return () => { cancelled = true }
+}, [dishId, user])
+```
+
+Also confirm where `<ReviewFlow />` is rendered with `existingPhotoUrl={null}` hardcoded (search the file for `existingPhotoUrl`):
+```bash
+grep -n "existingPhotoUrl" src/pages/Dish.jsx
+```
+Expected: one hardcoded `null` site inside the inline ReviewFlow render.
+
+- [ ] **Step 2: Add photo state + import dishPhotosApi**
+
+Near the other `useState` declarations in `Dish()` (around lines 37-39), add:
+```javascript
+const [existingPhotoUrl, setExistingPhotoUrl] = useState(null)
+```
+
+At the imports (top of file, near line 19 where `authApi` is imported), add:
+```javascript
+import { dishPhotosApi } from '../api/dishPhotosApi'
+```
+
+- [ ] **Step 3: Rewrite the prior-state fetch as parallel**
+
+Replace the `useEffect` from Step 1 with:
+
+```javascript
+useEffect(() => {
+  if (!user || !dishId) {
+    setPriorVote(null)
+    setExistingPhotoUrl(null)
+    return
+  }
+  let cancelled = false
+  Promise.all([
+    authApi.getUserVoteForDish(dishId, user.id),
+    dishPhotosApi.getUserPhotoForDish(dishId),
+  ])
+    .then(([vote, photo]) => {
+      if (cancelled) return
+      setPriorVote(vote)
+      setExistingPhotoUrl(photo?.photo_url ?? null)
+    })
+    .catch((err) => { logger.error('Failed to fetch prior state:', err) })
+  return () => { cancelled = true }
+}, [dishId, user])
+```
+
+- [ ] **Step 4: Also refresh the photo on successful vote submission**
+
+Find `handleVoteSubmitted` (around lines 93-102). After the submit closes the flow and re-fetches prior vote, also re-fetch the photo. Replace the existing `handleVoteSubmitted` body with:
+
+```javascript
+const handleVoteSubmitted = () => {
+  setShowRateFlow(false)
+  if (user && dishId) {
+    Promise.all([
+      authApi.getUserVoteForDish(dishId, user.id),
+      dishPhotosApi.getUserPhotoForDish(dishId),
+    ])
+      .then(([vote, photo]) => {
+        setPriorVote(vote)
+        setExistingPhotoUrl(photo?.photo_url ?? null)
+      })
+      .catch((err) => { logger.error('Failed to refresh prior state:', err) })
+  }
+  handleVote?.()
+}
+```
+
+- [ ] **Step 5: Pass `existingPhotoUrl` to `<ReviewFlow />`**
+
+Find the `<ReviewFlow ... />` render inside the Dish component. Change:
+```jsx
+existingPhotoUrl={null}
+```
+to:
+```jsx
+existingPhotoUrl={existingPhotoUrl}
+```
+
+- [ ] **Step 6: Build + sanity test**
+
+Run:
+```bash
+npm run build 2>&1 | tail -3
+npm run test -- --run 2>&1 | tail -3
+```
+Expected: build + test pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pages/Dish.jsx
+git commit -m "feat(dish): wire existingPhotoUrl from dishPhotosApi into ReviewFlow
+
+Lights up the Keep/Replace/Remove thumbnail UI that was wired but dark
+in Phase 1. Fetches prior vote and prior photo in parallel, refreshes
+both on successful submit."
+```
+
+---
+
+## Task 7: Update `supabase/README.md`
+
+**Files:**
+- Modify: `supabase/README.md`
+
+- [ ] **Step 1: Find references to the binary**
+
+```bash
+grep -n -B 1 -A 3 "would_order_again\|worth.?it\|yes_votes\|percent_worth_it" supabase/README.md
+```
+
+- [ ] **Step 2: Remove or rewrite each reference**
+
+For each hit, edit the surrounding sentence. Typical patterns:
+- `votes (would_order_again boolean, rating_10 numeric, ...)` → `votes (rating_10 numeric, ...)`
+- `The vote is a (would_order_again, rating_10) pair.` → `The vote is a rating_10 value (1–10).`
+- `Percent worth it is derived from would_order_again.` → remove the sentence entirely.
+
+Keep the README's overall structure and tone. Don't refactor the document — only scrub binary references.
+
+- [ ] **Step 3: Verify clean**
+
+```bash
+grep -n "would_order_again\|percent_worth_it\|yes_votes" supabase/README.md
+```
+Expected: zero output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/README.md
+git commit -m "docs(supabase): remove binary-vote references from README"
+```
+
+---
+
+## Task 8: Final verification, deploy instructions, and PR
+
+**Files:** none (verification + PR only)
+
+- [ ] **Step 1: Full grep audit**
+
+Run each of these. Each should return zero output or only pre-existing expected references.
+
+```bash
+grep -rn "p_would_order_again" src/ supabase/migrations/ supabase/schema.sql 2>/dev/null
+```
+Expected: only in the FROZEN migration `supabase/migrations/2026-04-12-binary-vote-removal.sql` (Phase 1's artifact, never edited). New Phase 2 migration and current `schema.sql` must be clean.
+
+```bash
+grep -rn "vote_submitted\|binary_removed" src/ 2>/dev/null
+```
+Expected: zero output (these were Phase 1 analytics compat fields).
+
+```bash
+grep -rn "yes_votes\|percent_worth_it" src/ supabase/schema.sql 2>/dev/null
+```
+Expected: zero output (the Phase 2 migration explicitly drops these from all return signatures).
+
+```bash
+grep -n "would_order_again" supabase/schema.sql
+```
+Expected: exactly one hit — line 82, the column definition itself. No RPC, no view should reference it.
+
+- [ ] **Step 2: Build + test + lint**
+
+```bash
+npm run build 2>&1 | tail -3
+npm run test -- --run 2>&1 | tail -3
+npm run lint 2>&1 | grep -E "^/Users" | grep -v "whats-good-here-soul" | head -20
+```
+
+Expected: build passes, 312+ tests pass (or whatever the Phase 1 baseline is — no regression), no NEW lint errors introduced in touched files (pre-existing baseline is fine).
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push -u origin feat/binary-vote-removal-phase-2
+```
+
+- [ ] **Step 4: Open the PR**
+
+Use `gh pr create` with this body:
+
+```bash
+gh pr create --title "Binary vote removal — Phase 2 (cleanup)" --body "$(cat <<'EOF'
+## Summary
+
+Removes every Phase 1 compat shim. The binary vote concept is now
+fully gone from the write path, read paths, analytics, and docs. The
+votes.would_order_again column stays (historical integrity).
+
+Spec: \`docs/superpowers/specs/2026-04-13-binary-vote-removal-phase-2-design.md\`
+Plan: \`docs/superpowers/plans/2026-04-13-binary-vote-removal-phase-2.md\`
+
+## Manual deploy steps before / after merging
+
+- [ ] Run \`supabase/migrations/2026-04-13-binary-vote-removal-phase-2.sql\` in Supabase SQL Editor against project \`vpioftosgdkyiwvhxewy\`.
+- [ ] After merge, deploy seed-reviews Edge Function: \`supabase functions deploy seed-reviews --project-ref vpioftosgdkyiwvhxewy\`.
+
+## Test plan
+
+- [x] \`npm run build\` passes
+- [x] \`npm run test -- --run\` passes
+- [ ] Grep audit: no residual \`vote_submitted\` / \`binary_removed\` / \`yes_votes\` / \`percent_worth_it\` / \`p_would_order_again\` in src or schema.sql
+- [ ] Manual: submit a rating on prod, verify only \`rating_submitted\` fires in PostHog (no \`vote_submitted\` sibling)
+- [ ] Manual: dish detail for a dish you've rated and photographed shows the Keep/Replace/Remove photo UI
+- [ ] Manual: no 500s or function-signature errors on voting
+
+## Known risk
+
+Stale PWA bundles still passing the 8-arg \`submit_vote_atomic\` signature will error. User base is effectively you + Denis + early testers; recovery is a single hard refresh. Capacitor launch makes this a one-time cost.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Report the PR URL and outstanding manual steps**
+
+Final output to the caller:
+- PR URL.
+- Manual step: run the migration in Supabase SQL Editor.
+- Manual step: deploy the Edge Function after merge.
+- Manual step: verify PostHog 24h after deploy.

--- a/docs/superpowers/specs/2026-04-13-binary-vote-removal-phase-2-design.md
+++ b/docs/superpowers/specs/2026-04-13-binary-vote-removal-phase-2-design.md
@@ -1,0 +1,290 @@
+# Binary Vote Removal — Phase 2 Design Spec
+
+**Date:** 2026-04-13
+**Status:** Approved design, ready for implementation plan
+**Owner:** Dan
+**Builds on:** `docs/superpowers/specs/2026-04-12-binary-vote-removal-design.md` (Phase 1, shipped)
+
+---
+
+## Problem
+
+Phase 1 shipped compat shims so stale PWA bundles wouldn't hard-break: `submit_vote_atomic` kept `p_would_order_again` as an optional param and derived the boolean from rating when omitted; read RPCs kept returning `yes_votes` / `percent_worth_it` / `would_order_again`; analytics dual-emitted `vote_submitted` (old name) and `rating_submitted` (canonical).
+
+Dan is moving to a native iOS app via Capacitor for the Memorial Day launch. Capacitor ships bundles with the app binary, so the "stale PWA service worker" class of risk goes away. Keeping compat shims baked into a v1.0 native binary is worse than cutting them now.
+
+## Goal
+
+Remove every Phase 1 compat shim. Leave a clean final shape for the Capacitor build.
+
+The `votes.would_order_again` column stays (historical integrity). Everything else that references the binary in the server return path, the writer path, or the analytics contract gets deleted.
+
+Additionally, wire up the `existingPhotoUrl` prop that `ReviewFlow` currently accepts but `Dish.jsx` passes as `null`, so the Keep/Replace/Remove photo UI lights up for users with a prior photo.
+
+## Scope boundaries
+
+**In scope:**
+- Drop `p_would_order_again` parameter from `submit_vote_atomic`. Signature goes 8 → 7 params.
+- Delete the rating-derivation block inside `submit_vote_atomic`. Column writes `NULL` for all new rows.
+- Drop `yes_votes` and `percent_worth_it` from `get_ranked_dishes`, `get_restaurant_dishes`, `get_dish_variants` return signatures. Remove the SUM/weighted-count math that computes them.
+- Drop `would_order_again` from `get_friends_votes_for_dish` and `get_friends_votes_for_restaurant` return signatures.
+- Drop `would_order_again` from the `public_votes` view.
+- `votesApi.submitVote`: drop the `vote_submitted` dual-emit. Keep only `rating_submitted`. Drop the `binary_removed: true` property and the derived `would_order_again` field from its payload.
+- `seed-reviews` Edge Function: insert `would_order_again: null`. Refactor `buildReviewSnippet(phrases, wouldOrderAgain)` to `buildReviewSnippet(phrases, rating)` with `rating >= 7.0` gate inside.
+- `Dish.jsx`: fetch the user's prior dish photo in parallel with the prior-vote fetch; pass the resulting `photo_url` to `ReviewFlow` as `existingPhotoUrl`. Use the existing `dishPhotosApi.getUserPhotoForDish(dishId)` helper.
+- `dishPhotosApi.getUserPhotoForDish`: add `.order('created_at', { ascending: false }).limit(1)` before `.maybeSingle()` as multi-photo safety.
+- `supabase/README.md`: update vote-shape documentation to remove `would_order_again`.
+- Forward migration file + `supabase/schema.sql` both updated to match.
+- Tests updated.
+
+**Out of scope:**
+- AI/seeded review removal (Dan's running that as a separate piece of work before launch).
+- Any UI changes beyond lighting up the existing Keep/Replace/Remove photo UI.
+- Capacitor / native app wrapping.
+- `votes.would_order_again` column removal (historical data stays).
+
+---
+
+## Data / RPC Changes
+
+### `submit_vote_atomic`
+
+Drop and recreate. Final signature:
+
+```sql
+CREATE OR REPLACE FUNCTION submit_vote_atomic(
+  p_dish_id UUID,
+  p_user_id UUID,
+  p_rating_10 DECIMAL DEFAULT NULL,
+  p_review_text TEXT DEFAULT NULL,
+  p_purity_score DECIMAL DEFAULT NULL,
+  p_war_score DECIMAL DEFAULT NULL,
+  p_badge_hash TEXT DEFAULT NULL
+) RETURNS votes
+```
+
+Body:
+- Access-control guard preserved (service-role OR user operating on own row).
+- No derivation of `would_order_again`. Insert writes `NULL` for that column.
+- Validation: `RAISE EXCEPTION 'rating_10 is required'` if `p_rating_10 IS NULL`.
+- `ON CONFLICT (dish_id, user_id) WHERE source = 'user'` preserved.
+- `DO UPDATE` no longer touches `would_order_again` at all (stays at whatever existing value the prior row had, which might be NULL from Phase 1 writes or a boolean from pre-Phase-1 writes — irrelevant now).
+- `source = 'user'` preserved.
+- `RETURNS votes` (rowtype) preserved.
+- `SECURITY DEFINER SET search_path = public` preserved.
+
+`DROP FUNCTION IF EXISTS submit_vote_atomic(UUID, UUID, BOOLEAN, DECIMAL, TEXT, DECIMAL, DECIMAL, TEXT)` precedes the CREATE.
+
+`GRANT EXECUTE ON FUNCTION submit_vote_atomic(UUID, UUID, DECIMAL, TEXT, DECIMAL, DECIMAL, TEXT) TO authenticated`.
+
+### Read RPCs
+
+For each of `get_ranked_dishes`, `get_restaurant_dishes`, `get_dish_variants`:
+- Remove `yes_votes BIGINT` and `percent_worth_it INT` (or equivalent types) from the `RETURNS TABLE (...)` clause.
+- Remove the `SUM(CASE WHEN v.would_order_again ...)` aggregation.
+- Remove the `ROUND((yes_votes / NULLIF(total_votes, 0)) * 100)` percent computation.
+- Keep all other return columns and computation (avg_rating, total_votes, distance, value_score, etc.) unchanged.
+
+For `get_friends_votes_for_dish` and `get_friends_votes_for_restaurant`:
+- Remove `would_order_again` column from `RETURNS TABLE (...)`.
+- Remove it from the SELECT list inside the function body.
+
+### `public_votes` view
+
+- Drop `would_order_again` column from the view's SELECT list.
+- Recreate the view without the column.
+
+### Column
+
+- `votes.would_order_again` column stays. Nullable (set by Phase 1). Historical rows preserved.
+
+### Migration artifact
+
+`supabase/migrations/2026-04-13-binary-vote-removal-phase-2.sql` contains:
+1. DROP + CREATE for `submit_vote_atomic`.
+2. CREATE OR REPLACE for each of the 5 affected read RPCs.
+3. CREATE OR REPLACE for `public_votes` view.
+4. GRANT statements to match new signatures.
+
+`supabase/schema.sql` updated to mirror the migration.
+
+---
+
+## API + Analytics Changes
+
+### `src/api/votesApi.js`
+
+**`submitVote` RPC call:**
+- Drop `p_would_order_again` from the payload.
+
+**Analytics:**
+
+Before (Phase 1):
+```js
+capture('vote_submitted', {
+  dish_id: dishId,
+  would_order_again: derivedWouldOrderAgain,
+  rating: rating10,
+  has_review: !!reviewText,
+  binary_removed: true,
+})
+capture('rating_submitted', {
+  dish_id: dishId,
+  rating: rating10,
+  has_review: !!reviewText,
+  binary_removed: true,
+})
+```
+
+After (Phase 2):
+```js
+capture('rating_submitted', {
+  dish_id: dishId,
+  rating: rating10,
+  has_review: !!reviewText,
+})
+```
+
+### `src/api/dishPhotosApi.js`
+
+Add safety ordering to the existing `getUserPhotoForDish(dishId)`:
+
+```js
+const { data, error } = await supabase
+  .from('dish_photos')
+  .select('*')
+  .eq('dish_id', dishId)
+  .eq('user_id', user.id)
+  .order('created_at', { ascending: false })
+  .limit(1)
+  .maybeSingle()
+```
+
+No signature change; return shape unchanged. Just guards against a case where a user has somehow submitted multiple photos for the same dish.
+
+### `src/pages/Dish.jsx`
+
+Parallel fetch alongside existing prior-vote fetch:
+
+```js
+useEffect(() => {
+  if (!user || !dishId) {
+    setPriorVote(null)
+    setExistingPhotoUrl(null)
+    return
+  }
+  let cancelled = false
+  Promise.all([
+    authApi.getUserVoteForDish(dishId, user.id),
+    dishPhotosApi.getUserPhotoForDish(dishId),
+  ])
+    .then(([vote, photo]) => {
+      if (cancelled) return
+      setPriorVote(vote)
+      setExistingPhotoUrl(photo?.photo_url ?? null)
+    })
+    .catch((err) => logger.error('Failed to fetch prior state:', err))
+  return () => { cancelled = true }
+}, [dishId, user])
+```
+
+Pass `existingPhotoUrl={existingPhotoUrl}` to `<ReviewFlow />` instead of the current hardcoded `null`.
+
+---
+
+## Seed Function Changes
+
+### `supabase/functions/seed-reviews/index.ts`
+
+**`buildReviewSnippet`:**
+
+Before:
+```ts
+function buildReviewSnippet(phrases: string[], wouldOrderAgain: boolean): string | null {
+  ...
+  const closers = wouldOrderAgain
+    ? [' Would definitely order again.', ' A must-try.', ' Highly recommend.']
+    : [' Probably wouldn\'t order again.', ' Not my favorite.']
+  ...
+}
+```
+
+After:
+```ts
+function buildReviewSnippet(phrases: string[], rating: number | null): string | null {
+  ...
+  const positive = rating != null && rating >= 7.0
+  const closers = positive
+    ? [' Would definitely order again.', ' A must-try.', ' Highly recommend.']
+    : [' Probably wouldn\'t order again.', ' Not my favorite.']
+  ...
+}
+```
+
+The caller site passes `rating10` (the actual rating being written) instead of the derived boolean.
+
+**Insert:**
+```ts
+const { error: insertErr } = await supabase.from('votes').insert({
+  dish_id: matched.id,
+  user_id: AI_SYSTEM_USER_ID,
+  would_order_again: null,  // column is nullable; Phase 2 stops writing this signal
+  rating_10: rating10,
+  ...
+})
+```
+
+Stale compat comments referencing Phase 1 are removed.
+
+Edge Function deploys manually after the PR merges (same flow as Phase 1: `supabase functions deploy seed-reviews --project-ref <id>`).
+
+---
+
+## Documentation
+
+`supabase/README.md`:
+- Find the section documenting the `votes` table shape or the vote-submission flow.
+- Remove any mention of `would_order_again` as a required / produced field.
+- Note that `rating_10` is the canonical single input.
+
+---
+
+## Test Updates
+
+- `src/api/votesApi.test.js`: drop the `vote_submitted` assertions. Keep `rating_submitted`. Drop assertions on `would_order_again` field in the RPC payload.
+- `src/api/dishesApi.test.js` + any test referencing `yes_votes` / `percent_worth_it` in expected RPC returns: update mocks so the RPC mock no longer returns those fields.
+- `src/hooks/useVote.test.js`: confirmed already clean from Phase 1, no change expected.
+- No new tests required — this is subtractive work with one trivial additive change (photo fetch in Dish.jsx).
+
+---
+
+## Rollout Sequence
+
+1. Land this PR.
+2. Deploy migration via Supabase SQL Editor (Dan's flow, same as Phase 1).
+3. Deploy `seed-reviews` Edge Function via CLI.
+4. Vercel auto-deploys the frontend on merge.
+5. Spot-check production: submit a rating, verify `rating_submitted` fires in PostHog with no `vote_submitted` sibling. Verify no 500s on `/dish/:id` load (stale client compat is not required).
+
+---
+
+## Success Criteria
+
+- `supabase/schema.sql` contains no reference to `p_would_order_again`, no SUM-based `yes_votes` computation, no `percent_worth_it` ROUND expression.
+- `public_votes` view does not project `would_order_again`.
+- `grep -rn "vote_submitted" src/` returns zero hits (outside test cleanup artifacts, if any).
+- `grep -rn "binary_removed" src/` returns zero hits.
+- `grep -rn "percent_worth_it\|yes_votes" src/ supabase/` returns zero hits outside historical migration files (which are frozen artifacts).
+- `Dish.jsx` logged-in-with-prior-photo manual test: photo thumbnail appears in ReviewFlow with Keep/Replace/Remove options.
+- `npm run build` and `npm run test -- --run` pass.
+- Deployed migration's `submit_vote_atomic` call succeeds with 7 args (no boolean) and rejects calls that still pass 8 args.
+
+---
+
+## Surfaces Verified Clean
+
+From the Phase 1 grep audit + Codex's Phase 2 inventory check:
+- No other RPCs reference `would_order_again` in their return or body.
+- No UI components still read `percent_worth_it` or `yes_votes` (all stripped in Phase 1).
+- No other analytics events carry binary-vote properties.
+- No email / push templates reference the feature.

--- a/src/api/dishPhotosApi.js
+++ b/src/api/dishPhotosApi.js
@@ -243,6 +243,8 @@ export const dishPhotosApi = {
         .select('*')
         .eq('dish_id', dishId)
         .eq('user_id', user.id)
+        .order('created_at', { ascending: false })
+        .limit(1)
         .maybeSingle()
 
       if (error) {

--- a/src/api/dishPhotosApi.test.js
+++ b/src/api/dishPhotosApi.test.js
@@ -73,6 +73,8 @@ describe('Dish Photos API', () => {
       const mockPhoto = { id: 'photo-1', photo_url: 'https://example.com/1.jpg' }
       const mockSelect = vi.fn(() => ({
         eq: vi.fn(function() { return this }),
+        order: vi.fn(function() { return this }),
+        limit: vi.fn(function() { return this }),
         maybeSingle: vi.fn().mockResolvedValueOnce({ data: mockPhoto, error: null }),
       }))
       supabase.from.mockReturnValueOnce({ select: mockSelect })
@@ -89,6 +91,8 @@ describe('Dish Photos API', () => {
 
       const mockSelect = vi.fn(() => ({
         eq: vi.fn(function() { return this }),
+        order: vi.fn(function() { return this }),
+        limit: vi.fn(function() { return this }),
         maybeSingle: vi.fn().mockResolvedValueOnce({ data: null, error: new Error('DB error') }),
       }))
       supabase.from.mockReturnValueOnce({ select: mockSelect })

--- a/src/api/votesApi.js
+++ b/src/api/votesApi.js
@@ -117,7 +117,7 @@ export const votesApi = {
    * Submit or update a vote for a dish
    * @param {Object} params
    * @param {string} params.dishId - Dish ID
-   * @param {number} params.rating10 - 1-10 rating (sole vote signal; server derives legacy binary shadow)
+   * @param {number} params.rating10 - 1-10 rating (sole vote signal)
    * @param {string} params.reviewText - Optional review text (max 200 chars)
    * @returns {Promise<Object>} Success status
    */

--- a/src/api/votesApi.js
+++ b/src/api/votesApi.js
@@ -103,24 +103,10 @@ async function upsertVoteRecord({ userId, dishId, rating10, reviewText, purityDa
     }
   }
 
-  // Analytics compat window: dual-emit during Phase 1 rollout.
-  //   - `vote_submitted` keeps existing PostHog funnels working. `would_order_again`
-  //     is derived from rating (>=7.0) so downstream dashboards don't break.
-  //   - `rating_submitted` is the new canonical event; Phase 2 drops `vote_submitted`.
-  //   - `binary_removed: true` tags both events so we can filter stale-client traffic.
-  var derivedWouldOrderAgain = rating10 != null ? rating10 >= 7.0 : null
-  capture('vote_submitted', {
-    dish_id: dishId,
-    would_order_again: derivedWouldOrderAgain,
-    rating: rating10,
-    has_review: !!reviewText,
-    binary_removed: true,
-  })
   capture('rating_submitted', {
     dish_id: dishId,
     rating: rating10,
     has_review: !!reviewText,
-    binary_removed: true,
   })
 
   return { success: true, vote }

--- a/src/api/votesApi.test.js
+++ b/src/api/votesApi.test.js
@@ -180,7 +180,7 @@ describe('votesApi', () => {
       })).rejects.toThrow('Unable to verify vote limit. Please try again.')
     })
 
-    it('should dual-emit vote_submitted (compat) + rating_submitted for analytics', async () => {
+    it('emits rating_submitted with clean payload (no binary fields)', async () => {
       supabase.rpc
         .mockResolvedValueOnce({ data: { allowed: true }, error: null })
         .mockResolvedValueOnce({ data: { id: 'vote-1' }, error: null })
@@ -191,50 +191,29 @@ describe('votesApi', () => {
         reviewText: 'Great!',
       })
 
-      // Compat: old event name stays. would_order_again derived from rating >= 7.0.
-      expect(capture).toHaveBeenCalledWith('vote_submitted', {
-        dish_id: 'dish-1',
-        would_order_again: true,
-        rating: 8,
-        has_review: true,
-        binary_removed: true,
-      })
-      // New event name — no binary field.
       expect(capture).toHaveBeenCalledWith('rating_submitted', {
         dish_id: 'dish-1',
         rating: 8,
         has_review: true,
-        binary_removed: true,
       })
+      // Phase 2: vote_submitted is gone, binary_removed property is gone
+      const allCalls = capture.mock.calls.map(c => c[0])
+      expect(allCalls).not.toContain('vote_submitted')
     })
 
-    it('should derive compat would_order_again=false when rating < 7', async () => {
+    it('does not send p_would_order_again to submit_vote_atomic', async () => {
       supabase.rpc
         .mockResolvedValueOnce({ data: { allowed: true }, error: null })
         .mockResolvedValueOnce({ data: { id: 'vote-1' }, error: null })
 
       await votesApi.submitVote({
         dishId: 'dish-1',
-        rating10: 5,
+        rating10: 8,
       })
 
-      expect(capture).toHaveBeenCalledWith('vote_submitted', expect.objectContaining({
-        would_order_again: false,
-      }))
-    })
-
-    it('should derive compat would_order_again=null when rating is null', async () => {
-      supabase.rpc
-        .mockResolvedValueOnce({ data: { allowed: true }, error: null })
-        .mockResolvedValueOnce({ data: { id: 'vote-1' }, error: null })
-
-      await votesApi.submitVote({
-        dishId: 'dish-1',
-      })
-
-      expect(capture).toHaveBeenCalledWith('vote_submitted', expect.objectContaining({
-        would_order_again: null,
-      }))
+      const submitCall = supabase.rpc.mock.calls.find(c => c[0] === 'submit_vote_atomic')
+      expect(submitCall).toBeTruthy()
+      expect(submitCall[1]).not.toHaveProperty('p_would_order_again')
     })
 
     it('should throw classified error on database failure', async () => {

--- a/src/components/ReviewFlow.jsx
+++ b/src/components/ReviewFlow.jsx
@@ -199,9 +199,9 @@ export function ReviewFlow({
       return
     }
 
-    // Analytics: votesApi.submitVote already dual-emits vote_submitted +
-    // rating_submitted for every vote. Dashboards that need dish/restaurant
-    // context can join against dish_id in PostHog.
+    // Analytics: votesApi.submitVote emits rating_submitted for every vote.
+    // Dashboards that need dish/restaurant context can join against dish_id
+    // in PostHog.
 
     setPriorRating(sliderValue)
     if (reviewTextToSubmit) setPriorReviewText(reviewTextToSubmit)

--- a/src/pages/Dish.jsx
+++ b/src/pages/Dish.jsx
@@ -54,16 +54,24 @@ export function Dish() {
       return
     }
     let cancelled = false
-    Promise.all([
+    // allSettled so a photo-fetch failure doesn't also discard the vote fetch —
+    // otherwise the CTA label silently regresses to "Rate this dish" for re-raters.
+    Promise.allSettled([
       authApi.getUserVoteForDish(dishId, user.id),
       dishPhotosApi.getUserPhotoForDish(dishId),
-    ])
-      .then(([vote, photo]) => {
-        if (cancelled) return
-        setPriorVote(vote)
-        setExistingPhotoUrl(photo?.photo_url ?? null)
-      })
-      .catch((err) => { logger.error('Failed to fetch prior state:', err) })
+    ]).then(([voteResult, photoResult]) => {
+      if (cancelled) return
+      if (voteResult.status === 'fulfilled') {
+        setPriorVote(voteResult.value)
+      } else {
+        logger.error('Failed to fetch prior vote:', voteResult.reason)
+      }
+      if (photoResult.status === 'fulfilled') {
+        setExistingPhotoUrl(photoResult.value?.photo_url ?? null)
+      } else {
+        logger.error('Failed to fetch prior photo:', photoResult.reason)
+      }
+    })
     return () => { cancelled = true }
   }, [dishId, user])
 
@@ -108,16 +116,23 @@ export function Dish() {
   const handleVoteSubmitted = () => {
     setShowRateFlow(false)
     // Refresh prior-vote and prior-photo so CTA label and thumbnail stay current.
+    // allSettled so a photo-fetch failure doesn't discard the vote result.
     if (user && dishId) {
-      Promise.all([
+      Promise.allSettled([
         authApi.getUserVoteForDish(dishId, user.id),
         dishPhotosApi.getUserPhotoForDish(dishId),
-      ])
-        .then(([vote, photo]) => {
-          setPriorVote(vote)
-          setExistingPhotoUrl(photo?.photo_url ?? null)
-        })
-        .catch((err) => { logger.error('Failed to refresh prior state:', err) })
+      ]).then(([voteResult, photoResult]) => {
+        if (voteResult.status === 'fulfilled') {
+          setPriorVote(voteResult.value)
+        } else {
+          logger.error('Failed to refresh prior vote:', voteResult.reason)
+        }
+        if (photoResult.status === 'fulfilled') {
+          setExistingPhotoUrl(photoResult.value?.photo_url ?? null)
+        } else {
+          logger.error('Failed to refresh prior photo:', photoResult.reason)
+        }
+      })
     }
     handleVote?.()
   }

--- a/src/pages/Dish.jsx
+++ b/src/pages/Dish.jsx
@@ -17,6 +17,7 @@ import { getStorageItem, setStorageItem, STORAGE_KEYS } from '../lib/storage'
 import { MIN_VOTES_FOR_RANKING } from '../constants/app'
 import { sanitizeUrl } from '../utils/sanitize'
 import { authApi } from '../api/authApi'
+import { dishPhotosApi } from '../api/dishPhotosApi'
 
 export function Dish() {
   const { dishId } = useParams()
@@ -37,22 +38,32 @@ export function Dish() {
   const [showRateFlow, setShowRateFlow] = useState(false)
   const [pendingAction, setPendingAction] = useState(null) // 'rate' | null
   const [priorVote, setPriorVote] = useState(null)
+  const [existingPhotoUrl, setExistingPhotoUrl] = useState(null)
   const { isFavorite, toggleFavorite } = useFavorites(user?.id)
 
   // Ear icon tooltip — show once per device
   const [showEarTooltip, setShowEarTooltip] = useState(false)
   const tooltipChecked = useRef(false)
 
-  // Fetch prior vote to decide CTA label and preserve it after submit.
+  // Fetch prior vote + prior photo in parallel so the CTA label and the
+  // ReviewFlow photo thumbnail both reflect current state.
   useEffect(() => {
     if (!user || !dishId) {
       setPriorVote(null)
+      setExistingPhotoUrl(null)
       return
     }
     let cancelled = false
-    authApi.getUserVoteForDish(dishId, user.id)
-      .then((vote) => { if (!cancelled) setPriorVote(vote) })
-      .catch((err) => { logger.error('Failed to fetch prior vote:', err) })
+    Promise.all([
+      authApi.getUserVoteForDish(dishId, user.id),
+      dishPhotosApi.getUserPhotoForDish(dishId),
+    ])
+      .then(([vote, photo]) => {
+        if (cancelled) return
+        setPriorVote(vote)
+        setExistingPhotoUrl(photo?.photo_url ?? null)
+      })
+      .catch((err) => { logger.error('Failed to fetch prior state:', err) })
     return () => { cancelled = true }
   }, [dishId, user])
 
@@ -96,11 +107,17 @@ export function Dish() {
 
   const handleVoteSubmitted = () => {
     setShowRateFlow(false)
-    // Refresh prior-vote state so the CTA label updates to "Update your rating".
+    // Refresh prior-vote and prior-photo so CTA label and thumbnail stay current.
     if (user && dishId) {
-      authApi.getUserVoteForDish(dishId, user.id)
-        .then(setPriorVote)
-        .catch((err) => { logger.error('Failed to refresh prior vote:', err) })
+      Promise.all([
+        authApi.getUserVoteForDish(dishId, user.id),
+        dishPhotosApi.getUserPhotoForDish(dishId),
+      ])
+        .then(([vote, photo]) => {
+          setPriorVote(vote)
+          setExistingPhotoUrl(photo?.photo_url ?? null)
+        })
+        .catch((err) => { logger.error('Failed to refresh prior state:', err) })
     }
     handleVote?.()
   }
@@ -304,7 +321,7 @@ export function Dish() {
                   price={dish.price}
                   totalVotes={dish.total_votes}
                   isRanked={isRanked}
-                  existingPhotoUrl={null}
+                  existingPhotoUrl={existingPhotoUrl}
                   onVote={handleVoteSubmitted}
                   onLoginRequired={handleLoginRequired}
                   onPhotoUploaded={handlePhotoUploaded}

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -50,7 +50,7 @@ supabase/
 - `profiles` - User profiles (extends Supabase auth.users)
 - `restaurants` - Restaurant listings
 - `dishes` - Menu items
-- `votes` - User ratings (would_order_again + rating_10)
+- `votes` - User ratings (rating_10, 1-10 scale)
 - `dish_photos` - User-uploaded photos
 - `follows` - Social connections
 - `notifications` - User notifications

--- a/supabase/functions/seed-reviews/index.ts
+++ b/supabase/functions/seed-reviews/index.ts
@@ -54,7 +54,7 @@ interface ExtractedDishMention {
 /**
  * Build a short review snippet from descriptive phrases (max 200 chars)
  */
-function buildReviewSnippet(phrases: string[], wouldOrderAgain: boolean): string | null {
+function buildReviewSnippet(phrases: string[], rating: number | null): string | null {
   if (!phrases || phrases.length === 0) return null
 
   // Capitalize first phrase
@@ -75,7 +75,8 @@ function buildReviewSnippet(phrases: string[], wouldOrderAgain: boolean): string
   }
 
   // Add a closing sentiment if there's room
-  const closers = wouldOrderAgain
+  const positive = rating != null && rating >= 7.0
+  const closers = positive
     ? [' Would definitely order again.', ' A must-try.', ' Highly recommend.']
     : [' Probably wouldn\'t order again.', ' Not my favorite.']
   const closer = closers[Math.floor(Math.random() * closers.length)]
@@ -357,9 +358,10 @@ serve(async (req) => {
             totalMatched++
 
             const rating10 = mapToWghRating(review.rating, mention.sentiment)
-            // Phase 1 compat: mirror submit_vote_atomic's rating>=7.0 derivation. Phase 2 will pass NULL and drop snippet dependence.
+            // Phase 2: the votes.would_order_again column is nullable and no longer
+            // surfaced anywhere. Insert NULL; the snippet builder derives its own
+            // positive/negative closer from the rating.
             const wghRating = rating10
-            const wouldOrderAgain = wghRating != null ? wghRating >= 7.0 : null
 
             // Check if we already seeded this dish (avoid duplicates)
             const { data: existing } = await supabase
@@ -372,12 +374,12 @@ serve(async (req) => {
             // Max 3 AI votes per dish to avoid over-seeding
             if ((existing?.length || 0) >= 3) continue
 
-            const reviewSnippet = buildReviewSnippet(mention.descriptive_phrases, wouldOrderAgain ?? false)
+            const reviewSnippet = buildReviewSnippet(mention.descriptive_phrases, wghRating)
 
             const { error: insertErr } = await supabase.from('votes').insert({
               dish_id: matched.id,
               user_id: AI_SYSTEM_USER_ID,
-              would_order_again: wouldOrderAgain,
+              would_order_again: null,
               rating_10: rating10,
               review_text: reviewSnippet,
               source: 'ai_estimated',

--- a/supabase/migrations/2026-04-13-binary-vote-removal-phase-2.sql
+++ b/supabase/migrations/2026-04-13-binary-vote-removal-phase-2.sql
@@ -1,0 +1,472 @@
+-- Binary Vote Removal — Phase 2
+-- Design spec: docs/superpowers/specs/2026-04-13-binary-vote-removal-phase-2-design.md
+--
+-- Drops every Phase 1 compat shim:
+--   1. submit_vote_atomic loses p_would_order_again parameter (8 → 7 args).
+--   2. Read RPCs stop returning binary-derived fields.
+--   3. public_votes view stops projecting would_order_again.
+-- The votes.would_order_again column stays in the table for historical
+-- integrity. It just stops being read, written, or projected anywhere.
+
+-- ============================================================
+-- 1. submit_vote_atomic: drop boolean param, stop writing the column
+-- ============================================================
+
+DROP FUNCTION IF EXISTS submit_vote_atomic(
+  UUID, UUID, BOOLEAN, DECIMAL, TEXT, DECIMAL, DECIMAL, TEXT
+);
+
+CREATE OR REPLACE FUNCTION submit_vote_atomic(
+  p_dish_id UUID,
+  p_user_id UUID,
+  p_rating_10 DECIMAL DEFAULT NULL,
+  p_review_text TEXT DEFAULT NULL,
+  p_purity_score DECIMAL DEFAULT NULL,
+  p_war_score DECIMAL DEFAULT NULL,
+  p_badge_hash TEXT DEFAULT NULL
+)
+RETURNS votes AS $$
+DECLARE
+  submitted_vote votes;
+BEGIN
+  IF auth.role() <> 'service_role' AND (select auth.uid()) IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'Access denied';
+  END IF;
+
+  IF p_rating_10 IS NULL THEN
+    RAISE EXCEPTION 'rating_10 is required';
+  END IF;
+
+  INSERT INTO votes (
+    dish_id,
+    user_id,
+    rating_10,
+    review_text,
+    review_created_at,
+    purity_score,
+    war_score,
+    badge_hash,
+    source
+  )
+  VALUES (
+    p_dish_id,
+    p_user_id,
+    p_rating_10,
+    p_review_text,
+    CASE WHEN p_review_text IS NOT NULL THEN NOW() ELSE NULL END,
+    p_purity_score,
+    p_war_score,
+    p_badge_hash,
+    'user'
+  )
+  ON CONFLICT (dish_id, user_id) WHERE source = 'user'
+  DO UPDATE SET
+    rating_10 = EXCLUDED.rating_10,
+    review_text = COALESCE(EXCLUDED.review_text, votes.review_text),
+    review_created_at = COALESCE(EXCLUDED.review_created_at, votes.review_created_at),
+    purity_score = COALESCE(EXCLUDED.purity_score, votes.purity_score),
+    war_score = COALESCE(EXCLUDED.war_score, votes.war_score),
+    badge_hash = COALESCE(EXCLUDED.badge_hash, votes.badge_hash)
+  RETURNING * INTO submitted_vote;
+
+  RETURN submitted_vote;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+GRANT EXECUTE ON FUNCTION submit_vote_atomic(
+  UUID, UUID, DECIMAL, TEXT, DECIMAL, DECIMAL, TEXT
+) TO authenticated;
+
+-- ============================================================
+-- 2. public_votes view: drop would_order_again column
+-- ============================================================
+
+CREATE OR REPLACE VIEW public_votes AS
+SELECT
+  id,
+  dish_id,
+  rating_10,
+  review_text,
+  review_created_at,
+  user_id,
+  source
+FROM votes;
+
+-- ============================================================
+-- 3. Read RPCs: drop yes_votes, percent_worth_it, would_order_again
+-- ============================================================
+
+-- get_ranked_dishes: drop yes_votes + percent_worth_it from RETURNS TABLE
+-- and the SUM(CASE WHEN v.would_order_again ...) aggregations.
+CREATE OR REPLACE FUNCTION get_ranked_dishes(
+  user_lat DECIMAL,
+  user_lng DECIMAL,
+  radius_miles INT DEFAULT 50,
+  filter_category TEXT DEFAULT NULL,
+  filter_town TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+  dish_id UUID,
+  dish_name TEXT,
+  restaurant_id UUID,
+  restaurant_name TEXT,
+  restaurant_town TEXT,
+  category TEXT,
+  tags TEXT[],
+  cuisine TEXT,
+  price DECIMAL,
+  photo_url TEXT,
+  total_votes BIGINT,
+  avg_rating DECIMAL,
+  distance_miles DECIMAL,
+  has_variants BOOLEAN,
+  variant_count INT,
+  best_variant_name TEXT,
+  best_variant_rating DECIMAL,
+  value_score DECIMAL,
+  value_percentile DECIMAL,
+  search_score DECIMAL,
+  featured_photo_url TEXT,
+  restaurant_lat DECIMAL,
+  restaurant_lng DECIMAL,
+  restaurant_address TEXT,
+  restaurant_phone TEXT,
+  restaurant_website_url TEXT,
+  toast_slug TEXT,
+  order_url TEXT
+) AS $$
+DECLARE
+  lat_delta DECIMAL := radius_miles / 69.0;
+  lng_delta DECIMAL := radius_miles / (69.0 * COS(RADIANS(user_lat)));
+BEGIN
+  RETURN QUERY
+  WITH global_stats AS (
+    SELECT COALESCE(AVG(dishes.avg_rating), 7.0) AS global_mean
+    FROM dishes
+    WHERE dishes.total_votes > 0 AND dishes.avg_rating IS NOT NULL
+  ),
+  nearby_restaurants AS (
+    SELECT r.id, r.name, r.town, r.lat, r.lng, r.cuisine,
+           r.address, r.phone, r.website_url, r.toast_slug, r.order_url
+    FROM restaurants r
+    WHERE r.is_open = true
+      AND r.lat BETWEEN (user_lat - lat_delta) AND (user_lat + lat_delta)
+      AND r.lng BETWEEN (user_lng - lng_delta) AND (user_lng + lng_delta)
+      AND (filter_town IS NULL OR r.town = filter_town)
+  ),
+  restaurants_with_distance AS (
+    SELECT
+      nr.id, nr.name, nr.town, nr.lat, nr.lng, nr.cuisine,
+      nr.address, nr.phone, nr.website_url, nr.toast_slug, nr.order_url,
+      ROUND((
+        3959 * ACOS(
+          LEAST(1.0, GREATEST(-1.0,
+            COS(RADIANS(user_lat)) * COS(RADIANS(nr.lat)) *
+            COS(RADIANS(nr.lng) - RADIANS(user_lng)) +
+            SIN(RADIANS(user_lat)) * SIN(RADIANS(nr.lat))
+          ))
+        )
+      )::NUMERIC, 2) AS distance
+    FROM nearby_restaurants nr
+  ),
+  filtered_restaurants AS (
+    SELECT * FROM restaurants_with_distance WHERE distance <= radius_miles
+  ),
+  variant_stats AS (
+    SELECT
+      d.parent_dish_id,
+      COUNT(DISTINCT d.id)::INT AS child_count,
+      SUM(COALESCE(ds.vote_count, 0))::NUMERIC AS total_child_votes
+    FROM dishes d
+    LEFT JOIN (
+      SELECT v.dish_id,
+        SUM(CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END)::NUMERIC AS vote_count
+      FROM votes v GROUP BY v.dish_id
+    ) ds ON ds.dish_id = d.id
+    WHERE d.parent_dish_id IS NOT NULL
+    GROUP BY d.parent_dish_id
+  ),
+  best_variants AS (
+    SELECT DISTINCT ON (d.parent_dish_id)
+      d.parent_dish_id,
+      d.name AS best_name,
+      ROUND(AVG(v.rating_10)::NUMERIC, 1) AS best_rating
+    FROM dishes d
+    LEFT JOIN votes v ON v.dish_id = d.id
+    WHERE d.parent_dish_id IS NOT NULL
+    GROUP BY d.parent_dish_id, d.id, d.name
+    HAVING COUNT(v.id) >= 1
+    ORDER BY d.parent_dish_id, AVG(v.rating_10) DESC NULLS LAST, COUNT(v.id) DESC
+  ),
+  recent_vote_counts AS (
+    SELECT votes.dish_id, COUNT(*)::INT AS recent_votes
+    FROM votes
+    WHERE votes.created_at > NOW() - INTERVAL '14 days'
+    GROUP BY votes.dish_id
+  ),
+  best_photos AS (
+    SELECT DISTINCT ON (dp.dish_id)
+      dp.dish_id,
+      dp.photo_url
+    FROM dish_photos dp
+    INNER JOIN dishes d2 ON dp.dish_id = d2.id
+    INNER JOIN filtered_restaurants fr2 ON d2.restaurant_id = fr2.id
+    WHERE dp.status IN ('featured', 'community')
+      AND d2.parent_dish_id IS NULL
+    ORDER BY dp.dish_id,
+      CASE dp.source_type WHEN 'restaurant' THEN 0 ELSE 1 END,
+      CASE dp.status WHEN 'featured' THEN 0 ELSE 1 END,
+      dp.quality_score DESC NULLS LAST,
+      dp.created_at DESC
+  )
+  SELECT
+    d.id AS dish_id,
+    d.name AS dish_name,
+    fr.id AS restaurant_id,
+    fr.name AS restaurant_name,
+    fr.town AS restaurant_town,
+    d.category,
+    d.tags,
+    fr.cuisine,
+    d.price,
+    d.photo_url,
+    COALESCE(vs.total_child_votes,
+      SUM(CASE WHEN v.source = 'user' THEN 1.0 WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END)
+    )::BIGINT AS total_votes,
+    COALESCE(ROUND(
+      (SUM(CASE WHEN v.source = 'user' THEN v.rating_10
+                WHEN v.source = 'ai_estimated' THEN v.rating_10 * 0.5
+                ELSE 0 END) /
+       NULLIF(SUM(CASE WHEN v.source = 'user' THEN 1.0
+                       WHEN v.source = 'ai_estimated' THEN 0.5
+                       ELSE 0 END), 0)
+      )::NUMERIC, 1), 0) AS avg_rating,
+    fr.distance AS distance_miles,
+    (vs.child_count IS NOT NULL AND vs.child_count > 0) AS has_variants,
+    COALESCE(vs.child_count, 0)::INT AS variant_count,
+    bv.best_name AS best_variant_name,
+    bv.best_rating AS best_variant_rating,
+    d.value_score,
+    d.value_percentile,
+    dish_search_score(
+      COALESCE(ROUND(
+        (SUM(CASE WHEN v.source = 'user' THEN v.rating_10
+                  WHEN v.source = 'ai_estimated' THEN v.rating_10 * 0.5
+                  ELSE 0 END) /
+         NULLIF(SUM(CASE WHEN v.source = 'user' THEN 1.0
+                         WHEN v.source = 'ai_estimated' THEN 0.5
+                         ELSE 0 END), 0)
+        )::NUMERIC, 1), 0),
+      COALESCE(vs.total_child_votes,
+        SUM(CASE WHEN v.source = 'user' THEN 1.0 WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END))::NUMERIC,
+      fr.distance,
+      COALESCE(rvc.recent_votes, 0),
+      (SELECT global_mean FROM global_stats)
+    ) AS search_score,
+    bp.photo_url AS featured_photo_url,
+    fr.lat AS restaurant_lat,
+    fr.lng AS restaurant_lng,
+    fr.address AS restaurant_address,
+    fr.phone AS restaurant_phone,
+    fr.website_url AS restaurant_website_url,
+    fr.toast_slug,
+    fr.order_url
+  FROM dishes d
+  INNER JOIN filtered_restaurants fr ON d.restaurant_id = fr.id
+  LEFT JOIN votes v ON d.id = v.dish_id
+  LEFT JOIN variant_stats vs ON vs.parent_dish_id = d.id
+  LEFT JOIN best_variants bv ON bv.parent_dish_id = d.id
+  LEFT JOIN recent_vote_counts rvc ON rvc.dish_id = d.id
+  LEFT JOIN best_photos bp ON bp.dish_id = d.id
+  WHERE (filter_category IS NULL OR d.category = filter_category)
+    AND d.parent_dish_id IS NULL
+  GROUP BY d.id, d.name, fr.id, fr.name, fr.town, d.category, d.tags, fr.cuisine,
+           d.price, d.photo_url, fr.distance, fr.lat, fr.lng,
+           fr.address, fr.phone, fr.website_url, fr.toast_slug, fr.order_url,
+           vs.total_child_votes, vs.child_count,
+           bv.best_name, bv.best_rating,
+           d.value_score, d.value_percentile,
+           rvc.recent_votes,
+           bp.photo_url
+  ORDER BY search_score DESC NULLS LAST, total_votes DESC;
+END;
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public;
+
+-- get_restaurant_dishes: drop yes_votes + percent_worth_it from RETURNS TABLE
+-- and the SUM(CASE WHEN v.would_order_again ...) aggregations.
+CREATE OR REPLACE FUNCTION get_restaurant_dishes(
+  p_restaurant_id UUID
+)
+RETURNS TABLE (
+  dish_id UUID,
+  dish_name TEXT,
+  restaurant_id UUID,
+  restaurant_name TEXT,
+  category TEXT,
+  menu_section TEXT,
+  price DECIMAL,
+  photo_url TEXT,
+  total_votes BIGINT,
+  avg_rating DECIMAL,
+  has_variants BOOLEAN,
+  variant_count INT,
+  best_variant_id UUID,
+  best_variant_name TEXT,
+  best_variant_rating DECIMAL,
+  tags TEXT[]
+) AS $$
+BEGIN
+  RETURN QUERY
+  WITH variant_stats AS (
+    SELECT
+      d.parent_dish_id,
+      COUNT(DISTINCT d.id)::INT AS child_count,
+      SUM(COALESCE(ds.vote_count, 0))::NUMERIC AS total_child_votes,
+      CASE
+        WHEN SUM(COALESCE(ds.vote_count, 0)) > 0
+        THEN ROUND((SUM(COALESCE(ds.rating_sum, 0)) / NULLIF(SUM(COALESCE(ds.vote_count, 0)), 0))::NUMERIC, 1)
+        ELSE NULL
+      END AS combined_avg_rating
+    FROM dishes d
+    LEFT JOIN (
+      SELECT v.dish_id,
+        SUM(CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END)::NUMERIC AS vote_count,
+        SUM(COALESCE(v.rating_10, 0) * (CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END))::DECIMAL AS rating_sum
+      FROM votes v GROUP BY v.dish_id
+    ) ds ON ds.dish_id = d.id
+    WHERE d.parent_dish_id IS NOT NULL
+    GROUP BY d.parent_dish_id
+  ),
+  best_variants AS (
+    SELECT DISTINCT ON (d.parent_dish_id)
+      d.parent_dish_id, d.id AS best_id, d.name AS best_name,
+      ROUND(AVG(v.rating_10)::NUMERIC, 1) AS best_rating
+    FROM dishes d
+    LEFT JOIN votes v ON v.dish_id = d.id
+    WHERE d.parent_dish_id IS NOT NULL
+    GROUP BY d.parent_dish_id, d.id, d.name
+    HAVING COUNT(v.id) >= 1
+    ORDER BY d.parent_dish_id, AVG(v.rating_10) DESC NULLS LAST, COUNT(v.id) DESC
+  ),
+  dish_vote_stats AS (
+    SELECT d.id AS dish_id, COUNT(v.id)::BIGINT AS direct_votes,
+      ROUND(AVG(v.rating_10)::NUMERIC, 1) AS direct_avg
+    FROM dishes d LEFT JOIN votes v ON v.dish_id = d.id
+    WHERE d.parent_dish_id IS NULL
+    GROUP BY d.id
+  )
+  SELECT
+    d.id AS dish_id, d.name AS dish_name, r.id AS restaurant_id, r.name AS restaurant_name,
+    d.category, d.menu_section, d.price, d.photo_url,
+    COALESCE(vs.total_child_votes, dvs.direct_votes, 0)::BIGINT AS total_votes,
+    COALESCE(vs.combined_avg_rating, dvs.direct_avg) AS avg_rating,
+    (vs.child_count IS NOT NULL AND vs.child_count > 0) AS has_variants,
+    COALESCE(vs.child_count, 0)::INT AS variant_count,
+    bv.best_id AS best_variant_id, bv.best_name AS best_variant_name, bv.best_rating AS best_variant_rating,
+    d.tags
+  FROM dishes d
+  INNER JOIN restaurants r ON d.restaurant_id = r.id
+  LEFT JOIN variant_stats vs ON vs.parent_dish_id = d.id
+  LEFT JOIN best_variants bv ON bv.parent_dish_id = d.id
+  LEFT JOIN dish_vote_stats dvs ON dvs.dish_id = d.id
+  WHERE d.restaurant_id = p_restaurant_id
+    AND r.is_open = true
+    AND d.parent_dish_id IS NULL
+  GROUP BY d.id, d.name, r.id, r.name, d.category, d.menu_section, d.price, d.photo_url, d.tags,
+           vs.total_child_votes, vs.combined_avg_rating, vs.child_count,
+           dvs.direct_votes, dvs.direct_avg,
+           bv.best_id, bv.best_name, bv.best_rating
+  ORDER BY
+    CASE WHEN COALESCE(vs.total_child_votes, dvs.direct_votes, 0) >= 5 THEN 0 ELSE 1 END,
+    COALESCE(vs.combined_avg_rating, dvs.direct_avg) DESC NULLS LAST,
+    COALESCE(vs.total_child_votes, dvs.direct_votes, 0) DESC;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- get_dish_variants: drop yes_votes + percent_worth_it from RETURNS TABLE
+-- and the SUM(CASE WHEN v.would_order_again ...) aggregations.
+CREATE OR REPLACE FUNCTION get_dish_variants(
+  p_parent_dish_id UUID
+)
+RETURNS TABLE (
+  dish_id UUID,
+  dish_name TEXT,
+  price DECIMAL,
+  photo_url TEXT,
+  display_order INT,
+  total_votes BIGINT,
+  avg_rating DECIMAL
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    d.id AS dish_id, d.name AS dish_name, d.price, d.photo_url, d.display_order,
+    COUNT(v.id)::BIGINT AS total_votes,
+    ROUND(AVG(v.rating_10)::NUMERIC, 1) AS avg_rating
+  FROM dishes d
+  LEFT JOIN votes v ON d.id = v.dish_id
+  WHERE d.parent_dish_id = p_parent_dish_id
+  GROUP BY d.id, d.name, d.price, d.photo_url, d.display_order
+  ORDER BY d.display_order, d.name;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- get_friends_votes_for_dish: drop would_order_again from RETURNS TABLE and SELECT.
+CREATE OR REPLACE FUNCTION get_friends_votes_for_dish(
+  p_user_id UUID,
+  p_dish_id UUID
+)
+RETURNS TABLE (
+  user_id UUID,
+  display_name TEXT,
+  rating_10 DECIMAL(3, 1),
+  voted_at TIMESTAMPTZ,
+  category_expertise TEXT
+)
+LANGUAGE SQL STABLE SET search_path = public AS $$
+  SELECT
+    p.id AS user_id, p.display_name, v.rating_10,
+    v.created_at AS voted_at,
+    CASE
+      WHEN EXISTS (SELECT 1 FROM user_badges ub WHERE ub.user_id = p.id AND ub.badge_key = 'authority_' || REPLACE(d.category, ' ', '_')) THEN 'authority'
+      WHEN EXISTS (SELECT 1 FROM user_badges ub WHERE ub.user_id = p.id AND ub.badge_key = 'specialist_' || REPLACE(d.category, ' ', '_')) THEN 'specialist'
+      ELSE NULL
+    END AS category_expertise
+  FROM follows f
+  JOIN profiles p ON p.id = f.followed_id
+  JOIN votes v ON v.user_id = f.followed_id AND v.dish_id = p_dish_id
+  JOIN dishes d ON d.id = p_dish_id
+  WHERE f.follower_id = p_user_id
+  ORDER BY v.created_at DESC;
+$$;
+
+-- get_friends_votes_for_restaurant: drop would_order_again from RETURNS TABLE and SELECT.
+CREATE OR REPLACE FUNCTION get_friends_votes_for_restaurant(
+  p_user_id UUID,
+  p_restaurant_id UUID
+)
+RETURNS TABLE (
+  user_id UUID,
+  display_name TEXT,
+  dish_id UUID,
+  dish_name TEXT,
+  rating_10 DECIMAL(3, 1),
+  voted_at TIMESTAMPTZ,
+  category_expertise TEXT
+)
+LANGUAGE SQL STABLE SET search_path = public AS $$
+  SELECT
+    p.id AS user_id, p.display_name, d.id AS dish_id, d.name AS dish_name,
+    v.rating_10, v.created_at AS voted_at,
+    CASE
+      WHEN EXISTS (SELECT 1 FROM user_badges ub WHERE ub.user_id = p.id AND ub.badge_key = 'authority_' || REPLACE(d.category, ' ', '_')) THEN 'authority'
+      WHEN EXISTS (SELECT 1 FROM user_badges ub WHERE ub.user_id = p.id AND ub.badge_key = 'specialist_' || REPLACE(d.category, ' ', '_')) THEN 'specialist'
+      ELSE NULL
+    END AS category_expertise
+  FROM follows f
+  JOIN profiles p ON p.id = f.followed_id
+  JOIN votes v ON v.user_id = f.followed_id
+  JOIN dishes d ON d.id = v.dish_id AND d.restaurant_id = p_restaurant_id
+  WHERE f.follower_id = p_user_id
+  ORDER BY d.name, v.created_at DESC;
+$$;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -343,7 +343,6 @@ CREATE OR REPLACE VIEW public_votes AS
 SELECT
   id,
   dish_id,
-  would_order_again,
   rating_10,
   review_text,
   review_created_at,
@@ -753,8 +752,6 @@ RETURNS TABLE (
   price DECIMAL,
   photo_url TEXT,
   total_votes BIGINT,
-  yes_votes BIGINT,
-  percent_worth_it INT,
   avg_rating DECIMAL,
   distance_miles DECIMAL,
   has_variants BOOLEAN,
@@ -814,13 +811,11 @@ BEGIN
     SELECT
       d.parent_dish_id,
       COUNT(DISTINCT d.id)::INT AS child_count,
-      SUM(COALESCE(ds.vote_count, 0))::NUMERIC AS total_child_votes,
-      SUM(COALESCE(ds.yes_count, 0))::NUMERIC AS total_child_yes
+      SUM(COALESCE(ds.vote_count, 0))::NUMERIC AS total_child_votes
     FROM dishes d
     LEFT JOIN (
       SELECT v.dish_id,
-        SUM(CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END)::NUMERIC AS vote_count,
-        SUM(CASE WHEN v.would_order_again THEN (CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END) ELSE 0 END)::NUMERIC AS yes_count
+        SUM(CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END)::NUMERIC AS vote_count
       FROM votes v GROUP BY v.dish_id
     ) ds ON ds.dish_id = d.id
     WHERE d.parent_dish_id IS NOT NULL
@@ -873,24 +868,6 @@ BEGIN
     COALESCE(vs.total_child_votes,
       SUM(CASE WHEN v.source = 'user' THEN 1.0 WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END)
     )::BIGINT AS total_votes,
-    COALESCE(vs.total_child_yes,
-      SUM(CASE WHEN v.would_order_again AND v.source = 'user' THEN 1.0
-               WHEN v.would_order_again AND v.source = 'ai_estimated' THEN 0.5
-               ELSE 0 END)
-    )::BIGINT AS yes_votes,
-    CASE
-      WHEN COALESCE(vs.total_child_votes,
-        SUM(CASE WHEN v.source = 'user' THEN 1.0 WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END)) > 0
-      THEN ROUND(100.0 *
-        COALESCE(vs.total_child_yes,
-          SUM(CASE WHEN v.would_order_again AND v.source = 'user' THEN 1.0
-                   WHEN v.would_order_again AND v.source = 'ai_estimated' THEN 0.5
-                   ELSE 0 END)) /
-        COALESCE(vs.total_child_votes,
-          SUM(CASE WHEN v.source = 'user' THEN 1.0 WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END))
-      )::INT
-      ELSE 0
-    END AS percent_worth_it,
     COALESCE(ROUND(
       (SUM(CASE WHEN v.source = 'user' THEN v.rating_10
                 WHEN v.source = 'ai_estimated' THEN v.rating_10 * 0.5
@@ -941,7 +918,7 @@ BEGIN
   GROUP BY d.id, d.name, fr.id, fr.name, fr.town, d.category, d.tags, fr.cuisine,
            d.price, d.photo_url, fr.distance, fr.lat, fr.lng,
            fr.address, fr.phone, fr.website_url, fr.toast_slug, fr.order_url,
-           vs.total_child_votes, vs.total_child_yes, vs.child_count,
+           vs.total_child_votes, vs.child_count,
            bv.best_name, bv.best_rating,
            d.value_score, d.value_percentile,
            rvc.recent_votes,
@@ -964,8 +941,6 @@ RETURNS TABLE (
   price DECIMAL,
   photo_url TEXT,
   total_votes BIGINT,
-  yes_votes BIGINT,
-  percent_worth_it INT,
   avg_rating DECIMAL,
   has_variants BOOLEAN,
   variant_count INT,
@@ -981,7 +956,6 @@ BEGIN
       d.parent_dish_id,
       COUNT(DISTINCT d.id)::INT AS child_count,
       SUM(COALESCE(ds.vote_count, 0))::NUMERIC AS total_child_votes,
-      SUM(COALESCE(ds.yes_count, 0))::NUMERIC AS total_child_yes,
       CASE
         WHEN SUM(COALESCE(ds.vote_count, 0)) > 0
         THEN ROUND((SUM(COALESCE(ds.rating_sum, 0)) / NULLIF(SUM(COALESCE(ds.vote_count, 0)), 0))::NUMERIC, 1)
@@ -991,7 +965,6 @@ BEGIN
     LEFT JOIN (
       SELECT v.dish_id,
         SUM(CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END)::NUMERIC AS vote_count,
-        SUM(CASE WHEN v.would_order_again THEN (CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END) ELSE 0 END)::NUMERIC AS yes_count,
         SUM(COALESCE(v.rating_10, 0) * (CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END))::DECIMAL AS rating_sum
       FROM votes v GROUP BY v.dish_id
     ) ds ON ds.dish_id = d.id
@@ -1011,7 +984,6 @@ BEGIN
   ),
   dish_vote_stats AS (
     SELECT d.id AS dish_id, COUNT(v.id)::BIGINT AS direct_votes,
-      SUM(CASE WHEN v.would_order_again THEN 1 ELSE 0 END)::BIGINT AS direct_yes,
       ROUND(AVG(v.rating_10)::NUMERIC, 1) AS direct_avg
     FROM dishes d LEFT JOIN votes v ON v.dish_id = d.id
     WHERE d.parent_dish_id IS NULL
@@ -1021,12 +993,6 @@ BEGIN
     d.id AS dish_id, d.name AS dish_name, r.id AS restaurant_id, r.name AS restaurant_name,
     d.category, d.menu_section, d.price, d.photo_url,
     COALESCE(vs.total_child_votes, dvs.direct_votes, 0)::BIGINT AS total_votes,
-    COALESCE(vs.total_child_yes, dvs.direct_yes, 0)::BIGINT AS yes_votes,
-    CASE
-      WHEN COALESCE(vs.total_child_votes, dvs.direct_votes, 0) > 0
-      THEN ROUND(100.0 * COALESCE(vs.total_child_yes, dvs.direct_yes, 0) / COALESCE(vs.total_child_votes, dvs.direct_votes, 1))::INT
-      ELSE 0
-    END AS percent_worth_it,
     COALESCE(vs.combined_avg_rating, dvs.direct_avg) AS avg_rating,
     (vs.child_count IS NOT NULL AND vs.child_count > 0) AS has_variants,
     COALESCE(vs.child_count, 0)::INT AS variant_count,
@@ -1041,16 +1007,12 @@ BEGIN
     AND r.is_open = true
     AND d.parent_dish_id IS NULL
   GROUP BY d.id, d.name, r.id, r.name, d.category, d.menu_section, d.price, d.photo_url, d.tags,
-           vs.total_child_votes, vs.total_child_yes, vs.combined_avg_rating, vs.child_count,
-           dvs.direct_votes, dvs.direct_yes, dvs.direct_avg,
+           vs.total_child_votes, vs.combined_avg_rating, vs.child_count,
+           dvs.direct_votes, dvs.direct_avg,
            bv.best_id, bv.best_name, bv.best_rating
   ORDER BY
     CASE WHEN COALESCE(vs.total_child_votes, dvs.direct_votes, 0) >= 5 THEN 0 ELSE 1 END,
-    CASE
-      WHEN COALESCE(vs.total_child_votes, dvs.direct_votes, 0) > 0
-      THEN ROUND(100.0 * COALESCE(vs.total_child_yes, dvs.direct_yes, 0) / COALESCE(vs.total_child_votes, dvs.direct_votes, 1))
-      ELSE 0
-    END DESC,
+    COALESCE(vs.combined_avg_rating, dvs.direct_avg) DESC NULLS LAST,
     COALESCE(vs.total_child_votes, dvs.direct_votes, 0) DESC;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
@@ -1066,8 +1028,6 @@ RETURNS TABLE (
   photo_url TEXT,
   display_order INT,
   total_votes BIGINT,
-  yes_votes BIGINT,
-  percent_worth_it INT,
   avg_rating DECIMAL
 ) AS $$
 BEGIN
@@ -1075,12 +1035,6 @@ BEGIN
   SELECT
     d.id AS dish_id, d.name AS dish_name, d.price, d.photo_url, d.display_order,
     COUNT(v.id)::BIGINT AS total_votes,
-    SUM(CASE WHEN v.would_order_again THEN 1 ELSE 0 END)::BIGINT AS yes_votes,
-    CASE
-      WHEN COUNT(v.id) > 0
-      THEN ROUND(100.0 * SUM(CASE WHEN v.would_order_again THEN 1 ELSE 0 END) / COUNT(v.id))::INT
-      ELSE 0
-    END AS percent_worth_it,
     ROUND(AVG(v.rating_10)::NUMERIC, 1) AS avg_rating
   FROM dishes d
   LEFT JOIN votes v ON d.id = v.dish_id
@@ -1146,13 +1100,12 @@ RETURNS TABLE (
   user_id UUID,
   display_name TEXT,
   rating_10 DECIMAL(3, 1),
-  would_order_again BOOLEAN,
   voted_at TIMESTAMPTZ,
   category_expertise TEXT
 )
 LANGUAGE SQL STABLE SET search_path = public AS $$
   SELECT
-    p.id AS user_id, p.display_name, v.rating_10, v.would_order_again,
+    p.id AS user_id, p.display_name, v.rating_10,
     v.created_at AS voted_at,
     CASE
       WHEN EXISTS (SELECT 1 FROM user_badges ub WHERE ub.user_id = p.id AND ub.badge_key = 'authority_' || REPLACE(d.category, ' ', '_')) THEN 'authority'
@@ -1178,14 +1131,13 @@ RETURNS TABLE (
   dish_id UUID,
   dish_name TEXT,
   rating_10 DECIMAL(3, 1),
-  would_order_again BOOLEAN,
   voted_at TIMESTAMPTZ,
   category_expertise TEXT
 )
 LANGUAGE SQL STABLE SET search_path = public AS $$
   SELECT
     p.id AS user_id, p.display_name, d.id AS dish_id, d.name AS dish_name,
-    v.rating_10, v.would_order_again, v.created_at AS voted_at,
+    v.rating_10, v.created_at AS voted_at,
     CASE
       WHEN EXISTS (SELECT 1 FROM user_badges ub WHERE ub.user_id = p.id AND ub.badge_key = 'authority_' || REPLACE(d.category, ' ', '_')) THEN 'authority'
       WHEN EXISTS (SELECT 1 FROM user_badges ub WHERE ub.user_id = p.id AND ub.badge_key = 'specialist_' || REPLACE(d.category, ' ', '_')) THEN 'specialist'
@@ -1712,10 +1664,15 @@ $$;
 
 -- Atomic user vote upsert. Targets the partial unique index:
 -- votes_user_unique ON votes (dish_id, user_id) WHERE source = 'user'.
+-- DROP guarantees replay against an existing DB with the pre-Phase-2 signature
+-- cleanly swaps in the new 7-arg form.
+DROP FUNCTION IF EXISTS submit_vote_atomic(
+  UUID, UUID, BOOLEAN, DECIMAL, TEXT, DECIMAL, DECIMAL, TEXT
+);
+
 CREATE OR REPLACE FUNCTION submit_vote_atomic(
   p_dish_id UUID,
   p_user_id UUID,
-  p_would_order_again BOOLEAN DEFAULT NULL,
   p_rating_10 DECIMAL DEFAULT NULL,
   p_review_text TEXT DEFAULT NULL,
   p_purity_score DECIMAL DEFAULT NULL,
@@ -1725,30 +1682,18 @@ CREATE OR REPLACE FUNCTION submit_vote_atomic(
 RETURNS votes AS $$
 DECLARE
   submitted_vote votes;
-  v_effective_would_order BOOLEAN;
 BEGIN
   IF auth.role() <> 'service_role' AND (select auth.uid()) IS DISTINCT FROM p_user_id THEN
     RAISE EXCEPTION 'Access denied';
   END IF;
 
-  -- Shadow-write compatibility (Phase 1): if caller omits the binary (new
-  -- clients), derive it from the rating. Stale PWA bundles that still pass
-  -- a boolean are honored as-is. Threshold 7.0 is duplicated in
-  -- supabase/functions/seed-reviews/index.ts; both sites must stay aligned
-  -- through Phase 1 and are deleted together in Phase 2.
-  IF p_would_order_again IS NULL THEN
-    IF p_rating_10 IS NULL THEN
-      RAISE EXCEPTION 'rating_10 is required';
-    END IF;
-    v_effective_would_order := (p_rating_10 >= 7.0);
-  ELSE
-    v_effective_would_order := p_would_order_again;
+  IF p_rating_10 IS NULL THEN
+    RAISE EXCEPTION 'rating_10 is required';
   END IF;
 
   INSERT INTO votes (
     dish_id,
     user_id,
-    would_order_again,
     rating_10,
     review_text,
     review_created_at,
@@ -1760,7 +1705,6 @@ BEGIN
   VALUES (
     p_dish_id,
     p_user_id,
-    v_effective_would_order,
     p_rating_10,
     p_review_text,
     CASE WHEN p_review_text IS NOT NULL THEN NOW() ELSE NULL END,
@@ -1771,7 +1715,6 @@ BEGIN
   )
   ON CONFLICT (dish_id, user_id) WHERE source = 'user'
   DO UPDATE SET
-    would_order_again = EXCLUDED.would_order_again,
     rating_10 = EXCLUDED.rating_10,
     review_text = COALESCE(EXCLUDED.review_text, votes.review_text),
     review_created_at = COALESCE(EXCLUDED.review_created_at, votes.review_created_at),
@@ -2863,7 +2806,7 @@ GRANT EXECUTE ON FUNCTION get_smart_snippet(UUID) TO authenticated;
 GRANT EXECUTE ON FUNCTION get_smart_snippet(UUID) TO anon;
 GRANT EXECUTE ON FUNCTION check_and_record_rate_limit TO authenticated;
 GRANT EXECUTE ON FUNCTION check_vote_rate_limit TO authenticated;
-GRANT EXECUTE ON FUNCTION submit_vote_atomic(UUID, UUID, BOOLEAN, DECIMAL, TEXT, DECIMAL, DECIMAL, TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION submit_vote_atomic(UUID, UUID, DECIMAL, TEXT, DECIMAL, DECIMAL, TEXT) TO authenticated;
 GRANT EXECUTE ON FUNCTION check_photo_upload_rate_limit TO authenticated;
 GRANT EXECUTE ON FUNCTION check_restaurant_create_rate_limit TO authenticated;
 GRANT EXECUTE ON FUNCTION check_dish_create_rate_limit TO authenticated;


### PR DESCRIPTION
## Summary

Removes every Phase 1 compat shim. The binary vote concept is now
fully gone from the write path, read paths, analytics, and docs. The
votes.would_order_again column stays (historical integrity).

Spec: \`docs/superpowers/specs/2026-04-13-binary-vote-removal-phase-2-design.md\`
Plan: \`docs/superpowers/plans/2026-04-13-binary-vote-removal-phase-2.md\`

## Manual deploy steps before / after merging

- [ ] Run \`supabase/migrations/2026-04-13-binary-vote-removal-phase-2.sql\` in Supabase SQL Editor against project \`vpioftosgdkyiwvhxewy\`.
- [ ] After merge, deploy seed-reviews Edge Function: \`supabase functions deploy seed-reviews --project-ref vpioftosgdkyiwvhxewy\`.

## Test plan

- [x] \`npm run build\` passes
- [x] \`npm run test -- --run\` passes (311/311)
- [ ] Grep audit: no residual \`vote_submitted\` / \`binary_removed\` / \`yes_votes\` / \`percent_worth_it\` / \`p_would_order_again\` in src or schema.sql
- [ ] Manual: submit a rating on prod, verify only \`rating_submitted\` fires in PostHog (no \`vote_submitted\` sibling)
- [ ] Manual: dish detail for a dish you've rated and photographed shows the Keep/Replace/Remove photo UI
- [ ] Manual: no 500s or function-signature errors on voting

## Known risk

Stale PWA bundles still passing the 8-arg \`submit_vote_atomic\` signature will error. User base is effectively you + Denis + early testers; recovery is a single hard refresh. Capacitor launch makes this a one-time cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)