### PR TITLE
docs(legal): L1 Privacy + Terms update for App Store submission

### DIFF
--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -237,7 +237,9 @@ export function Privacy() {
               You can access, update, or delete your profile information at any time through
               the app. If you are a California resident, you have additional rights under the
               CCPA, including the right to request a copy of the personal information we hold
-              about you and the right to request deletion. Email us to make a formal request.
+              about you and the right to request deletion. We also comply with other applicable
+              state privacy laws, including those of your state of residence — email us to make
+              a formal request under any of them.
             </p>
           </section>
 

--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -31,14 +31,15 @@ export function Privacy() {
           <WghSeal size={96} />
         </div>
         <div className="rounded-2xl p-6 space-y-6" style={{ background: 'var(--color-surface-elevated)', border: '1px solid var(--color-divider)' }}>
-          <p className="text-sm" style={{ color: 'var(--color-text-tertiary)' }}>Last updated: April 2026</p>
+          <p className="text-sm" style={{ color: 'var(--color-text-tertiary)' }}>Last updated: April 18, 2026</p>
 
           <section>
             <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
               Overview
             </h2>
             <p className="leading-relaxed mb-3" style={{ color: 'var(--color-text-secondary)' }}>
-              What's Good Here is operated by Daniel Walsh. Contact:{' '}
+              What's Good Here is operated by Daniel Walsh (Martha's Vineyard, Massachusetts).
+              Contact:{' '}
               <a
                 href="mailto:hello@whatsgoodhere.app"
                 className="font-medium"
@@ -46,12 +47,12 @@ export function Privacy() {
               >
                 hello@whatsgoodhere.app
               </a>
-              .
+              . A mailing address is available on request for formal data access requests.
             </p>
             <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
-              What's Good Here ("we", "our", or "the app") is a community-driven food discovery platform
-              for Martha's Vineyard. This Privacy Policy explains how we collect, use, and protect your
-              information when you use our service.
+              What's Good Here ("we", "our", or "the app") is a community-driven food discovery
+              platform for Martha's Vineyard. This Privacy Policy explains what we collect, what
+              we do with it, and what choices you have.
             </p>
           </section>
 
@@ -62,30 +63,93 @@ export function Privacy() {
             <div className="space-y-4 leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
               <div>
                 <h3 className="font-medium mb-1" style={{ color: 'var(--color-text-primary)' }}>Account Information</h3>
-                <p>When you create an account, we collect your email address and display name.
-                If you sign in with Google, we receive your name and email from Google.</p>
+                <p>
+                  When you create an account, we collect your email address and display name.
+                  If you sign in with Google or Apple, we receive your name (if you choose to
+                  share it) and email from the provider. Apple users can select "Hide My Email,"
+                  in which case we receive a private-relay address (ending in{' '}
+                  <code>@privaterelay.appleid.com</code>) that forwards to your real inbox.
+                  If you use the same verified email across providers, we automatically link
+                  your accounts so you don't end up with duplicates.
+                </p>
               </div>
               <div>
-                <h3 className="font-medium mb-1" style={{ color: 'var(--color-text-primary)' }}>User Content</h3>
-                <p>We store the votes and ratings you submit for dishes, as well as any dishes
-                you save to your favorites.</p>
+                <h3 className="font-medium mb-1" style={{ color: 'var(--color-text-primary)' }}>Dish Ratings and Reviews</h3>
+                <p>
+                  We store the ratings and written reviews you submit, the dishes you save as
+                  favorites, and playlists you create. Ratings are aggregated into public rankings;
+                  your individual rating is not shown on the dish page alongside your name unless
+                  you explicitly post a review.
+                </p>
+              </div>
+              <div>
+                <h3 className="font-medium mb-1" style={{ color: 'var(--color-text-primary)' }}>Dish Photos</h3>
+                <p>
+                  When you upload a photo of a dish, we store the image, the dish it's attached
+                  to, and a timestamp. We don't use your photos for anything other than displaying
+                  them on the dish page and in your profile. You can delete a photo you uploaded
+                  at any time.
+                </p>
               </div>
               <div>
                 <h3 className="font-medium mb-1" style={{ color: 'var(--color-text-primary)' }}>Location Data</h3>
-                <p>With your permission, we access your device's location to show nearby restaurants
-                and dishes. This data is used only to provide location-based features and is not
-                stored on our servers.</p>
+                <p>
+                  With your permission, we access your device's location to show nearby
+                  restaurants and dishes and to anchor the map on where you are. We do not
+                  store your location history on our servers — the coordinates are only used
+                  in the moment to answer a query.
+                </p>
+              </div>
+              <div>
+                <h3 className="font-medium mb-1" style={{ color: 'var(--color-text-primary)' }}>Typing Cadence (Jitter)</h3>
+                <p>
+                  To protect reviews from bots and coordinated manipulation, we measure how you
+                  type while writing a review. This includes per-key dwell time, timing between
+                  keys, typo/edit rate, pause frequency, common key pairings (bigrams), cursor
+                  and touch movement in the input area, and whether you pasted text or used
+                  non-keyboard input. The aggregated profile is
+                  stored associated with your account and we may send it to a trust-scoring
+                  service so your reviews can be attested as human-written. We do not use it
+                  to identify you outside the service, we do not sell it, and we do not share
+                  it with advertisers. Learn more at{' '}
+                  <a
+                    href="/jitter"
+                    className="font-medium"
+                    style={{ color: 'var(--color-primary)' }}
+                  >
+                    whatsgoodhere.app/jitter
+                  </a>
+                  .
+                </p>
+              </div>
+              <div>
+                <h3 className="font-medium mb-1" style={{ color: 'var(--color-text-primary)' }}>Reports and Blocks</h3>
+                <p>
+                  The app lets you report content and block other users. If you do, we store
+                  your report (the content you flagged, the reason, and a timestamp) and your
+                  block list, so we can filter out content from users you've chosen not to see.
+                  Reports are not shared back to the person who was reported.
+                </p>
               </div>
               <div>
                 <h3 className="font-medium mb-1" style={{ color: 'var(--color-text-primary)' }}>Usage Analytics</h3>
-                <p>We use PostHog to understand how people use the app. This includes pages visited,
-                features used, and session recordings (with sensitive data automatically masked).
-                This helps us improve the app experience.</p>
+                <p>
+                  We use PostHog to understand how people use the app. This includes pages you
+                  visit, features you interact with, and session recordings. Form inputs
+                  (passwords, email fields, text fields) are masked in recordings by default;
+                  rendered content on a page is captured to help us see what users actually
+                  experienced. We use this to prioritize what to improve.
+                </p>
               </div>
               <div>
                 <h3 className="font-medium mb-1" style={{ color: 'var(--color-text-primary)' }}>Error Tracking</h3>
-                <p>We use Sentry to track errors and crashes. This helps us fix bugs quickly.
-                Error reports may include technical information about your device and browser.</p>
+                <p>
+                  We use Sentry to catch errors and crashes. Error reports include technical
+                  context like the device model, operating system version, browser version,
+                  and a stack trace. When an error happens, Sentry may also capture a replay
+                  of the few seconds leading up to it (with form inputs masked) so we can see
+                  what triggered the bug. We use this only to fix problems.
+                </p>
               </div>
             </div>
           </section>
@@ -99,23 +163,27 @@ export function Privacy() {
               <li>To display community ratings and rankings</li>
               <li>To show you relevant dishes and restaurants near you</li>
               <li>To track your voting history and saved dishes</li>
+              <li>To protect reviews from bots and coordinated manipulation</li>
+              <li>To respond to reports and enforce our community guidelines</li>
               <li>To fix bugs and improve app performance</li>
-              <li>To understand how the app is being used</li>
             </ul>
           </section>
 
           <section>
             <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
-              Data Sharing
+              Third-Party Services
             </h2>
             <p className="leading-relaxed mb-3" style={{ color: 'var(--color-text-secondary)' }}>
-              We do not sell your personal information. We share data only with:
+              We do not sell your personal information. We share data only with services that
+              help us run the app:
             </p>
             <ul className="list-disc list-inside space-y-2" style={{ color: 'var(--color-text-secondary)' }}>
-              <li><strong>Supabase</strong> - Our database and authentication provider</li>
-              <li><strong>PostHog</strong> - For product analytics</li>
-              <li><strong>Sentry</strong> - For error tracking</li>
-              <li><strong>Vercel</strong> - Our hosting provider</li>
+              <li><strong>Supabase</strong> — our database, authentication, and file storage</li>
+              <li><strong>Vercel</strong> — our hosting provider</li>
+              <li><strong>Google</strong> — Sign in with Google, and the Google Places API for restaurant discovery (we send location queries to Google to find nearby places)</li>
+              <li><strong>Apple</strong> — Sign in with Apple on iOS and web (subject to Apple's privacy policy)</li>
+              <li><strong>PostHog</strong> — product analytics</li>
+              <li><strong>Sentry</strong> — error tracking</li>
             </ul>
           </section>
 
@@ -124,20 +192,40 @@ export function Privacy() {
               Your Votes Are Public
             </h2>
             <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
-              When you rate a dish, your vote contributes to the public ranking. While we don't
-              display your name next to individual votes, your overall statistics (like total
-              dishes rated) are visible on your profile.
+              When you rate a dish, your rating contributes to the public ranking. Written reviews
+              you post are public and attributed to your display name. Your overall statistics
+              (total dishes rated, favorites count, trust badges) are visible on your profile.
             </p>
           </section>
 
           <section>
             <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
-              Data Retention
+              Device Permissions
+            </h2>
+            <p className="leading-relaxed mb-3" style={{ color: 'var(--color-text-secondary)' }}>
+              The app asks your permission before accessing:
+            </p>
+            <ul className="list-disc list-inside space-y-2" style={{ color: 'var(--color-text-secondary)' }}>
+              <li><strong>Location</strong> — to show nearby restaurants and dishes</li>
+              <li><strong>Camera</strong> — to take a photo of a dish to upload</li>
+              <li><strong>Photos library</strong> — to pick an existing photo to upload</li>
+            </ul>
+            <p className="leading-relaxed mt-3" style={{ color: 'var(--color-text-secondary)' }}>
+              You can change these permissions anytime in your device settings. On iPhone,
+              this is <strong>Settings → What's Good Here</strong>.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
+              Deleting Your Account
             </h2>
             <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
-              You can delete your account anytime from Settings. Deletion is
-              permanent and removes your votes, reviews, photos, favorites, and profile.
-              Dish rankings that included your votes will be recalculated without them.
+              You can delete your account from the in-app settings menu (tap the gear icon,
+              then <strong>Delete Account</strong>). Deletion is permanent and removes your
+              votes, reviews, photos, favorites, playlists, and profile. Dish rankings that
+              included your votes will be recalculated without them. Deletion happens in-app —
+              you do not need to email us to close your account.
             </p>
           </section>
 
@@ -147,8 +235,72 @@ export function Privacy() {
             </h2>
             <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
               You can access, update, or delete your profile information at any time through
-              the app — including a full account deletion from Settings. For
-              questions about your data, contact us at the email below.
+              the app. If you are a California resident, you have additional rights under the
+              CCPA, including the right to request a copy of the personal information we hold
+              about you and the right to request deletion. Email us to make a formal request.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
+              Children
+            </h2>
+            <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
+              What's Good Here is not intended for children under 13. We do not knowingly collect
+              information from children under 13. If you believe a child has provided us with
+              personal information, please contact us and we will delete it.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
+              Data Retention
+            </h2>
+            <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
+              We keep your account information, votes, reviews, photos, and playlists for as
+              long as your account is active. When you delete your account, we remove this
+              data from our systems. Aggregated, de-identified statistics (like the number
+              of votes a dish has received) may remain in rankings. Error reports, session
+              replays, and analytics events are retained for a limited period (typically no
+              longer than twelve months) in line with our providers' default retention
+              settings, and are deleted or aggregated after that.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
+              Where Your Data Lives
+            </h2>
+            <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
+              Our database, file storage, and hosting are located in the United States. If you
+              use the app from outside the U.S., your information is transferred to and
+              processed in the U.S., which may have different data-protection rules than
+              your home country.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
+              Copyright (DMCA)
+            </h2>
+            <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
+              If you believe a dish photo or review on the app infringes your copyright, send
+              a written notice to{' '}
+              <a
+                href="mailto:hello@whatsgoodhere.app"
+                className="font-medium"
+                style={{ color: 'var(--color-primary)' }}
+              >
+                hello@whatsgoodhere.app
+              </a>
+              {' '}that includes: (1) an identification of the copyrighted work you claim has
+              been infringed; (2) the URL or description of the infringing content; (3) your
+              contact information (name, address, phone, email); (4) a statement that you have
+              a good-faith belief that the use is not authorized by the copyright owner, its
+              agent, or the law; (5) a statement, under penalty of perjury, that the
+              information in your notice is accurate and that you are the copyright owner or
+              authorized to act on the owner's behalf; and (6) your physical or electronic
+              signature. We review and act on valid takedown requests promptly.
             </p>
           </section>
 
@@ -157,8 +309,8 @@ export function Privacy() {
               Changes to This Policy
             </h2>
             <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
-              We may update this Privacy Policy from time to time. We'll notify you of any
-              significant changes by posting a notice in the app.
+              We may update this Privacy Policy from time to time. We'll update the "Last updated"
+              date at the top and notify you in the app for material changes.
             </p>
           </section>
 

--- a/src/pages/Terms.jsx
+++ b/src/pages/Terms.jsx
@@ -31,7 +31,7 @@ export function Terms() {
           <WghSeal size={96} />
         </div>
         <div className="rounded-2xl p-6 space-y-6" style={{ background: 'var(--color-surface-elevated)', border: '1px solid var(--color-divider)' }}>
-          <p className="text-sm" style={{ color: 'var(--color-text-tertiary)' }}>Last updated: January 2025</p>
+          <p className="text-sm" style={{ color: 'var(--color-text-tertiary)' }}>Last updated: April 18, 2026</p>
 
           <section>
             <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
@@ -39,8 +39,8 @@ export function Terms() {
             </h2>
             <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
               These Terms of Service ("Terms") govern your use of the What's Good Here app and
-              website ("Service"). By using the Service, you agree to these Terms. If you don't
-              agree, please don't use the Service.
+              website ("Service"), operated by Daniel Walsh. By using the Service, you agree to
+              these Terms. If you don't agree, please don't use the Service.
             </p>
           </section>
 
@@ -50,8 +50,8 @@ export function Terms() {
             </h2>
             <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
               What's Good Here is a community-driven platform that helps people discover great
-              dishes on Martha's Vineyard. Users rate dishes, and we aggregate those ratings to
-              create rankings that help others find the best food.
+              dishes on Martha's Vineyard. Users rate dishes, write reviews, upload photos, and
+              we aggregate those signals to create rankings that help others find the best food.
             </p>
           </section>
 
@@ -61,12 +61,16 @@ export function Terms() {
             </h2>
             <div className="space-y-3 leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
               <p>
-                To vote on dishes, you need to create an account. You're responsible for keeping
-                your account secure and for all activity under your account.
+                To vote, review, or upload photos, you need an account. You're responsible for
+                keeping your account secure and for all activity under your account.
               </p>
               <p>
                 You must provide accurate information when creating your account. One account per
-                person, please - creating multiple accounts to manipulate ratings is not allowed.
+                person, please — creating multiple accounts to manipulate ratings is not allowed.
+              </p>
+              <p>
+                You can delete your account anytime from the in-app settings menu (tap the
+                gear icon, then <strong>Delete Account</strong>).
               </p>
             </div>
           </section>
@@ -80,7 +84,7 @@ export function Terms() {
             </p>
             <ul className="list-disc list-inside space-y-2" style={{ color: 'var(--color-text-secondary)' }}>
               <li>Only rate dishes you've actually tried</li>
-              <li>Be honest - your votes help others make decisions</li>
+              <li>Be honest — your votes help others make decisions</li>
               <li>Don't create fake votes to promote or demote specific dishes</li>
               <li>Don't ask others to vote in a coordinated way to manipulate rankings</li>
             </ul>
@@ -94,9 +98,9 @@ export function Terms() {
               Restaurant Information
             </h2>
             <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
-              We try to keep restaurant information (hours, location, etc.) accurate, but we can't
-              guarantee it's always up to date. Please verify details with the restaurant directly,
-              especially for special hours or closures.
+              We try to keep restaurant information (hours, location, menus) accurate, but we
+              can't guarantee it's always up to date. Please verify details with the restaurant
+              directly, especially for special hours or closures.
             </p>
           </section>
 
@@ -109,7 +113,8 @@ export function Terms() {
             </p>
             <ul className="list-disc list-inside space-y-2" style={{ color: 'var(--color-text-secondary)' }}>
               <li>Harass, abuse, or harm others</li>
-              <li>Post spam or misleading content</li>
+              <li>Post spam, hate speech, or misleading content</li>
+              <li>Post sexually explicit or violent content</li>
               <li>Attempt to access accounts that aren't yours</li>
               <li>Scrape data or interfere with the Service's operation</li>
               <li>Violate any laws</li>
@@ -118,13 +123,49 @@ export function Terms() {
 
           <section>
             <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
+              Moderation, Reporting, and Blocking
+            </h2>
+            <div className="space-y-3 leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
+              <p>
+                If you see a review, photo, dish, or user that violates these Terms, the app
+                provides a way to report it. Reports go to our moderation queue and we aim to
+                review them within 48 hours. We may remove content, warn users, or terminate
+                accounts depending on severity.
+              </p>
+              <p>
+                The app also lets you block another user. When you block someone, you will no
+                longer see their reviews, ratings, or photos, and they won't see yours. You can
+                review and manage your block list from within the app.
+              </p>
+              <p>
+                We do not tolerate objectionable content. Accounts that post harassing, abusive,
+                or illegal content may be terminated without notice.
+              </p>
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
+              Your Content
+            </h2>
+            <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
+              You retain ownership of the reviews, ratings, and photos you submit. By posting
+              content to the Service, you grant us a worldwide, non-exclusive, royalty-free
+              license to display, store, and distribute that content as part of operating the
+              Service. This license ends when you delete the content or your account, except
+              to the extent others have already relied on the content (for example, aggregated
+              ratings already factored into rankings).
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
               Intellectual Property
             </h2>
             <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
-              The What's Good Here name, logo, and app design are our property. The aggregated
-              ratings and rankings are community-generated content. You retain rights to any
-              personal content you submit, but you grant us a license to use it as part of
-              the Service.
+              The What's Good Here name, logo, seal, and app design are our property. The
+              aggregated ratings and rankings are community-generated content. You may not use
+              our name or branding in a way that suggests endorsement without written permission.
             </p>
           </section>
 
@@ -133,9 +174,10 @@ export function Terms() {
               Disclaimer
             </h2>
             <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
-              The Service is provided "as is" without warranties of any kind. We're not responsible
-              for your dining experiences - ratings reflect community opinions and your experience
-              may differ. We're not affiliated with the restaurants listed unless explicitly stated.
+              The Service is provided "as is" without warranties of any kind. We're not
+              responsible for your dining experiences — ratings reflect community opinions and
+              your experience may differ. We're not affiliated with the restaurants listed
+              unless explicitly stated.
             </p>
           </section>
 
@@ -145,9 +187,52 @@ export function Terms() {
             </h2>
             <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
               To the maximum extent permitted by law, we won't be liable for any indirect,
-              incidental, or consequential damages arising from your use of the Service.
-              Our total liability is limited to the amount you paid us (which is zero, since
-              the app is free).
+              incidental, or consequential damages arising from your use of the Service. Our
+              total liability is limited to the amount you paid us (which is zero, since the
+              app is free).
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
+              App Store Terms (iOS)
+            </h2>
+            <div className="space-y-3 leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
+              <p>
+                If you downloaded the iOS app from the Apple App Store, you acknowledge:
+              </p>
+              <ul className="list-disc list-inside space-y-2">
+                <li>These Terms are between you and Daniel Walsh, not Apple. Apple is not responsible for the app or its content.</li>
+                <li>You are granted a limited, non-transferable, non-exclusive license to install and use the app only on Apple-branded devices that you own or control, and as permitted by the App Store Terms of Service.</li>
+                <li>Apple has no obligation to provide maintenance or support for the app.</li>
+                <li>If the app fails to conform to any applicable warranty, you may notify Apple for a refund of the purchase price (if any). Apple has no other warranty obligations.</li>
+                <li>Any claims relating to the app (product liability, consumer protection, non-conformity) are our responsibility, not Apple's.</li>
+                <li>Any third-party intellectual property claims are our responsibility, not Apple's.</li>
+                <li>You must comply with any applicable third-party terms when using the app (for example, your wireless carrier's terms).</li>
+                <li>Apple and Apple's subsidiaries are third-party beneficiaries of these Terms and may enforce them against you.</li>
+                <li>You represent that you are not located in a country subject to U.S. government embargo or designated as a "terrorist supporting" country, and you are not on any U.S. government list of prohibited or restricted parties.</li>
+                <li>Any questions or complaints about the app should be directed to{' '}
+                  <a
+                    href="mailto:hello@whatsgoodhere.app"
+                    className="font-medium"
+                    style={{ color: 'var(--color-primary)' }}
+                  >
+                    hello@whatsgoodhere.app
+                  </a>
+                  .
+                </li>
+              </ul>
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
+              Governing Law
+            </h2>
+            <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
+              These Terms are governed by the laws of the Commonwealth of Massachusetts, without
+              regard to its conflict-of-laws rules. Any disputes will be resolved in the state
+              or federal courts located in Massachusetts.
             </p>
           </section>
 
@@ -167,9 +252,10 @@ export function Terms() {
               Termination
             </h2>
             <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
-              You can stop using the Service at any time. We may suspend or terminate accounts
-              that violate these Terms. Upon termination, your right to use the Service ends,
-              but these Terms will continue to apply to past use.
+              You can stop using the Service at any time and delete your account from the
+              in-app settings menu. We may suspend or terminate accounts that violate these
+              Terms. Upon termination, your right to use the Service ends, but these Terms
+              will continue to apply to past use.
             </p>
           </section>
 


### PR DESCRIPTION
## Summary
Closes L1 from [app-store-readiness.md](docs/superpowers/plans/2026-04-13-app-store-readiness.md). Brings Privacy + Terms to submission-ready state for the Memorial Day Apple App Store push.

- **Privacy.jsx** — discloses dish photos, Jitter keystroke telemetry (full profile + attestation), reports/blocks, Apple Sign-In, device permissions, Sentry replay-on-error, data retention, US residency, DMCA takedown (full 17 USC 512(c)(3) notice), CCPA, under-13 statement. Fixed deletion path to match real UI.
- **Terms.jsx** — moderation/reporting/blocking section, full Apple minimum-EULA bullets (scope of license, maintenance, warranty refund, third-party beneficiary, etc.), Massachusetts governing law, corrected deletion path.

## Why
Apple auto-rejects apps whose Privacy + ToS don't disclose what the app actually does. Previous copy missed photo uploads, keystroke biometrics, UGC moderation, Apple-specific EULA terms, and pointed the deletion flow at a screen that doesn't exist. All gaps closed.

## Review method
Codex `gpt-5.4` at `high` reasoning, two rounds:
- **Round 1** caught factual under-disclosure on Jitter and stale UI promises ("Profile → Delete Account" when real path is settings gear menu).
- **Round 2** caught residual stale paths in Terms.jsx and a missed Sentry replay disclosure.
- Both rounds' findings applied. Final copy matches the actual code.

## Known couplings (must land before Apple submission)
Two disclosures describe launch-day state, not today:
- **Apple Sign-In** — Privacy references it, but `LoginModal.jsx:264` currently renders `FEATURES.APPLE_SIGNIN_ENABLED && null`. H2 Sign in with Apple must merge before this copy is public-facing.
- **Reports and Blocks** — backend shipped, frontend pending. H3 frontend must merge before submission.

Neither can ship before this copy is live without a chicken-and-egg: Apple reviewers read this page AND look for the features. Submission readiness = L1 + H2 + H3 all landed.

## Decisions needing your confirmation
- **Governing law = Massachusetts.** Defaulted based on your location. Say the word if you want a different state.
- **Physical address.** Current copy points at `hello@whatsgoodhere.app` for contact + DMCA + developer contact. Per Apple min terms item 8, a mailing address is expected. Email-only is defensible for an online-only individual developer today, but App Store Connect submission form will require a real physical address — recommend setting up a P.O. Box before submission.

## Test plan
- [ ] `npm run build` succeeds (confirmed locally)
- [ ] Visit `/privacy` and `/terms` in preview — copy renders cleanly, no layout regressions vs. old version
- [ ] External links (mailto, /jitter) resolve
- [ ] Mobile viewport — no text overflow or unreadable lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)