### PR TITLE
feat(playlists): WGH food icons + real photos for covers

### DIFF
--- a/src/components/playlists/PlaylistCover.jsx
+++ b/src/components/playlists/PlaylistCover.jsx
@@ -1,7 +1,7 @@
-import { DEFAULT_CATEGORY_EMOJI, categoryEmojiFor } from '../../constants/categories'
+import { getCategoryNeonImage, categoryEmojiFor } from '../../constants/categories'
 
-// Warm coral / amber / copper / green — the four WGH brand tiles.
-const BG_COLORS = [
+// Brand tile background colors — used behind icons when no photo is available.
+var BG_COLORS = [
   'var(--color-accent-gold)',
   'var(--color-primary)',
   'var(--color-medal-bronze)',
@@ -9,15 +9,27 @@ const BG_COLORS = [
 ]
 
 /**
- * 4-tile emoji cover grid. Used as the default visual identity for a
- * playlist when no uploaded cover exists. Takes a `coverCategories` array
- * of category ids (from the read RPCs' cover_categories field) and maps
- * each to its emoji; fills missing tiles with the fallback.
+ * 4-tile cover grid for playlists. Priority per tile:
+ * 1. Real dish photo (coverPhotos[i]) — when dishes have user-uploaded photos
+ * 2. Category icon (WGH flat illustrated WebP from public/categories/icons/)
+ * 3. Emoji fallback
+ *
+ * @param {string[]} coverCategories - Category IDs for first 4 dishes
+ * @param {string[]} coverPhotos - Photo URLs for first 4 dishes (optional)
+ * @param {number} size - Grid size in px
  */
-export function PlaylistCover({ coverCategories = [], size = 120 }) {
-  const tiles = [0, 1, 2, 3].map((i) =>
-    coverCategories[i] ? categoryEmojiFor(coverCategories[i]) : DEFAULT_CATEGORY_EMOJI
-  )
+export function PlaylistCover({ coverCategories, coverPhotos, size }) {
+  if (coverCategories === undefined) coverCategories = []
+  if (coverPhotos === undefined) coverPhotos = []
+  if (size === undefined) size = 120
+
+  var tiles = [0, 1, 2, 3].map(function (i) {
+    var photo = coverPhotos[i] || null
+    var category = coverCategories[i] || null
+    var iconSrc = category ? getCategoryNeonImage(category) : null
+    return { photo: photo, iconSrc: iconSrc, category: category }
+  })
+
   return (
     <div
       style={{
@@ -30,20 +42,63 @@ export function PlaylistCover({ coverCategories = [], size = 120 }) {
         overflow: 'hidden',
       }}
     >
-      {tiles.map((emoji, i) => (
-        <div
-          key={i}
-          style={{
-            background: BG_COLORS[i],
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            fontSize: Math.round(size / 3.5),
-          }}
-        >
-          {emoji}
-        </div>
-      ))}
+      {tiles.map(function (tile, i) {
+        // Real photo — full cover
+        if (tile.photo) {
+          return (
+            <div
+              key={i}
+              style={{
+                backgroundImage: 'url(' + tile.photo + ')',
+                backgroundSize: 'cover',
+                backgroundPosition: 'center',
+              }}
+            />
+          )
+        }
+
+        // Category icon (WebP) — centered on brand color
+        if (tile.iconSrc) {
+          return (
+            <div
+              key={i}
+              style={{
+                background: BG_COLORS[i],
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: Math.round(size / 12),
+              }}
+            >
+              <img
+                src={tile.iconSrc}
+                alt={tile.category || ''}
+                style={{
+                  width: '70%',
+                  height: '70%',
+                  objectFit: 'contain',
+                }}
+              />
+            </div>
+          )
+        }
+
+        // Emoji fallback
+        return (
+          <div
+            key={i}
+            style={{
+              background: BG_COLORS[i],
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: Math.round(size / 3.5),
+            }}
+          >
+            {categoryEmojiFor(tile.category)}
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/src/pages/Playlist.jsx
+++ b/src/pages/Playlist.jsx
@@ -70,6 +70,7 @@ export function Playlist() {
 
   var items = playlist.items || []
   var covers = (playlist.cover_categories || []).slice(0, 4)
+  var coverPhotos = items.slice(0, 4).map(function (item) { return item.photo_url || null })
 
   var toggleFollow = function () {
     if (!user) { navigate('/login'); return }
@@ -95,7 +96,7 @@ export function Playlist() {
       {/* Header with cover gradient */}
       <div style={{ padding: 20, background: 'linear-gradient(180deg, var(--color-primary) 0%, var(--color-bg) 100%)' }}>
         <div className="flex justify-center">
-          <PlaylistCover coverCategories={covers} size={240} />
+          <PlaylistCover coverCategories={covers} coverPhotos={coverPhotos} size={240} />
         </div>
         <h1
           style={{


### PR DESCRIPTION
## Summary
Playlist covers now use the WGH illustrated food icons instead of emoji, and real dish photos take priority when available.

**Cover tile priority:**
1. Real dish photo → full-bleed image tile
2. WGH category icon (flat illustrated WebP) → centered on brand color
3. Emoji fallback → for categories without icons

## Test plan
- [ ] Create a playlist with dishes that have photos → cover shows real photos
- [ ] Create a playlist with dishes that have NO photos → cover shows illustrated food icons (burger.webp, pizza.webp, etc.)
- [ ] Mix of photos and no-photos → tiles show the right type per position

🤖 Generated with [Claude Code](https://claude.com/claude-code)