### PR TITLE
fix(splash): period pops right after wink

### DIFF
--- a/src/components/WelcomeSplash.jsx
+++ b/src/components/WelcomeSplash.jsx
@@ -2,8 +2,9 @@ import { useState, useEffect, useMemo } from 'react'
 import { SmileyPin } from './SmileyPin'
 
 // Total animation runtime before natural dismiss (ms).
-// Matches CSS timing: pin drop 0.5s + 2.6s, period ghost 5.9s + 0.55s ≈ 6.5s.
-const SPLASH_DURATION_MS = 6500
+// Matches CSS timing: wink fires at 4.2s, period ghosts in at 4.7s + 0.55s.
+// Hold ~0.6s after the period settles so the final state reads as intentional.
+const SPLASH_DURATION_MS = 5800
 const FADE_OUT_MS = 300
 
 // Module-level flag — persists across re-renders within a session so

--- a/src/index.css
+++ b/src/index.css
@@ -284,7 +284,7 @@
     display: inline-block;
     transform-origin: center;
     color: var(--color-primary);
-    animation: ghostIn 0.55s 5.9s cubic-bezier(.34, 1.4, .5, 1) both;
+    animation: ghostIn 0.55s 4.7s cubic-bezier(.34, 1.4, .5, 1) both;
   }
 
   .wgh-splash .pin-drop {


### PR DESCRIPTION
## Summary
- Period ghost moved from 5.9s → **4.7s** so it lands right as the right eye completes its wink.
- Total splash runtime trimmed from 6.5s → **5.8s** — removes the dead beat between the wink and dismissal.

## Test plan
- [ ] Wink happens, period pops in immediately after, splash fades

🤖 Generated with [Claude Code](https://claude.com/claude-code)