### PR TITLE
Fix: clear review + photo Remove/Replace actually work

### DIFF
--- a/src/components/ReviewFlow.jsx
+++ b/src/components/ReviewFlow.jsx
@@ -6,6 +6,7 @@ import { usePurityTracker } from '../hooks/usePurityTracker'
 import JitterBox from '../utils/jitter-box'
 import { jitterApi } from '../api/jitterApi'
 import { authApi } from '../api/authApi'
+import { dishPhotosApi } from '../api/dishPhotosApi'
 import { FoodRatingSlider } from './FoodRatingSlider'
 import { MAX_REVIEW_LENGTH } from '../constants/app'
 import {
@@ -31,7 +32,7 @@ export function ReviewFlow({
   price,
   totalVotes = 0,
   isRanked = false,
-  existingPhotoUrl = null,
+  existingPhoto = null,
   onVote,
   onLoginRequired,
   onPhotoUploaded,
@@ -199,6 +200,20 @@ export function ReviewFlow({
       return
     }
 
+    // Photo lifecycle: if the user had a prior photo and chose Remove, or
+    // chose Replace and successfully uploaded a new one, delete the old row.
+    // Vote already saved; photo failure is logged but doesn't roll back the rating.
+    if (existingPhoto?.id && (
+      existingPhotoAction === 'remove' ||
+      (existingPhotoAction === 'replace' && photoAdded)
+    )) {
+      try {
+        await dishPhotosApi.deletePhoto(existingPhoto.id)
+      } catch (err) {
+        logger.error('Failed to delete old photo after vote update:', err)
+      }
+    }
+
     // Analytics: votesApi.submitVote emits rating_submitted for every vote.
     // Dashboards that need dish/restaurant context can join against dish_id
     // in PostHog.
@@ -301,13 +316,13 @@ export function ReviewFlow({
       )}
 
       {/* Photo — collapsed by default; if user had a prior photo, show thumbnail + keep/replace/remove. */}
-      {existingPhotoUrl && !photoAdded ? (
+      {existingPhoto && !photoAdded ? (
         <div
           className="p-3 rounded-xl space-y-2"
           style={{ background: 'var(--color-surface-elevated)', border: '1px solid var(--color-divider)' }}
         >
           <div className="flex items-center gap-3">
-            <img src={existingPhotoUrl} alt="Your existing photo" className="w-16 h-16 rounded-lg object-cover" />
+            <img src={existingPhoto.photo_url} alt="Your existing photo" className="w-16 h-16 rounded-lg object-cover" />
             <div className="flex-1 space-y-1">
               <p className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>Your photo</p>
               <div className="flex gap-2">

--- a/src/pages/Dish.jsx
+++ b/src/pages/Dish.jsx
@@ -38,7 +38,7 @@ export function Dish() {
   const [showRateFlow, setShowRateFlow] = useState(false)
   const [pendingAction, setPendingAction] = useState(null) // 'rate' | null
   const [priorVote, setPriorVote] = useState(null)
-  const [existingPhotoUrl, setExistingPhotoUrl] = useState(null)
+  const [existingPhoto, setExistingPhoto] = useState(null)
   const { isFavorite, toggleFavorite } = useFavorites(user?.id)
 
   // Ear icon tooltip — show once per device
@@ -50,7 +50,7 @@ export function Dish() {
   useEffect(() => {
     if (!user || !dishId) {
       setPriorVote(null)
-      setExistingPhotoUrl(null)
+      setExistingPhoto(null)
       return
     }
     let cancelled = false
@@ -67,7 +67,7 @@ export function Dish() {
         logger.error('Failed to fetch prior vote:', voteResult.reason)
       }
       if (photoResult.status === 'fulfilled') {
-        setExistingPhotoUrl(photoResult.value?.photo_url ?? null)
+        setExistingPhoto(photoResult.value ? { id: photoResult.value.id, photo_url: photoResult.value.photo_url } : null)
       } else {
         logger.error('Failed to fetch prior photo:', photoResult.reason)
       }
@@ -128,7 +128,7 @@ export function Dish() {
           logger.error('Failed to refresh prior vote:', voteResult.reason)
         }
         if (photoResult.status === 'fulfilled') {
-          setExistingPhotoUrl(photoResult.value?.photo_url ?? null)
+          setExistingPhoto(photoResult.value ? { id: photoResult.value.id, photo_url: photoResult.value.photo_url } : null)
         } else {
           logger.error('Failed to refresh prior photo:', photoResult.reason)
         }
@@ -336,7 +336,7 @@ export function Dish() {
                   price={dish.price}
                   totalVotes={dish.total_votes}
                   isRanked={isRanked}
-                  existingPhotoUrl={existingPhotoUrl}
+                  existingPhoto={existingPhoto}
                   onVote={handleVoteSubmitted}
                   onLoginRequired={handleLoginRequired}
                   onPhotoUploaded={handlePhotoUploaded}

--- a/supabase/migrations/2026-04-13-review-text-clear-on-submit.sql
+++ b/supabase/migrations/2026-04-13-review-text-clear-on-submit.sql
@@ -1,0 +1,81 @@
+-- Fix: clearing review text is a no-op because submit_vote_atomic's
+-- ON CONFLICT DO UPDATE uses COALESCE(EXCLUDED.review_text, votes.review_text),
+-- which silently preserves the old value when caller sends NULL.
+--
+-- New semantics:
+--   review_text       = EXCLUDED.review_text (whatever caller sends wins)
+--   review_created_at = NOW() when the text changed to something new,
+--                       NULL when cleared,
+--                       preserved when text is unchanged (rating-only edits)
+--
+-- Also fixes: delete-remove-photo support in ReviewFlow (see src/pages/Dish.jsx
+-- + src/components/ReviewFlow.jsx for the client side).
+
+DROP FUNCTION IF EXISTS submit_vote_atomic(
+  UUID, UUID, DECIMAL, TEXT, DECIMAL, DECIMAL, TEXT
+);
+
+CREATE OR REPLACE FUNCTION submit_vote_atomic(
+  p_dish_id UUID,
+  p_user_id UUID,
+  p_rating_10 DECIMAL DEFAULT NULL,
+  p_review_text TEXT DEFAULT NULL,
+  p_purity_score DECIMAL DEFAULT NULL,
+  p_war_score DECIMAL DEFAULT NULL,
+  p_badge_hash TEXT DEFAULT NULL
+)
+RETURNS votes AS $$
+DECLARE
+  submitted_vote votes;
+BEGIN
+  IF auth.role() <> 'service_role' AND (select auth.uid()) IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'Access denied';
+  END IF;
+
+  IF p_rating_10 IS NULL THEN
+    RAISE EXCEPTION 'rating_10 is required';
+  END IF;
+
+  INSERT INTO votes (
+    dish_id,
+    user_id,
+    rating_10,
+    review_text,
+    review_created_at,
+    purity_score,
+    war_score,
+    badge_hash,
+    source
+  )
+  VALUES (
+    p_dish_id,
+    p_user_id,
+    p_rating_10,
+    p_review_text,
+    CASE WHEN p_review_text IS NOT NULL THEN NOW() ELSE NULL END,
+    p_purity_score,
+    p_war_score,
+    p_badge_hash,
+    'user'
+  )
+  ON CONFLICT (dish_id, user_id) WHERE source = 'user'
+  DO UPDATE SET
+    rating_10 = EXCLUDED.rating_10,
+    review_text = EXCLUDED.review_text,
+    review_created_at = CASE
+      WHEN EXCLUDED.review_text IS DISTINCT FROM votes.review_text
+        THEN (CASE WHEN EXCLUDED.review_text IS NOT NULL THEN NOW() ELSE NULL END)
+      ELSE votes.review_created_at
+    END,
+    purity_score = COALESCE(EXCLUDED.purity_score, votes.purity_score),
+    war_score = COALESCE(EXCLUDED.war_score, votes.war_score),
+    badge_hash = COALESCE(EXCLUDED.badge_hash, votes.badge_hash)
+  RETURNING * INTO submitted_vote;
+
+  RETURN submitted_vote;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+GRANT EXECUTE ON FUNCTION submit_vote_atomic(
+  UUID, UUID, DECIMAL, TEXT, DECIMAL, DECIMAL, TEXT
+) TO authenticated;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1716,8 +1716,12 @@ BEGIN
   ON CONFLICT (dish_id, user_id) WHERE source = 'user'
   DO UPDATE SET
     rating_10 = EXCLUDED.rating_10,
-    review_text = COALESCE(EXCLUDED.review_text, votes.review_text),
-    review_created_at = COALESCE(EXCLUDED.review_created_at, votes.review_created_at),
+    review_text = EXCLUDED.review_text,
+    review_created_at = CASE
+      WHEN EXCLUDED.review_text IS DISTINCT FROM votes.review_text
+        THEN (CASE WHEN EXCLUDED.review_text IS NOT NULL THEN NOW() ELSE NULL END)
+      ELSE votes.review_created_at
+    END,
     purity_score = COALESCE(EXCLUDED.purity_score, votes.purity_score),
     war_score = COALESCE(EXCLUDED.war_score, votes.war_score),
     badge_hash = COALESCE(EXCLUDED.badge_hash, votes.badge_hash)


### PR DESCRIPTION
## Summary

Two shipped UX bugs caught by Codex post-launch review.

### Fix 1: Clearing review text was a no-op
`submit_vote_atomic`'s `ON CONFLICT DO UPDATE` used `review_text = COALESCE(EXCLUDED.review_text, votes.review_text)` — if a user cleared the textbox and submitted, the null-ified input was ignored and the old review stuck. UI said it saved. DB disagreed.

New semantics:
- `review_text = EXCLUDED.review_text` — caller wins.
- `review_created_at` is smart: NOW() when the review text changed to something new, NULL when cleared, preserved when unchanged (so rating-only edits don't refresh the timestamp).

### Fix 2: Photo Remove/Replace leaked old rows
`ReviewFlow` tracked `existingPhotoAction` (keep/replace/remove) but `handleSubmit` never acted on it. Remove did nothing. Replace uploaded a new photo row but left the old one lying around.

- Changed prop contract: `Dish.jsx` now passes `existingPhoto={ id, photo_url }` object (was bare URL string).
- `ReviewFlow.handleSubmit` calls `dishPhotosApi.deletePhoto(existingPhoto.id)` after a successful vote submit when action === 'remove' OR (action === 'replace' && photoAdded).
- Photo delete failure is logged but does NOT roll back the vote — the rating already landed.

## Manual deploy before merging

- [ ] Run `supabase/migrations/2026-04-13-review-text-clear-on-submit.sql` in Supabase SQL Editor against `vpioftosgdkyiwvhxewy`.

## Test plan

- [x] `npm run build` passes
- [x] `npm run test -- --run` passes (312/312)
- [ ] Manual: clear a review on a dish you've rated, submit, reload — review is actually gone
- [ ] Manual: remove a photo on a dish you've rated, submit, reload — thumbnail no longer appears
- [ ] Manual: replace a photo — new one shows, old one is deleted (check dish_photos table)
- [ ] Manual: edit only the rating (don't touch review) — review_created_at stays at its old value

🤖 Generated with [Claude Code](https://claude.com/claude-code)