### PR TITLE
feat(auth): Sign in with Apple — dormant web code behind feature flag

### DIFF
--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -75,6 +75,51 @@ export const authApi = {
   },
 
   /**
+   * Sign in with Apple OAuth (web flow).
+   *
+   * Apple rule 4.8: any app with third-party social login must offer Sign in
+   * with Apple as an equivalent option. The button that calls this is gated
+   * on FEATURES.APPLE_SIGNIN_ENABLED and stays hidden in production until the
+   * Supabase Apple provider is configured.
+   *
+   * Web flow uses signInWithOAuth → full-page redirect to Apple → Supabase
+   * validates the ID token on the callback. Native (Capacitor) flow using
+   * signInWithIdToken is deferred — see the H2 plan.
+   *
+   * Note: Apple's identity token does NOT include the user's name (unlike
+   * Google), so display_name will be null on first sign-in via web. The
+   * WelcomeModal handles that case by opening when display_name is missing.
+   *
+   * @param {string|null} redirectUrl - Optional custom redirect URL (must be same-origin)
+   * @returns {Promise<Object>} Auth response
+   */
+  async signInWithApple(redirectUrl = null) {
+    try {
+      const rateLimit = checkRateLimit('auth', RATE_LIMITS.auth)
+      if (!rateLimit.allowed) {
+        throw new Error(rateLimit.message)
+      }
+
+      capture('login_started', { method: 'apple' })
+
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: 'apple',
+        options: {
+          redirectTo: getSafeRedirectUrl(redirectUrl),
+        },
+      })
+      if (error) {
+        capture('login_failed', { method: 'apple', error: error.message })
+        throw createClassifiedError(error)
+      }
+      return { success: true }
+    } catch (error) {
+      logger.error('Error signing in with Apple:', error)
+      throw error.type ? error : createClassifiedError(error)
+    }
+  },
+
+  /**
    * Sign in with magic link via email
    * @param {string} email - User email
    * @param {string|null} redirectUrl - Optional custom redirect URL (must be same-origin)

--- a/src/components/Auth/LoginModal.jsx
+++ b/src/components/Auth/LoginModal.jsx
@@ -74,6 +74,10 @@ export function LoginModal({ isOpen, onClose, pendingAction = null }) {
     }
   }
 
+  // Pre-wired for activation: gets referenced when the compliant Apple
+  // button JSX is dropped in. See the Sign in with Apple comment block in
+  // the options-mode section below for activation steps.
+  // eslint-disable-next-line no-unused-vars
   const handleAppleSignIn = async () => {
     try {
       setLoading(true)
@@ -239,26 +243,25 @@ export function LoginModal({ isOpen, onClose, pendingAction = null }) {
           {/* Options Mode - Show all login options */}
           {mode === 'options' && (
             <div className="space-y-4">
-              {/* Sign in with Apple — gated behind feature flag until
-                  Supabase Apple provider is configured. Placed ABOVE Google
-                  per Apple HIG (must be at least as prominent as other
-                  third-party sign-in options).
-                  TODO before enabling: verify button against Apple's current
-                  official button spec (logo proportions, padding, label). */}
-              {FEATURES.APPLE_SIGNIN_ENABLED && (
-                <button
-                  onClick={handleAppleSignIn}
-                  disabled={loading}
-                  className="w-full flex items-center justify-center gap-2 px-6 py-4 rounded-xl font-semibold active:scale-[0.98] transition-all disabled:opacity-50"
-                  style={{ background: '#000000', color: '#FFFFFF' }}
-                  aria-label="Sign in with Apple"
-                >
-                  <svg className="w-5 h-5" viewBox="0 0 24 24" fill="#FFFFFF" aria-hidden="true">
-                    <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/>
-                  </svg>
-                  Sign in with Apple
-                </button>
-              )}
+              {/* Sign in with Apple — handler is wired (handleAppleSignIn
+                  above) and the flag gates the render slot, but the button
+                  JSX itself is intentionally absent. Apple HIG requires the
+                  button to use Apple's official asset (specific logo
+                  proportions, padding, corner radius). Hand-authored SVG is
+                  a known App Store rejection risk — the iOS Capacitor build
+                  will render this same React code in WKWebView, so a
+                  non-compliant button would fail review.
+
+                  Activation steps (after Supabase Apple provider config):
+                    1. Drop in Apple's official SIWA button asset:
+                       https://developer.apple.com/design/human-interface-guidelines/sign-in-with-apple/overview/buttons/
+                       OR install `react-apple-signin-auth` (use only its
+                       button styling — auth flow stays on Supabase).
+                    2. Replace the `null` below with the compliant button,
+                       wired to handleAppleSignIn, placed ABOVE Google per
+                       equal-prominence.
+                    3. Set VITE_FEATURES_APPLE_SIGNIN=true in deploy env. */}
+              {FEATURES.APPLE_SIGNIN_ENABLED && null}
 
               {/* Google Sign In */}
               <button

--- a/src/components/Auth/LoginModal.jsx
+++ b/src/components/Auth/LoginModal.jsx
@@ -3,6 +3,7 @@ import { authApi } from '../../api/authApi'
 import { getPendingVoteFromStorage } from '../../lib/storage'
 import { useFocusTrap } from '../../hooks/useFocusTrap'
 import { logger } from '../../utils/logger'
+import { FEATURES } from '../../constants/features'
 
 // SECURITY: Email is NOT persisted to storage to prevent XSS exposure of PII
 
@@ -54,15 +55,29 @@ export function LoginModal({ isOpen, onClose, pendingAction = null }) {
 
   if (!isOpen) return null
 
+  const buildOAuthRedirect = () => {
+    const redirectUrl = new URL(window.location.href)
+    const pending = getPendingVoteFromStorage()
+    if (pending?.dishId) {
+      redirectUrl.searchParams.set('votingDish', pending.dishId)
+    }
+    return redirectUrl.toString()
+  }
+
   const handleGoogleSignIn = async () => {
     try {
       setLoading(true)
-      const redirectUrl = new URL(window.location.href)
-      const pending = getPendingVoteFromStorage()
-      if (pending?.dishId) {
-        redirectUrl.searchParams.set('votingDish', pending.dishId)
-      }
-      await authApi.signInWithGoogle(redirectUrl.toString())
+      await authApi.signInWithGoogle(buildOAuthRedirect())
+    } catch (error) {
+      setMessage({ type: 'error', text: error.message })
+      setLoading(false)
+    }
+  }
+
+  const handleAppleSignIn = async () => {
+    try {
+      setLoading(true)
+      await authApi.signInWithApple(buildOAuthRedirect())
     } catch (error) {
       setMessage({ type: 'error', text: error.message })
       setLoading(false)
@@ -224,6 +239,27 @@ export function LoginModal({ isOpen, onClose, pendingAction = null }) {
           {/* Options Mode - Show all login options */}
           {mode === 'options' && (
             <div className="space-y-4">
+              {/* Sign in with Apple — gated behind feature flag until
+                  Supabase Apple provider is configured. Placed ABOVE Google
+                  per Apple HIG (must be at least as prominent as other
+                  third-party sign-in options).
+                  TODO before enabling: verify button against Apple's current
+                  official button spec (logo proportions, padding, label). */}
+              {FEATURES.APPLE_SIGNIN_ENABLED && (
+                <button
+                  onClick={handleAppleSignIn}
+                  disabled={loading}
+                  className="w-full flex items-center justify-center gap-2 px-6 py-4 rounded-xl font-semibold active:scale-[0.98] transition-all disabled:opacity-50"
+                  style={{ background: '#000000', color: '#FFFFFF' }}
+                  aria-label="Sign in with Apple"
+                >
+                  <svg className="w-5 h-5" viewBox="0 0 24 24" fill="#FFFFFF" aria-hidden="true">
+                    <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/>
+                  </svg>
+                  Sign in with Apple
+                </button>
+              )}
+
               {/* Google Sign In */}
               <button
                 onClick={handleGoogleSignIn}

--- a/src/components/Auth/WelcomeModal.jsx
+++ b/src/components/Auth/WelcomeModal.jsx
@@ -52,11 +52,12 @@ export function WelcomeModal() {
   useEffect(() => {
     if (user && !loading && profile) {
       // Open for net-new users, and also for anyone whose display_name is
-      // still null — covers Apple users who declined name share on first
+      // still missing — covers Apple users who declined name share on first
       // sign-in, Google users whose provider didn't supply a name, and any
       // past user who got into a weird data state. display_name is required
       // to vote, so we can't let onboarded-but-nameless users slip through.
-      if (!profile.has_onboarded || !profile.display_name) {
+      // Use trim() to match the hasName semantics elsewhere in the component.
+      if (!profile.has_onboarded || !profile.display_name?.trim()) {
         setIsOpen(true)
         capture('onboarding_started')
       }

--- a/src/components/Auth/WelcomeModal.jsx
+++ b/src/components/Auth/WelcomeModal.jsx
@@ -51,7 +51,12 @@ export function WelcomeModal() {
 
   useEffect(() => {
     if (user && !loading && profile) {
-      if (!profile.has_onboarded) {
+      // Open for net-new users, and also for anyone whose display_name is
+      // still null — covers Apple users who declined name share on first
+      // sign-in, Google users whose provider didn't supply a name, and any
+      // past user who got into a weird data state. display_name is required
+      // to vote, so we can't let onboarded-but-nameless users slip through.
+      if (!profile.has_onboarded || !profile.display_name) {
         setIsOpen(true)
         capture('onboarding_started')
       }

--- a/src/constants/features.js
+++ b/src/constants/features.js
@@ -3,4 +3,9 @@
 export const FEATURES = {
   // Rating Identity System - tracks user rating bias and pending votes
   RATING_IDENTITY_ENABLED: import.meta.env.VITE_RATING_IDENTITY_ENABLED === 'true',
+  // Sign in with Apple — code is wired up; button only renders when this flag
+  // is true. Flip on after the Supabase Apple provider is configured (requires
+  // Apple Developer enrollment + App ID + Services ID + .p8 key).
+  // Plan: docs/superpowers/plans/2026-04-13-h2-sign-in-with-apple.md
+  APPLE_SIGNIN_ENABLED: import.meta.env.VITE_FEATURES_APPLE_SIGNIN === 'true',
 }

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -89,6 +89,10 @@ export function Login() {
     }
   }
 
+  // Pre-wired for activation: gets referenced when the compliant Apple
+  // button JSX is dropped in. See the Sign in with Apple comment block in
+  // the options-mode section below for activation steps.
+  // eslint-disable-next-line no-unused-vars
   const handleAppleSignIn = async () => {
     try {
       setLoading(true)
@@ -362,26 +366,25 @@ export function Login() {
             {/* Options Mode */}
             {mode === 'options' && (
               <div className="w-full max-w-sm space-y-4">
-                {/* Sign in with Apple — gated behind feature flag until
-                    Supabase Apple provider is configured. Placed ABOVE Google
-                    per Apple HIG (must be at least as prominent as other
-                    third-party sign-in options).
-                    TODO before enabling: verify button against Apple's current
-                    official button spec (logo proportions, padding, label). */}
-                {FEATURES.APPLE_SIGNIN_ENABLED && (
-                  <button
-                    onClick={handleAppleSignIn}
-                    disabled={loading}
-                    className="w-full flex items-center justify-center gap-2 px-6 py-4 rounded-xl font-semibold active:scale-[0.98] transition-all disabled:opacity-50"
-                    style={{ background: '#000000', color: '#FFFFFF' }}
-                    aria-label="Sign in with Apple"
-                  >
-                    <svg className="w-5 h-5" viewBox="0 0 24 24" fill="#FFFFFF" aria-hidden="true">
-                      <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/>
-                    </svg>
-                    Sign in with Apple
-                  </button>
-                )}
+                {/* Sign in with Apple — handler is wired (handleAppleSignIn
+                    above) and the flag gates the render slot, but the button
+                    JSX itself is intentionally absent. Apple HIG requires the
+                    button to use Apple's official asset (specific logo
+                    proportions, padding, corner radius). Hand-authored SVG
+                    is a known App Store rejection risk — the iOS Capacitor
+                    build will render this same React code in WKWebView, so a
+                    non-compliant button would fail review.
+
+                    Activation steps (after Supabase Apple provider config):
+                      1. Drop in Apple's official SIWA button asset:
+                         https://developer.apple.com/design/human-interface-guidelines/sign-in-with-apple/overview/buttons/
+                         OR install `react-apple-signin-auth` (use only its
+                         button styling — auth flow stays on Supabase).
+                      2. Replace the `null` below with the compliant button,
+                         wired to handleAppleSignIn, placed ABOVE Google per
+                         equal-prominence.
+                      3. Set VITE_FEATURES_APPLE_SIGNIN=true in deploy env. */}
+                {FEATURES.APPLE_SIGNIN_ENABLED && null}
 
                 {/* Google Sign In */}
                 <button

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -5,6 +5,7 @@ import { useAuth } from '../context/AuthContext'
 import { logger } from '../utils/logger'
 import { CameraIcon } from '../components/CameraIcon'
 import { WghLogo } from '../components/WghLogo'
+import { FEATURES } from '../constants/features'
 
 // SECURITY: Email is NOT persisted to storage to prevent XSS exposure of PII
 
@@ -68,17 +69,30 @@ export function Login() {
     return () => clearTimeout(timer)
   }, [username, mode])
 
+  const buildOAuthRedirect = () => {
+    const fromLocation = location.state?.from
+    return fromLocation
+      ? new URL(
+          fromLocation.pathname + (fromLocation.search || '') + (fromLocation.hash || ''),
+          window.location.origin
+        ).toString()
+      : null
+  }
+
   const handleGoogleSignIn = async () => {
     try {
       setLoading(true)
-      const fromLocation = location.state?.from
-      const redirectUrl = fromLocation
-        ? new URL(
-            fromLocation.pathname + (fromLocation.search || '') + (fromLocation.hash || ''),
-            window.location.origin
-          ).toString()
-        : null
-      await authApi.signInWithGoogle(redirectUrl)
+      await authApi.signInWithGoogle(buildOAuthRedirect())
+    } catch (error) {
+      setMessage({ type: 'error', text: error.message })
+      setLoading(false)
+    }
+  }
+
+  const handleAppleSignIn = async () => {
+    try {
+      setLoading(true)
+      await authApi.signInWithApple(buildOAuthRedirect())
     } catch (error) {
       setMessage({ type: 'error', text: error.message })
       setLoading(false)
@@ -348,6 +362,27 @@ export function Login() {
             {/* Options Mode */}
             {mode === 'options' && (
               <div className="w-full max-w-sm space-y-4">
+                {/* Sign in with Apple — gated behind feature flag until
+                    Supabase Apple provider is configured. Placed ABOVE Google
+                    per Apple HIG (must be at least as prominent as other
+                    third-party sign-in options).
+                    TODO before enabling: verify button against Apple's current
+                    official button spec (logo proportions, padding, label). */}
+                {FEATURES.APPLE_SIGNIN_ENABLED && (
+                  <button
+                    onClick={handleAppleSignIn}
+                    disabled={loading}
+                    className="w-full flex items-center justify-center gap-2 px-6 py-4 rounded-xl font-semibold active:scale-[0.98] transition-all disabled:opacity-50"
+                    style={{ background: '#000000', color: '#FFFFFF' }}
+                    aria-label="Sign in with Apple"
+                  >
+                    <svg className="w-5 h-5" viewBox="0 0 24 24" fill="#FFFFFF" aria-hidden="true">
+                      <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/>
+                    </svg>
+                    Sign in with Apple
+                  </button>
+                )}
+
                 {/* Google Sign In */}
                 <button
                   onClick={handleGoogleSignIn}


### PR DESCRIPTION
## Summary

Stacked on #25. Lands the Sign in with Apple web code in a dormant state so activation is (mostly) a flag flip.

**Apple sign-in is an App Store hard gate** (Apple rule 4.8: any app with third-party social login must offer Sign in with Apple). WGH offers Google. This unblocks that requirement on the code side.

## What ships

- `FEATURES.APPLE_SIGNIN_ENABLED` flag in `src/constants/features.js` (reads `VITE_FEATURES_APPLE_SIGNIN`, defaults false)
- `authApi.signInWithApple` — mirrors `signInWithGoogle`, web OAuth flow via `supabase.auth.signInWithOAuth({ provider: 'apple' })`
- Pre-wired handlers in `LoginModal` and `Login.jsx` (eslint-disable for the temporary unused-var state)
- Feature-flag gate in both sign-in surfaces, with a comment block documenting activation steps
- `WelcomeModal` open condition extended: now fires when `!profile.display_name?.trim()` too — covers providers (like Apple via web) that don't return a name

## What's intentionally NOT shipped

- **Button JSX.** Apple HIG requires the official button asset; hand-authored SVG is a known App Store rejection risk (the iOS Capacitor build will render this same React in WKWebView). Flipping the flag today renders nothing. Activation steps documented in the code.
- **Privacy.jsx copy update.** Holds until the flag flips, or the policy becomes a lie.
- **Native Capacitor flow.** Blocked on Capacitor scaffold, which doesn't exist in the repo yet. Separate PR when that lands.

## Activation sequence (external)

1. Enroll in Apple Developer Program (individual, per existing plan)
2. Create App ID + Services ID + .p8 key
3. Configure Supabase Auth → Providers → Apple
4. Drop Apple's official SIWA button asset into the render slot in `LoginModal` and `Login.jsx`
5. Ship Privacy.jsx copy update in a follow-up PR
6. Set `VITE_FEATURES_APPLE_SIGNIN=true` in Vercel env

## Review notes

Went through two rounds of Codex review (gpt-5.4, high reasoning). See:
- Plan: `docs/superpowers/plans/2026-04-13-h2-sign-in-with-apple.md`
- Codex flagged a race in onboarding (fixed in #25) and the non-compliant SVG risk (fixed here — button removed until official asset is in place)

## Test plan

- [x] `npm run build` green
- [x] `npm run test` green — 311/311 tests pass
- [x] ESLint clean on touched files
- [ ] Manual — confirm flag unset → Apple button does NOT render in LoginModal or Login
- [ ] Manual — confirm WelcomeModal still opens for net-new users (regression check on the open condition)
- [ ] (Post-Apple-Dev) — manual E2E of the full SIWA flow on web

🤖 Generated with [Claude Code](https://claude.com/claude-code)