### PR TITLE
feat(seal): place WghSeal hero on Privacy + Terms

### DIFF
--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom'
+import { WghSeal } from '../components/WghSeal'
 
 export function Privacy() {
   const navigate = useNavigate()
@@ -26,6 +27,9 @@ export function Privacy() {
 
       {/* Content */}
       <div className="max-w-2xl mx-auto px-4 py-8">
+        <div className="flex justify-center mb-6">
+          <WghSeal size={96} />
+        </div>
         <div className="rounded-2xl p-6 space-y-6" style={{ background: 'var(--color-surface-elevated)', border: '1px solid var(--color-divider)' }}>
           <p className="text-sm" style={{ color: 'var(--color-text-tertiary)' }}>Last updated: April 2026</p>
 

--- a/src/pages/Terms.jsx
+++ b/src/pages/Terms.jsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom'
+import { WghSeal } from '../components/WghSeal'
 
 export function Terms() {
   const navigate = useNavigate()
@@ -26,6 +27,9 @@ export function Terms() {
 
       {/* Content */}
       <div className="max-w-2xl mx-auto px-4 py-8">
+        <div className="flex justify-center mb-6">
+          <WghSeal size={96} />
+        </div>
         <div className="rounded-2xl p-6 space-y-6" style={{ background: 'var(--color-surface-elevated)', border: '1px solid var(--color-divider)' }}>
           <p className="text-sm" style={{ color: 'var(--color-text-tertiary)' }}>Last updated: January 2025</p>
 


### PR DESCRIPTION
## Summary
- Adds a centered `<WghSeal size={96} />` above the policy card on both `/privacy` and `/terms`.
- Functions as an editorial letterhead — says "official What's Good Here document" without shouting.
- First in-app surface for the Seal after the favicon.

## Test plan
- [ ] Navigate to `/privacy` — Seal appears at top, centered
- [ ] Navigate to `/terms` — same
- [ ] Confirm no regressions on pages that use SmileyPin (Splash, Login, WelcomeModal, ResetPassword)

🤖 Generated with [Claude Code](https://claude.com/claude-code)