### PR TITLE
fix(reset-password): use SmileyPin on landing page

### DIFF
--- a/src/pages/ResetPassword.jsx
+++ b/src/pages/ResetPassword.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { authApi } from '../api/authApi'
+import { SmileyPin } from '../components/SmileyPin'
 
 export function ResetPassword() {
   const navigate = useNavigate()
@@ -72,11 +73,9 @@ export function ResetPassword() {
       style={{ background: 'var(--color-surface)' }}
     >
       {/* Logo */}
-      <img
-        src="/logo.webp"
-        alt="What's Good Here"
-        className="w-48 h-auto mb-6"
-      />
+      <div className="mb-6">
+        <SmileyPin size={96} />
+      </div>
 
       {/* Heading */}
       <h1 className="text-2xl font-bold text-center mb-2" style={{ color: 'var(--color-text-primary)' }}>


### PR DESCRIPTION
## Summary
- `/reset-password` now renders `<SmileyPin size={96} />` instead of the old `/logo.webp`.
- Closes the visual disconnect: users click the branded reset email → land on a page with the same mark.

## Test plan
- [ ] Trigger a password reset from `/login` → email arrives with SmileyPin
- [ ] Click link → `/reset-password` renders with SmileyPin (not the old logo)
- [ ] Submit new password → redirects to home, logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)