### PR TITLE
fix(menu-refresh): unblock cron pipeline + website-url fallback

### DIFF
--- a/src/api/restaurantsApi.js
+++ b/src/api/restaurantsApi.js
@@ -298,27 +298,6 @@ export const restaurantsApi = {
     }
   },
 
-  /**
-   * Trigger menu import for a restaurant via menu-refresh Edge Function.
-   * Fire-and-forget — does not throw on failure.
-   */
-  async refreshMenu(restaurantId) {
-    try {
-      const { data, error } = await supabase.functions.invoke('menu-refresh', {
-        body: { restaurant_id: restaurantId },
-      })
-      if (error) {
-        logger.warn('Menu refresh failed (non-blocking):', error)
-        return null
-      }
-      logger.info('Menu refresh triggered:', data)
-      return data
-    } catch (error) {
-      logger.warn('Menu refresh failed (non-blocking):', error)
-      return null
-    }
-  },
-
   async getById(restaurantId) {
     try {
       const { data, error } = await supabase

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -7,3 +7,12 @@
 # rejected at the gateway with 401 "Invalid JWT" before the function could run.
 [functions.delete-account]
 verify_jwt = false
+
+# menu-refresh is invoked by pg_cron using the legacy service_role JWT from vault.
+# The Supabase Functions gateway stopped accepting that legacy JWT around 2026-04-12,
+# returning 401 for every cron call and silently stalling every menu import since.
+# The function auths to the DB via its own SUPABASE_SERVICE_ROLE_KEY env var, so the
+# gateway check is pure gating — disable it. Request body only accepts {mode},
+# {restaurant_id} (must match an existing row), or {} — no arbitrary URL injection.
+[functions.menu-refresh]
+verify_jwt = false

--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -727,6 +727,14 @@ serve(async (req) => {
             if (found) {
               menuUrl = found
               dbUpdates.menu_url = menuUrl
+            } else {
+              // Fallback: many restaurants have their menu as a PDF linked only from
+              // the homepage (e.g. /wp-content/uploads/*.pdf) — paths findMenuUrl's
+              // probe list misses. Using the homepage as menuUrl lets the downstream
+              // extractPdfMenuUrls scan find those links. If no PDFs exist, Sonnet
+              // still gets a shot at extracting from the homepage HTML itself.
+              menuUrl = websiteUrl
+              dbUpdates.menu_url = menuUrl
             }
           }
 

--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -618,6 +618,25 @@ serve(async (req) => {
     return new Response('ok', { headers: corsHeaders })
   }
 
+  // Shared-secret gate. The function runs with verify_jwt = false at the
+  // gateway (so pg_cron can invoke it after the legacy service_role JWT
+  // stopped being accepted ~2026-04-12), but the function itself is
+  // privileged: it mutates with service role and calls the paid Sonnet API.
+  // Require an explicit CRON_SECRET match so this isn't a public endpoint.
+  const cronSecret = Deno.env.get('CRON_SECRET')
+  if (!cronSecret) {
+    return new Response(JSON.stringify({ error: 'CRON_SECRET not configured' }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    })
+  }
+  if (req.headers.get('Authorization') !== `Bearer ${cronSecret}`) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    })
+  }
+
   try {
     if (!ANTHROPIC_API_KEY) {
       return new Response(JSON.stringify({ error: 'ANTHROPIC_API_KEY not configured' }), {
@@ -728,13 +747,17 @@ serve(async (req) => {
               menuUrl = found
               dbUpdates.menu_url = menuUrl
             } else {
-              // Fallback: many restaurants have their menu as a PDF linked only from
-              // the homepage (e.g. /wp-content/uploads/*.pdf) — paths findMenuUrl's
-              // probe list misses. Using the homepage as menuUrl lets the downstream
-              // extractPdfMenuUrls scan find those links. If no PDFs exist, Sonnet
-              // still gets a shot at extracting from the homepage HTML itself.
-              menuUrl = websiteUrl
-              dbUpdates.menu_url = menuUrl
+              // Ephemeral fallback for THIS run only. Many restaurants link the
+              // menu as a PDF (e.g. /wp-content/uploads/*.pdf) only from the
+              // homepage — paths findMenuUrl's probe list misses. Letting the
+              // downstream pipeline see the homepage gives extractPdfMenuUrls a
+              // chance to find those links and Sonnet a shot at the homepage
+              // HTML. We do NOT persist this to dbUpdates.menu_url — that would
+              // lock the restaurant into the homepage forever and prevent
+              // future discovery of a real /menu URL.
+              let normalized = websiteUrl.replace(/\/+$/, '')
+              if (!normalized.startsWith('http')) normalized = 'https://' + normalized
+              menuUrl = normalized
             }
           }
 

--- a/supabase/migrations/2026-04-19-menu-refresh-cron-secret.sql
+++ b/supabase/migrations/2026-04-19-menu-refresh-cron-secret.sql
@@ -1,0 +1,54 @@
+-- 2026-04-19: Update process-menu-import-queue cron to use cron_secret
+--
+-- The menu-refresh edge function now requires Authorization: Bearer $CRON_SECRET
+-- (in addition to verify_jwt = false at the gateway). Update the cron caller
+-- to pass that secret from vault instead of the legacy service_role_key, which
+-- the Functions gateway stopped accepting around 2026-04-12 and which would
+-- not satisfy the new in-function check anyway.
+--
+-- PRE-DEPLOY MANUAL STEP (Supabase dashboard):
+--   1. Generate a high-entropy secret (e.g. `openssl rand -hex 32`)
+--   2. Vault: add secret named 'cron_secret' with that value
+--      (Supabase dashboard → Project Settings → Vault → New secret)
+--   3. Edge Functions env: set CRON_SECRET to the SAME value on the
+--      menu-refresh function (Settings → Edge Functions → menu-refresh)
+--   4. Then run this migration in the SQL editor.
+
+SELECT cron.unschedule('process-menu-import-queue');
+
+SELECT cron.schedule(
+  'process-menu-import-queue',
+  '* * * * *',
+  $$
+  SELECT net.http_post(
+    url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'supabase_url' LIMIT 1) || '/functions/v1/menu-refresh',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'cron_secret' LIMIT 1)
+    ),
+    body := '{"mode": "queue"}'::jsonb
+  );
+  $$
+);
+
+-- Verify the job is registered with the new headers
+SELECT jobname, schedule, command FROM cron.job WHERE jobname = 'process-menu-import-queue';
+
+-- ROLLBACK:
+-- SELECT cron.unschedule('process-menu-import-queue');
+-- SELECT cron.schedule(
+--   'process-menu-import-queue',
+--   '* * * * *',
+--   $$
+--   SELECT net.http_post(
+--     url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'supabase_url' LIMIT 1) || '/functions/v1/menu-refresh',
+--     headers := jsonb_build_object(
+--       'Content-Type', 'application/json',
+--       'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'service_role_key' LIMIT 1)
+--     ),
+--     body := '{"mode": "queue"}'::jsonb
+--   );
+--   $$
+-- );
+-- Note: if rolling back, also revert the menu-refresh function's verify_jwt setting
+-- and remove the in-function CRON_SECRET check.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -3291,6 +3291,11 @@ GRANT EXECUTE ON FUNCTION enqueue_menu_import(UUID, TEXT, INT) TO authenticated,
 CREATE EXTENSION IF NOT EXISTS pg_net;
 
 -- pg_cron: process queue every 60 seconds
+-- Auth: passes vault secret 'cron_secret' which menu-refresh's serve() handler
+-- compares against the CRON_SECRET edge-function env var. The Functions gateway
+-- has verify_jwt = false on this function so pg_cron can reach it (the legacy
+-- service_role JWT stopped being accepted ~2026-04-12), so the in-function
+-- shared-secret check is the only auth on this privileged endpoint.
 SELECT cron.schedule(
   'process-menu-import-queue',
   '* * * * *',
@@ -3299,7 +3304,7 @@ SELECT cron.schedule(
     url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'supabase_url' LIMIT 1) || '/functions/v1/menu-refresh',
     headers := jsonb_build_object(
       'Content-Type', 'application/json',
-      'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'service_role_key' LIMIT 1)
+      'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'cron_secret' LIMIT 1)
     ),
     body := '{"mode": "queue"}'::jsonb
   );


### PR DESCRIPTION
## Summary

Fix the menu-refresh cron pipeline that's been silently 401'ing since 2026-04-12, **without** opening the function up as a public endpoint.

**Code changes:**
- `supabase/config.toml` — `verify_jwt = false` on `menu-refresh` so pg_cron can call it (gateway stopped accepting the legacy service_role JWT around 2026-04-12).
- `supabase/functions/menu-refresh/index.ts`:
  - **Shared-secret gate.** Top of `serve()` requires `Authorization: Bearer $CRON_SECRET`. Fails closed (500) if the env var isn't set; rejects (401) if the header doesn't match. Function is privileged (mutates with service role, calls paid Sonnet API), so this is required even with `verify_jwt = false` at the gateway.
  - **Ephemeral homepage fallback.** When `findMenuUrl` can't locate a menu link, use the website URL for THIS run only — don't persist it to `dbUpdates.menu_url`. Prevents permanently locking a restaurant to its homepage and losing future `/menu` discovery.
  - **URL normalization** before using website URL as fallback (mirrors `findMenuUrl` internal behavior).
- `src/api/restaurantsApi.js` — drop dead `refreshMenu()` method (no callers in `src/`).

**Schema + migration:**
- `supabase/schema.sql` — update `process-menu-import-queue` cron definition to use `cron_secret` from vault (matches the migration; prevents schema-snapshot drift).
- `supabase/migrations/2026-04-19-menu-refresh-cron-secret.sql` — re-schedule the cron to pass `Bearer $cron_secret` instead of `service_role_key`. Includes ROLLBACK block per CLAUDE.md policy.

## Pre-deploy steps — STRICT ORDER (Supabase dashboard)

Order matters. If you run the migration before the function is deployed, cron will flap between 401 and 500 every minute until the function catches up.

1. **Generate secret:** `openssl rand -hex 32`
2. **Vault** → New secret named `cron_secret` with that value
3. **Edge Functions → menu-refresh → Settings** → set env var `CRON_SECRET` to the **same value**
4. **Deploy** the updated `menu-refresh` function (Supabase CLI or dashboard) — config.toml `verify_jwt = false` takes effect on deploy
5. Verify the function is live and accepts the secret:
   ```
   curl -i -H "Authorization: Bearer $CRON_SECRET" \
        -H "Content-Type: application/json" \
        -d '{"mode":"queue"}' \
        $SUPABASE_URL/functions/v1/menu-refresh
   ```
   Expect 200 (or 200 with "No jobs to process"). Without the header → 401.
6. **SQL Editor** → run `supabase/migrations/2026-04-19-menu-refresh-cron-secret.sql`

## Why this scope expanded mid-PR

Codex review on the initial 17-line patch caught two real bugs:
1. **HIGH** — `verify_jwt = false` without an in-function auth check made this a public DoS / cost-amplification vector. I had cited `delete-account` as precedent, but that function re-verifies the caller's JWT in-function — `menu-refresh` had nothing.
2. **MEDIUM** — the homepage fallback was persisting `menu_url`, which would prevent re-discovery on future runs.

Round 3 (after schema alignment): "looks clean."

## Test plan

- [ ] Run pre-deploy steps **in order**
- [ ] Confirm pg_cron logs show 200 (not 401) on `process-menu-import-queue` invocations within 1-2 minutes of the migration
- [ ] Negative test: same `curl` without the header → 401
- [ ] Pick one restaurant with a homepage-only PDF menu, kick a manual queue job, confirm dishes upsert AND `menu_url` stays NULL on the restaurant row

🤖 Generated with [Claude Code](https://claude.com/claude-code)