### PR TITLE
feat(splash): Amatic SC wordmark (variant for review)

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
     <link rel="preconnect" href="https://images.unsplash.com" crossorigin />
     <link rel="dns-prefetch" href="https://us.posthog.com" />
 
-    <!-- Fonts: Amatic SC (display/headers), Outfit (body), Fraunces (splash wordmark) -->
-    <link href="https://fonts.googleapis.com/css2?family=Amatic+SC:wght@400;700&family=Fraunces:ital,wght@1,900&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+    <!-- Fonts: Amatic SC (display/headers, splash wordmark), Outfit (body) -->
+    <link href="https://fonts.googleapis.com/css2?family=Amatic+SC:wght@400;700&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
 
     <!-- Mobile-first viewport with safe area support -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />

--- a/src/index.css
+++ b/src/index.css
@@ -220,7 +220,7 @@
 
   /* ===========================
      WelcomeSplash — SmileyPin pierce animation
-     Pin drops from above, pierces through stacked Fraunces wordmark,
+     Pin drops from above, pierces through stacked Amatic SC wordmark,
      letters form a V, plate + eyes + smile reveal, right eye winks.
      =========================== */
 
@@ -258,12 +258,11 @@
   }
 
   .wgh-splash__text {
-    font-family: 'Fraunces', 'Outfit', serif;
-    font-style: italic;
-    font-weight: 900;
-    font-size: 56px;
-    letter-spacing: -2.8px;
-    line-height: 0.88;
+    font-family: 'Amatic SC', cursive;
+    font-weight: 700;
+    font-size: 104px;
+    letter-spacing: 0.02em;
+    line-height: 0.82;
     color: var(--color-text-primary);
     animation: groundShake 0.6s 1.9s linear both;
   }
@@ -271,11 +270,14 @@
   .wgh-splash__b1 { animation: fadeIn 0.3s 0.6s both; }
   .wgh-splash__line { display: block; }
 
+  /* Amatic SC tops out at weight 700 — text-stroke fakes heavier weight.
+     Applied per-letter so the period (a separate span) stays a clean coral dot. */
   .wgh-splash__letter {
     display: inline-block;
     transform-origin: center bottom;
     animation: letterDeflect 1.6s cubic-bezier(.45, .05, .55, .95) var(--delay, 0s) both;
     will-change: transform;
+    -webkit-text-stroke: 1px currentColor;
   }
 
   .wgh-splash__period {


### PR DESCRIPTION
## Summary
- Swaps the splash wordmark from **Fraunces italic 900** → **Amatic SC 700 at 104px** with `-webkit-text-stroke: 1px` for apparent heavier weight (Amatic SC tops out at 700).
- Drops the Fraunces font load entirely — lighter font payload.
- Brand coherence: splash now uses the same display font as the TopBar "What's Good Here" wordmark.

## Why
Dan noticed the splash (Fraunces — editorial serif) clashed with the TopBar (Amatic SC — chalkboard). This PR makes them speak the same voice.

## Test plan
- [ ] Preview URL plays the animation smoothly with Amatic SC
- [ ] Wordmark feels bold enough at 104px + 1px text-stroke (not wimpy)
- [ ] Period at end of "here." still renders coral, no stroke artifact
- [ ] V-deflection animation still hits correctly (per-letter spans preserved)
- [ ] Compare against prod (Fraunces version) — pick a winner

## Decision needed from Dan
Merge this OR keep prod Fraunces version. If neither feels right, we iterate on weight/size in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)