### PR TITLE
docs: session hygiene + launch-readiness dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,17 @@ Mobile-first food discovery app for Martha's Vineyard (expanding to Nantucket + 
 You are the senior project manager and design partner, not an order-taker. Your job is to make this the best dish rating app there ever was. That means: push back when an idea is wrong, propose better alternatives, flag when something will hurt UX or create debt. Agree when you genuinely agree — but never just to be agreeable. Honest disagreement is more valuable than fast compliance.
 
 ## Session Startup
-Always read `SPEC.md` and `TASKS.md` before beginning any work.
+
+Run this checklist before touching anything:
+
+1. **Read `CURRENT_FOCUS.md`** — one paragraph on what we're working on *right now*. Source of truth for this session's scope. If it's stale, ask Dan to update before starting.
+2. **Read `SPEC.md` and `TASKS.md`** — system state and backlog.
+3. **Glance at `LAUNCH-READINESS.md`** — know what's shipped vs. outstanding for Memorial Day.
+4. **Collision check for parallel work.** Multiple Claude sessions (Dan's + Denis's + scheduled agents) can claim the same surface. Before editing:
+   - `git fetch origin main --quiet && git log --oneline HEAD..origin/main` — commits on main since your branch point. If this is non-empty, another session shipped work — rebase or pull before editing.
+   - `git status` — modified or untracked files you didn't create = in-flight work from another session.
+   - Read the **Active handoff** block in `CURRENT_FOCUS.md`. If another session has claimed files/modules you want to touch, STOP and ask Dan what's happening — don't duplicate or overwrite.
+   - If any of these signals fire and you're not sure, ask Dan before editing.
 
 ## Quick Commands
 ```bash
@@ -30,6 +40,9 @@ npm run test:e2e:business # manager persona E2E
 ```
 
 ## Key Docs
+- `CURRENT_FOCUS.md` - What we're working on RIGHT NOW (read at session start)
+- `LAUNCH-READINESS.md` - Memorial Day checklist, any Claude ticks boxes as work ships
+- `SMOKE-TEST.md` - Test accounts + golden-path recipes for verifying UI changes
 - `SPEC.md` - Full system specification (data model, features, RPCs, RLS)
 - `TASKS.md` - Prioritized backlog of high-leverage tasks
 - `NOTES.md` - Design tokens, architecture, file locations, category system
@@ -72,6 +85,7 @@ These rules are absolute. Violating any of them is a bug.
 - **`ROUND()` needs `::NUMERIC` cast on float expressions.** `ROUND(expression::NUMERIC, 2)`.
 - **New RPC functions must be run in Supabase SQL Editor.** Adding to `schema.sql` does NOT deploy. Run the CREATE FUNCTION, then verify with a test call.
 - **Always qualify column references in PL/pgSQL functions.** `RETURNS TABLE` column names become variables inside the function body. Bare `dish_id` is ambiguous if a joined table also has `dish_id`. Always use `tablename.column` (e.g., `votes.dish_id`, not `dish_id`).
+- **Every risky migration must declare a rollback path.** If a migration changes column types, drops/recreates triggers, alters FK strategies, or rewrites policies, include a commented `-- ROLLBACK:` block at the bottom of the file with paste-ready SQL to revert. Pure additive `CREATE INDEX IF NOT EXISTS` and `CREATE OR REPLACE FUNCTION` changes don't need one (rollback is obvious). If no SQL rollback is possible (e.g., the migration triggers a data backfill), say so explicitly: `-- No SQL rollback. Recovery requires restore from the <timestamp> backup.`
 
 ### 1.6 Auth Gates
 - **Voting, favorites, and photo uploads require login.** Check `user` from `useAuth()` first, show `<LoginModal>` if null. Pattern: `Browse.jsx`.

