### PR TITLE
fix(auth): preserve Google OAuth intent + surface onboarding errors

### DIFF
--- a/src/components/Auth/WelcomeModal.jsx
+++ b/src/components/Auth/WelcomeModal.jsx
@@ -61,10 +61,13 @@ export function WelcomeModal() {
   const displayName = name.trim() || profile?.display_name || ''
 
   const completeOnboarding = async (nameSet) => {
+    // Snapshot the name at submit time so a late-typed character can't desync
+    // what gets persisted from what the celebration screen shows.
+    const submittedName = name.trim()
     setSaving(true)
     setSaveError(null)
     const updates = { has_onboarded: true }
-    if (name.trim()) updates.display_name = name.trim()
+    if (submittedName) updates.display_name = submittedName
     const { error } = await updateProfile(updates)
     setSaving(false)
 
@@ -323,7 +326,8 @@ export function WelcomeModal() {
                 placeholder="Your name"
                 autoFocus
                 maxLength={50}
-                className="w-full px-4 py-4 border-2 rounded-xl text-lg text-center focus:outline-none transition-colors"
+                disabled={saving}
+                className="w-full px-4 py-4 border-2 rounded-xl text-lg text-center focus:outline-none transition-colors disabled:opacity-60"
                 style={{
                   background: 'var(--color-bg)',
                   borderColor: saveError ? 'var(--color-danger)' : 'var(--color-divider)',

--- a/src/components/Auth/WelcomeModal.jsx
+++ b/src/components/Auth/WelcomeModal.jsx
@@ -3,6 +3,7 @@ import { useAuth } from '../../context/AuthContext'
 import { useProfile } from '../../hooks/useProfile'
 import { WghLogo } from '../WghLogo'
 import { capture } from '../../lib/analytics'
+import { getUserMessage } from '../../utils/errorHandler'
 
 const STEPS = [
   {
@@ -40,6 +41,7 @@ export function WelcomeModal() {
   const [step, setStep] = useState(0)
   const [name, setName] = useState('')
   const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState(null)
   const [isOpen, setIsOpen] = useState(false)
   const [phase, setPhase] = useState('onboarding') // 'onboarding' | 'celebration' | 'fade-out'
 
@@ -60,11 +62,20 @@ export function WelcomeModal() {
 
   const completeOnboarding = async (nameSet) => {
     setSaving(true)
+    setSaveError(null)
     const updates = { has_onboarded: true }
     if (name.trim()) updates.display_name = name.trim()
-    await updateProfile(updates)
-    capture('onboarding_completed', { name_set: nameSet })
+    const { error } = await updateProfile(updates)
     setSaving(false)
+
+    if (error) {
+      // Surface the error so the user can correct it (most likely: duplicate display_name)
+      setSaveError(getUserMessage(error, 'saving your name'))
+      capture('onboarding_failed', { name_set: nameSet, error: error.message })
+      return
+    }
+
+    capture('onboarding_completed', { name_set: nameSet })
 
     // Show celebration screen
     setPhase('celebration')
@@ -305,17 +316,29 @@ export function WelcomeModal() {
                 aria-label="Your name"
                 type="text"
                 value={name}
-                onChange={(e) => setName(e.target.value)}
+                onChange={(e) => {
+                  setName(e.target.value)
+                  if (saveError) setSaveError(null)
+                }}
                 placeholder="Your name"
                 autoFocus
                 maxLength={50}
                 className="w-full px-4 py-4 border-2 rounded-xl text-lg text-center focus:outline-none transition-colors"
                 style={{
                   background: 'var(--color-bg)',
-                  borderColor: 'var(--color-divider)',
+                  borderColor: saveError ? 'var(--color-danger)' : 'var(--color-divider)',
                   color: 'var(--color-text-primary)',
                 }}
               />
+              {saveError && (
+                <p
+                  role="alert"
+                  className="text-sm text-center"
+                  style={{ color: 'var(--color-danger)' }}
+                >
+                  {saveError}
+                </p>
+              )}
               <button
                 type="submit"
                 disabled={!name.trim() || saving}
@@ -336,6 +359,15 @@ export function WelcomeModal() {
             </form>
           ) : (
             <div className="space-y-3">
+              {saveError && (
+                <p
+                  role="alert"
+                  className="text-sm text-center"
+                  style={{ color: 'var(--color-danger)' }}
+                >
+                  {saveError}
+                </p>
+              )}
               <button
                 onClick={handleNext}
                 disabled={saving}

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -71,7 +71,14 @@ export function Login() {
   const handleGoogleSignIn = async () => {
     try {
       setLoading(true)
-      await authApi.signInWithGoogle()
+      const fromLocation = location.state?.from
+      const redirectUrl = fromLocation
+        ? new URL(
+            fromLocation.pathname + (fromLocation.search || '') + (fromLocation.hash || ''),
+            window.location.origin
+          ).toString()
+        : null
+      await authApi.signInWithGoogle(redirectUrl)
     } catch (error) {
       setMessage({ type: 'error', text: error.message })
       setLoading(false)


### PR DESCRIPTION
## Summary

Two pre-existing bugs surfaced during the Sign in with Apple plan review. Both affect current Google/email users today — no Apple dependency.

- **Login.jsx Google OAuth lost its destination.** `handleGoogleSignIn` called `signInWithGoogle()` with no redirect. A logged-out user clicking a dish link and signing in with Google landed on `/` instead of the dish. Email signin already preserved `location.state?.from`; Google now does the same.
- **WelcomeModal silent-error swallow.** `completeOnboarding` awaited `updateProfile()` but discarded the `{ data, error }` return. A duplicate display_name (unique lowercase constraint) failed silently — user saw the celebration screen, their name wasn't saved. Now destructures the error, surfaces a friendly message via `getUserMessage`, and bails before celebration on failure. Input disabled during save; name snapshotted before the async call (Codex-flagged race).

## Test plan

- [x] `npm run build` green
- [x] `npm run test` green — 311/311 tests pass
- [x] ESLint clean on both files
- [ ] Manual — log out → visit `/dish/:id` → sign in with Google → should land on `/dish/:id`, not `/`
- [ ] Manual — attempt onboarding with a duplicate display_name → should see inline error, not silent success
- [ ] Manual — onboarding with a unique display_name still celebrates as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)