### PR TITLE
chore(gitignore): ignore build artifacts + side-checkouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,12 @@ playwright-report/
 test-results/
 blob-report/
 .superpowers/
+
+# Auto-generated build artifacts
+public/bundle-stats.html
+
+# Alternate codebase checkout (separate project, not part of this repo)
+whats-good-here-soul/
+
+# Claude Code scheduled tasks
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary
Adds three entries to `.gitignore`:
- `public/bundle-stats.html` — regenerated by Rollup visualizer on every build
- `whats-good-here-soul/` — separate project checkout, not part of this repo
- `.claude/scheduled_tasks.lock` — ephemeral lock from Claude Code's `/loop` scheduling

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)