### PR TITLE
chore(email): add branded Reset Password template

### DIFF
--- a/supabase/templates/reset-password.html
+++ b/supabase/templates/reset-password.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reset your password</title>
+  <!-- Modern clients (Apple Mail, Gmail) render this; Outlook falls back to system fonts -->
+  <link href="https://fonts.googleapis.com/css2?family=Amatic+SC:wght@700&display=swap" rel="stylesheet">
+</head>
+<body style="margin: 0; padding: 0; background-color: #F0ECE8; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #F0ECE8;">
+    <tr>
+      <td align="center" style="padding: 64px 24px;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width: 440px; background-color: #FFFFFF; border-radius: 16px;">
+          <tr>
+            <td align="center" style="padding: 48px 32px;">
+
+              <!-- SmileyPin logo (inline SVG — renders in Apple Mail, Gmail, Outlook 365) -->
+              <!--[if !mso]><!-->
+              <div style="margin-bottom: 20px; line-height: 0;">
+                <svg width="64" height="64" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" style="display: block; margin: 0 auto;">
+                  <path d="M100 20 C60 20, 30 50, 30 90 C30 130, 100 185, 100 185 C100 185, 170 130, 170 90 C170 50, 140 20, 100 20 Z" fill="#E4440A"/>
+                  <circle cx="100" cy="90" r="48" fill="#F7F4F1"/>
+                  <circle cx="84" cy="80" r="7" fill="#C48A12"/>
+                  <circle cx="116" cy="80" r="7" fill="#C48A12"/>
+                  <circle cx="81.5" cy="77.5" r="2" fill="#F7F4F1" opacity="0.95"/>
+                  <circle cx="113.5" cy="77.5" r="2" fill="#F7F4F1" opacity="0.95"/>
+                  <path d="M78 100 Q 100 124, 122 100" stroke="#E4440A" stroke-width="5.5" fill="none" stroke-linecap="round"/>
+                </svg>
+              </div>
+              <!--<![endif]-->
+
+              <!-- Brand wordmark — Amatic SC with system fallback -->
+              <p style="margin: 0 0 32px 0; font-family: 'Amatic SC', 'Georgia', serif; font-size: 40px; font-weight: 700; color: #1A1A1A; letter-spacing: 0.02em; line-height: 1;">
+                What&rsquo;s <span style="color: #E4440A;">Good</span> Here
+              </p>
+
+              <!-- Heading -->
+              <p style="margin: 0 0 12px 0; font-size: 22px; font-weight: 700; color: #1A1A1A; letter-spacing: -0.01em;">
+                Let&rsquo;s get you back in.
+              </p>
+
+              <!-- Subtext -->
+              <p style="margin: 0 0 32px 0; font-size: 15px; color: #555555; line-height: 1.55;">
+                Tap below to set a new password.
+              </p>
+
+              <!-- CTA -->
+              <a href="{{ .ConfirmationURL }}"
+                 style="display: inline-block; background-color: #E4440A; color: #FFFFFF; font-size: 15px; font-weight: 600; text-decoration: none; padding: 14px 48px; border-radius: 10px; letter-spacing: -0.01em;">
+                Reset Password
+              </a>
+
+              <!-- Fine print -->
+              <p style="margin: 40px 0 0 0; font-size: 12px; color: #767676; line-height: 1.55;">
+                This link expires in 1 hour.<br>If you didn&rsquo;t request this, you can safely ignore it.
+              </p>
+
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `supabase/templates/reset-password.html` — same brand treatment as the magic-link + confirm-signup templates (cream bg, white card, inline SmileyPin, Amatic SC wordmark, coral CTA).
- Headline: "Let's get you back in." — friendly, not shamey.

## Not auto-deployed
Paste into Supabase Dashboard → Auth → Emails → Email Templates → **Reset Password** → Message (HTML), save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)