### PR TITLE
fix(p1): complete tabs pattern on restaurant view + polish

### DIFF
--- a/src/pages/Map.jsx
+++ b/src/pages/Map.jsx
@@ -341,7 +341,21 @@ export function Map() {
           <div className="fixed inset-0" style={{ zIndex: 1 }}>
             <ErrorBoundary>
               <Suspense fallback={
-                <div className="w-full h-full" style={{ background: 'var(--color-bg)' }} />
+                <div
+                  role="status"
+                  aria-label="Loading map"
+                  className="w-full h-full flex items-center justify-center"
+                  style={{ background: 'var(--color-bg)' }}
+                >
+                  <div
+                    className="w-8 h-8 rounded-full animate-spin"
+                    style={{
+                      border: '3px solid var(--color-divider)',
+                      borderTopColor: 'var(--color-accent-gold)',
+                    }}
+                  />
+                  <span className="sr-only">Loading map</span>
+                </div>
               }>
                 <RestaurantMap
                   mode="dish"

--- a/src/pages/RestaurantDetail.jsx
+++ b/src/pages/RestaurantDetail.jsx
@@ -5,6 +5,7 @@ import { useAuth } from '../context/AuthContext'
 import { ReportModal } from '../components/ReportModal'
 import { PlaceAttributions } from '../components/PlaceAttributions'
 import { logger } from '../utils/logger'
+import { getUserMessage } from '../utils/errorHandler'
 import { shareOrCopy } from '../utils/share'
 import { sanitizeUrl } from '../utils/sanitize'
 import { restaurantsApi } from '../api/restaurantsApi'
@@ -226,7 +227,7 @@ export function RestaurantDetail() {
       <div className="min-h-screen flex items-center justify-center" style={{ background: 'var(--color-bg)' }}>
         <div className="text-center px-4">
           <p role="alert" className="text-sm mb-4" style={{ color: 'var(--color-danger)' }}>
-            {fetchError?.message || 'Failed to load restaurant'}
+            {getUserMessage(fetchError, 'loading this restaurant')}
           </p>
           <button
             onClick={() => navigate('/restaurants')}
@@ -550,25 +551,40 @@ export function RestaurantDetail() {
             background: 'var(--color-surface-elevated)',
             border: '1px solid var(--color-divider)',
           }}
-          role="group"
+          role="tablist"
           aria-label="Restaurant view"
+          onKeyDown={(e) => {
+            if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return
+            e.preventDefault()
+            const next = (activeTab || 'top') === 'top' ? 'menu' : 'top'
+            setActiveTab(next)
+            requestAnimationFrame(() => {
+              document.getElementById('restaurant-tab-' + next)?.focus()
+            })
+          }}
         >
           <button
-            role="button"
-            aria-pressed={activeTab === 'top'}
+            role="tab"
+            aria-selected={(activeTab || 'top') === 'top'}
+            aria-controls="restaurant-tab-panel"
+            id="restaurant-tab-top"
+            tabIndex={(activeTab || 'top') === 'top' ? 0 : -1}
             onClick={() => setActiveTab('top')}
             className="flex-1 py-1.5 text-sm font-semibold rounded-lg transition-all"
             style={{
-              background: activeTab === 'top' ? 'var(--color-primary)' : 'transparent',
-              color: activeTab === 'top' ? 'white' : 'var(--color-text-secondary)',
+              background: (activeTab || 'top') === 'top' ? 'var(--color-primary)' : 'transparent',
+              color: (activeTab || 'top') === 'top' ? 'white' : 'var(--color-text-secondary)',
               boxShadow: 'none',
             }}
           >
             Top Rated
           </button>
           <button
-            role="button"
-            aria-pressed={activeTab === 'menu'}
+            role="tab"
+            aria-selected={activeTab === 'menu'}
+            aria-controls="restaurant-tab-panel"
+            id="restaurant-tab-menu"
+            tabIndex={activeTab === 'menu' ? 0 : -1}
             onClick={() => setActiveTab('menu')}
             className="flex-1 py-1.5 text-sm font-semibold rounded-lg transition-all"
             style={{
@@ -592,6 +608,11 @@ export function RestaurantDetail() {
       )}
 
       {/* Dish Content */}
+      <div
+        role="tabpanel"
+        id="restaurant-tab-panel"
+        aria-labelledby={(activeTab || 'top') === 'top' ? 'restaurant-tab-top' : 'restaurant-tab-menu'}
+      >
       {(activeTab || 'top') === 'top' ? (
         <RestaurantDishes
           dishes={dishes}
@@ -614,6 +635,7 @@ export function RestaurantDetail() {
           menuSectionOrder={restaurant?.menu_section_order || []}
         />
       )}
+      </div>
 
       {/* Happening Here - Specials & Events (hidden until Launch 2.0 — stale scraped data) */}
       {false && (specials.length > 0 || events.length > 0) && (


### PR DESCRIPTION
## Summary
Three P1 quick-wins from the app-store-readiness plan:

1. **RestaurantDetail tabs** (role=\"button\"+aria-pressed → full tabs pattern with role=\"tablist\"/role=\"tab\"/role=\"tabpanel\", roving tabindex, arrow-key navigation). First draft was partial; Codex round 2 correctly flagged missing tabpanel + tabindex + keyboard handling. Fully implemented now.
2. **RestaurantDetail error state** — raw \`fetchError?.message\` → \`getUserMessage(fetchError, 'loading this restaurant')\` per CLAUDE.md §1.2 (no leaking supabase / network error strings to users).
3. **Map Suspense fallback** — blank div → centered spinner with role=\"status\" + sr-only label. In-family with Skeleton.jsx loaders.

## Review trail
Codex gpt-5.4 at high reasoning. Round 1 of Codex flagged:
- Tab pattern was incomplete (tablist/tab semantics without tabpanel, tabindex management, or arrow-key handling) → all addressed in this PR
- Error state + Suspense fallback: no findings, shipped as-is

## Test plan
- [ ] \`npm run build\` passes (confirmed locally)
- [ ] Focus the Top Rated / Menu toggle and press ArrowRight / ArrowLeft — active tab changes and focus follows
- [ ] Tab-navigate into the tablist from elsewhere on the page — only the active tab receives focus (roving tabindex working)
- [ ] Trigger a restaurant-detail fetch error (network tab offline) — user sees a clean friendly message instead of raw supabase text
- [ ] Navigate to \`/\` with slow connection — sees the spinner, not a blank screen, while Map chunk loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)