### PR TITLE
perf(supabase): 14 audit fixes across 5 migrations

### DIFF
--- a/AUDIT-SUPABASE-2026-04-16.md
+++ b/AUDIT-SUPABASE-2026-04-16.md
@@ -1,0 +1,88 @@
+# Supabase Database Audit — 2026-04-16
+
+Audit of `supabase/schema.sql` (4,500+ lines) against Supabase Postgres best practices.
+
+**Scope:** schema, RPCs, RLS policies, indexes, migrations, edge functions, `src/api/` usage patterns.
+
+**Status as of 2026-04-16 EOD:** **13 of 20 fixes shipped.** All CRITICAL and launch-blocking items complete. Rest are post-launch or deliberately skipped (see Closing Verdict).
+
+---
+
+## Deployed migrations
+
+| File | Contents |
+|---|---|
+| `supabase/migrations/2026-04-16-audit-fixes.sql` | #1, #2, #3, #5, #7, #9, #10 |
+| `supabase/migrations/2026-04-16-audit-fixes-phase-2.sql` | #4, #11, #12, #13 |
+| `supabase/migrations/2026-04-16-audit-fixes-phase-3.sql` | #20 (FK delete strategies) |
+
+---
+
+## Status table
+
+| # | Severity | Fix | Status | Notes |
+|---|---|---|---|---|
+| 1 | CRITICAL | `is_blocked_pair` N+1 in `get_ranked_dishes` | ✅ Shipped | Inline `NOT EXISTS` — verified 0.163ms plan |
+| 2 | CRITICAL | `get_open_reports` correlated subquery | ✅ Shipped | CTE rewrite |
+| 3 | CRITICAL | `idx_votes_dish_source_rating` | ✅ Shipped | Not used by `get_ranked_dishes` (LEFT JOIN blocks partial index) but helps vote-write triggers at schema.sql:1899, 2024 |
+| 4 | CRITICAL | Keyset pagination for `get_open_reports` | ✅ Shipped | No client callers yet, safe signature change |
+| 5 | CRITICAL | `is_blocked_pair` N+1 in follows RLS | ✅ Shipped | Single `NOT EXISTS` covering both edges |
+| 6 | HIGH | Report-count materialization for admin sort | ⏸ Deferred | Premature without evidence — admin queue is small |
+| 7 | HIGH | `idx_votes_user_dish_created` | ✅ Shipped | Verified in use (18 scans after testing) |
+| 8 | HIGH | DECIMAL/NUMERIC standardization | ⏭ Skipped | DECIMAL is an alias for NUMERIC in Postgres — purely cosmetic |
+| 9 | HIGH | `idx_votes_source_created` | ✅ Shipped | No hot-path callers yet; available for future analytics |
+| 10 | HIGH | `reports_target_status_idx` | ✅ Shipped | Ready for admin filtering by user |
+| 11 | MEDIUM | Partial index `idx_dish_photos_featured_community` | ✅ Shipped | ~50% smaller than the full index; doesn't replace it |
+| 12 | MEDIUM | `dishes.total_votes` INT → BIGINT | ✅ Shipped | Required view + trigger drop/recreate around the ALTER |
+| 13 | MEDIUM | FK index on `events.created_by` | ✅ Shipped | `specials.created_by` already had one |
+| 14 | MEDIUM | Batch `update_dish_avg_rating` trigger work | ⏸ Deferred | Premature — no evidence of bottleneck |
+| 15 | MEDIUM | Cache `global_mean` in `get_ranked_dishes` | ⏸ Deferred | Same — rerun after `pg_stat_statements` shows it |
+| 16 | MEDIUM | Trigram index on `profiles.display_name` | ⏸ Deferred | Only needed if fuzzy display-name search is a feature |
+| 17 | LOW | `get_friends_votes_*` naming | ⏭ Skipped | Cosmetic |
+| 18 | LOW | `is_blocked_pair` docs | ⏭ Skipped | Already commented at schema.sql:3907 |
+| 19 | LOW | DECIMAL/NUMERIC consistency | ⏭ Skipped | Duplicate of #8 |
+| 20 | LOW | FK `ON DELETE` strategy on `created_by` columns | ✅ Shipped | **Was a live bug** — see below |
+
+---
+
+## #20 findings — elevated to real bug, not cosmetic
+
+The audit originally tagged `ON DELETE` strategy as LOW "make it explicit." On closer look this was a **live bug** for the Delete Account flow shipped in commit `fd36e48`.
+
+`public.delete_auth_user` (`schema.sql:3345`) does a raw `DELETE FROM auth.users` and assumes cascades handle the rest. But several `created_by` and `used_by` FK columns had no explicit `ON DELETE` clause, defaulting to `NO ACTION` / `RESTRICT`. Any user who had created a restaurant, dish, event, special, invite, or admin record could not delete their account — the DELETE would raise a FK violation.
+
+**Tables touched by phase 3:**
+
+| Table | Column | Was | Now |
+|---|---|---|---|
+| `restaurants` | `created_by` | RESTRICT | SET NULL |
+| `dishes` | `created_by` | RESTRICT | SET NULL |
+| `admins` | `created_by` | RESTRICT | SET NULL |
+| `specials` | `created_by` | RESTRICT | SET NULL |
+| `restaurant_managers` | `created_by` | RESTRICT | SET NULL |
+| `restaurant_invites` | `created_by` (NOT NULL) | RESTRICT | CASCADE |
+| `restaurant_invites` | `used_by` | RESTRICT | SET NULL |
+| `curator_invites` | `created_by` | RESTRICT | SET NULL |
+| `curator_invites` | `used_by` | RESTRICT | SET NULL |
+| `events` | `created_by` | RESTRICT | SET NULL |
+
+**Semantics preserved:** user-owned data still cascades (votes, favorites, photos, follows). `created_by` on content tables now anonymizes instead of blocking account deletion. Pending invites die with the creator. Completed-invite audit records anonymize.
+
+---
+
+## Closing verdict
+
+**Shipped:** everything that moves a launch-critical metric, eliminates a known N+1 / RLS hot loop, or closes a live bug.
+
+**Skipped or deferred:** items that are purely cosmetic (DECIMAL/NUMERIC), premature optimization without `pg_stat_statements` evidence (trigger batching, `global_mean` cache), or speculative (display_name trigram index).
+
+**Follow-ups to revisit post-launch:**
+- Run `SELECT * FROM pg_stat_user_indexes WHERE idx_scan = 0` after 1–2 weeks of traffic to find dead indexes
+- Run `pg_stat_statements` to surface the actual slow queries, then pick whichever of #6, #14, #15 is backed by data
+- The 3 RPCs still declaring `total_votes INT` in return types (`get_local_list_by_user`, `get_my_local_list`) will start erroring if any dish exceeds 2.1B votes. Not a 2026 problem, but worth a grep-and-fix pass when convenient.
+
+**What's not covered by this audit (requires running queries, not reading files):**
+- Actual index usage across live traffic
+- Slow-query log (`pg_stat_statements`)
+- Bloat / vacuum health
+- Connection pool sizing vs. Fluid Compute concurrency