--- a/CURRENT_FOCUS.md
+++ b/CURRENT_FOCUS.md
@@ -1,0 +1,50 @@
+# Current Focus
+
+*Dan (or any Claude session starting work) updates this file at session start. Every other Claude session reads it first to avoid collisions.*
+
+**Last updated:** 2026-04-17
+
+---
+
+## Active handoff
+
+<!-- Fill this in BEFORE touching files. Clear it when done.
+     This is the collision-prevention surface — if it's stale, the whole
+     system weakens. Keep it honest. -->
+
+- **Owner / session:** _(Dan's terminal | Dan's other Claude | Denis's Claude | scheduled agent name)_
+- **Branch:** _(e.g., audit/supabase-2026-04-16 — or `main` if directly committing)_
+- **Files / modules claimed:** _(e.g., `src/api/votesApi.js`, `supabase/schema.sql §votes`, `src/pages/Profile.jsx`)_
+- **Safe for others to continue:** _(what parts of the repo are NOT touched and open for parallel work)_
+- **Do not duplicate:** _(specific tasks already in-flight — PR numbers, migration filenames, feature names)_
+
+---
+
+## This session — the goal
+
+<!-- One paragraph. What are we actually shipping this session?
+     Skip the long context — CLAUDE.md + SPEC.md provide that. -->
+
+_(stub)_
+
+## Blockers / waiting on
+
+<!-- Anything held up on Denis, Apple review, a design decision, etc.
+     Claude should NOT quietly start work that's waiting on someone else. -->
+
+- _(nothing)_
+
+## Not this session
+
+<!-- Stuff explicitly parked. Claude: don't pick this up even if it looks tempting. -->
+
+- _(nothing)_
+
+---
+
+## Protocol
+
+- **Update BEFORE touching files.** If you skip the update, you are the collision.
+- **Clear the "Active handoff" block when the session ends** (commit or stash, then reset this section). A stale handoff is worse than none — the next session will assume it's accurate.
+- **If `Last updated` is >24h old, treat the whole file as stale** — ask Dan what's current before assuming anything.
+- **One active handoff per surface.** Two sessions can run in parallel if their scopes don't overlap — append a second handoff block, clearly labeled. But never two sessions on the same files at the same time.

--- a/LAUNCH-READINESS.md
+++ b/LAUNCH-READINESS.md
@@ -1,0 +1,68 @@
+# Launch Readiness — Memorial Day 2026-05-25
+
+**~38 days remaining as of 2026-04-17.**
+
+Any Claude session (Dan's, Denis's, mine, a future one) can check items off as work ships. If you see `[ ]` and you just shipped the thing, tick it. If you see `[x]` on something that's actually broken, flip it back and leave a one-line note.
+
+> **Dan:** I seeded this with what I knew from session history. Review and correct — I marked only items I was sure about.
+
+---
+
+## Core experience
+
+- [ ] Dish rankings + map discovery — polished, verified on iOS + Android
+- [ ] "50 Best Dishes on MV" curated list (Denis)
+- [ ] Toast POS integration — Order Now buttons with auto-detected slugs (Denis)
+- [ ] Ask WGH v1 — conversational dish finder, rate-limited (2 guest / 6 logged-in per hour), prompt-cached
+- [ ] Check In + action buttons (Order / Directions / Call) on dishes + restaurants (Denis)
+- [ ] Dual-mode homepage (list/map) tested end-to-end on mobile Safari + Chrome
+
+## Trust & safety
+
+- [ ] Jitter WAR v2 — keystroke biometrics for review trust (Denis)
+- [x] Column-lock triggers on dishes/specials/events — PR #37
+- [x] Vote-gated delete policy — PR #37
+- [x] FK `ON DELETE` strategies unblock Delete Account — PR #36
+- [ ] Rate limiting verified under synthetic load
+- [ ] Content safety (`validateUserContent`) verified end-to-end
+- [ ] Admin moderation queue smoke-tested with a real report
+
+## Infrastructure & performance
+
+- [x] Supabase audit — 14 fixes across 5 migrations — PR #36
+- [ ] `pg_stat_statements` baseline captured pre-launch
+- [ ] `pg_stat_user_indexes` checked ~1 week post-launch (drop dead indexes)
+- [ ] Sentry alerting wired on 5xx and unhandled client errors
+- [ ] CSP locked down in production `vercel.json`
+- [ ] PostHog funnels + retention dashboards live
+
+## iOS native (Capacitor)
+
+- [ ] Apple Developer account active (individual now, LLC transfer post-launch)
+- [ ] Capacitor shell builds locally
+- [ ] App Store review passed
+- [ ] Sign In with Apple wired
+
+## Marketing / launch content
+
+- [ ] Landing copy final
+- [ ] Social share assets (OG images verified)
+- [ ] Launch post drafted — where is it going?
+- [ ] First 100 users plan — who, how, when
+
+## Post-launch punch list (NOT blocking)
+
+- Review decay system
+- Shareable profile cards
+- Biggest Movers feature
+- Nantucket expansion
+- Cape Cod expansion
+- B2B analytics dashboard
+
+---
+
+## How to use this file
+
+- One tick = shipped AND verified. If the PR merged but you haven't confirmed in prod, don't tick yet.
+- Keep the "NOT blocking" section short. If a post-launch item starts creeping into scope, either move it up (and accept the tradeoff) or delete it.
+- When Dan is slammed at work, this file is how any Claude session answers *"are we on track?"* without needing Dan's head.

--- a/SMOKE-TEST.md
+++ b/SMOKE-TEST.md
@@ -1,0 +1,105 @@
+# Smoke Test Recipes
+
+*How to verify a UI change actually works. Any Claude session that ships frontend or RPC work should walk the relevant golden path in a browser before claiming done — if it can't, it must say so explicitly.*
+
+> **Dan:** the account list and a few paths below are placeholders. Fill in with real test creds and tweak the recipes when something changes. Commit to the repo so every Claude session shares the same recipe.
+
+---
+
+## Test accounts
+
+Keep these in `.env.local.test` (gitignored). Ask Dan if you don't have access.
+
+| Role | Email | Password | What it tests |
+|---|---|---|---|
+| **anon** | — | — | Browse, Map, Dish detail without login |
+| **user** | _(Dan: fill)_ | _(Dan: fill)_ | Voting, favorites, reviews, profile |
+| **manager** | _(Dan: fill)_ | _(Dan: fill)_ | `/manage` portal for _(restaurant name)_ |
+| **admin** | _(Dan: fill)_ | _(Dan: fill)_ | `/admin` moderation queue |
+| **curator** | _(Dan: fill)_ | _(Dan: fill)_ | Local lists / playlists authoring |
+
+If a feature needs a specific data shape (e.g., a dish with zero votes, a user with 10+ votes for taste-match), note it in the recipe's **Data preconditions** line so the next Claude session knows exactly what state to seed or select.
+
+---
+
+## Golden paths by feature
+
+### Voting
+**Data preconditions:** any dish with `total_votes >= 3` (so the review appears alongside existing ones); **user** account has no prior vote on it.
+1. Sign in as **user**
+2. Navigate to `/dish/:id`
+3. Rate 8/10, add a short review, submit
+4. Refresh page — vote persists, review appears in snippets
+5. Check `/profile` — the vote shows up in the journal feed
+
+### Favorites
+**Data preconditions:** **user** account has zero favorites (so the "add" is unambiguous).
+1. Sign in as **user**
+2. Tap heart on any dish card on `/browse`
+3. Navigate to `/profile` → Favorites tab
+4. Dish appears in favorites list
+5. Tap heart again to remove — disappears on refresh
+
+### Homepage dual-mode
+**Data preconditions:** none — anon flow.
+1. Visit `/` as **anon**
+2. List mode renders by default
+3. Tap `ModeFAB` (bottom-right) → map mode activates
+4. Category emoji pins render on map
+5. Tap a pin → bottom sheet with dish info
+6. Tap "See on map" from dish detail → routes back to map mode
+7. Refresh while in map mode — mode persists
+
+### Manager delete (vote-gated)
+**Data preconditions:** **manager** owns a restaurant with *both* a dish where `total_votes = 0` AND a dish where `total_votes > 0`. If not, seed by adding a new dish (which starts at 0 votes) and using an existing voted dish.
+1. Sign in as **manager**
+2. Navigate to `/manage`
+3. On a dish with `total_votes = 0` → delete button is visible and works (dish disappears)
+4. On a dish with `total_votes > 0` → delete control is **disabled in the UI** with a tooltip/message explaining why (dish belongs to the crowd once voted on). This is important: silently missing buttons is bad UX; we want an explicit explanation.
+5. Also verify the DB enforces it: open DevTools → attempt `supabase.from('dishes').delete().eq('id', voted_dish_id)` → should return 0 rows affected (RLS blocks). The UI gate + RLS gate are two independent layers.
+6. Edit a dish's name/price → saves successfully
+7. Open DevTools → try `supabase.from('dishes').update({ avg_rating: 10 })` → should fail (column-lock trigger rejects the update; error should be surfaced, not silent)
+
+### Admin moderation
+**Data preconditions:** at least 1 open report, ideally 3+ with varying `reported_user_id` so the priority sort is observable.
+1. Sign in as **admin**
+2. Navigate to `/admin`
+3. Queue shows open reports sorted by `target_user_open_report_count DESC, created_at DESC`
+4. _(With a real report)_ Open → reject → status becomes `reviewed`
+5. Verify keyset pagination: scroll to bottom, next page loads using `(open_count, created_at, id)` cursor — not `offset`. Check Network tab for the RPC call.
+
+### Ask WGH _(once shipped)_
+**Data preconditions:** a location within the MV serving area (else the geo filter returns empty).
+1. Visit `/` as **anon**, tap Ask WGH entry point
+2. Ask "what's a good burger near me?" — gets a streaming response with real dish names
+3. Ask 2 more questions — third one hits the rate limit (2/hour for anon)
+4. Sign in as **user**, rate limit resets to 6/hour
+5. Confirm prompt caching hits in logs (should see `cache_read_input_tokens` > 0 on later turns)
+
+---
+
+## How to run locally
+
+```bash
+npm run dev        # localhost:5173
+npm run test:e2e   # runs Playwright across all 3 personas
+```
+
+For a targeted check:
+```bash
+npm run test:e2e:browser   # tourist persona (anon)
+npm run test:e2e:pioneer   # foodie (logged-in user)
+npm run test:e2e:business  # manager portal
+```
+
+---
+
+## If you can't smoke-test
+
+Sometimes a session is SQL-only, or the dev environment isn't available, or you're mid-refactor and the app doesn't render. In those cases:
+
+- **Say so explicitly in the final message.** Don't claim the feature works if you haven't seen it work.
+- **Run `npm run build` and `npm run test`** as the minimum sanity check.
+- **Flag the verification gap** so Dan (or the next Claude session) knows to test manually before shipping.
+
+"I didn't run the UI" is honest. "It works" when you haven't checked is not.


### PR DESCRIPTION
## Summary

Four docs changes that make parallel Claude sessions (Dan's + Denis's + scheduled agents) stop colliding — and give any session a clear answer to *"are we on track for Memorial Day?"*

- **CLAUDE.md** — Session Startup expanded from one line to a 4-step checklist: read `CURRENT_FOCUS.md`, `SPEC`/`TASKS`, `LAUNCH-READINESS`, then run a real collision check (`git log HEAD..origin/main` + the Active handoff block). Also adds a rollback-SQL requirement for risky migrations.
- **CURRENT_FOCUS.md** *(new)* — one-paragraph "this session" + an **Active handoff** block (owner, branch, claimed files, safe-for-others, do-not-duplicate). This is the control plane for parallel sessions.
- **LAUNCH-READINESS.md** *(new)* — Memorial Day checkbox dashboard across core experience, trust & safety, infra, iOS native, and marketing. Pre-seeded with today's shipped items; rest marked for confirmation.
- **SMOKE-TEST.md** *(new)* — per-feature golden-path recipes with explicit "Data preconditions." Manager-delete recipe verifies the disabled-with-explanation UI gate AND the RLS gate as independent defenses.

## Why now

Today's session nearly re-did the PR #37 manager-auth work because nothing flagged that another session had shipped it. These docs make that class of miss impossible — if anyone bothers to update `CURRENT_FOCUS.md`.

## Review

- Reviewed by Codex (`gpt-5.4`, high reasoning) across two rounds. Flagged three issues in round 1 (weak `git status` signal, CURRENT_FOCUS lacked handoff structure, SMOKE-TEST blessed silent failure on manager delete) — all addressed. Round 2 caught two wording nits (git-log direction, handoff plurality) — both fixed.
- No code changes; pure docs. CI-safe.

## Test plan

- [x] Codex round-trip review (both rounds green)
- [x] Locally confirmed `git log HEAD..origin/main` works as described
- [ ] Dan updates `CURRENT_FOCUS.md` stub at start of next session (proves the system in use)
- [ ] Dan fills test-account placeholders in `SMOKE-TEST.md` when convenient
- [ ] Dan reviews `LAUNCH-READINESS.md` pre-seed and corrects any items I got wrong

🤖 Generated with [Claude Code](https://claude.com/claude-code)