### PR TITLE
feat(support): add /support page + settings link

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,6 +59,7 @@ const Admin = lazyWithRetry(() => import('./pages/Admin'), 'Admin')
 const Login = lazyWithRetry(() => import('./pages/Login'), 'Login')
 const Privacy = lazyWithRetry(() => import('./pages/Privacy'), 'Privacy')
 const Terms = lazyWithRetry(() => import('./pages/Terms'), 'Terms')
+const Support = lazyWithRetry(() => import('./pages/Support'), 'Support')
 const UserProfile = lazyWithRetry(() => import('./pages/UserProfile'), 'UserProfile')
 const ResetPassword = lazyWithRetry(() => import('./pages/ResetPassword'), 'ResetPassword')
 const AcceptInvite = lazyWithRetry(() => import('./pages/AcceptInvite'), 'AcceptInvite')
@@ -147,6 +148,7 @@ function App() {
               <Route path="/manage" element={<ProtectedRoute><ManageRestaurant /></ProtectedRoute>} />
               <Route path="/privacy" element={<Privacy />} />
               <Route path="/terms" element={<Terms />} />
+              <Route path="/support" element={<Support />} />
               <Route path="/how-reviews-work" element={<Layout><HowReviewsWork /></Layout>} />
               <Route path="/for-restaurants" element={<ForRestaurants />} />
               <Route path="/playlist/:id" element={<Layout><PlaylistPage /></Layout>} />

--- a/src/components/SettingsDropdown.jsx
+++ b/src/components/SettingsDropdown.jsx
@@ -190,6 +190,20 @@ export function SettingsDropdown() {
             </svg>
           </a>
 
+          {/* Support / Help */}
+          <a
+            role="menuitem"
+            href="/support"
+            onClick={() => setShowDropdown(false)}
+            className="w-full px-4 py-3 flex items-center justify-between transition-colors border-b"
+            style={{ borderColor: 'var(--color-divider)' }}
+          >
+            <span className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>Help &amp; Support</span>
+            <svg className="w-4 h-4" style={{ color: 'var(--color-text-tertiary)' }} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </a>
+
           {/* Blocked Users */}
           <button
             role="menuitem"

--- a/src/pages/Support.jsx
+++ b/src/pages/Support.jsx
@@ -1,0 +1,172 @@
+import { useNavigate } from 'react-router-dom'
+import { WghSeal } from '../components/WghSeal'
+
+export function Support() {
+  const navigate = useNavigate()
+
+  return (
+    <div className="min-h-screen" style={{ background: 'var(--color-surface)' }}>
+      {/* Header */}
+      <header className="px-4 py-4" style={{ background: 'var(--color-bg)', borderBottom: '1px solid var(--color-divider)' }}>
+        <div className="max-w-2xl mx-auto flex items-center gap-4">
+          <button
+            onClick={() => navigate(-1)}
+            className="flex items-center gap-1 text-sm font-medium"
+            style={{ color: 'var(--color-primary)' }}
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            Back
+          </button>
+          <h1 className="text-lg font-bold" style={{ color: 'var(--color-text-primary)' }}>
+            Support
+          </h1>
+        </div>
+      </header>
+
+      {/* Content */}
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        <div className="flex justify-center mb-6">
+          <WghSeal size={96} />
+        </div>
+        <div className="rounded-2xl p-6 space-y-6" style={{ background: 'var(--color-surface-elevated)', border: '1px solid var(--color-divider)' }}>
+          <section>
+            <h2
+              className="mb-3"
+              style={{
+                fontFamily: "'Amatic SC', cursive",
+                color: 'var(--color-text-primary)',
+                fontSize: '32px',
+                fontWeight: 700,
+                letterSpacing: '0.02em',
+                lineHeight: 1.1,
+              }}
+            >
+              How can we help?
+            </h2>
+            <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
+              What's Good Here is a small operation on Martha's Vineyard. If you run into
+              something broken, want to report content, need to change your account, or
+              just want to talk about dishes — get in touch below.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
+              Email us
+            </h2>
+            <p className="leading-relaxed mb-3" style={{ color: 'var(--color-text-secondary)' }}>
+              The fastest way to reach us:
+            </p>
+            <a
+              href="mailto:hello@whatsgoodhere.app"
+              className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl font-semibold"
+              style={{ background: 'var(--color-primary)', color: 'var(--color-text-on-primary)', fontSize: '14px' }}
+            >
+              hello@whatsgoodhere.app
+            </a>
+            <p className="leading-relaxed mt-3" style={{ color: 'var(--color-text-secondary)', fontSize: '13px' }}>
+              We read every email. Typical response time: 1-2 business days.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
+              Common questions
+            </h2>
+            <div className="space-y-4 leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
+              <div>
+                <h3 className="font-medium mb-1" style={{ color: 'var(--color-text-primary)' }}>I want to delete my account.</h3>
+                <p>
+                  Open the app, tap the gear icon (Settings), and choose <strong>Delete Account</strong>.
+                  Deletion is immediate and permanent — it removes your votes, reviews, photos,
+                  favorites, playlists, and profile.
+                </p>
+              </div>
+              <div>
+                <h3 className="font-medium mb-1" style={{ color: 'var(--color-text-primary)' }}>I want to report a review, photo, or user.</h3>
+                <p>
+                  Tap the three-dot menu on the item (review card, photo, or user profile) and
+                  choose <strong>Report</strong>. Reports go to our moderation queue and we aim
+                  to review them within 48 hours.
+                </p>
+              </div>
+              <div>
+                <h3 className="font-medium mb-1" style={{ color: 'var(--color-text-primary)' }}>I own a restaurant on the app. Can I manage it?</h3>
+                <p>
+                  Yes. See{' '}
+                  <a
+                    href="/for-restaurants"
+                    className="font-medium"
+                    style={{ color: 'var(--color-primary)' }}
+                  >
+                    whatsgoodhere.app/for-restaurants
+                  </a>
+                  {' '}or email us to claim your restaurant and get access to the manager portal.
+                </p>
+              </div>
+              <div>
+                <h3 className="font-medium mb-1" style={{ color: 'var(--color-text-primary)' }}>Something's wrong with a dish or restaurant listing.</h3>
+                <p>
+                  Tap the three-dot menu on the dish page and choose <strong>Report</strong>,
+                  or email us at the address above with the link and what's off. We fix data
+                  issues quickly.
+                </p>
+              </div>
+              <div>
+                <h3 className="font-medium mb-1" style={{ color: 'var(--color-text-primary)' }}>I forgot my password.</h3>
+                <p>
+                  On the login screen, choose <strong>Forgot password?</strong>. We'll email
+                  you a reset link.
+                </p>
+              </div>
+              <div>
+                <h3 className="font-medium mb-1" style={{ color: 'var(--color-text-primary)' }}>How do ratings work?</h3>
+                <p>
+                  See{' '}
+                  <a
+                    href="/how-reviews-work"
+                    className="font-medium"
+                    style={{ color: 'var(--color-primary)' }}
+                  >
+                    whatsgoodhere.app/how-reviews-work
+                  </a>
+                  {' '}for the full breakdown.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
+              Privacy and Terms
+            </h2>
+            <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
+              Read our{' '}
+              <a href="/privacy" className="font-medium" style={{ color: 'var(--color-primary)' }}>
+                Privacy Policy
+              </a>
+              {' '}and{' '}
+              <a href="/terms" className="font-medium" style={{ color: 'var(--color-primary)' }}>
+                Terms of Service
+              </a>
+              .
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
+              Who runs this
+            </h2>
+            <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
+              What's Good Here is operated by Daniel Walsh from Martha's Vineyard,
+              Massachusetts. Small team, real people. Your emails don't go into a
+              ticketing black hole.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Support.jsx
+++ b/src/pages/Support.jsx
@@ -87,9 +87,10 @@ export function Support() {
               <div>
                 <h3 className="font-medium mb-1" style={{ color: 'var(--color-text-primary)' }}>I want to report a review, photo, or user.</h3>
                 <p>
-                  Tap the three-dot menu on the item (review card, photo, or user profile) and
-                  choose <strong>Report</strong>. Reports go to our moderation queue and we aim
-                  to review them within 48 hours.
+                  Every review, photo, dish, and user profile has a <strong>Report</strong>
+                  control — a small ellipsis button on review cards, a Report button in the
+                  photo lightbox, the three-dot menu on user profiles. Reports go to our
+                  moderation queue and we aim to review them within 48 hours.
                 </p>
               </div>
               <div>
@@ -109,9 +110,9 @@ export function Support() {
               <div>
                 <h3 className="font-medium mb-1" style={{ color: 'var(--color-text-primary)' }}>Something's wrong with a dish or restaurant listing.</h3>
                 <p>
-                  Tap the three-dot menu on the dish page and choose <strong>Report</strong>,
-                  or email us at the address above with the link and what's off. We fix data
-                  issues quickly.
+                  Use the <strong>Report</strong> control on the dish page (the small
+                  ellipsis button next to the action bar), or email us at the address above
+                  with the link and what's off. We fix data issues quickly.
                 </p>
               </div>
               <div>
@@ -159,10 +160,13 @@ export function Support() {
             <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
               Who runs this
             </h2>
-            <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
+            <p className="leading-relaxed mb-3" style={{ color: 'var(--color-text-secondary)' }}>
               What's Good Here is operated by Daniel Walsh from Martha's Vineyard,
-              Massachusetts. Small team, real people. Your emails don't go into a
-              ticketing black hole.
+              Massachusetts. An actual person reads every email — your messages don't
+              go into a ticketing black hole.
+            </p>
+            <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
+              Mailing address available on written request via the email above.
             </p>
           </section>
         </div>


### PR DESCRIPTION
## Summary
Adds a real Support page at \`/support\`. Apple's App Store Connect submission form requires a reachable support URL — can't be a mailto, an email-only contact page, or a 404.

**What's on the page:**
- Contact email (hello@whatsgoodhere.app) with stated response window
- FAQ: account deletion, reporting content, restaurant claims, password reset, ratings explainer
- Links to /privacy, /terms, /how-reviews-work, /for-restaurants
- "Who runs this" — names Daniel Walsh / Martha's Vineyard

**Where it's linked from:**
- Settings gear menu → \"Help & Support\" entry (between Terms and Blocked users)

## Why
Submission gate on App Store Connect. Writing the page today so the URL is live long before we reserve the app name / create the record.

## Test plan
- [ ] \`npm run build\` passes (confirmed locally)
- [ ] Visit \`/support\` — renders cleanly, matches Privacy/Terms visual style
- [ ] Settings gear → Help & Support → navigates to /support
- [ ] All internal links work (/privacy, /terms, /how-reviews-work, /for-restaurants)
- [ ] Mailto link opens default mail app

🤖 Generated with [Claude Code](https://claude.com/claude-code)