--- a/supabase/migrations/2026-04-16-audit-fixes-phase-2.sql
+++ b/supabase/migrations/2026-04-16-audit-fixes-phase-2.sql
@@ -1,0 +1,165 @@
+-- Audit 2026-04-16 — Phase 2 (admin-only + MEDIUM fixes)
+-- Source: AUDIT-SUPABASE-2026-04-16.md
+--
+-- Fixes bundled in this migration:
+--   #4  Keyset pagination for get_open_reports (replaces OFFSET)
+--   #11 Partial index on dish_photos (featured/community only)
+--   #12 dishes.total_votes INT → BIGINT (prevents 2.1B overflow)
+--   #13 Missing idx_events_created_by (idx_specials_created_by already exists)
+--
+-- Safe to run more than once — CREATE INDEX IF NOT EXISTS, CREATE OR REPLACE,
+-- and ALTER TABLE is idempotent against BIGINT.
+--
+-- Signature change on get_open_reports is SAFE — it has no client callers yet
+-- (grep verified in src/ at time of writing).
+
+BEGIN;
+
+-- ============================================================================
+-- #11: partial index on dish_photos for featured/community only
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_dish_photos_featured_community
+  ON dish_photos(dish_id, quality_score DESC)
+  WHERE status IN ('featured', 'community');
+
+
+-- ============================================================================
+-- #12: dishes.total_votes INT → BIGINT
+--   INT caps at 2.147B; trigger-maintained column, so no backfill.
+--   Downstream RPCs that declare `total_votes INT` in their return type will
+--   cast implicitly. They remain correct at current scale and can be updated
+--   incrementally if a dish ever exceeds INT range.
+--   NOTE: two dependencies block the ALTER and must be dropped + recreated:
+--     - view category_median_prices (schema.sql:327)
+--     - trigger trigger_compute_value_score (schema.sql:2082) which lists
+--       total_votes in its UPDATE OF clause
+-- ============================================================================
+
+DROP TRIGGER IF EXISTS trigger_compute_value_score ON dishes;
+DROP VIEW IF EXISTS category_median_prices;
+
+ALTER TABLE dishes
+  ALTER COLUMN total_votes SET DATA TYPE BIGINT;
+
+CREATE OR REPLACE VIEW category_median_prices
+WITH (security_invoker = true) AS
+SELECT category,
+  PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY price) AS median_price,
+  COUNT(*) AS dish_count
+FROM dishes
+WHERE price IS NOT NULL AND price > 0 AND total_votes >= 8
+GROUP BY category;
+
+CREATE TRIGGER trigger_compute_value_score
+  BEFORE INSERT OR UPDATE OF avg_rating, total_votes, price, category ON dishes
+  FOR EACH ROW EXECUTE FUNCTION compute_value_score();
+
+
+-- ============================================================================
+-- #13: FK index on events.created_by
+--   (specials.created_by already has idx_specials_created_by at schema.sql:424)
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_events_created_by ON events(created_by);
+
+
+-- ============================================================================
+-- #4: keyset pagination for get_open_reports
+--   Signature changes:
+--     BEFORE: get_open_reports(p_limit INT, p_offset INT)
+--     AFTER:  get_open_reports(p_limit INT, p_cursor_open_count BIGINT,
+--                               p_cursor_created_at TIMESTAMPTZ, p_cursor_id UUID)
+--   No client callers today (src/ grep returned 0 matches), so this is safe.
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS get_open_reports(INT, INT);
+
+CREATE OR REPLACE FUNCTION get_open_reports(
+  p_limit INT DEFAULT 50,
+  p_cursor_open_count BIGINT DEFAULT NULL,
+  p_cursor_created_at TIMESTAMPTZ DEFAULT NULL,
+  p_cursor_id UUID DEFAULT NULL
+)
+RETURNS TABLE (
+  report_id UUID, reporter_id UUID, reporter_name TEXT,
+  reported_type TEXT, reported_id UUID, reported_user_id UUID, reported_user_name TEXT,
+  reason TEXT, details TEXT, target_snapshot JSONB, created_at TIMESTAMPTZ,
+  target_user_open_report_count BIGINT
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  IF NOT is_admin() THEN RAISE EXCEPTION 'Admin access required'; END IF;
+
+  p_limit := LEAST(GREATEST(p_limit, 1), 200);
+
+  -- Cursor guard: require all three parts OR none. Partial cursors would make
+  -- the tuple comparison return NULL and silently produce empty pages.
+  -- NOTE: open_count is a live aggregate, so rows can shift between pages if
+  -- reports are opened/closed during moderation. Acceptable for admin use.
+  IF NOT (
+    (p_cursor_open_count IS NULL AND p_cursor_created_at IS NULL AND p_cursor_id IS NULL)
+    OR
+    (p_cursor_open_count IS NOT NULL AND p_cursor_created_at IS NOT NULL AND p_cursor_id IS NOT NULL)
+  ) THEN
+    RAISE EXCEPTION 'Partial cursor: pass all three of p_cursor_open_count, p_cursor_created_at, p_cursor_id (or none).';
+  END IF;
+
+  RETURN QUERY
+  WITH open_counts AS (
+    SELECT reported_user_id, COUNT(*)::BIGINT AS open_count
+    FROM reports
+    WHERE status = 'open' AND reported_user_id IS NOT NULL
+    GROUP BY reported_user_id
+  )
+  SELECT r.id, r.reporter_id, rp.display_name,
+    r.reported_type, r.reported_id, r.reported_user_id, up.display_name,
+    r.reason, r.details, r.target_snapshot, r.created_at,
+    COALESCE(oc.open_count, 0)
+  FROM reports r
+  LEFT JOIN profiles rp ON rp.id = r.reporter_id
+  LEFT JOIN profiles up ON up.id = r.reported_user_id
+  LEFT JOIN open_counts oc ON oc.reported_user_id = r.reported_user_id
+  WHERE r.status = 'open'
+    AND (
+      p_cursor_open_count IS NULL
+      OR (COALESCE(oc.open_count, 0), r.created_at, r.id)
+         < (p_cursor_open_count, p_cursor_created_at, p_cursor_id)
+    )
+  ORDER BY COALESCE(oc.open_count, 0) DESC, r.created_at DESC, r.id DESC
+  LIMIT p_limit;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION get_open_reports(INT, BIGINT, TIMESTAMPTZ, UUID) FROM public, anon;
+GRANT EXECUTE ON FUNCTION get_open_reports(INT, BIGINT, TIMESTAMPTZ, UUID) TO authenticated;
+
+COMMIT;
+
+
+-- ============================================================================
+-- Post-deploy verification
+-- ============================================================================
+--
+-- 1. First page:
+--   SELECT * FROM get_open_reports(50);
+--
+-- 2. Next page (pass back last row's values):
+--   SELECT * FROM get_open_reports(
+--     50,
+--     <target_user_open_report_count from last row>,
+--     <created_at from last row>,
+--     <report_id from last row>
+--   );
+--
+-- 3. Confirm BIGINT column:
+--   SELECT data_type FROM information_schema.columns
+--   WHERE table_name = 'dishes' AND column_name = 'total_votes';
+--   -- expect: bigint
+--
+-- 4. Confirm new indexes exist:
+--   SELECT indexname FROM pg_indexes
+--   WHERE indexname IN (
+--     'idx_events_created_by',
+--     'idx_dish_photos_featured_community'
+--   );

--- a/supabase/migrations/2026-04-16-audit-fixes-phase-3.sql
+++ b/supabase/migrations/2026-04-16-audit-fixes-phase-3.sql
@@ -1,0 +1,157 @@
+-- Audit 2026-04-16 — Phase 3 (FK ON DELETE strategies for Delete Account flow)
+-- Source: AUDIT-SUPABASE-2026-04-16.md §20
+--
+-- Bug context: public.delete_auth_user (schema.sql:3345) does a raw
+-- DELETE FROM auth.users WHERE id = X. Any user who created a restaurant,
+-- dish, event, special, invite, or admin record could not delete their
+-- account — the DELETE would raise a FK violation because several
+-- `created_by` / `used_by` columns had no explicit ON DELETE clause and
+-- defaulted to NO ACTION / RESTRICT.
+--
+-- Strategy choices:
+--   - `created_by` on CONTENT tables (restaurant/dish/event/special) →
+--     SET NULL. Preserves the content, forgets the author.
+--   - `created_by` on AUXILIARY records (admins, restaurant_managers) →
+--     SET NULL. Preserves the record, forgets who granted access.
+--   - `restaurant_invites.created_by` is NOT NULL → CASCADE. Pending invites
+--     die with the user who issued them.
+--   - `used_by` on invites → SET NULL. Preserves the audit trail, anonymizes.
+--
+-- User-owned data (votes, favorites, photos, follows, playlists, ...)
+-- already CASCADEs correctly and is not touched by this migration.
+--
+-- Safe to run more than once — each constraint is dropped by generated name
+-- and re-added with the desired clause.
+
+BEGIN;
+
+-- ============================================================================
+-- restaurants.created_by → SET NULL
+-- ============================================================================
+
+ALTER TABLE restaurants
+  DROP CONSTRAINT IF EXISTS restaurants_created_by_fkey,
+  ADD CONSTRAINT restaurants_created_by_fkey
+    FOREIGN KEY (created_by) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+-- ============================================================================
+-- dishes.created_by → SET NULL
+-- ============================================================================
+
+ALTER TABLE dishes
+  DROP CONSTRAINT IF EXISTS dishes_created_by_fkey,
+  ADD CONSTRAINT dishes_created_by_fkey
+    FOREIGN KEY (created_by) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+-- ============================================================================
+-- admins.created_by → SET NULL
+-- ============================================================================
+
+ALTER TABLE admins
+  DROP CONSTRAINT IF EXISTS admins_created_by_fkey,
+  ADD CONSTRAINT admins_created_by_fkey
+    FOREIGN KEY (created_by) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+-- ============================================================================
+-- specials.created_by → SET NULL
+-- ============================================================================
+
+ALTER TABLE specials
+  DROP CONSTRAINT IF EXISTS specials_created_by_fkey,
+  ADD CONSTRAINT specials_created_by_fkey
+    FOREIGN KEY (created_by) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+-- ============================================================================
+-- restaurant_managers.created_by → SET NULL
+-- ============================================================================
+
+ALTER TABLE restaurant_managers
+  DROP CONSTRAINT IF EXISTS restaurant_managers_created_by_fkey,
+  ADD CONSTRAINT restaurant_managers_created_by_fkey
+    FOREIGN KEY (created_by) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+-- ============================================================================
+-- restaurant_invites.created_by → CASCADE (NOT NULL, no SET NULL option)
+-- restaurant_invites.used_by    → SET NULL
+-- ============================================================================
+
+ALTER TABLE restaurant_invites
+  DROP CONSTRAINT IF EXISTS restaurant_invites_created_by_fkey,
+  ADD CONSTRAINT restaurant_invites_created_by_fkey
+    FOREIGN KEY (created_by) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+ALTER TABLE restaurant_invites
+  DROP CONSTRAINT IF EXISTS restaurant_invites_used_by_fkey,
+  ADD CONSTRAINT restaurant_invites_used_by_fkey
+    FOREIGN KEY (used_by) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+-- ============================================================================
+-- curator_invites.created_by → SET NULL
+-- curator_invites.used_by    → SET NULL
+-- ============================================================================
+
+ALTER TABLE curator_invites
+  DROP CONSTRAINT IF EXISTS curator_invites_created_by_fkey,
+  ADD CONSTRAINT curator_invites_created_by_fkey
+    FOREIGN KEY (created_by) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+ALTER TABLE curator_invites
+  DROP CONSTRAINT IF EXISTS curator_invites_used_by_fkey,
+  ADD CONSTRAINT curator_invites_used_by_fkey
+    FOREIGN KEY (used_by) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+-- ============================================================================
+-- events.created_by → SET NULL
+-- ============================================================================
+
+ALTER TABLE events
+  DROP CONSTRAINT IF EXISTS events_created_by_fkey,
+  ADD CONSTRAINT events_created_by_fkey
+    FOREIGN KEY (created_by) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+COMMIT;
+
+
+-- ============================================================================
+-- Post-deploy verification
+-- ============================================================================
+--
+-- 1. Confirm all 10 FK constraints now have the intended ON DELETE action:
+--
+--   SELECT
+--     c.conrelid::regclass AS table_name,
+--     a.attname            AS column_name,
+--     c.confdeltype        AS on_delete
+--   FROM pg_constraint c
+--   JOIN pg_attribute a
+--     ON a.attrelid = c.conrelid AND a.attnum = ANY (c.conkey)
+--   WHERE c.contype = 'f'
+--     AND c.confrelid = 'auth.users'::regclass
+--     AND a.attname IN ('created_by', 'used_by')
+--     AND c.conrelid::regclass::text IN (
+--       'restaurants', 'dishes', 'admins', 'specials',
+--       'restaurant_managers', 'restaurant_invites',
+--       'curator_invites', 'events'
+--     )
+--   ORDER BY table_name, column_name;
+--
+-- confdeltype key:
+--   'a' = NO ACTION (this is the bug, should not appear for any of these rows)
+--   'r' = RESTRICT
+--   'c' = CASCADE
+--   'n' = SET NULL
+--   'd' = SET DEFAULT
+--
+-- Expect 'n' everywhere EXCEPT restaurant_invites.created_by which is 'c'.
+--
+-- 2. Smoke test (optional, destructive): create a throwaway user, have them
+--    insert a restaurant row, then call delete_auth_user(<throwaway-uuid>).
+--    Should succeed; the restaurant row should remain with created_by = NULL.

--- a/supabase/migrations/2026-04-16-audit-fixes-phase-4.sql
+++ b/supabase/migrations/2026-04-16-audit-fixes-phase-4.sql
@@ -1,0 +1,117 @@
+-- Audit 2026-04-16 — Phase 4 (return-type consistency for total_votes)
+-- Source: AUDIT-SUPABASE-2026-04-16.md closing notes
+--
+-- Context: phase 2 widened dishes.total_votes from INT to BIGINT. Three RPCs
+-- still declared `total_votes INT` in their RETURNS TABLE signature. At
+-- current scale the implicit BIGINT → INT downcast is safe, but if a dish
+-- ever exceeds INT range (2.147B) those RPCs would raise an overflow error.
+-- Standardize on BIGINT now while the change is cheap.
+--
+-- RPCs touched:
+--   - get_my_local_list()
+--   - get_local_list_by_user(UUID)
+--
+-- (get_local_list_by_user has two shadowed definitions in schema.sql; the
+-- deployed one is the H3 UGC override at schema.sql:4723, replicated below.)
+--
+-- Changing a RETURNS TABLE column type requires DROP FUNCTION + CREATE, not
+-- just CREATE OR REPLACE.
+
+BEGIN;
+
+-- ============================================================================
+-- get_my_local_list
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS get_my_local_list();
+
+CREATE OR REPLACE FUNCTION get_my_local_list()
+RETURNS TABLE (
+  list_id UUID,
+  title TEXT,
+  description TEXT,
+  curator_tagline TEXT,
+  is_active BOOLEAN,
+  "position" INT,
+  dish_id UUID,
+  dish_name TEXT,
+  restaurant_name TEXT,
+  restaurant_id UUID,
+  avg_rating NUMERIC,
+  total_votes BIGINT,
+  category TEXT,
+  note TEXT
+)
+LANGUAGE SQL STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT
+    ll.id AS list_id,
+    ll.title,
+    ll.description,
+    ll.curator_tagline,
+    ll.is_active,
+    li."position",
+    d.id AS dish_id,
+    d.name AS dish_name,
+    r.name AS restaurant_name,
+    r.id AS restaurant_id,
+    d.avg_rating,
+    d.total_votes,
+    d.category,
+    li.note
+  FROM local_lists ll
+  LEFT JOIN local_list_items li ON li.list_id = ll.id
+  LEFT JOIN dishes d ON d.id = li.dish_id
+  LEFT JOIN restaurants r ON r.id = d.restaurant_id
+  WHERE ll.user_id = auth.uid()
+  ORDER BY li."position";
+$$;
+
+
+-- ============================================================================
+-- get_local_list_by_user (H3 UGC override — blocks viewers pair-blocked with curator)
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS get_local_list_by_user(UUID);
+
+CREATE OR REPLACE FUNCTION get_local_list_by_user(target_user_id UUID)
+RETURNS TABLE (
+  list_id UUID, title TEXT, description TEXT, user_id UUID,
+  display_name TEXT, "position" INT, dish_id UUID, dish_name TEXT,
+  restaurant_name TEXT, restaurant_id UUID, avg_rating NUMERIC,
+  total_votes BIGINT, category TEXT, note TEXT,
+  restaurant_lat FLOAT, restaurant_lng FLOAT
+)
+LANGUAGE SQL STABLE AS $$
+  SELECT ll.id, ll.title, ll.description, ll.user_id, p.display_name,
+    li."position", d.id, d.name, r.name, r.id, d.avg_rating, d.total_votes,
+    d.category, li.note, r.lat, r.lng
+  FROM local_lists ll
+  JOIN profiles p ON p.id = ll.user_id
+  JOIN local_list_items li ON li.list_id = ll.id
+  JOIN dishes d ON d.id = li.dish_id
+  JOIN restaurants r ON r.id = d.restaurant_id
+  WHERE ll.user_id = target_user_id
+    AND ll.is_active = true
+    AND ((select auth.uid()) IS NULL
+         OR NOT is_blocked_pair((select auth.uid()), target_user_id))
+  ORDER BY li."position";
+$$;
+
+COMMIT;
+
+
+-- ============================================================================
+-- Post-deploy verification
+-- ============================================================================
+--
+-- Confirm both RPCs now declare total_votes as bigint:
+--
+--   SELECT
+--     p.proname        AS function_name,
+--     pg_get_function_result(p.oid) AS return_shape
+--   FROM pg_proc p
+--   WHERE p.proname IN ('get_my_local_list', 'get_local_list_by_user')
+--     AND pg_function_is_visible(p.oid);
+--
+-- Both return_shape strings should contain `total_votes bigint`.

--- a/supabase/migrations/2026-04-16-audit-fixes-phase-5.sql
+++ b/supabase/migrations/2026-04-16-audit-fixes-phase-5.sql
@@ -1,0 +1,223 @@
+-- Audit 2026-04-16 — Phase 5 (anon short-circuit in get_ranked_dishes.best_photos)
+--
+-- Phase 1 replaced is_blocked_pair() per-row with inline NOT EXISTS (correct
+-- N+1 fix). This migration tightens that predicate further:
+--
+--   1. Short-circuit when the viewer is anonymous ((select auth.uid()) IS NULL).
+--      Anonymous traffic is the majority; skipping the user_blocks probe
+--      entirely for those requests is free performance.
+--
+--   2. Split the single `OR`-combined EXISTS into two separate EXISTS clauses.
+--      The planner can then use user_blocks_blocker_id_blocked_id_key as two
+--      direct index seeks instead of a bitmap OR, which matters once
+--      user_blocks starts carrying real data.
+--
+-- No behavior change. Pure plan-shape / work-avoidance.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION get_ranked_dishes(
+  user_lat DECIMAL,
+  user_lng DECIMAL,
+  radius_miles INT DEFAULT 50,
+  filter_category TEXT DEFAULT NULL,
+  filter_town TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+  dish_id UUID,
+  dish_name TEXT,
+  restaurant_id UUID,
+  restaurant_name TEXT,
+  restaurant_town TEXT,
+  category TEXT,
+  tags TEXT[],
+  cuisine TEXT,
+  price DECIMAL,
+  photo_url TEXT,
+  total_votes BIGINT,
+  avg_rating DECIMAL,
+  distance_miles DECIMAL,
+  has_variants BOOLEAN,
+  variant_count INT,
+  best_variant_name TEXT,
+  best_variant_rating DECIMAL,
+  value_score DECIMAL,
+  value_percentile DECIMAL,
+  search_score DECIMAL,
+  featured_photo_url TEXT,
+  restaurant_lat DECIMAL,
+  restaurant_lng DECIMAL,
+  restaurant_address TEXT,
+  restaurant_phone TEXT,
+  restaurant_website_url TEXT,
+  toast_slug TEXT,
+  order_url TEXT
+) AS $$
+DECLARE
+  lat_delta DECIMAL := radius_miles / 69.0;
+  lng_delta DECIMAL := radius_miles / (69.0 * COS(RADIANS(user_lat)));
+BEGIN
+  RETURN QUERY
+  WITH global_stats AS (
+    SELECT COALESCE(AVG(dishes.avg_rating), 7.0) AS global_mean
+    FROM dishes
+    WHERE dishes.total_votes > 0 AND dishes.avg_rating IS NOT NULL
+  ),
+  nearby_restaurants AS (
+    SELECT r.id, r.name, r.town, r.lat, r.lng, r.cuisine,
+           r.address, r.phone, r.website_url, r.toast_slug, r.order_url
+    FROM restaurants r
+    WHERE r.is_open = true
+      AND r.lat BETWEEN (user_lat - lat_delta) AND (user_lat + lat_delta)
+      AND r.lng BETWEEN (user_lng - lng_delta) AND (user_lng + lng_delta)
+      AND (filter_town IS NULL OR r.town = filter_town)
+  ),
+  restaurants_with_distance AS (
+    SELECT
+      nr.id, nr.name, nr.town, nr.lat, nr.lng, nr.cuisine,
+      nr.address, nr.phone, nr.website_url, nr.toast_slug, nr.order_url,
+      ROUND((
+        3959 * ACOS(
+          LEAST(1.0, GREATEST(-1.0,
+            COS(RADIANS(user_lat)) * COS(RADIANS(nr.lat)) *
+            COS(RADIANS(nr.lng) - RADIANS(user_lng)) +
+            SIN(RADIANS(user_lat)) * SIN(RADIANS(nr.lat))
+          ))
+        )
+      )::NUMERIC, 2) AS distance
+    FROM nearby_restaurants nr
+  ),
+  filtered_restaurants AS (
+    SELECT * FROM restaurants_with_distance WHERE distance <= radius_miles
+  ),
+  variant_stats AS (
+    SELECT
+      d.parent_dish_id,
+      COUNT(DISTINCT d.id)::INT AS child_count,
+      SUM(COALESCE(ds.vote_count, 0))::NUMERIC AS total_child_votes
+    FROM dishes d
+    LEFT JOIN (
+      SELECT v.dish_id,
+        SUM(CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END)::NUMERIC AS vote_count
+      FROM votes v GROUP BY v.dish_id
+    ) ds ON ds.dish_id = d.id
+    WHERE d.parent_dish_id IS NOT NULL
+    GROUP BY d.parent_dish_id
+  ),
+  best_variants AS (
+    SELECT DISTINCT ON (d.parent_dish_id)
+      d.parent_dish_id,
+      d.name AS best_name,
+      ROUND(AVG(v.rating_10)::NUMERIC, 1) AS best_rating
+    FROM dishes d
+    LEFT JOIN votes v ON v.dish_id = d.id
+    WHERE d.parent_dish_id IS NOT NULL
+    GROUP BY d.parent_dish_id, d.id, d.name
+    HAVING COUNT(v.id) >= 1
+    ORDER BY d.parent_dish_id, AVG(v.rating_10) DESC NULLS LAST, COUNT(v.id) DESC
+  ),
+  recent_vote_counts AS (
+    SELECT votes.dish_id, COUNT(*)::INT AS recent_votes
+    FROM votes
+    WHERE votes.created_at > NOW() - INTERVAL '14 days'
+    GROUP BY votes.dish_id
+  ),
+  best_photos AS (
+    -- Anon short-circuit + split EXISTS for index-friendly user_blocks probe.
+    SELECT DISTINCT ON (dp.dish_id)
+      dp.dish_id,
+      dp.photo_url
+    FROM dish_photos dp
+    INNER JOIN dishes d2 ON dp.dish_id = d2.id
+    INNER JOIN filtered_restaurants fr2 ON d2.restaurant_id = fr2.id
+    WHERE dp.status IN ('featured', 'community')
+      AND d2.parent_dish_id IS NULL
+      AND (
+        (select auth.uid()) IS NULL
+        OR (
+          NOT EXISTS (SELECT 1 FROM user_blocks ub
+                      WHERE ub.blocker_id = (select auth.uid()) AND ub.blocked_id = dp.user_id)
+          AND NOT EXISTS (SELECT 1 FROM user_blocks ub
+                          WHERE ub.blocker_id = dp.user_id AND ub.blocked_id = (select auth.uid()))
+        )
+      )
+    ORDER BY dp.dish_id,
+      CASE dp.source_type WHEN 'restaurant' THEN 0 ELSE 1 END,
+      CASE dp.status WHEN 'featured' THEN 0 ELSE 1 END,
+      dp.quality_score DESC NULLS LAST,
+      dp.created_at DESC
+  )
+  SELECT
+    d.id AS dish_id,
+    d.name AS dish_name,
+    fr.id AS restaurant_id,
+    fr.name AS restaurant_name,
+    fr.town AS restaurant_town,
+    d.category,
+    d.tags,
+    fr.cuisine,
+    d.price,
+    d.photo_url,
+    COALESCE(vs.total_child_votes,
+      SUM(CASE WHEN v.source = 'user' THEN 1.0 WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END)
+    )::BIGINT AS total_votes,
+    COALESCE(ROUND(
+      (SUM(CASE WHEN v.source = 'user' THEN v.rating_10
+                WHEN v.source = 'ai_estimated' THEN v.rating_10 * 0.5
+                ELSE 0 END) /
+       NULLIF(SUM(CASE WHEN v.source = 'user' THEN 1.0
+                       WHEN v.source = 'ai_estimated' THEN 0.5
+                       ELSE 0 END), 0)
+      )::NUMERIC, 1), 0) AS avg_rating,
+    fr.distance AS distance_miles,
+    (vs.child_count IS NOT NULL AND vs.child_count > 0) AS has_variants,
+    COALESCE(vs.child_count, 0)::INT AS variant_count,
+    bv.best_name AS best_variant_name,
+    bv.best_rating AS best_variant_rating,
+    d.value_score,
+    d.value_percentile,
+    dish_search_score(
+      COALESCE(ROUND(
+        (SUM(CASE WHEN v.source = 'user' THEN v.rating_10
+                  WHEN v.source = 'ai_estimated' THEN v.rating_10 * 0.5
+                  ELSE 0 END) /
+         NULLIF(SUM(CASE WHEN v.source = 'user' THEN 1.0
+                         WHEN v.source = 'ai_estimated' THEN 0.5
+                         ELSE 0 END), 0)
+        )::NUMERIC, 1), 0),
+      COALESCE(vs.total_child_votes,
+        SUM(CASE WHEN v.source = 'user' THEN 1.0 WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END))::NUMERIC,
+      fr.distance,
+      COALESCE(rvc.recent_votes, 0),
+      (SELECT global_mean FROM global_stats)
+    ) AS search_score,
+    bp.photo_url AS featured_photo_url,
+    fr.lat AS restaurant_lat,
+    fr.lng AS restaurant_lng,
+    fr.address AS restaurant_address,
+    fr.phone AS restaurant_phone,
+    fr.website_url AS restaurant_website_url,
+    fr.toast_slug,
+    fr.order_url
+  FROM dishes d
+  INNER JOIN filtered_restaurants fr ON d.restaurant_id = fr.id
+  LEFT JOIN votes v ON d.id = v.dish_id
+  LEFT JOIN variant_stats vs ON vs.parent_dish_id = d.id
+  LEFT JOIN best_variants bv ON bv.parent_dish_id = d.id
+  LEFT JOIN recent_vote_counts rvc ON rvc.dish_id = d.id
+  LEFT JOIN best_photos bp ON bp.dish_id = d.id
+  WHERE (filter_category IS NULL OR d.category = filter_category)
+    AND d.parent_dish_id IS NULL
+  GROUP BY d.id, d.name, fr.id, fr.name, fr.town, d.category, d.tags, fr.cuisine,
+           d.price, d.photo_url, fr.distance, fr.lat, fr.lng,
+           fr.address, fr.phone, fr.website_url, fr.toast_slug, fr.order_url,
+           vs.total_child_votes, vs.child_count,
+           bv.best_name, bv.best_rating,
+           d.value_score, d.value_percentile,
+           rvc.recent_votes,
+           bp.photo_url
+  ORDER BY search_score DESC NULLS LAST, total_votes DESC;
+END;
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public;
+
+COMMIT;

--- a/supabase/migrations/2026-04-16-audit-fixes.sql
+++ b/supabase/migrations/2026-04-16-audit-fixes.sql
@@ -1,0 +1,350 @@
+-- Audit 2026-04-16 — Supabase best-practices fixes
+-- Source: AUDIT-SUPABASE-2026-04-16.md
+--
+-- Fixes bundled in this migration:
+--   CRITICAL
+--     #1  N+1 in get_ranked_dishes best_photos CTE (is_blocked_pair per row)
+--     #2  N+1 in get_open_reports (correlated subquery in SELECT)
+--     #3  Missing composite index idx_votes_dish_source_rating
+--     #5  N+1 in follows_select_not_blocked RLS policy
+--   HIGH
+--     #7  Missing idx_votes_user_dish_created (friends' votes hot path)
+--     #9  Missing idx_votes_source_created (weighted vote filters)
+--     #10 Missing reports_target_status_idx composite
+--
+-- Run this in Supabase SQL Editor. Safe to run more than once — all statements
+-- use CREATE INDEX IF NOT EXISTS, DROP POLICY IF EXISTS, and CREATE OR REPLACE.
+--
+-- CREATE INDEX CONCURRENTLY cannot run inside a transaction block; Supabase's
+-- SQL Editor wraps statements in one, so we use CREATE INDEX (blocking) here.
+-- All indexes are small compared to the votes table volume; build time should
+-- be seconds. If you need non-blocking builds, paste each CREATE INDEX block
+-- into the editor on its own (Supabase will run it outside a transaction).
+
+BEGIN;
+
+-- ============================================================================
+-- #3, #7, #9: new composite indexes on votes
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_votes_dish_source_rating
+  ON votes(dish_id, source, rating_10)
+  WHERE rating_10 IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_votes_user_dish_created
+  ON votes(user_id, dish_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_votes_source_created
+  ON votes(source, created_at DESC);
+
+
+-- ============================================================================
+-- #10: composite on reports for admin filtering by (user, status)
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS reports_target_status_idx
+  ON reports(reported_user_id, status, created_at DESC)
+  WHERE reported_user_id IS NOT NULL;
+
+
+-- ============================================================================
+-- #5: follows_select_not_blocked — inline NOT EXISTS instead of 2x is_blocked_pair
+-- ============================================================================
+
+DROP POLICY IF EXISTS "follows_select_public" ON follows;
+DROP POLICY IF EXISTS "follows_select_not_blocked" ON follows;
+CREATE POLICY "follows_select_not_blocked" ON follows
+  FOR SELECT USING (
+    (select auth.uid()) IS NULL
+    OR NOT EXISTS (
+      SELECT 1 FROM user_blocks ub
+      WHERE (ub.blocker_id = (select auth.uid())
+             AND (ub.blocked_id = follower_id OR ub.blocked_id = followed_id))
+         OR (ub.blocked_id = (select auth.uid())
+             AND (ub.blocker_id = follower_id OR ub.blocker_id = followed_id))
+    )
+  );
+
+
+-- ============================================================================
+-- #2: get_open_reports — pre-aggregate counts in a CTE
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION get_open_reports(
+  p_limit INT DEFAULT 50,
+  p_offset INT DEFAULT 0
+)
+RETURNS TABLE (
+  report_id UUID, reporter_id UUID, reporter_name TEXT,
+  reported_type TEXT, reported_id UUID, reported_user_id UUID, reported_user_name TEXT,
+  reason TEXT, details TEXT, target_snapshot JSONB, created_at TIMESTAMPTZ,
+  target_user_open_report_count BIGINT
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  IF NOT is_admin() THEN RAISE EXCEPTION 'Admin access required'; END IF;
+
+  p_limit := LEAST(GREATEST(p_limit, 1), 200);
+  p_offset := GREATEST(p_offset, 0);
+
+  RETURN QUERY
+  WITH open_counts AS (
+    SELECT reported_user_id, COUNT(*)::BIGINT AS open_count
+    FROM reports
+    WHERE status = 'open' AND reported_user_id IS NOT NULL
+    GROUP BY reported_user_id
+  )
+  SELECT r.id, r.reporter_id, rp.display_name,
+    r.reported_type, r.reported_id, r.reported_user_id, up.display_name,
+    r.reason, r.details, r.target_snapshot, r.created_at,
+    COALESCE(oc.open_count, 0)
+  FROM reports r
+  LEFT JOIN profiles rp ON rp.id = r.reporter_id
+  LEFT JOIN profiles up ON up.id = r.reported_user_id
+  LEFT JOIN open_counts oc ON oc.reported_user_id = r.reported_user_id
+  WHERE r.status = 'open'
+  ORDER BY COALESCE(oc.open_count, 0) DESC, r.created_at DESC
+  LIMIT p_limit OFFSET p_offset;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION get_open_reports(INT, INT) FROM public, anon;
+GRANT EXECUTE ON FUNCTION get_open_reports(INT, INT) TO authenticated;
+
+
+-- ============================================================================
+-- #1: get_ranked_dishes — best_photos CTE replaces is_blocked_pair() call
+--     with inline NOT EXISTS so Postgres hash-joins user_blocks once.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION get_ranked_dishes(
+  user_lat DECIMAL,
+  user_lng DECIMAL,
+  radius_miles INT DEFAULT 50,
+  filter_category TEXT DEFAULT NULL,
+  filter_town TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+  dish_id UUID,
+  dish_name TEXT,
+  restaurant_id UUID,
+  restaurant_name TEXT,
+  restaurant_town TEXT,
+  category TEXT,
+  tags TEXT[],
+  cuisine TEXT,
+  price DECIMAL,
+  photo_url TEXT,
+  total_votes BIGINT,
+  avg_rating DECIMAL,
+  distance_miles DECIMAL,
+  has_variants BOOLEAN,
+  variant_count INT,
+  best_variant_name TEXT,
+  best_variant_rating DECIMAL,
+  value_score DECIMAL,
+  value_percentile DECIMAL,
+  search_score DECIMAL,
+  featured_photo_url TEXT,
+  restaurant_lat DECIMAL,
+  restaurant_lng DECIMAL,
+  restaurant_address TEXT,
+  restaurant_phone TEXT,
+  restaurant_website_url TEXT,
+  toast_slug TEXT,
+  order_url TEXT
+) AS $$
+DECLARE
+  lat_delta DECIMAL := radius_miles / 69.0;
+  lng_delta DECIMAL := radius_miles / (69.0 * COS(RADIANS(user_lat)));
+BEGIN
+  RETURN QUERY
+  WITH global_stats AS (
+    SELECT COALESCE(AVG(dishes.avg_rating), 7.0) AS global_mean
+    FROM dishes
+    WHERE dishes.total_votes > 0 AND dishes.avg_rating IS NOT NULL
+  ),
+  nearby_restaurants AS (
+    SELECT r.id, r.name, r.town, r.lat, r.lng, r.cuisine,
+           r.address, r.phone, r.website_url, r.toast_slug, r.order_url
+    FROM restaurants r
+    WHERE r.is_open = true
+      AND r.lat BETWEEN (user_lat - lat_delta) AND (user_lat + lat_delta)
+      AND r.lng BETWEEN (user_lng - lng_delta) AND (user_lng + lng_delta)
+      AND (filter_town IS NULL OR r.town = filter_town)
+  ),
+  restaurants_with_distance AS (
+    SELECT
+      nr.id, nr.name, nr.town, nr.lat, nr.lng, nr.cuisine,
+      nr.address, nr.phone, nr.website_url, nr.toast_slug, nr.order_url,
+      ROUND((
+        3959 * ACOS(
+          LEAST(1.0, GREATEST(-1.0,
+            COS(RADIANS(user_lat)) * COS(RADIANS(nr.lat)) *
+            COS(RADIANS(nr.lng) - RADIANS(user_lng)) +
+            SIN(RADIANS(user_lat)) * SIN(RADIANS(nr.lat))
+          ))
+        )
+      )::NUMERIC, 2) AS distance
+    FROM nearby_restaurants nr
+  ),
+  filtered_restaurants AS (
+    SELECT * FROM restaurants_with_distance WHERE distance <= radius_miles
+  ),
+  variant_stats AS (
+    SELECT
+      d.parent_dish_id,
+      COUNT(DISTINCT d.id)::INT AS child_count,
+      SUM(COALESCE(ds.vote_count, 0))::NUMERIC AS total_child_votes
+    FROM dishes d
+    LEFT JOIN (
+      SELECT v.dish_id,
+        SUM(CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END)::NUMERIC AS vote_count
+      FROM votes v GROUP BY v.dish_id
+    ) ds ON ds.dish_id = d.id
+    WHERE d.parent_dish_id IS NOT NULL
+    GROUP BY d.parent_dish_id
+  ),
+  best_variants AS (
+    SELECT DISTINCT ON (d.parent_dish_id)
+      d.parent_dish_id,
+      d.name AS best_name,
+      ROUND(AVG(v.rating_10)::NUMERIC, 1) AS best_rating
+    FROM dishes d
+    LEFT JOIN votes v ON v.dish_id = d.id
+    WHERE d.parent_dish_id IS NOT NULL
+    GROUP BY d.parent_dish_id, d.id, d.name
+    HAVING COUNT(v.id) >= 1
+    ORDER BY d.parent_dish_id, AVG(v.rating_10) DESC NULLS LAST, COUNT(v.id) DESC
+  ),
+  recent_vote_counts AS (
+    SELECT votes.dish_id, COUNT(*)::INT AS recent_votes
+    FROM votes
+    WHERE votes.created_at > NOW() - INTERVAL '14 days'
+    GROUP BY votes.dish_id
+  ),
+  best_photos AS (
+    -- H3: exclude photos authored by users the viewer has blocked.
+    -- Inline NOT EXISTS so Postgres hash-joins user_blocks once instead of
+    -- invoking is_blocked_pair() per dish_photo row.
+    SELECT DISTINCT ON (dp.dish_id)
+      dp.dish_id,
+      dp.photo_url
+    FROM dish_photos dp
+    INNER JOIN dishes d2 ON dp.dish_id = d2.id
+    INNER JOIN filtered_restaurants fr2 ON d2.restaurant_id = fr2.id
+    WHERE dp.status IN ('featured', 'community')
+      AND d2.parent_dish_id IS NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM user_blocks ub
+        WHERE (ub.blocker_id = (select auth.uid()) AND ub.blocked_id = dp.user_id)
+           OR (ub.blocker_id = dp.user_id AND ub.blocked_id = (select auth.uid()))
+      )
+    ORDER BY dp.dish_id,
+      CASE dp.source_type WHEN 'restaurant' THEN 0 ELSE 1 END,
+      CASE dp.status WHEN 'featured' THEN 0 ELSE 1 END,
+      dp.quality_score DESC NULLS LAST,
+      dp.created_at DESC
+  )
+  SELECT
+    d.id AS dish_id,
+    d.name AS dish_name,
+    fr.id AS restaurant_id,
+    fr.name AS restaurant_name,
+    fr.town AS restaurant_town,
+    d.category,
+    d.tags,
+    fr.cuisine,
+    d.price,
+    d.photo_url,
+    COALESCE(vs.total_child_votes,
+      SUM(CASE WHEN v.source = 'user' THEN 1.0 WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END)
+    )::BIGINT AS total_votes,
+    COALESCE(ROUND(
+      (SUM(CASE WHEN v.source = 'user' THEN v.rating_10
+                WHEN v.source = 'ai_estimated' THEN v.rating_10 * 0.5
+                ELSE 0 END) /
+       NULLIF(SUM(CASE WHEN v.source = 'user' THEN 1.0
+                       WHEN v.source = 'ai_estimated' THEN 0.5
+                       ELSE 0 END), 0)
+      )::NUMERIC, 1), 0) AS avg_rating,
+    fr.distance AS distance_miles,
+    (vs.child_count IS NOT NULL AND vs.child_count > 0) AS has_variants,
+    COALESCE(vs.child_count, 0)::INT AS variant_count,
+    bv.best_name AS best_variant_name,
+    bv.best_rating AS best_variant_rating,
+    d.value_score,
+    d.value_percentile,
+    dish_search_score(
+      COALESCE(ROUND(
+        (SUM(CASE WHEN v.source = 'user' THEN v.rating_10
+                  WHEN v.source = 'ai_estimated' THEN v.rating_10 * 0.5
+                  ELSE 0 END) /
+         NULLIF(SUM(CASE WHEN v.source = 'user' THEN 1.0
+                         WHEN v.source = 'ai_estimated' THEN 0.5
+                         ELSE 0 END), 0)
+        )::NUMERIC, 1), 0),
+      COALESCE(vs.total_child_votes,
+        SUM(CASE WHEN v.source = 'user' THEN 1.0 WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END))::NUMERIC,
+      fr.distance,
+      COALESCE(rvc.recent_votes, 0),
+      (SELECT global_mean FROM global_stats)
+    ) AS search_score,
+    bp.photo_url AS featured_photo_url,
+    fr.lat AS restaurant_lat,
+    fr.lng AS restaurant_lng,
+    fr.address AS restaurant_address,
+    fr.phone AS restaurant_phone,
+    fr.website_url AS restaurant_website_url,
+    fr.toast_slug,
+    fr.order_url
+  FROM dishes d
+  INNER JOIN filtered_restaurants fr ON d.restaurant_id = fr.id
+  LEFT JOIN votes v ON d.id = v.dish_id
+  LEFT JOIN variant_stats vs ON vs.parent_dish_id = d.id
+  LEFT JOIN best_variants bv ON bv.parent_dish_id = d.id
+  LEFT JOIN recent_vote_counts rvc ON rvc.dish_id = d.id
+  LEFT JOIN best_photos bp ON bp.dish_id = d.id
+  WHERE (filter_category IS NULL OR d.category = filter_category)
+    AND d.parent_dish_id IS NULL
+  GROUP BY d.id, d.name, fr.id, fr.name, fr.town, d.category, d.tags, fr.cuisine,
+           d.price, d.photo_url, fr.distance, fr.lat, fr.lng,
+           fr.address, fr.phone, fr.website_url, fr.toast_slug, fr.order_url,
+           vs.total_child_votes, vs.child_count,
+           bv.best_name, bv.best_rating,
+           d.value_score, d.value_percentile,
+           rvc.recent_votes,
+           bp.photo_url
+  ORDER BY search_score DESC NULLS LAST, total_votes DESC;
+END;
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public;
+
+COMMIT;
+
+
+-- ============================================================================
+-- Post-deploy verification queries (run interactively, not in the migration)
+-- ============================================================================
+--
+-- Confirm the new indexes exist and have a non-zero idx_scan after a few ranked
+-- queries:
+--
+--   SELECT indexrelname, idx_scan, idx_tup_read
+--   FROM pg_stat_user_indexes
+--   WHERE indexrelname IN (
+--     'idx_votes_dish_source_rating',
+--     'idx_votes_user_dish_created',
+--     'idx_votes_source_created',
+--     'reports_target_status_idx'
+--   );
+--
+-- Confirm get_ranked_dishes now hits the new index. Expect:
+--   Index Scan using idx_votes_dish_source_rating on votes
+--
+--   EXPLAIN (ANALYZE, BUFFERS)
+--   SELECT * FROM get_ranked_dishes(NULL, NULL, NULL, NULL, 'popular', 50);
+--
+-- Confirm get_open_reports no longer shows SubPlan in the plan:
+--
+--   EXPLAIN (ANALYZE, BUFFERS)
+--   SELECT * FROM get_open_reports(50, 0);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -32,7 +32,7 @@ CREATE TABLE IF NOT EXISTS restaurants (
   cuisine TEXT,
   town TEXT,
   region TEXT NOT NULL DEFAULT 'mv',
-  created_by UUID REFERENCES auth.users(id),
+  created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
   google_place_id TEXT,
   website_url TEXT,
   facebook_url TEXT,
@@ -58,11 +58,11 @@ CREATE TABLE IF NOT EXISTS dishes (
   photo_url TEXT,
   parent_dish_id UUID REFERENCES dishes(id) ON DELETE SET NULL,
   display_order INT DEFAULT 0,
-  created_by UUID REFERENCES auth.users(id),
+  created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
   tags TEXT[] DEFAULT '{}',
   cuisine TEXT,
   avg_rating DECIMAL(3, 1),
-  total_votes INT DEFAULT 0,
+  total_votes BIGINT DEFAULT 0,
   weighted_vote_count NUMERIC DEFAULT 0,
   consensus_rating NUMERIC(3, 1),
   consensus_ready BOOLEAN DEFAULT FALSE,
@@ -125,7 +125,7 @@ CREATE TABLE IF NOT EXISTS admins (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE UNIQUE NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-  created_by UUID REFERENCES auth.users(id)
+  created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL
 );
 
 -- 1g. dish_photos
@@ -237,7 +237,7 @@ CREATE TABLE IF NOT EXISTS specials (
   is_promoted BOOLEAN DEFAULT false,
   source TEXT DEFAULT 'manual' CHECK (source IN ('manual', 'auto_scrape')),
   expires_at TIMESTAMPTZ,
-  created_by UUID REFERENCES auth.users(id)
+  created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL
 );
 
 -- 1p. restaurant_managers
@@ -248,7 +248,7 @@ CREATE TABLE IF NOT EXISTS restaurant_managers (
   role TEXT NOT NULL DEFAULT 'manager',
   invited_at TIMESTAMPTZ DEFAULT NOW(),
   accepted_at TIMESTAMPTZ,
-  created_by UUID REFERENCES auth.users(id),
+  created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
   UNIQUE(user_id, restaurant_id)
 );
 
@@ -257,10 +257,10 @@ CREATE TABLE IF NOT EXISTS restaurant_invites (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   token TEXT UNIQUE NOT NULL DEFAULT encode(gen_random_bytes(24), 'hex'),
   restaurant_id UUID NOT NULL REFERENCES restaurants(id) ON DELETE CASCADE,
-  created_by UUID NOT NULL REFERENCES auth.users(id),
+  created_by UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   created_at TIMESTAMPTZ DEFAULT NOW(),
   expires_at TIMESTAMPTZ DEFAULT NOW() + INTERVAL '7 days',
-  used_by UUID REFERENCES auth.users(id),
+  used_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
   used_at TIMESTAMPTZ
 );
 
@@ -268,9 +268,9 @@ CREATE TABLE IF NOT EXISTS restaurant_invites (
 CREATE TABLE IF NOT EXISTS curator_invites (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   token TEXT NOT NULL UNIQUE DEFAULT encode(gen_random_bytes(16), 'hex'),
-  created_by UUID REFERENCES auth.users(id),
+  created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
   expires_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() + INTERVAL '30 days'),
-  used_by UUID REFERENCES auth.users(id),
+  used_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
   used_at TIMESTAMPTZ,
   created_at TIMESTAMPTZ DEFAULT NOW()
 );
@@ -319,7 +319,7 @@ CREATE TABLE IF NOT EXISTS events (
   is_promoted BOOLEAN DEFAULT false,
   source TEXT DEFAULT 'manual' CHECK (source IN ('manual', 'auto_scrape')),
   created_at TIMESTAMPTZ DEFAULT NOW(),
-  created_by UUID REFERENCES auth.users(id)
+  created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL
 );
 
 -- 1v. category_median_prices (view)
@@ -382,6 +382,12 @@ CREATE INDEX IF NOT EXISTS idx_votes_review_text ON votes(dish_id) WHERE review_
 CREATE INDEX IF NOT EXISTS idx_votes_unscored ON votes(dish_id) WHERE scored_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_votes_user_dish ON votes(user_id, dish_id);
 CREATE INDEX IF NOT EXISTS idx_votes_user_position ON votes(user_id, vote_position);
+-- Audit 2026-04-16: covers get_ranked_dishes weighted aggregations (dish + source + rating).
+CREATE INDEX IF NOT EXISTS idx_votes_dish_source_rating ON votes(dish_id, source, rating_10) WHERE rating_10 IS NOT NULL;
+-- Audit 2026-04-16: covers get_friends_votes_for_dish / _for_restaurant hot path.
+CREATE INDEX IF NOT EXISTS idx_votes_user_dish_created ON votes(user_id, dish_id, created_at DESC);
+-- Audit 2026-04-16: filters weighted votes by source with recency.
+CREATE INDEX IF NOT EXISTS idx_votes_source_created ON votes(source, created_at DESC);
 
 -- profiles
 CREATE UNIQUE INDEX IF NOT EXISTS profiles_display_name_unique ON profiles(LOWER(display_name)) WHERE display_name IS NOT NULL;
@@ -390,6 +396,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS profiles_display_name_unique ON profiles(LOWER
 CREATE INDEX IF NOT EXISTS idx_dish_photos_dish ON dish_photos(dish_id);
 CREATE INDEX IF NOT EXISTS idx_dish_photos_user ON dish_photos(user_id);
 CREATE INDEX IF NOT EXISTS idx_dish_photos_status ON dish_photos(dish_id, status, quality_score DESC);
+-- Audit 2026-04-16: partial index for the hot path (best_photos CTE); excludes
+-- hidden/rejected so the index is roughly half the size of the one above.
+CREATE INDEX IF NOT EXISTS idx_dish_photos_featured_community
+  ON dish_photos(dish_id, quality_score DESC)
+  WHERE status IN ('featured', 'community');
 
 -- follows
 CREATE INDEX IF NOT EXISTS idx_follows_follower ON follows(follower_id);
@@ -439,6 +450,8 @@ CREATE INDEX IF NOT EXISTS idx_rate_limits_cleanup ON rate_limits(created_at);
 CREATE INDEX IF NOT EXISTS idx_events_restaurant ON events(restaurant_id);
 CREATE INDEX IF NOT EXISTS idx_events_active_upcoming ON events(event_date, is_promoted DESC) WHERE is_active = true;
 CREATE INDEX IF NOT EXISTS idx_events_type ON events(event_type) WHERE is_active = true;
+-- Audit 2026-04-16: FK index on events.created_by.
+CREATE INDEX IF NOT EXISTS idx_events_created_by ON events(created_by);
 
 -- jitter_samples (keep only last 30 samples per user, rolling window)
 CREATE INDEX IF NOT EXISTS idx_jitter_samples_user ON jitter_samples (user_id, collected_at DESC);
@@ -840,7 +853,11 @@ BEGIN
     GROUP BY votes.dish_id
   ),
   best_photos AS (
-    -- H3: exclude photos authored by users the viewer has blocked
+    -- H3: exclude photos authored by users the viewer has blocked.
+    -- Anon short-circuit skips the user_blocks probe entirely for the
+    -- unauthenticated majority. The pair of EXISTS clauses (instead of one
+    -- with OR) lets the planner use user_blocks_blocker_id_blocked_id_key as
+    -- two index seeks rather than a bitmap OR.
     SELECT DISTINCT ON (dp.dish_id)
       dp.dish_id,
       dp.photo_url
@@ -849,7 +866,15 @@ BEGIN
     INNER JOIN filtered_restaurants fr2 ON d2.restaurant_id = fr2.id
     WHERE dp.status IN ('featured', 'community')
       AND d2.parent_dish_id IS NULL
-      AND NOT is_blocked_pair((select auth.uid()), dp.user_id)
+      AND (
+        (select auth.uid()) IS NULL
+        OR (
+          NOT EXISTS (SELECT 1 FROM user_blocks ub
+                      WHERE ub.blocker_id = (select auth.uid()) AND ub.blocked_id = dp.user_id)
+          AND NOT EXISTS (SELECT 1 FROM user_blocks ub
+                          WHERE ub.blocker_id = dp.user_id AND ub.blocked_id = (select auth.uid()))
+        )
+      )
     ORDER BY dp.dish_id,
       CASE dp.source_type WHEN 'restaurant' THEN 0 ELSE 1 END,
       CASE dp.status WHEN 'featured' THEN 0 ELSE 1 END,
@@ -2573,7 +2598,7 @@ RETURNS TABLE (
   restaurant_name TEXT,
   restaurant_id UUID,
   avg_rating NUMERIC,
-  total_votes INT,
+  total_votes BIGINT,
   category TEXT,
   note TEXT,
   restaurant_lat FLOAT,
@@ -2716,7 +2741,7 @@ RETURNS TABLE (
   restaurant_name TEXT,
   restaurant_id UUID,
   avg_rating NUMERIC,
-  total_votes INT,
+  total_votes BIGINT,
   category TEXT,
   note TEXT
 )
@@ -3890,6 +3915,12 @@ CREATE INDEX IF NOT EXISTS reports_by_target_user_idx
 CREATE INDEX IF NOT EXISTS reports_by_reporter_idx
   ON reports (reporter_id, created_at DESC);
 
+-- Audit 2026-04-16: covers admin filtering by (user, status) without scanning
+-- reports_by_target_user_idx and discarding non-matching statuses.
+CREATE INDEX IF NOT EXISTS reports_target_status_idx
+  ON reports (reported_user_id, status, created_at DESC)
+  WHERE reported_user_id IS NOT NULL;
+
 
 CREATE TABLE IF NOT EXISTS user_blocks (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -3951,9 +3982,12 @@ DROP POLICY IF EXISTS "follows_select_not_blocked" ON follows;
 CREATE POLICY "follows_select_not_blocked" ON follows
   FOR SELECT USING (
     (select auth.uid()) IS NULL
-    OR (
-      NOT is_blocked_pair((select auth.uid()), follower_id)
-      AND NOT is_blocked_pair((select auth.uid()), followed_id)
+    OR NOT EXISTS (
+      SELECT 1 FROM user_blocks ub
+      WHERE (ub.blocker_id = (select auth.uid())
+             AND (ub.blocked_id = follower_id OR ub.blocked_id = followed_id))
+         OR (ub.blocked_id = (select auth.uid())
+             AND (ub.blocker_id = follower_id OR ub.blocker_id = followed_id))
     )
   );
 
@@ -4226,9 +4260,15 @@ REVOKE EXECUTE ON FUNCTION get_my_reports() FROM public, anon;
 GRANT EXECUTE ON FUNCTION get_my_reports() TO authenticated;
 
 
+-- Audit 2026-04-16 phase 2: keyset pagination. Caller passes back the last row's
+-- (target_user_open_report_count, created_at, report_id) to get the next page.
+-- First page: omit all cursor args. No client callers existed when this ran.
+DROP FUNCTION IF EXISTS get_open_reports(INT, INT);
 CREATE OR REPLACE FUNCTION get_open_reports(
   p_limit INT DEFAULT 50,
-  p_offset INT DEFAULT 0
+  p_cursor_open_count BIGINT DEFAULT NULL,
+  p_cursor_created_at TIMESTAMPTZ DEFAULT NULL,
+  p_cursor_id UUID DEFAULT NULL
 )
 RETURNS TABLE (
   report_id UUID, reporter_id UUID, reporter_name TEXT,
@@ -4241,25 +4281,45 @@ BEGIN
   IF NOT is_admin() THEN RAISE EXCEPTION 'Admin access required'; END IF;
 
   p_limit := LEAST(GREATEST(p_limit, 1), 200);
-  p_offset := GREATEST(p_offset, 0);
+
+  -- Cursor guard: require all three parts OR none. Partial cursors would make
+  -- the tuple comparison return NULL and silently produce empty pages.
+  IF NOT (
+    (p_cursor_open_count IS NULL AND p_cursor_created_at IS NULL AND p_cursor_id IS NULL)
+    OR
+    (p_cursor_open_count IS NOT NULL AND p_cursor_created_at IS NOT NULL AND p_cursor_id IS NOT NULL)
+  ) THEN
+    RAISE EXCEPTION 'Partial cursor: pass all three of p_cursor_open_count, p_cursor_created_at, p_cursor_id (or none).';
+  END IF;
 
   RETURN QUERY
+  WITH open_counts AS (
+    SELECT reported_user_id, COUNT(*)::BIGINT AS open_count
+    FROM reports
+    WHERE status = 'open' AND reported_user_id IS NOT NULL
+    GROUP BY reported_user_id
+  )
   SELECT r.id, r.reporter_id, rp.display_name,
     r.reported_type, r.reported_id, r.reported_user_id, up.display_name,
     r.reason, r.details, r.target_snapshot, r.created_at,
-    COALESCE((SELECT COUNT(*) FROM reports r2
-      WHERE r2.reported_user_id = r.reported_user_id AND r2.status = 'open'), 0)
+    COALESCE(oc.open_count, 0)
   FROM reports r
   LEFT JOIN profiles rp ON rp.id = r.reporter_id
   LEFT JOIN profiles up ON up.id = r.reported_user_id
+  LEFT JOIN open_counts oc ON oc.reported_user_id = r.reported_user_id
   WHERE r.status = 'open'
-  ORDER BY target_user_open_report_count DESC, r.created_at DESC
-  LIMIT p_limit OFFSET p_offset;
+    AND (
+      p_cursor_open_count IS NULL
+      OR (COALESCE(oc.open_count, 0), r.created_at, r.id)
+         < (p_cursor_open_count, p_cursor_created_at, p_cursor_id)
+    )
+  ORDER BY COALESCE(oc.open_count, 0) DESC, r.created_at DESC, r.id DESC
+  LIMIT p_limit;
 END;
 $$;
 
-REVOKE EXECUTE ON FUNCTION get_open_reports(INT, INT) FROM public, anon;
-GRANT EXECUTE ON FUNCTION get_open_reports(INT, INT) TO authenticated;
+REVOKE EXECUTE ON FUNCTION get_open_reports(INT, BIGINT, TIMESTAMPTZ, UUID) FROM public, anon;
+GRANT EXECUTE ON FUNCTION get_open_reports(INT, BIGINT, TIMESTAMPTZ, UUID) TO authenticated;
 
 
 -- 14h. Modified existing RPCs — full final definitions in the migration file.
@@ -4506,7 +4566,7 @@ RETURNS TABLE (
   list_id UUID, title TEXT, description TEXT, user_id UUID,
   display_name TEXT, "position" INT, dish_id UUID, dish_name TEXT,
   restaurant_name TEXT, restaurant_id UUID, avg_rating NUMERIC,
-  total_votes INT, category TEXT, note TEXT,
+  total_votes BIGINT, category TEXT, note TEXT,
   restaurant_lat FLOAT, restaurant_lng FLOAT
 )
 LANGUAGE SQL STABLE AS $$


### PR DESCRIPTION
## Summary

Full Supabase Postgres audit against [best-practices rules](https://github.com/supabase/supabase/tree/master/apps/docs). 14 of 20 audit items shipped across 5 migrations. All CRITICAL and launch-blocking work complete.

## What shipped

- **CRITICAL (5/5):** `is_blocked_pair` N+1 inlined in `get_ranked_dishes.best_photos` CTE and `follows_select_not_blocked` RLS policy. `get_open_reports` correlated subquery replaced with CTE. Keyset pagination for admin reports. New composite index `idx_votes_dish_source_rating`.
- **HIGH (4/5):** `idx_votes_user_dish_created`, `idx_votes_source_created`, `reports_target_status_idx`. (#6 report-count materialization deferred — no traffic data yet.)
- **MEDIUM (4/6):** partial index `idx_dish_photos_featured_community`, `dishes.total_votes INT → BIGINT` (with required view + trigger drop/recreate), `idx_events_created_by`, return-type consistency in `get_my_local_list` / `get_local_list_by_user`.
- **LOW (1/4):** FK `ON DELETE` strategies on 10 `created_by`/`used_by` columns — this was flagged LOW but turned out to be a **live bug** blocking the Delete Account flow shipped last week for any user who had created content.
- **Phase 5 follow-on:** anon short-circuit + split EXISTS on `user_blocks` probe in `best_photos` CTE (avoids index probe for the anonymous-traffic majority).

## What's deliberately skipped

Full rationale in `AUDIT-SUPABASE-2026-04-16.md`. Short version:

- `#8` DECIMAL/NUMERIC standardization — DECIMAL is an alias for NUMERIC in Postgres (purely cosmetic)
- `#14`, `#15` — premature optimization without `pg_stat_statements` evidence
- `#16` trigram index on `display_name` — speculative
- `#17`–`#19` — cosmetic

## Verification

- Build: ✅ exit 0 (`npm run build`, 22.25s)
- Unit tests: ✅ 325/325 pass (`npm run test`)
- Migrations 1–4 deployed and verified in SQL Editor (phase 5 is ready to deploy when convenient — pure optimization, no behavior change)
- EXPLAIN ANALYZE on `best_photos` N+1 fix: 0.163ms
- `idx_votes_user_dish_created` confirmed in use (18 `idx_scan`s during testing)

## Test plan

- [x] `npm run build` passes
- [x] `npm run test` passes
- [x] Migrations 1–4 ran cleanly against Denis's Supabase project
- [ ] Smoke test Delete Account flow end-to-end for a user who has created content (the FK bug this PR fixes)
- [ ] Deploy phase 5 migration when convenient (optional optimization)
- [ ] After 1–2 weeks of traffic, run `pg_stat_user_indexes` to confirm new indexes are hit and `pg_stat_statements` to revisit deferred items #6/#14/#15

🤖 Generated with [Claude Code](https://claude.com/claude-code)