### PR TITLE
fix(playlist): hoist useMemo above early returns

### DIFF
--- a/src/pages/Playlist.jsx
+++ b/src/pages/Playlist.jsx
@@ -18,6 +18,9 @@ export function Playlist() {
   const { follow, unfollow, removeDish } = usePlaylistMutations()
   const [searchSheetOpen, setSearchSheetOpen] = useState(false)
 
+  const items = playlist?.items || []
+  const existingDishIds = useMemo(() => items.map((i) => i.dish_id), [items])
+
   useEffect(() => {
     if (playlist) {
       capture('playlist_detail_viewed', {
@@ -68,10 +71,8 @@ export function Playlist() {
     )
   }
 
-  var items = playlist.items || []
   var covers = (playlist.cover_categories || []).slice(0, 4)
   var coverPhotos = items.slice(0, 4).map(function (item) { return item.photo_url || null })
-  var existingDishIds = useMemo(function () { return items.map(function (i) { return i.dish_id }) }, [items])
 
   var toggleFollow = function () {
     if (!user) { navigate('/login'); return }


### PR DESCRIPTION
## Summary

Clicking a playlist from the profile page showed ErrorBoundary's "Something went wrong" and refresh didn't help. `src/pages/Playlist.jsx` called `useMemo` after the loading / error / `!playlist` early returns, so once data arrived the hook count changed between renders and React threw a Rules of Hooks violation.

- Hoist `useMemo(existingDishIds)` above the conditional returns
- Derive `items` from `playlist?.items || []` so the hook is safe when `playlist` is still null
- Remove the duplicate `var items` declaration further down

## Review trail

- Codex (gpt-5.4, medium) read the fix: hooks-order correct, no other Rules of Hooks issues, happy-path logic unchanged, no broken references to `items`/`existingDishIds`.
- `npm run build` passes locally.

## Test plan

- [ ] Open a playlist from Profile → Playlists — detail page loads, no ErrorBoundary
- [ ] Open a playlist from Profile → Saved — same
- [ ] Open a playlist directly via shared URL (cold load) — still loads
- [ ] Owner: add/remove dishes from inside the playlist — `existingDishIds` still filters the Add sheet correctly
- [ ] Non-owner: Follow / Unfollow button still works
- [ ] Regression: other pages (Browse, Dish, Profile) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)