### PR TITLE
feat(manager): vote-gated delete + column-lock triggers

### DIFF
--- a/src/api/restaurantManagerApi.js
+++ b/src/api/restaurantManagerApi.js
@@ -1,7 +1,7 @@
 import { supabase } from '../lib/supabase'
 import { checkDishCreateRateLimit } from '../lib/rateLimiter'
 import { validateUserContent } from '../lib/reviewBlocklist'
-import { createClassifiedError } from '../utils/errorHandler'
+import { createClassifiedError, ErrorTypes } from '../utils/errorHandler'
 import { logger } from '../utils/logger'
 
 async function checkDishCreateRateLimitOnce() {
@@ -264,7 +264,7 @@ export const restaurantManagerApi = {
     try {
       const { data, error } = await supabase
         .from('dishes')
-        .select('id, name, category, price, photo_url')
+        .select('id, name, category, price, photo_url, total_votes')
         .eq('restaurant_id', restaurantId)
         .order('category')
         .order('name')
@@ -667,14 +667,24 @@ export const restaurantManagerApi = {
    */
   async deleteDish(dishId) {
     try {
-      const { error } = await supabase
+      // { count: 'exact' } makes the server return affected row count so we
+      // can distinguish "deleted" from "RLS silently blocked" (0 rows).
+      const { error, count } = await supabase
         .from('dishes')
-        .delete()
+        .delete({ count: 'exact' })
         .eq('id', dishId)
 
       if (error) {
         logger.error('Error deleting dish:', error)
         throw createClassifiedError(error)
+      }
+      if (count === 0) {
+        // RLS rejected: manager-scoped delete requires total_votes = 0
+        const err = new Error(
+          "This dish has community ratings and can't be removed. Contact support if it needs to be taken down."
+        )
+        err.type = ErrorTypes.UNAUTHORIZED
+        throw err
       }
     } catch (error) {
       logger.error('Error in deleteDish:', error)

--- a/src/components/restaurant-admin/DishesManager.jsx
+++ b/src/components/restaurant-admin/DishesManager.jsx
@@ -215,7 +215,18 @@ export function DishesManager({ restaurantId, dishes, onAdd, onUpdate, onDelete,
                     >
                       Edit
                     </button>
-                    {confirmDeleteId === dish.id ? (
+                    {dish.total_votes > 0 ? (
+                      <span
+                        title="Locked — this dish has ratings from the community. Contact support to remove."
+                        className="text-xs font-medium px-2 py-1 rounded inline-flex items-center gap-1"
+                        style={{ color: 'var(--color-text-tertiary)' }}
+                      >
+                        <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                        </svg>
+                        Locked
+                      </span>
+                    ) : confirmDeleteId === dish.id ? (
                       <div className="flex items-center gap-1">
                         <button
                           onClick={() => handleDelete(dish.id)}

--- a/supabase/migrations/2026-04-16-manager-auth-hardening.sql
+++ b/supabase/migrations/2026-04-16-manager-auth-hardening.sql
@@ -1,0 +1,267 @@
+-- =============================================================
+-- Manager Auth Hardening (2026-04-16)
+-- =============================================================
+-- Codex audit surfaced three holes in the restaurant manager portal:
+--
+--   1. Managers could not actually UPDATE their own restaurants or DELETE
+--      their own dishes — the UI promised these actions but RLS was admin-only.
+--      Result: silent-failing buttons in /manage.
+--
+--   2. RLS allowed row-scoped updates on dishes/specials/events, but had
+--      no column-level protection. A manager could open DevTools and write
+--      directly to computed fields like avg_rating, consensus_rating,
+--      weighted_vote_count, or to promotion flags like is_promoted.
+--
+--   3. RLS UPDATE policies on dishes/specials/events had USING but no
+--      WITH CHECK — making field tampering less visible in policy intent.
+--
+-- This migration closes all three. Pattern mirrors the existing
+-- profiles_update_own WITH CHECK + (separate) field-lock conventions.
+--
+-- Key technique: BEFORE UPDATE trigger that checks `current_user`. When
+-- called from a SECURITY DEFINER function (vote aggregations, RPCs),
+-- current_user switches to the function owner (postgres/supabase_admin)
+-- so system writes pass through. When called directly by an authenticated
+-- JWT (manager or plain user), current_user stays 'authenticated' and the
+-- trigger freezes protected fields to their OLD values.
+-- =============================================================
+
+-- -------------------------------------------------------------
+-- 1. dishes — freeze computed + identity fields on INSERT and UPDATE
+-- -------------------------------------------------------------
+CREATE OR REPLACE FUNCTION protect_dish_fields()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- System contexts bypass (service role, dashboard, SECURITY DEFINER triggers)
+  IF current_user IN ('postgres', 'service_role', 'supabase_admin') THEN
+    RETURN NEW;
+  END IF;
+
+  -- Admins logged in via JWT can modify anything
+  IF is_admin() THEN
+    RETURN NEW;
+  END IF;
+
+  -- Everyone else (managers + regular users): freeze protected fields
+  IF TG_OP = 'INSERT' THEN
+    -- Prevent audit/identity forgery on insert
+    NEW.id := uuid_generate_v4();
+    NEW.created_at := NOW();
+    -- Force computed fields to their initial defaults, regardless of input
+    NEW.avg_rating := NULL;
+    NEW.total_votes := 0;
+    NEW.weighted_vote_count := 0;
+    NEW.consensus_rating := NULL;
+    NEW.consensus_ready := FALSE;
+    NEW.consensus_votes := 0;
+    NEW.consensus_calculated_at := NULL;
+    NEW.value_score := NULL;
+    NEW.value_percentile := NULL;
+    NEW.category_median_price := NULL;
+  ELSIF TG_OP = 'UPDATE' THEN
+    NEW.id := OLD.id;
+    NEW.restaurant_id := OLD.restaurant_id;
+    NEW.created_by := OLD.created_by;
+    NEW.created_at := OLD.created_at;
+    NEW.avg_rating := OLD.avg_rating;
+    NEW.total_votes := OLD.total_votes;
+    NEW.weighted_vote_count := OLD.weighted_vote_count;
+    NEW.consensus_rating := OLD.consensus_rating;
+    NEW.consensus_ready := OLD.consensus_ready;
+    NEW.consensus_votes := OLD.consensus_votes;
+    NEW.consensus_calculated_at := OLD.consensus_calculated_at;
+    NEW.value_score := OLD.value_score;
+    NEW.value_percentile := OLD.value_percentile;
+    NEW.category_median_price := OLD.category_median_price;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- NOT SECURITY DEFINER: we want current_user to reflect the actual caller.
+
+-- Name starts with 'dishes_' (d) so it alphabetizes before
+-- 'trigger_compute_value_score' (t) and fires FIRST. That way when a
+-- manager updates price, we freeze any attempted avg_rating/value_score
+-- tampering, THEN compute_value_score legitimately recomputes value_score.
+DROP TRIGGER IF EXISTS dishes_protect_fields ON dishes;
+CREATE TRIGGER dishes_protect_fields
+BEFORE INSERT OR UPDATE ON dishes
+FOR EACH ROW
+EXECUTE FUNCTION protect_dish_fields();
+
+-- Allow managers to delete dishes at their restaurant
+DROP POLICY IF EXISTS "Admins can delete dishes" ON dishes;
+DROP POLICY IF EXISTS "Admin or manager delete dishes" ON dishes;
+CREATE POLICY "Admin or manager delete dishes" ON dishes FOR DELETE
+  USING (is_admin() OR is_restaurant_manager(restaurant_id));
+
+-- Add WITH CHECK to the existing UPDATE policy so new row must also
+-- be at a restaurant the user manages (prevents moving dishes across
+-- restaurants, even though the trigger also freezes restaurant_id).
+DROP POLICY IF EXISTS "Admin or manager update dishes" ON dishes;
+CREATE POLICY "Admin or manager update dishes" ON dishes FOR UPDATE
+  USING (is_admin() OR is_restaurant_manager(restaurant_id))
+  WITH CHECK (is_admin() OR is_restaurant_manager(restaurant_id));
+
+-- -------------------------------------------------------------
+-- 2. specials — freeze is_promoted, source, identity fields on INSERT and UPDATE
+-- -------------------------------------------------------------
+CREATE OR REPLACE FUNCTION protect_special_fields()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF current_user IN ('postgres', 'service_role', 'supabase_admin') THEN
+    RETURN NEW;
+  END IF;
+
+  IF is_admin() THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'INSERT' THEN
+    -- Pin audit/identity fields (specials has no INSERT policy constraining these)
+    NEW.id := gen_random_uuid();
+    NEW.created_at := NOW();
+    NEW.created_by := (SELECT auth.uid());
+    -- Can't self-promote or forge provenance at insert time
+    NEW.is_promoted := FALSE;
+    NEW.source := 'manual';
+  ELSIF TG_OP = 'UPDATE' THEN
+    NEW.id := OLD.id;
+    NEW.restaurant_id := OLD.restaurant_id;
+    NEW.created_by := OLD.created_by;
+    NEW.created_at := OLD.created_at;
+    NEW.is_promoted := OLD.is_promoted;
+    NEW.source := OLD.source;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS specials_protect_fields ON specials;
+CREATE TRIGGER specials_protect_fields
+BEFORE INSERT OR UPDATE ON specials
+FOR EACH ROW
+EXECUTE FUNCTION protect_special_fields();
+
+-- Tighten UPDATE policy with explicit WITH CHECK
+DROP POLICY IF EXISTS "Admin or manager update specials" ON specials;
+CREATE POLICY "Admin or manager update specials" ON specials FOR UPDATE
+  USING (is_admin() OR is_restaurant_manager(restaurant_id))
+  WITH CHECK (is_admin() OR is_restaurant_manager(restaurant_id));
+
+-- -------------------------------------------------------------
+-- 3. events — same pattern as specials, both INSERT and UPDATE
+-- -------------------------------------------------------------
+CREATE OR REPLACE FUNCTION protect_event_fields()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF current_user IN ('postgres', 'service_role', 'supabase_admin') THEN
+    RETURN NEW;
+  END IF;
+
+  IF is_admin() THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'INSERT' THEN
+    NEW.id := gen_random_uuid();
+    NEW.created_at := NOW();
+    NEW.created_by := (SELECT auth.uid());
+    NEW.is_promoted := FALSE;
+    NEW.source := 'manual';
+  ELSIF TG_OP = 'UPDATE' THEN
+    NEW.id := OLD.id;
+    NEW.restaurant_id := OLD.restaurant_id;
+    NEW.created_by := OLD.created_by;
+    NEW.created_at := OLD.created_at;
+    NEW.is_promoted := OLD.is_promoted;
+    NEW.source := OLD.source;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS events_protect_fields ON events;
+CREATE TRIGGER events_protect_fields
+BEFORE INSERT OR UPDATE ON events
+FOR EACH ROW
+EXECUTE FUNCTION protect_event_fields();
+
+DROP POLICY IF EXISTS "Admin or manager update events" ON events;
+CREATE POLICY "Admin or manager update events" ON events FOR UPDATE
+  USING (is_admin() OR is_restaurant_manager(restaurant_id))
+  WITH CHECK (is_admin() OR is_restaurant_manager(restaurant_id));
+
+-- -------------------------------------------------------------
+-- 4. restaurants — allow managers to UPDATE, freeze identity/geo fields
+-- -------------------------------------------------------------
+-- Managers can change: is_open, cuisine, phone, website_url, facebook_url,
+--   instagram_url, menu_url, menu_section_order, toast_slug, order_url
+-- Managers canNOT change: id, name, address, lat, lng, region, town,
+--   google_place_id, created_by, created_at, menu_last_checked,
+--   menu_content_hash (last two are menu-refresh bookkeeping — mutating
+--   them would let a manager force or skip auto-scrapes).
+CREATE OR REPLACE FUNCTION protect_restaurant_fields()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF current_user IN ('postgres', 'service_role', 'supabase_admin') THEN
+    RETURN NEW;
+  END IF;
+
+  IF is_admin() THEN
+    RETURN NEW;
+  END IF;
+
+  NEW.id := OLD.id;
+  NEW.name := OLD.name;
+  NEW.address := OLD.address;
+  NEW.lat := OLD.lat;
+  NEW.lng := OLD.lng;
+  NEW.region := OLD.region;
+  NEW.town := OLD.town;
+  NEW.google_place_id := OLD.google_place_id;
+  NEW.created_by := OLD.created_by;
+  NEW.created_at := OLD.created_at;
+  NEW.menu_last_checked := OLD.menu_last_checked;
+  NEW.menu_content_hash := OLD.menu_content_hash;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS restaurants_protect_fields ON restaurants;
+CREATE TRIGGER restaurants_protect_fields
+BEFORE UPDATE ON restaurants
+FOR EACH ROW
+EXECUTE FUNCTION protect_restaurant_fields();
+
+-- Replace admin-only UPDATE policy with admin-or-manager
+DROP POLICY IF EXISTS "Admins can update restaurants" ON restaurants;
+DROP POLICY IF EXISTS "Admin or manager update restaurants" ON restaurants;
+CREATE POLICY "Admin or manager update restaurants" ON restaurants FOR UPDATE
+  USING (is_admin() OR is_restaurant_manager(id))
+  WITH CHECK (is_admin() OR is_restaurant_manager(id));
+
+-- =============================================================
+-- Verification queries (run manually after deployment):
+-- =============================================================
+-- 1. Confirm triggers exist:
+--    SELECT tgname FROM pg_trigger WHERE tgname LIKE '%_protect_fields' ORDER BY tgname;
+--    Expect 4 rows: dishes/events/restaurants/specials _protect_fields
+--
+-- 2. Confirm policies updated:
+--    SELECT polname, polcmd FROM pg_policy
+--    WHERE polname LIKE '%delete dishes%' OR polname LIKE 'Admin or manager%'
+--    ORDER BY polname;
+--
+-- 3. Smoke test as a manager JWT:
+--    - UPDATE dishes SET price = 99.99 WHERE id = ...;              -- should succeed
+--    - UPDATE dishes SET avg_rating = 10 WHERE id = ...;             -- should no-op silently
+--    - UPDATE dishes SET restaurant_id = '<other>' WHERE id = ...;   -- should no-op (frozen)
+--    - DELETE FROM dishes WHERE id = ...;                            -- should succeed
+--    - UPDATE restaurants SET phone = '555-...' WHERE id = ...;      -- should succeed
+--    - UPDATE restaurants SET name = 'hijack' WHERE id = ...;        -- should no-op silently
+-- =============================================================

--- a/supabase/migrations/2026-04-16-manager-delete-votes-lock.sql
+++ b/supabase/migrations/2026-04-16-manager-delete-votes-lock.sql
@@ -1,0 +1,40 @@
+-- =============================================================
+-- Manager DELETE policy follow-up (2026-04-16)
+-- =============================================================
+-- Refinement of 2026-04-16-manager-auth-hardening.sql.
+--
+-- Principle:
+--   "A manager can fix and remove dishes up until the crowd has an opinion.
+--    Once a dish has any user votes, it belongs to the crowd."
+--
+-- Why:
+--   Scraper mistakes and ghost dishes (items never actually served) need a
+--   cleanup path for managers — otherwise /manage feels broken. But once a
+--   dish has even one user vote, the rating record belongs to the public.
+--   Letting managers delete voted dishes turns WGH into Yelp: a curated
+--   highlight reel where businesses hide embarrassing reviews.
+--
+-- Admin override still exists for edge cases (legal takedowns, true
+-- duplicates, etc). Managers file a request; admins act.
+-- =============================================================
+
+DROP POLICY IF EXISTS "Admin or manager delete dishes" ON dishes;
+CREATE POLICY "Admin or manager delete dishes" ON dishes FOR DELETE
+  USING (
+    is_admin()
+    OR (is_restaurant_manager(restaurant_id) AND total_votes = 0)
+  );
+
+-- =============================================================
+-- Verification:
+--
+--   -- Confirm policy shape:
+--   SELECT polname, pg_get_expr(polqual, polrelid) AS using_expr
+--   FROM pg_policy
+--   WHERE polrelid = 'dishes'::regclass
+--     AND polcmd = 'd';
+--
+--   -- Smoke test as a manager JWT:
+--   -- (dish with total_votes = 0) DELETE succeeds.
+--   -- (dish with total_votes > 0) DELETE returns 0 rows affected (RLS blocks).
+-- =============================================================

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -481,7 +481,7 @@ ALTER TABLE restaurant_managers ENABLE ROW LEVEL SECURITY;
 ALTER TABLE restaurant_invites ENABLE ROW LEVEL SECURITY;
 ALTER TABLE rate_limits ENABLE ROW LEVEL SECURITY;
 
--- restaurants: public read, admin write (+ manager policies below)
+-- restaurants: public read, admin + manager write (column-level protection via trigger)
 CREATE POLICY "Public read access" ON restaurants FOR SELECT USING (true);
 CREATE POLICY "Authenticated users can insert restaurants" ON restaurants FOR INSERT WITH CHECK (
   (SELECT auth.uid()) IS NOT NULL
@@ -489,10 +489,12 @@ CREATE POLICY "Authenticated users can insert restaurants" ON restaurants FOR IN
   AND (is_admin()
     OR (SELECT count(*) FROM restaurants WHERE created_by = (SELECT auth.uid()) AND created_at > now() - interval '1 hour') < 5)
 );
-CREATE POLICY "Admins can update restaurants" ON restaurants FOR UPDATE USING (is_admin());
+CREATE POLICY "Admin or manager update restaurants" ON restaurants FOR UPDATE
+  USING (is_admin() OR is_restaurant_manager(id))
+  WITH CHECK (is_admin() OR is_restaurant_manager(id));
 CREATE POLICY "Admins can delete restaurants" ON restaurants FOR DELETE USING (is_admin());
 
--- dishes: public read, admin + manager write
+-- dishes: public read, admin + manager write (column-level protection via trigger)
 CREATE POLICY "Public read access" ON dishes FOR SELECT USING (true);
 CREATE POLICY "Authenticated users can insert dishes" ON dishes FOR INSERT WITH CHECK (
   (SELECT auth.uid()) IS NOT NULL
@@ -500,8 +502,17 @@ CREATE POLICY "Authenticated users can insert dishes" ON dishes FOR INSERT WITH 
   AND (is_admin() OR auth.role() = 'service_role'
     OR (SELECT count(*) FROM dishes WHERE created_by = (SELECT auth.uid()) AND created_at > now() - interval '1 hour') < 20)
 );
-CREATE POLICY "Admin or manager update dishes" ON dishes FOR UPDATE USING (is_admin() OR is_restaurant_manager(restaurant_id));
-CREATE POLICY "Admins can delete dishes" ON dishes FOR DELETE USING (is_admin());
+CREATE POLICY "Admin or manager update dishes" ON dishes FOR UPDATE
+  USING (is_admin() OR is_restaurant_manager(restaurant_id))
+  WITH CHECK (is_admin() OR is_restaurant_manager(restaurant_id));
+-- Managers can only delete dishes that have never been voted on (scraper
+-- errors, ghost items). Once a dish has any user votes, the rating record
+-- belongs to the crowd. Admins can always delete (legal takedowns, duplicates).
+CREATE POLICY "Admin or manager delete dishes" ON dishes FOR DELETE
+  USING (
+    is_admin()
+    OR (is_restaurant_manager(restaurant_id) AND total_votes = 0)
+  );
 
 -- votes: restricted read, users manage own (optimized auth.uid())
 CREATE POLICY "Own users, admins, and service role can read votes" ON votes FOR SELECT USING (
@@ -568,7 +579,9 @@ CREATE POLICY "System can insert badges" ON user_badges FOR INSERT WITH CHECK (a
 -- specials: conditional read, admin + manager write
 CREATE POLICY "Read specials" ON specials FOR SELECT USING (is_active = true OR is_admin() OR is_restaurant_manager(restaurant_id));
 CREATE POLICY "Admin or manager insert specials" ON specials FOR INSERT WITH CHECK (is_admin() OR is_restaurant_manager(restaurant_id));
-CREATE POLICY "Admin or manager update specials" ON specials FOR UPDATE USING (is_admin() OR is_restaurant_manager(restaurant_id));
+CREATE POLICY "Admin or manager update specials" ON specials FOR UPDATE
+  USING (is_admin() OR is_restaurant_manager(restaurant_id))
+  WITH CHECK (is_admin() OR is_restaurant_manager(restaurant_id));
 CREATE POLICY "Admin or manager delete specials" ON specials FOR DELETE USING (is_admin() OR is_restaurant_manager(restaurant_id));
 
 -- restaurant_managers: admins + own rows
@@ -590,7 +603,9 @@ CREATE POLICY "Users can view own rate limits" ON rate_limits FOR SELECT USING (
 ALTER TABLE events ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "Read active events" ON events FOR SELECT USING (is_active = true OR is_admin() OR is_restaurant_manager(restaurant_id));
 CREATE POLICY "Admin or manager insert events" ON events FOR INSERT WITH CHECK (is_admin() OR is_restaurant_manager(restaurant_id));
-CREATE POLICY "Admin or manager update events" ON events FOR UPDATE USING (is_admin() OR is_restaurant_manager(restaurant_id));
+CREATE POLICY "Admin or manager update events" ON events FOR UPDATE
+  USING (is_admin() OR is_restaurant_manager(restaurant_id))
+  WITH CHECK (is_admin() OR is_restaurant_manager(restaurant_id));
 CREATE POLICY "Admin or manager delete events" ON events FOR DELETE USING (is_admin() OR is_restaurant_manager(restaurant_id));
 
 -- jitter_profiles + jitter_samples: users can read own profile, insert own samples, service role manages all
@@ -854,10 +869,8 @@ BEGIN
   ),
   best_photos AS (
     -- H3: exclude photos authored by users the viewer has blocked.
-    -- Anon short-circuit skips the user_blocks probe entirely for the
-    -- unauthenticated majority. The pair of EXISTS clauses (instead of one
-    -- with OR) lets the planner use user_blocks_blocker_id_blocked_id_key as
-    -- two index seeks rather than a bitmap OR.
+    -- Inline NOT EXISTS so Postgres hash-joins user_blocks once instead of
+    -- invoking is_blocked_pair() per dish_photo row.
     SELECT DISTINCT ON (dp.dish_id)
       dp.dish_id,
       dp.photo_url
@@ -866,14 +879,10 @@ BEGIN
     INNER JOIN filtered_restaurants fr2 ON d2.restaurant_id = fr2.id
     WHERE dp.status IN ('featured', 'community')
       AND d2.parent_dish_id IS NULL
-      AND (
-        (select auth.uid()) IS NULL
-        OR (
-          NOT EXISTS (SELECT 1 FROM user_blocks ub
-                      WHERE ub.blocker_id = (select auth.uid()) AND ub.blocked_id = dp.user_id)
-          AND NOT EXISTS (SELECT 1 FROM user_blocks ub
-                          WHERE ub.blocker_id = dp.user_id AND ub.blocked_id = (select auth.uid()))
-        )
+      AND NOT EXISTS (
+        SELECT 1 FROM user_blocks ub
+        WHERE (ub.blocker_id = (select auth.uid()) AND ub.blocked_id = dp.user_id)
+           OR (ub.blocker_id = dp.user_id AND ub.blocked_id = (select auth.uid()))
       )
     ORDER BY dp.dish_id,
       CASE dp.source_type WHEN 'restaurant' THEN 0 ELSE 1 END,
@@ -2074,6 +2083,156 @@ DROP TRIGGER IF EXISTS trigger_compute_value_score ON dishes;
 CREATE TRIGGER trigger_compute_value_score
   BEFORE INSERT OR UPDATE OF avg_rating, total_votes, price, category ON dishes
   FOR EACH ROW EXECUTE FUNCTION compute_value_score();
+
+-- 13g. Column-level field protection on tables managers can write to.
+-- Non-admin writes (managers + regular users) cannot modify computed/identity
+-- fields. System contexts (service_role, postgres, supabase_admin) and
+-- SECURITY DEFINER triggers bypass via current_user check. Trigger names
+-- sort before 'trigger_compute_value_score' so they fire first.
+
+CREATE OR REPLACE FUNCTION protect_dish_fields()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF current_user IN ('postgres', 'service_role', 'supabase_admin') THEN
+    RETURN NEW;
+  END IF;
+  IF is_admin() THEN
+    RETURN NEW;
+  END IF;
+  IF TG_OP = 'INSERT' THEN
+    NEW.id := uuid_generate_v4();
+    NEW.created_at := NOW();
+    NEW.avg_rating := NULL;
+    NEW.total_votes := 0;
+    NEW.weighted_vote_count := 0;
+    NEW.consensus_rating := NULL;
+    NEW.consensus_ready := FALSE;
+    NEW.consensus_votes := 0;
+    NEW.consensus_calculated_at := NULL;
+    NEW.value_score := NULL;
+    NEW.value_percentile := NULL;
+    NEW.category_median_price := NULL;
+  ELSIF TG_OP = 'UPDATE' THEN
+    NEW.id := OLD.id;
+    NEW.restaurant_id := OLD.restaurant_id;
+    NEW.created_by := OLD.created_by;
+    NEW.created_at := OLD.created_at;
+    NEW.avg_rating := OLD.avg_rating;
+    NEW.total_votes := OLD.total_votes;
+    NEW.weighted_vote_count := OLD.weighted_vote_count;
+    NEW.consensus_rating := OLD.consensus_rating;
+    NEW.consensus_ready := OLD.consensus_ready;
+    NEW.consensus_votes := OLD.consensus_votes;
+    NEW.consensus_calculated_at := OLD.consensus_calculated_at;
+    NEW.value_score := OLD.value_score;
+    NEW.value_percentile := OLD.value_percentile;
+    NEW.category_median_price := OLD.category_median_price;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS dishes_protect_fields ON dishes;
+CREATE TRIGGER dishes_protect_fields
+BEFORE INSERT OR UPDATE ON dishes
+FOR EACH ROW EXECUTE FUNCTION protect_dish_fields();
+
+CREATE OR REPLACE FUNCTION protect_special_fields()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF current_user IN ('postgres', 'service_role', 'supabase_admin') THEN
+    RETURN NEW;
+  END IF;
+  IF is_admin() THEN
+    RETURN NEW;
+  END IF;
+  IF TG_OP = 'INSERT' THEN
+    NEW.id := gen_random_uuid();
+    NEW.created_at := NOW();
+    NEW.created_by := (SELECT auth.uid());
+    NEW.is_promoted := FALSE;
+    NEW.source := 'manual';
+  ELSIF TG_OP = 'UPDATE' THEN
+    NEW.id := OLD.id;
+    NEW.restaurant_id := OLD.restaurant_id;
+    NEW.created_by := OLD.created_by;
+    NEW.created_at := OLD.created_at;
+    NEW.is_promoted := OLD.is_promoted;
+    NEW.source := OLD.source;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS specials_protect_fields ON specials;
+CREATE TRIGGER specials_protect_fields
+BEFORE INSERT OR UPDATE ON specials
+FOR EACH ROW EXECUTE FUNCTION protect_special_fields();
+
+CREATE OR REPLACE FUNCTION protect_event_fields()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF current_user IN ('postgres', 'service_role', 'supabase_admin') THEN
+    RETURN NEW;
+  END IF;
+  IF is_admin() THEN
+    RETURN NEW;
+  END IF;
+  IF TG_OP = 'INSERT' THEN
+    NEW.id := gen_random_uuid();
+    NEW.created_at := NOW();
+    NEW.created_by := (SELECT auth.uid());
+    NEW.is_promoted := FALSE;
+    NEW.source := 'manual';
+  ELSIF TG_OP = 'UPDATE' THEN
+    NEW.id := OLD.id;
+    NEW.restaurant_id := OLD.restaurant_id;
+    NEW.created_by := OLD.created_by;
+    NEW.created_at := OLD.created_at;
+    NEW.is_promoted := OLD.is_promoted;
+    NEW.source := OLD.source;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS events_protect_fields ON events;
+CREATE TRIGGER events_protect_fields
+BEFORE INSERT OR UPDATE ON events
+FOR EACH ROW EXECUTE FUNCTION protect_event_fields();
+
+CREATE OR REPLACE FUNCTION protect_restaurant_fields()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF current_user IN ('postgres', 'service_role', 'supabase_admin') THEN
+    RETURN NEW;
+  END IF;
+  IF is_admin() THEN
+    RETURN NEW;
+  END IF;
+  -- Managers can only change contact/social/menu/order fields. Identity + geo frozen.
+  -- menu_last_checked + menu_content_hash are menu-refresh bookkeeping — frozen
+  -- so managers can't force or skip auto-scrapes.
+  NEW.id := OLD.id;
+  NEW.name := OLD.name;
+  NEW.address := OLD.address;
+  NEW.lat := OLD.lat;
+  NEW.lng := OLD.lng;
+  NEW.region := OLD.region;
+  NEW.town := OLD.town;
+  NEW.google_place_id := OLD.google_place_id;
+  NEW.created_by := OLD.created_by;
+  NEW.created_at := OLD.created_at;
+  NEW.menu_last_checked := OLD.menu_last_checked;
+  NEW.menu_content_hash := OLD.menu_content_hash;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS restaurants_protect_fields ON restaurants;
+CREATE TRIGGER restaurants_protect_fields
+BEFORE UPDATE ON restaurants
+FOR EACH ROW EXECUTE FUNCTION protect_restaurant_fields();
 
 -- 13h. Batch recalculate value percentiles (called by pg_cron every 2 hours)
 CREATE OR REPLACE FUNCTION recalculate_value_percentiles()


### PR DESCRIPTION
## Summary

Closes three auth holes in the restaurant manager portal, surfaced via Codex audit + product review today.

**Before:**
- `/manage` "Update Info" and "Delete Dish" buttons silently failed — RLS policies were admin-only
- A manager could open DevTools and tamper with `avg_rating`, `consensus_*`, `value_score`, `is_promoted`, or forge audit fields (`id`, `created_at`, `created_by`) on INSERT — RLS was row-scoped only, no column protection
- Blanket manager DELETE was the Yelp path (hide embarrassing ratings)

**After:**
- Managers can UPDATE their restaurant (contact/social/menu fields) and DELETE dishes **only when `total_votes = 0`** (scraper ghosts, not voted dishes)
- BEFORE INSERT/UPDATE triggers on `dishes`, `specials`, `events`, `restaurants` freeze computed/identity/audit fields for non-admin writes
- `current_user IN ('postgres', 'service_role', 'supabase_admin')` bypass means SECURITY DEFINER contexts (vote aggregations, menu-refresh) pass through untouched — vote pipeline unaffected
- UI shows a Locked badge instead of Remove button for voted dishes
- `deleteDish` now verifies affected row count and throws a classified error if RLS silently blocks

**Product rule:**
> A manager can fix and remove dishes up until the crowd has an opinion. Once a dish has any user votes, it belongs to the crowd.

## Review trail
- 3 Codex passes (gpt-5.4, xhigh reasoning) — all high/medium findings addressed
- Second opinion pending on [wgh-phone #154](https://github.com/Denisgingras75/wgh-phone/issues/154)
- Column-level protection mirrors the existing `profiles_update_own WITH CHECK` pattern

## Deployment status
- Both migrations already deployed to Denis's Supabase project (`vpioftosgdkyiwvhxewy`)
- 4 triggers verified live via `pg_trigger` query
- Vote-gated DELETE policy verified live via `pg_policy` query

## Test plan
- [ ] As a manager, /manage → Update Info (phone/website/social) saves
- [ ] As a manager, try to delete a dish with 0 votes → succeeds
- [ ] As a manager, attempt to delete a dish with ≥1 vote → Locked badge visible, direct API call returns readable error
- [ ] As a regular user, cast a vote → `avg_rating` and `total_votes` update (aggregation pipeline unaffected)
- [ ] As a manager via DevTools, try `update({ avg_rating: 10 })` → silent no-op (column-lock trigger)
- [ ] As a manager via DevTools, try `insert({ is_promoted: true })` on specials → stored as `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)