### PR TITLE
fix: search respects mile radius on homepage + browse

### DIFF
--- a/src/hooks/useDishSearch.js
+++ b/src/hooks/useDishSearch.js
@@ -1,29 +1,51 @@
 import { useMemo } from 'react'
 import { useAllDishes } from './useAllDishes'
 import { searchDishes } from '../utils/dishSearch'
+import { calculateDistance } from '../utils/distance'
 
 /**
  * Search dishes with instant client-side filtering.
- * Same API signature as previous server-based version.
+ *
  * @param {string} query - Search query
  * @param {number} limit - Max results (default 5)
+ * @param {Object|null} geo - Optional location/radius filter
+ * @param {number} geo.lat - User latitude
+ * @param {number} geo.lng - User longitude
+ * @param {number} geo.radiusMiles - Radius in miles (0 = no filter)
+ * @param {boolean} geo.isUsingDefault - If true, skip distance filter
  * @returns {Object} { results, loading, error }
  */
-export function useDishSearch(query, limit = 5) {
-  const trimmedQuery = query?.trim() || ''
-  const isActive = trimmedQuery.length >= 2
+export function useDishSearch(query, limit, geo) {
+  if (limit === undefined || limit === null) limit = 5
+  var trimmedQuery = (query || '').trim()
+  var isActive = trimmedQuery.length >= 2
 
-  const { dishes, loading: cacheLoading, error } = useAllDishes({ enabled: isActive })
+  var { dishes, loading: cacheLoading, error } = useAllDishes({ enabled: isActive })
 
-  const results = useMemo(() => {
+  var lat = geo && geo.lat
+  var lng = geo && geo.lng
+  var radiusMiles = geo && geo.radiusMiles
+  var isUsingDefault = geo && geo.isUsingDefault
+
+  var results = useMemo(function () {
     if (trimmedQuery.length < 2) return []
     if (!dishes.length) return []
-    return searchDishes(dishes, trimmedQuery, { limit })
-  }, [dishes, trimmedQuery, limit])
+    var matches = searchDishes(dishes, trimmedQuery, { limit: limit * 3 })
+
+    // Apply radius filter if we have real GPS + a non-zero radius
+    if (lat && lng && radiusMiles && radiusMiles > 0 && !isUsingDefault) {
+      matches = matches.filter(function (d) {
+        if (d.restaurant_lat == null || d.restaurant_lng == null) return true
+        return calculateDistance(lat, lng, d.restaurant_lat, d.restaurant_lng) <= radiusMiles
+      })
+    }
+
+    return matches.slice(0, limit)
+  }, [dishes, trimmedQuery, limit, lat, lng, radiusMiles, isUsingDefault])
 
   return {
-    results,
+    results: results,
     loading: cacheLoading && trimmedQuery.length >= 2,
-    error,
+    error: error,
   }
 }

--- a/src/pages/Browse.jsx
+++ b/src/pages/Browse.jsx
@@ -47,7 +47,12 @@ export function Browse() {
   const { stats: userStats } = useUserVotes(user?.id)
 
   // Search results from API using React Query hook
-  const { results: searchResults, loading: searchLoading } = useDishSearch(debouncedSearchQuery, 50)
+  const { results: searchResults, loading: searchLoading } = useDishSearch(debouncedSearchQuery, 50, {
+    lat: location ? location.lat : null,
+    lng: location ? location.lng : null,
+    radiusMiles: radius,
+    isUsingDefault: isUsingDefault,
+  })
 
   // Google Places restaurant search — don't bias by default MV location or Browse radius
   const placesLat = isUsingDefault ? null : location?.lat

--- a/src/pages/Map.jsx
+++ b/src/pages/Map.jsx
@@ -114,7 +114,12 @@ export function Map() {
   }, [])
 
   // Search results (no town filter — shows whole island)
-  var searchData = useDishSearch(searchQuery, searchLimit, null)
+  var searchData = useDishSearch(searchQuery, searchLimit, {
+    lat: location ? location.lat : null,
+    lng: location ? location.lng : null,
+    radiusMiles: radius,
+    isUsingDefault: permissionState !== 'granted',
+  })
   var searchResults = searchData.results
   var searchLoading = searchData.loading
 


### PR DESCRIPTION
## Summary
Homepage "What are you craving?" and Browse page search now filter results by the user's mile radius setting. Previously search returned dishes from all locations regardless of radius.

## How it works
- `useDishSearch` now accepts optional `{ lat, lng, radiusMiles, isUsingDefault }` geo param
- When GPS is granted + radius > 0: dishes outside the radius are filtered out
- Radius = 0 ("All"): no filter, same as before
- GPS denied: no filter (expansion-safe)
- Fetches 3x limit from the search engine, then filters by distance, then trims to limit — so radius filtering doesn't starve results

## Test plan
- [ ] Set radius to 10 mi → search "burger" → only nearby burgers appear
- [ ] Set radius to "All" → search "burger" → burgers from everywhere appear
- [ ] Deny GPS → search "burger" → all burgers appear (no distance filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)