### PR TITLE
fix(index): update Supabase preconnect to current project

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <!-- Preconnect to critical origins for faster resource loading -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="preconnect" href="https://fzgbxwonitnqmeguqixn.supabase.co" crossorigin />
+    <link rel="preconnect" href="https://vpioftosgdkyiwvhxewy.supabase.co" crossorigin />
     <link rel="preconnect" href="https://images.unsplash.com" crossorigin />
     <link rel="dns-prefetch" href="https://us.posthog.com" />
 


### PR DESCRIPTION
## Summary
- `index.html:13` preconnect was pointing at the dead `fzgbxwonitnqmeguqixn` Supabase project (old project, migrated away from on 2026-04-07).
- Swap to `vpioftosgdkyiwvhxewy` — matches `VITE_SUPABASE_URL` and the runtime Supabase client (`src/lib/supabase.js`).

## Why it matters
Every page load was burning a TCP+TLS handshake to a project we no longer use, and the project that actually serves auth/data got no preconnect warmup. First Supabase call after page load will now land on an already-warm connection.

## Scope
Pure performance cleanup. Zero behavior change. Reviewed with Codex (gpt-5.4, high effort) — confirmed the fix is correct, CSP in `vercel.json` already allows `https://*.supabase.co`, and no other stale `fzgbxwonitnqmeguqixn` references remain in `index.html`.

## Test plan
- [ ] `npm run build` succeeds
- [ ] Load prod/preview, DevTools Network tab shows preconnect to `vpioftosgdkyiwvhxewy.supabase.co`
- [ ] No console errors about failed preconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)