### PR TITLE
docs: archive Mar–Apr planning artifacts + add 2 menu seeds

### DIFF
--- a/docs/superpowers/plans/2026-03-10-pwa-native-experience.md
+++ b/docs/superpowers/plans/2026-03-10-pwa-native-experience.md
@@ -1,0 +1,826 @@
+# PWA Native Experience — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the existing web app feel like a native iOS app when installed to the home screen — proper icon, splash screen, full-screen standalone mode, and a tasteful install prompt.
+
+**Architecture:** The app already has `vite-plugin-pwa` with a service worker for caching, but the manifest is disabled (`manifest: false`). We enable the web app manifest, generate proper icon sizes from the existing `logo.webp` asset, add iOS-specific splash screens, and build a lightweight install prompt component for mobile Safari users. No new dependencies.
+
+**Tech Stack:** vite-plugin-pwa (already installed), Workbox (already configured), native HTML meta tags, CSS variables (existing design tokens)
+
+---
+
+## Current State (what exists today)
+
+| Asset | Status | Issue |
+|---|---|---|
+| `vite-plugin-pwa` | Installed, service worker active | `manifest: false` — no web app manifest at all |
+| `apple-mobile-web-app-capable` | Present in `index.html:26` | Already set to `yes` |
+| `apple-mobile-web-app-status-bar-style` | Present in `index.html:27` | Set to `black` — should be `black-translucent` for edge-to-edge |
+| `apple-mobile-web-app-title` | Present in `index.html:28` | Set to `What's Good Here` |
+| `theme-color` | Present in `index.html:23` | Set to `#000000` — should match app bg `#F0ECE8` |
+| `wgh-icon.png` | 200x200, dark background | Too small for iOS (needs 180x180 minimum, 512x512 for manifest). Dark bg looks bad on light home screens |
+| `logo.webp` | Coral checkmark on white, large source | Good source for generating app icons |
+| `favicon.png` | 32x32 | Fine as-is |
+| `wgh-splash.webp` | 1536x1024 landscape | Wrong orientation/size for iOS splash screens |
+| Install prompt | Does not exist | No way to nudge users to install |
+
+## File Structure
+
+### Files to create:
+| File | Responsibility |
+|---|---|
+| `public/icons/icon-192x192.png` | Android/manifest icon (required by manifest spec) |
+| `public/icons/icon-512x512.png` | Android/manifest large icon + splash fallback |
+| `public/icons/apple-touch-icon.png` | iOS home screen icon (180x180) |
+| `src/components/InstallPrompt.jsx` | "Add to Home Screen" banner for mobile Safari |
+| `src/hooks/useInstallPrompt.js` | Install prompt detection + dismissal logic |
+
+### Files to modify:
+| File | What changes |
+|---|---|
+| `index.html` | Fix `theme-color`, `status-bar-style`, add `apple-touch-icon` link, remove stale theme script |
+| `vite.config.js` | Enable manifest with proper name, icons, colors, display: standalone |
+| `src/App.jsx` | Mount `<InstallPrompt />` |
+| `src/lib/storage.js` | Add `INSTALL_PROMPT_DISMISSED` key constant |
+
+### Files NOT changing:
+- No changes to any page component, hook, API module, or routing
+- No changes to the service worker caching strategy (already solid)
+- No changes to `src/index.css` or design tokens (existing `slideUp` keyframe reused)
+- No new npm dependencies
+- No Capacitor, no Expo, no React Native
+
+---
+
+## Chunk 1: Manifest + Meta Tags + Icons
+
+### Task 1: Generate app icon PNGs from source logo
+
+**Files:**
+- Create: `public/icons/icon-192x192.png`
+- Create: `public/icons/icon-512x512.png`
+- Create: `public/icons/apple-touch-icon.png`
+
+**Context:** `logo.webp` (coral fork-knife checkmark on white) is the brand icon. We need three sizes: 180x180 (iOS), 192x192 (Android/manifest), 512x512 (manifest + splash). All should have the warm stone background (`#F0ECE8`) matching the app, with the logo centered and padded ~15% from edges.
+
+- [ ] **Step 1: Create the icons directory**
+
+```bash
+mkdir -p public/icons
+```
+
+- [ ] **Step 2: Generate icon sizes using sips (macOS built-in)**
+
+Use `sips` to convert `logo.webp` to PNG and resize. The source logo is large enough to downscale cleanly.
+
+```bash
+# Convert source to PNG first
+sips -s format png public/logo.webp --out /tmp/wgh-logo-source.png
+
+# 512x512 — large manifest icon
+sips -z 512 512 /tmp/wgh-logo-source.png --out public/icons/icon-512x512.png
+
+# 192x192 — standard manifest icon
+sips -z 192 192 /tmp/wgh-logo-source.png --out public/icons/icon-192x192.png
+
+# 180x180 — iOS apple-touch-icon
+sips -z 180 180 /tmp/wgh-logo-source.png --out public/icons/apple-touch-icon.png
+```
+
+**Note:** If the logo.webp has transparent/white background and the icons look wrong on iOS (which adds white background for non-maskable), we may need to composite onto `#F0ECE8` background. Check the output visually before proceeding.
+
+- [ ] **Step 3: Verify icons look correct**
+
+```bash
+# Check sizes
+sips -g pixelWidth -g pixelHeight public/icons/icon-512x512.png
+sips -g pixelWidth -g pixelHeight public/icons/icon-192x192.png
+sips -g pixelWidth -g pixelHeight public/icons/apple-touch-icon.png
+
+# Open to visually verify
+open public/icons/apple-touch-icon.png
+```
+
+Expected: Three PNGs with the coral checkmark logo, looking clean at each size.
+
+- [ ] **Step 4: Commit icons**
+
+```bash
+git add public/icons/
+git commit -m "feat: add PWA app icons in 180/192/512 sizes
+
+Generated from logo.webp source for iOS home screen,
+Android manifest, and splash screen usage.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Enable web app manifest in vite-plugin-pwa
+
+**Files:**
+- Modify: `vite.config.js:72-74`
+
+**Context:** The manifest is currently disabled (`manifest: false`). We need to enable it with proper app metadata. The manifest tells the browser how to install the app — name, icons, colors, display mode.
+
+Reference: Current config at `vite.config.js:11-74`.
+
+- [ ] **Step 1: Write the failing test — verify manifest is served**
+
+No unit test needed here — this is build config. The verification is:
+
+```bash
+npm run build
+# Check that manifest.webmanifest is generated in dist/
+ls dist/manifest.webmanifest 2>/dev/null && echo "PASS: manifest exists" || echo "FAIL: no manifest"
+```
+
+Expected before change: FAIL
+
+- [ ] **Step 2: Replace `manifest: false` with full manifest config**
+
+In `vite.config.js`, replace the line:
+
+```js
+      // Minimal manifest (no installable PWA, just service worker)
+      manifest: false,
+```
+
+with:
+
+```js
+      manifest: {
+        name: "What's Good Here",
+        short_name: 'WGH',
+        description: 'Find the best dishes at restaurants near you. Crowd-sourced dish rankings for Martha\'s Vineyard.',
+        start_url: '/',
+        scope: '/',
+        display: 'standalone',
+        orientation: 'portrait',
+        theme_color: '#F0ECE8',
+        background_color: '#F0ECE8',
+        categories: ['food', 'lifestyle', 'travel'],
+        icons: [
+          {
+            src: '/icons/icon-192x192.png',
+            sizes: '192x192',
+            type: 'image/png',
+          },
+          {
+            src: '/icons/icon-512x512.png',
+            sizes: '512x512',
+            type: 'image/png',
+          },
+          {
+            src: '/icons/icon-512x512.png',
+            sizes: '512x512',
+            type: 'image/png',
+            purpose: 'maskable',
+          },
+        ],
+      },
+```
+
+- [ ] **Step 3: Build and verify manifest**
+
+```bash
+npm run build
+cat dist/manifest.webmanifest
+```
+
+Expected: JSON manifest with name, icons, display: standalone, correct colors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add vite.config.js
+git commit -m "feat: enable PWA web app manifest with standalone display mode
+
+Enables install-to-home-screen on both iOS and Android.
+App launches full-screen without browser chrome.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Fix meta tags in index.html
+
+**Files:**
+- Modify: `index.html:5-6,23,27`
+
+**Context:** Several meta tags need updating. The `theme-color` is black (leftover from dark mode era), the status bar style should be `black-translucent` for edge-to-edge on iOS, and we need the `apple-touch-icon` link. Also remove the stale theme-switching script on line 50-52 (light mode is the only mode now).
+
+- [ ] **Step 1: Update theme-color from black to warm stone**
+
+In `index.html`, change:
+
+```html
+    <meta name="theme-color" content="#000000" />
+```
+
+to:
+
+```html
+    <meta name="theme-color" content="#F0ECE8" />
+```
+
+- [ ] **Step 2: Update status bar style to black-translucent**
+
+Change:
+
+```html
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+```
+
+to:
+
+```html
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+```
+
+This makes the status bar transparent so the app content extends to the top edge, like native iOS apps.
+
+- [ ] **Step 3: Add apple-touch-icon link**
+
+After the favicon link (line 5), add:
+
+```html
+    <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
+```
+
+- [ ] **Step 4: Remove stale theme script**
+
+Delete lines 49-52:
+
+```html
+    <!-- Prevent flash of wrong theme on load -->
+    <script>
+      try { if (localStorage.getItem('wgh_theme') === 'light') document.documentElement.setAttribute('data-theme', 'light'); } catch(e) {}
+    </script>
+```
+
+This is dead code — light mode is the only mode (CLAUDE.md: "Light theme only"). There is no `[data-theme="dark"]` CSS, and `wgh_theme` is not in the localStorage keys table.
+
+- [ ] **Step 5: Build and verify**
+
+```bash
+npm run build
+# Check the output HTML has correct meta tags
+grep "theme-color" dist/index.html
+grep "apple-touch-icon" dist/index.html
+grep "black-translucent" dist/index.html
+# Verify dead theme script is gone
+grep "wgh_theme" dist/index.html && echo "FAIL: stale script still present" || echo "PASS: cleaned up"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add index.html
+git commit -m "fix: update PWA meta tags for proper iOS standalone experience
+
+- theme-color matches app background (#F0ECE8)
+- status bar uses black-translucent for edge-to-edge
+- apple-touch-icon link added
+- removed stale dark mode theme script
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Chunk 2: Install Prompt
+
+### Task 4: Add storage key for install prompt dismissal
+
+**Files:**
+- Modify: `src/lib/storage.js`
+
+**Context:** The install prompt should only show once. We need a localStorage key to track whether the user has dismissed it. All localStorage access goes through `src/lib/storage.js` per CLAUDE.md rules.
+
+- [ ] **Step 1: Read current storage.js to find where keys are defined**
+
+```bash
+# Find the key constants section
+grep -n "const\|STORAGE\|KEY" src/lib/storage.js | head -20
+```
+
+- [ ] **Step 2: Add the new key to STORAGE_KEYS object**
+
+In `src/lib/storage.js`, add to the `STORAGE_KEYS` object (after `EMAIL_CACHE` on line 89):
+
+```js
+  INSTALL_PROMPT_DISMISSED: 'wgh_install_prompt_dismissed',
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/storage.js
+git commit -m "feat: add INSTALL_PROMPT_DISMISSED storage key
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Create useInstallPrompt hook
+
+**Files:**
+- Create: `src/hooks/useInstallPrompt.js`
+- Create: `src/hooks/useInstallPrompt.test.js`
+
+**Context:** This hook detects whether to show the install prompt. Conditions:
+1. User is on mobile Safari (iOS, not in standalone mode already)
+2. User hasn't dismissed the prompt before (check localStorage)
+3. User has been on the app for at least 30 seconds (don't interrupt first impression)
+
+It also handles the Android `beforeinstallprompt` event for Chrome/Edge users.
+
+- [ ] **Step 1: Write the test file**
+
+```js
+// src/hooks/useInstallPrompt.test.js
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useInstallPrompt } from './useInstallPrompt'
+
+// Mock storage module
+vi.mock('../lib/storage', () => ({
+  getStorageItem: vi.fn(),
+  setStorageItem: vi.fn(),
+  STORAGE_KEYS: { INSTALL_PROMPT_DISMISSED: 'wgh_install_prompt_dismissed' },
+}))
+
+import { getStorageItem, setStorageItem } from '../lib/storage'
+
+describe('useInstallPrompt', () => {
+  var originalNavigator
+  var originalWindow
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    getStorageItem.mockReturnValue(null)
+    // Default: not standalone, not iOS
+    Object.defineProperty(window.navigator, 'standalone', {
+      value: false,
+      configurable: true,
+      writable: true,
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('should not show prompt if already dismissed', () => {
+    getStorageItem.mockReturnValue('true')
+    var { result } = renderHook(() => useInstallPrompt())
+    act(() => { vi.advanceTimersByTime(31000) })
+    expect(result.current.showPrompt).toBe(false)
+  })
+
+  it('should not show prompt if already in standalone mode', () => {
+    // matchMedia for standalone
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: query === '(display-mode: standalone)',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+    var { result } = renderHook(() => useInstallPrompt())
+    act(() => { vi.advanceTimersByTime(31000) })
+    expect(result.current.showPrompt).toBe(false)
+  })
+
+  it('dismiss should set storage and hide prompt', () => {
+    var { result } = renderHook(() => useInstallPrompt())
+    act(() => { result.current.dismiss() })
+    expect(setStorageItem).toHaveBeenCalledWith('wgh_install_prompt_dismissed', 'true')
+    expect(result.current.showPrompt).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm run test -- src/hooks/useInstallPrompt.test.js
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the hook**
+
+```js
+// src/hooks/useInstallPrompt.js
+import { useState, useEffect, useCallback } from 'react'
+import { getStorageItem, setStorageItem, STORAGE_KEYS } from '../lib/storage'
+
+/**
+ * Detects whether to show "Add to Home Screen" install prompt.
+ *
+ * Shows for:
+ * - Mobile Safari users not already in standalone mode
+ * - Android Chrome users (via beforeinstallprompt event)
+ *
+ * Waits 30s before showing to avoid interrupting first impression.
+ * Remembers dismissal in localStorage.
+ */
+export function useInstallPrompt() {
+  var [showPrompt, setShowPrompt] = useState(false)
+  var [deferredEvent, setDeferredEvent] = useState(null)
+
+  useEffect(function () {
+    // Already dismissed
+    if (getStorageItem(STORAGE_KEYS.INSTALL_PROMPT_DISMISSED)) return
+
+    // Already installed / in standalone mode
+    var isStandalone = window.navigator.standalone === true ||
+      window.matchMedia('(display-mode: standalone)').matches
+    if (isStandalone) return
+
+    // Android Chrome: capture the beforeinstallprompt event
+    function handleBeforeInstall(e) {
+      e.preventDefault()
+      setDeferredEvent(e)
+    }
+    window.addEventListener('beforeinstallprompt', handleBeforeInstall)
+
+    // Delay showing prompt by 30 seconds
+    var timer = setTimeout(function () {
+      setShowPrompt(true)
+    }, 30000)
+
+    return function () {
+      clearTimeout(timer)
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstall)
+    }
+  }, [])
+
+  var dismiss = useCallback(function () {
+    setStorageItem(STORAGE_KEYS.INSTALL_PROMPT_DISMISSED, 'true')
+    setShowPrompt(false)
+  }, [])
+
+  var install = useCallback(function () {
+    // Android: trigger native install prompt
+    if (deferredEvent) {
+      deferredEvent.prompt()
+      deferredEvent.userChoice.then(function () {
+        setDeferredEvent(null)
+        dismiss()
+      })
+      return
+    }
+    // iOS: can't trigger programmatically, just dismiss our banner
+    dismiss()
+  }, [deferredEvent, dismiss])
+
+  var isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent)
+
+  return {
+    showPrompt: showPrompt,
+    isIOS: isIOS,
+    dismiss: dismiss,
+    install: install,
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm run test -- src/hooks/useInstallPrompt.test.js
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useInstallPrompt.js src/hooks/useInstallPrompt.test.js
+git commit -m "feat: add useInstallPrompt hook for PWA install detection
+
+Detects mobile Safari and Android Chrome install eligibility.
+30s delay before showing, remembers dismissal via localStorage.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Create InstallPrompt component
+
+**Files:**
+- Create: `src/components/InstallPrompt.jsx`
+
+**Context:** A small, tasteful banner that slides up from the bottom (above BottomNav). Shows the app icon, "Add What's Good Here" message, and iOS-specific instructions ("Tap Share then Add to Home Screen") or a direct Install button for Android. Dismissible with X. Uses existing design tokens.
+
+- [ ] **Step 1: Create the component**
+
+```jsx
+// src/components/InstallPrompt.jsx
+import { useInstallPrompt } from '../hooks/useInstallPrompt'
+
+/**
+ * "Add to Home Screen" install banner.
+ * Shows for mobile browser users who haven't installed the PWA.
+ * Positioned above BottomNav (bottom: 72px to clear the nav bar).
+ */
+export function InstallPrompt() {
+  var { showPrompt, isIOS, dismiss, install } = useInstallPrompt()
+
+  if (!showPrompt) return null
+
+  return (
+    <div
+      className="fixed left-3 right-3 rounded-xl flex items-center gap-3 px-4 py-3"
+      style={{
+        bottom: '80px',
+        background: 'var(--color-surface-elevated)',
+        border: '1px solid var(--color-divider)',
+        boxShadow: '0 4px 24px rgba(0, 0, 0, 0.12)',
+        zIndex: 1000,
+        animation: 'slideUp 0.3s ease-out',
+      }}
+    >
+      {/* App icon */}
+      <img
+        src="/icons/apple-touch-icon.png"
+        alt="WGH"
+        className="rounded-xl flex-shrink-0"
+        style={{ width: '44px', height: '44px' }}
+      />
+
+      {/* Message */}
+      <div className="flex-1 min-w-0">
+        <p className="font-bold text-sm" style={{ color: 'var(--color-text-primary)' }}>
+          Add What&apos;s Good Here
+        </p>
+        {isIOS ? (
+          <p className="text-xs" style={{ color: 'var(--color-text-tertiary)', lineHeight: 1.4 }}>
+            Tap{' '}
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="inline-block" style={{ width: '14px', height: '14px', verticalAlign: '-2px', color: 'var(--color-primary)' }}>
+              <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
+              <polyline points="16 6 12 2 8 6" />
+              <line x1="12" y1="2" x2="12" y2="15" />
+            </svg>
+            {' '}then &ldquo;Add to Home Screen&rdquo;
+          </p>
+        ) : (
+          <p className="text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
+            Install for the full experience
+          </p>
+        )}
+      </div>
+
+      {/* Action */}
+      {!isIOS && (
+        <button
+          onClick={install}
+          className="flex-shrink-0 px-3 py-1.5 rounded-lg text-sm font-semibold"
+          style={{
+            background: 'var(--color-primary)',
+            color: 'var(--color-text-on-primary)',
+          }}
+        >
+          Install
+        </button>
+      )}
+
+      {/* Dismiss */}
+      <button
+        onClick={dismiss}
+        className="flex-shrink-0 p-1"
+        style={{ color: 'var(--color-text-tertiary)' }}
+        aria-label="Dismiss install prompt"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" style={{ width: '18px', height: '18px' }}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Note on animation**
+
+The `slideUp` keyframe already exists in `src/index.css:645`. The component references it via inline `animation` style. No CSS changes needed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/InstallPrompt.jsx
+git commit -m "feat: add InstallPrompt component for PWA home screen install
+
+Slide-up banner above BottomNav. iOS shows Share instructions,
+Android shows Install button via beforeinstallprompt API.
+Dismissible, remembers choice.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Mount InstallPrompt in App.jsx
+
+**Files:**
+- Modify: `src/App.jsx`
+
+**Context:** The `InstallPrompt` needs to render inside the `BrowserRouter` (so it's visible on all pages) but outside of `Suspense` (so it's not blocked by lazy loading). Place it right after `<WelcomeModal />`.
+
+- [ ] **Step 1: Add the import**
+
+At the top of `src/App.jsx`, add:
+
+```js
+import { InstallPrompt } from './components/InstallPrompt'
+```
+
+- [ ] **Step 2: Mount the component**
+
+After line 122 (`<WelcomeModal />`), add:
+
+```jsx
+          <InstallPrompt />
+```
+
+- [ ] **Step 3: Build and verify**
+
+```bash
+npm run build
+npm run test
+```
+
+Expected: Build passes, all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/App.jsx
+git commit -m "feat: mount InstallPrompt in app shell
+
+Shows install banner on all pages for eligible mobile browser users.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Chunk 3: Verification + Cleanup
+
+### Task 8: End-to-end verification
+
+**Files:** None (testing only)
+
+- [ ] **Step 1: Full build check**
+
+```bash
+npm run build
+npm run test
+```
+
+Expected: Build passes, all tests pass.
+
+- [ ] **Step 2: Verify manifest output**
+
+```bash
+cat dist/manifest.webmanifest | python3 -m json.tool
+```
+
+Expected output includes:
+- `"display": "standalone"`
+- `"theme_color": "#F0ECE8"`
+- `"background_color": "#F0ECE8"`
+- Three icon entries (192, 512, 512 maskable)
+
+- [ ] **Step 3: Verify index.html output**
+
+```bash
+grep -E "theme-color|apple-touch-icon|apple-mobile-web-app|manifest" dist/index.html
+```
+
+Expected:
+- `theme-color` content is `#F0ECE8`
+- `apple-touch-icon` href is `/icons/apple-touch-icon.png`
+- `apple-mobile-web-app-status-bar-style` is `black-translucent`
+- manifest link is present (auto-injected by vite-plugin-pwa)
+
+- [ ] **Step 4: Dev server smoke test**
+
+```bash
+npm run dev
+```
+
+Open on iOS Simulator or physical iPhone:
+1. Verify app loads normally
+2. Wait 30s — install prompt should slide up
+3. Dismiss — should not reappear on reload
+4. Clear localStorage → reload → tap Share → "Add to Home Screen"
+5. Launch from home screen — should be full-screen, no Safari chrome
+6. Verify splash screen shows app colors (warm stone background)
+
+- [ ] **Step 5: Verify no CLAUDE.md rule violations**
+
+```bash
+# No direct console.* calls in new files
+grep -r "console\." src/hooks/useInstallPrompt.js src/components/InstallPrompt.jsx || echo "PASS: no console calls"
+
+# No direct localStorage calls in new files
+grep -r "localStorage\." src/hooks/useInstallPrompt.js src/components/InstallPrompt.jsx || echo "PASS: no direct localStorage"
+
+# No Tailwind color classes in new files
+grep -rE "text-(gray|blue|white|red|green)" src/components/InstallPrompt.jsx || echo "PASS: no Tailwind colors"
+
+# No ES2023+ syntax
+grep -rE "\.toSorted|\.at\(" src/hooks/useInstallPrompt.js src/components/InstallPrompt.jsx || echo "PASS: no ES2023+"
+```
+
+---
+
+### Task 9: Update TASKS.md and SPEC.md
+
+**Files:**
+- Modify: `TASKS.md`
+- Modify: `SPEC.md`
+
+- [ ] **Step 1: Mark T29 as done in TASKS.md and add this sprint**
+
+Add after T29:
+
+```markdown
+## ~~T29: Add apple-touch-icon for iOS home screen~~ DONE
+
+**What was done:**
+- Full PWA manifest enabled via vite-plugin-pwa (display: standalone)
+- App icons generated at 180/192/512px from logo.webp source
+- apple-touch-icon link added to index.html
+- theme-color fixed to match app background (#F0ECE8)
+- Status bar style set to black-translucent for edge-to-edge
+- InstallPrompt component + useInstallPrompt hook for "Add to Home Screen" nudge
+- Removed stale dark mode theme-switching script
+- Stale localStorage keys cleaned up
+
+**Files:** `index.html`, `vite.config.js`, `src/App.jsx`, `src/components/InstallPrompt.jsx`, `src/hooks/useInstallPrompt.js`, `src/lib/storage.js`, `public/icons/`
+```
+
+- [ ] **Step 2: Add PWA section to SPEC.md**
+
+Add a new feature section:
+
+```markdown
+### Feature 22: Progressive Web App (PWA)
+
+**User flow:** Visit app in mobile browser → after 30s, install banner slides up → tap Share + "Add to Home Screen" (iOS) or Install button (Android) → app installs to home screen → launches full-screen without browser chrome
+
+**Components:** `InstallPrompt`
+**Hooks:** `useInstallPrompt`
+**Config:** `vite.config.js` (manifest), `index.html` (meta tags)
+**Assets:** `public/icons/` (apple-touch-icon.png, icon-192x192.png, icon-512x512.png)
+
+**Manifest:** `display: standalone`, warm stone background, portrait orientation. Service worker caches app shell, Supabase images (30 days), API responses (5 min NetworkFirst).
+
+**Install prompt:** 30s delay, dismissible, remembers dismissal via localStorage. iOS shows Share icon instructions, Android triggers native install via `beforeinstallprompt` API.
+
+**VERIFIED** — `vite.config.js`, `src/components/InstallPrompt.jsx`
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add TASKS.md SPEC.md
+git commit -m "docs: update TASKS.md and SPEC.md for PWA install experience
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Summary
+
+| Task | Files | Effort |
+|---|---|---|
+| 1. Generate app icons | `public/icons/` (3 new PNGs) | 10 min |
+| 2. Enable manifest | `vite.config.js` | 10 min |
+| 3. Fix meta tags | `index.html` | 10 min |
+| 4. Storage key | `src/lib/storage.js` | 5 min |
+| 5. useInstallPrompt hook | `src/hooks/useInstallPrompt.js` + test | 20 min |
+| 6. InstallPrompt component | `src/components/InstallPrompt.jsx` | 15 min |
+| 7. Mount in App | `src/App.jsx` | 5 min |
+| 8. E2E verification | Testing only | 15 min |
+| 9. Update docs | `TASKS.md`, `SPEC.md` | 10 min |
+
+**Total: ~1.5 hours of implementation**
+
+## What's NOT in this plan
+
+- No Capacitor, Expo, or React Native — that's a separate future plan if App Store is needed post-launch
+- No iOS splash screen images (Apple deprecated the old `apple-touch-startup-image` approach; the manifest `background_color` + icon is the modern replacement)
+- No push notifications — separate feature, not needed for launch
+- No changes to offline caching strategy — already solid
+- No changes to any existing component, page, hook, or API module

--- a/docs/superpowers/plans/2026-03-16-typography-system.md
+++ b/docs/superpowers/plans/2026-03-16-typography-system.md
@@ -1,0 +1,402 @@
+# Typography System: Amatic SC + Outfit
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish a consistent two-font typography system (Amatic SC for display, Outfit for body) across the entire app, removing all legacy font references (DM Sans, Cormorant, Typekit/Aglet Sans).
+
+**Architecture:** Remove Cormorant from Google Fonts link. Replace all inline `fontFamily` references to DM Sans and Cormorant with either Amatic SC (display headings) or nothing (inherit Outfit from body). Add Amatic SC section headers to pages that currently have no display font treatment.
+
+**Tech Stack:** Google Fonts (Amatic SC 700, Outfit 300-800), CSS custom properties, inline React styles.
+
+---
+
+## Font Roles
+
+| Font | CSS value | Role | Where |
+|------|-----------|------|-------|
+| Amatic SC | `'Amatic SC', cursive` | Display: brand name, section headers, page titles, empty states | Headings, section labels |
+| Outfit | `'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif` | Body: everything else | Inherited from body in index.css |
+| SF Mono | `'SF Mono', 'Fira Code', 'Cascadia Code', monospace` | Technical: Jitter badges only | No changes needed |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `index.html` | Remove Cormorant from Google Fonts link |
+| `src/pages/Dish.jsx:553,606` | Remove DM Sans fontFamily (inherit Outfit) |
+| `src/pages/Login.jsx:202` | Change Cormorant → Amatic SC, match homepage treatment |
+| `src/components/WelcomeSplash.jsx:79` | Change Cormorant → Amatic SC |
+| `src/components/Auth/WelcomeModal.jsx:122` | Change Cormorant → Amatic SC |
+| `src/pages/Browse.jsx` | Add Amatic SC section header |
+| `src/pages/Restaurants.jsx` | Add Amatic SC section headers |
+| `src/pages/RestaurantDetail.jsx` | Add Amatic SC restaurant name |
+| `src/components/restaurants/RestaurantMenu.jsx` | Add Amatic SC menu section names |
+| `src/pages/Profile.jsx` | Add Amatic SC section headers |
+| `src/pages/UserProfile.jsx` | Add Amatic SC section headers |
+| `src/pages/Discover.jsx` | Add Amatic SC section headers |
+| `CLAUDE.md` | Update font documentation |
+
+---
+
+## Chunk 1: Remove Legacy Fonts + Fix Existing References
+
+### Task 1: Clean up Google Fonts link
+
+**Files:**
+- Modify: `index.html:15`
+
+- [ ] **Step 1: Remove Cormorant from the Google Fonts link**
+
+Change line 15 from:
+```html
+<link href="https://fonts.googleapis.com/css2?family=Amatic+SC:wght@400;700&family=Cormorant:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+```
+To:
+```html
+<link href="https://fonts.googleapis.com/css2?family=Amatic+SC:wght@400;700&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+```
+
+Also update the comment above it:
+```html
+<!-- Fonts: Amatic SC (display/headers), Outfit (body) -->
+```
+
+- [ ] **Step 2: Verify the app still loads**
+
+Run: `npm run dev` — confirm no font loading errors in browser console.
+
+---
+
+### Task 2: Fix Dish.jsx — remove DM Sans
+
+**Files:**
+- Modify: `src/pages/Dish.jsx:553,606`
+
+- [ ] **Step 1: Remove fontFamily from dish name heading (line ~553)**
+
+Find:
+```jsx
+fontFamily: "'DM Sans', sans-serif",
+fontWeight: 800,
+fontSize: '22px',
+```
+Replace with:
+```jsx
+fontWeight: 800,
+fontSize: '22px',
+```
+
+The dish name inherits Outfit from body — correct per our system (data/readability = Outfit).
+
+- [ ] **Step 2: Remove fontFamily from rating score (line ~606)**
+
+Find:
+```jsx
+fontFamily: "'DM Sans', sans-serif",
+fontWeight: 800,
+fontSize: '40px',
+```
+Replace with:
+```jsx
+fontWeight: 800,
+fontSize: '40px',
+```
+
+- [ ] **Step 3: Verify dish page renders correctly**
+
+Navigate to any dish page. Confirm dish name and rating display in Outfit (the body font).
+
+---
+
+### Task 3: Fix Login.jsx — Cormorant → Amatic SC
+
+**Files:**
+- Modify: `src/pages/Login.jsx:202`
+
+- [ ] **Step 1: Update brand heading to Amatic SC**
+
+Find:
+```jsx
+fontFamily: "'Cormorant', Georgia, serif",
+fontSize: '36px',
+fontWeight: 700,
+```
+Replace with:
+```jsx
+fontFamily: "'Amatic SC', cursive",
+fontSize: '42px',
+fontWeight: 700,
+```
+
+Also update the `letterSpacing` from `'-0.02em'` to `'0.04em'` (Amatic SC needs positive tracking, not negative).
+
+- [ ] **Step 2: Add gold "Good" accent if the text says "What's Good Here"**
+
+Check if the JSX renders "What's Good Here" as plain text. If so, change to:
+```jsx
+What's <span style={{ color: 'var(--color-accent-gold)' }}>Good</span> Here
+```
+
+- [ ] **Step 3: Verify login page**
+
+Navigate to `/login`. Confirm heading matches homepage treatment.
+
+---
+
+### Task 4: Fix WelcomeSplash.jsx — Cormorant → Amatic SC
+
+**Files:**
+- Modify: `src/components/WelcomeSplash.jsx:79`
+
+- [ ] **Step 1: Update brand heading**
+
+Find:
+```jsx
+fontFamily: "'Cormorant', Georgia, serif",
+fontSize: '40px',
+fontWeight: 700,
+```
+Replace with:
+```jsx
+fontFamily: "'Amatic SC', cursive",
+fontSize: '42px',
+fontWeight: 700,
+```
+
+Update `letterSpacing` from `'-0.02em'` to `'0.04em'`.
+
+---
+
+### Task 5: Fix WelcomeModal.jsx — Cormorant → Amatic SC
+
+**Files:**
+- Modify: `src/components/Auth/WelcomeModal.jsx:122`
+
+- [ ] **Step 1: Update brand heading**
+
+Find:
+```jsx
+fontFamily: "'Cormorant', Georgia, serif",
+fontSize: '46px',
+fontWeight: 700,
+```
+Replace with:
+```jsx
+fontFamily: "'Amatic SC', cursive",
+fontSize: '42px',
+fontWeight: 700,
+```
+
+Update `letterSpacing` from `'-0.02em'` to `'0.04em'`.
+
+- [ ] **Step 2: Add gold "Good" accent**
+
+Change the text to:
+```jsx
+What's <span style={{ color: 'var(--color-accent-gold)' }}>Good</span> Here
+```
+
+---
+
+### Task 6: Commit legacy font cleanup
+
+- [ ] **Step 1: Run build**
+
+Run: `npm run build`
+Expected: Clean build, no errors.
+
+- [ ] **Step 2: Grep for any remaining DM Sans or Cormorant references**
+
+Run: `grep -r "DM Sans\|Cormorant" src/`
+Expected: Zero results.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add index.html src/index.css src/pages/Dish.jsx src/pages/Login.jsx src/components/WelcomeSplash.jsx src/components/Auth/WelcomeModal.jsx
+git commit -m "style: consolidate typography to Amatic SC + Outfit two-font system
+
+Remove Cormorant and DM Sans. Amatic SC for display/headers,
+Outfit for body/data. Consistent brand treatment across all
+auth screens and dish pages."
+```
+
+---
+
+## Chunk 2: Add Amatic SC Headers to Remaining Pages
+
+Every page that shows a title or section header should use Amatic SC 700 for consistency. The pattern is always the same inline style:
+
+```jsx
+style={{
+  fontFamily: "'Amatic SC', cursive",
+  fontSize: '28px',    // section headers (24px for smaller, 32px for page titles)
+  fontWeight: 700,
+  letterSpacing: '0.02em',
+  color: 'var(--color-text-primary)',
+}}
+```
+
+### Task 7: Browse.jsx — add Amatic SC section header
+
+**Files:**
+- Modify: `src/pages/Browse.jsx`
+
+- [ ] **Step 1: Find the category/section title heading**
+
+Read the file and find where the section title or category name is rendered (e.g., "Burgers", "Top Rated"). Apply Amatic SC styling to that heading element.
+
+- [ ] **Step 2: Verify browse page**
+
+Navigate to `/browse`, select a category. Confirm section header is in Amatic SC.
+
+---
+
+### Task 8: Restaurants.jsx — add Amatic SC headers
+
+**Files:**
+- Modify: `src/pages/Restaurants.jsx`
+
+- [ ] **Step 1: Find page title and tab headers**
+
+Read the file. Apply Amatic SC to the page title ("Restaurants") and any section headers (Open/Closed tabs header text if applicable). Keep tab button labels in Outfit (they're interactive).
+
+- [ ] **Step 2: Verify restaurants page**
+
+Navigate to `/restaurants`. Confirm page title uses Amatic SC.
+
+---
+
+### Task 9: RestaurantDetail.jsx — restaurant name in Amatic SC
+
+**Files:**
+- Modify: `src/pages/RestaurantDetail.jsx`
+
+- [ ] **Step 1: Find restaurant name heading**
+
+Read the file. Find the `<h1>` or main heading that displays the restaurant name. Apply Amatic SC at 32px:
+
+```jsx
+style={{
+  fontFamily: "'Amatic SC', cursive",
+  fontSize: '32px',
+  fontWeight: 700,
+  letterSpacing: '0.02em',
+}}
+```
+
+- [ ] **Step 2: Find section headers ("Top Rated", "Menu")**
+
+If there are tab labels or section dividers, apply Amatic SC at 24px to the non-interactive section labels.
+
+---
+
+### Task 10: RestaurantMenu.jsx — menu section names
+
+**Files:**
+- Modify: `src/components/restaurants/RestaurantMenu.jsx`
+
+- [ ] **Step 1: Find menu section headings**
+
+Read the file. Find where section names ("Starters", "Entrees", "Desserts") are rendered. Apply Amatic SC at 22px — this gives the menu board feel:
+
+```jsx
+style={{
+  fontFamily: "'Amatic SC', cursive",
+  fontSize: '22px',
+  fontWeight: 700,
+  letterSpacing: '0.02em',
+}}
+```
+
+Keep dish names, prices, and ratings in Outfit (inherited).
+
+---
+
+### Task 11: Profile.jsx — section headers
+
+**Files:**
+- Modify: `src/pages/Profile.jsx`
+
+- [ ] **Step 1: Find section headers**
+
+Read the file. Apply Amatic SC to section headers like "Your Ratings", "Favorites", badge section titles, etc. at 24-28px.
+
+---
+
+### Task 12: UserProfile.jsx — section headers
+
+**Files:**
+- Modify: `src/pages/UserProfile.jsx`
+
+- [ ] **Step 1: Apply same treatment as Profile.jsx**
+
+Any section headers get Amatic SC at 24-28px.
+
+---
+
+### Task 13: Discover.jsx — section headers
+
+**Files:**
+- Modify: `src/pages/Discover.jsx`
+
+- [ ] **Step 1: Apply Amatic SC to section headers**
+
+"Similar Taste", "Find Friends", etc. — Amatic SC at 24-28px.
+
+---
+
+### Task 14: Build verify + commit
+
+- [ ] **Step 1: Run build**
+
+Run: `npm run build`
+Expected: Clean build.
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm run test`
+Expected: All tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/ src/components/restaurants/RestaurantMenu.jsx
+git commit -m "style: apply Amatic SC headers across all pages
+
+Consistent display typography: Amatic SC for section headers,
+page titles, and restaurant names. Outfit for all body text,
+data, and interactive elements."
+```
+
+---
+
+## Chunk 3: Update Documentation
+
+### Task 15: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Update design tokens / fonts section**
+
+Add or update typography documentation:
+
+```markdown
+### 4.6 Typography
+| Font | Role | Weights | CSS |
+|------|------|---------|-----|
+| Amatic SC | Display: brand, section headers, page titles | 700 | `'Amatic SC', cursive` |
+| Outfit | Body: everything else | 400-800 | Inherited from body |
+| SF Mono | Technical: Jitter badges | 700 | `'SF Mono', 'Fira Code', monospace` |
+
+**Rule:** Amatic SC = section/page headings. Outfit = data, actions, body text.
+**Removed:** DM Sans, Cormorant, Aglet Sans (Typekit).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: update typography system in CLAUDE.md"
+```

--- a/docs/superpowers/plans/2026-03-27-profile-redesign.md
+++ b/docs/superpowers/plans/2026-03-27-profile-redesign.md
@@ -1,0 +1,305 @@
+# Profile Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Transform own-profile into a food journal and other-profiles into identity cards.
+
+**Architecture:** Modify Profile.jsx to remove dashboard cards, shelf filter, and share button — replace with simplified journal header + chronological JournalFeed. Modify JournalFeed to add date group headers and remove shelf logic. Redesign JournalCard for journal-entry styling. UserProfile.jsx gets identity card layout later (Task 4).
+
+**Tech Stack:** React 19, existing hooks (useUserVotes, useProfile, useFavorites), WGH design tokens
+
+---
+
+### Task 1: Simplify Profile.jsx — Journal Layout
+
+**Files:**
+- Modify: `src/pages/Profile.jsx`
+
+- [ ] **Step 1: Remove imports and state no longer needed**
+
+Remove: `ShelfFilter`, `SharePicksButton` imports. Remove `SHELVES` constant. Remove `activeShelf` state. Remove `favorites`/`useFavorites` hook (heard is killed). Remove `enrichedAvoid` memo (avoid still exists in data, just not shown separately). Keep: `useFavorites` import removed, `ShelfFilter` import removed, `SharePicksButton` import removed.
+
+- [ ] **Step 2: Replace the JSX between HeroIdentityCard and JournalFeed**
+
+Remove:
+- Dashboard cards section (lines ~254-369: "Recent" + "Highlights" cards)
+- SharePicksButton section (lines ~371-377)
+- ShelfFilter section (lines ~414-419)
+
+Replace with a simple journal title + divider:
+```jsx
+{/* Journal title */}
+<div style={{ padding: '16px 20px 0' }}>
+  <h2 style={{
+    fontFamily: "'Amatic SC', cursive",
+    fontSize: '28px',
+    fontWeight: 700,
+    color: 'var(--color-text-primary)',
+  }}>
+    Your Journal
+  </h2>
+</div>
+```
+
+- [ ] **Step 3: Simplify JournalFeed props — remove shelf filtering**
+
+Change JournalFeed invocation to only pass worthIt + avoid combined (no shelf, no heard):
+```jsx
+<JournalFeed
+  entries={enrichedWorthIt.concat(enrichedAvoid)}
+  loading={votesLoading}
+/>
+```
+
+- [ ] **Step 4: Clean up unused state and variables**
+
+Remove: `activeShelf`, `SHELVES`, `handleTriedIt` (heard is gone), favorites-related code. Keep unrated photos banner and DishModal — those still work.
+
+- [ ] **Step 5: Run build and verify**
+
+Run: `npm run build`
+Expected: Clean build, no errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/Profile.jsx
+git commit -m "refactor: simplify Profile to journal layout — remove shelves, dashboard cards, share button"
+```
+
+---
+
+### Task 2: Redesign JournalFeed — Date Groups, No Shelves
+
+**Files:**
+- Modify: `src/components/profile/JournalFeed.jsx`
+
+- [ ] **Step 1: Change props interface**
+
+New props: `entries` (pre-merged array of dishes with `voted_at`), `loading`. Remove: `worthIt`, `avoid`, `heard`, `activeShelf`, `onTriedIt`.
+
+- [ ] **Step 2: Add date grouping logic**
+
+Group entries by date label (Today, Yesterday, N days ago, or formatted date). Sort reverse-chronological first, then group.
+
+```jsx
+function getDateLabel(timestamp) {
+  if (!timestamp) return ''
+  var date = new Date(timestamp)
+  var now = new Date()
+  var diffMs = now - date
+  var diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+  if (diffDays === 0) return 'Today'
+  if (diffDays === 1) return 'Yesterday'
+  if (diffDays < 7) return diffDays + ' days ago'
+  if (diffDays < 14) return 'Last week'
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+```
+
+- [ ] **Step 3: Render with date headers**
+
+```jsx
+// Sort entries
+var sorted = entries.slice().sort(function(a, b) {
+  return new Date(b.voted_at || 0) - new Date(a.voted_at || 0)
+})
+
+// Group and render with date markers
+var lastLabel = ''
+var visibleEntries = sorted.slice(0, visibleCount)
+
+return (
+  <div style={{ padding: '0 16px 16px' }}>
+    {visibleEntries.map(function(dish) {
+      var label = getDateLabel(dish.voted_at)
+      var showLabel = label !== lastLabel
+      lastLabel = label
+      return (
+        <div key={dish.dish_id || dish.id}>
+          {showLabel && (
+            <div style={{
+              fontSize: '10px',
+              fontWeight: 700,
+              color: 'var(--color-accent-gold)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.5px',
+              padding: '14px 0 6px',
+            }}>
+              {label}
+            </div>
+          )}
+          <JournalCard dish={dish} />
+        </div>
+      )
+    })}
+    {/* Show more button */}
+  </div>
+)
+```
+
+- [ ] **Step 4: Run build and verify**
+
+Run: `npm run build`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/profile/JournalFeed.jsx
+git commit -m "refactor: JournalFeed — date-grouped chronological, remove shelf filtering"
+```
+
+---
+
+### Task 3: Redesign JournalCard — Journal Entry Style
+
+**Files:**
+- Modify: `src/components/profile/JournalCard.jsx`
+
+- [ ] **Step 1: Simplify to single variant**
+
+Remove `variant` prop, remove "heard" variant entirely. Every card is a rated dish. Keep the Link wrapper to `/dish/:id`.
+
+- [ ] **Step 2: Implement journal entry layout**
+
+Layout: `[icon 56px] [dish name + restaurant + review snippet] [big rating]`
+
+```jsx
+export function JournalCard({ dish }) {
+  var dishName = dish.dish_name || dish.name
+  var restaurantName = dish.restaurant_name
+  var dishId = dish.dish_id || dish.id
+  var categoryId = dish.category
+  var photoUrl = dish.photo_url
+  var rating = dish.rating
+  var reviewText = dish.review_text
+  var wouldOrderAgain = dish.would_order_again
+
+  return (
+    <Link
+      to={'/dish/' + dishId}
+      data-testid="journal-card"
+      className="flex gap-3 rounded-xl"
+      style={{
+        background: 'var(--color-card)',
+        padding: '14px',
+        marginBottom: '8px',
+        textDecoration: 'none',
+        opacity: wouldOrderAgain === false ? 0.7 : 1,
+      }}
+    >
+      {/* Icon */}
+      <div
+        className="flex-shrink-0 flex items-center justify-center"
+        style={{
+          width: '56px',
+          height: '56px',
+          borderRadius: '12px',
+          background: 'var(--color-category-strip)',
+        }}
+      >
+        {photoUrl ? (
+          <img src={photoUrl} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover', borderRadius: '12px' }} />
+        ) : (
+          <CategoryIcon categoryId={categoryId} dishName={dishName} size={40} />
+        )}
+      </div>
+
+      {/* Content */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: '16px', fontWeight: 700, color: 'var(--color-text-primary)' }}>
+          {dishName}
+        </div>
+        <div style={{ fontSize: '11px', color: 'var(--color-text-tertiary)', marginTop: '1px' }}>
+          {restaurantName}
+        </div>
+        {reviewText && (
+          <div style={{
+            fontSize: '12px',
+            color: 'var(--color-text-secondary)',
+            marginTop: '6px',
+            fontStyle: 'italic',
+            lineHeight: 1.4,
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}>
+            "{reviewText}"
+          </div>
+        )}
+      </div>
+
+      {/* Rating */}
+      {rating != null && (
+        <div style={{ flexShrink: 0, textAlign: 'right' }}>
+          <div style={{
+            fontSize: '28px',
+            fontWeight: 800,
+            color: getRatingColor(rating),
+            lineHeight: 1,
+          }}>
+            {Math.round(rating)}
+          </div>
+          <div style={{ fontSize: '10px', color: 'var(--color-text-tertiary)' }}>/10</div>
+        </div>
+      )}
+    </Link>
+  )
+}
+```
+
+- [ ] **Step 3: Run build and verify**
+
+Run: `npm run build`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/profile/JournalCard.jsx
+git commit -m "refactor: JournalCard — clean journal entry style, remove heard variant"
+```
+
+---
+
+### Task 4: Update barrel export — remove ShelfFilter from Profile imports
+
+**Files:**
+- Modify: `src/components/profile/index.js`
+
+- [ ] **Step 1: Remove ShelfFilter from barrel if it's only used in Profile**
+
+Check if ShelfFilter is used in UserProfile.jsx. If yes, keep the export. If no, remove.
+
+- [ ] **Step 2: Run build and verify**
+
+Run: `npm run build`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/profile/index.js
+git commit -m "chore: clean up profile barrel exports"
+```
+
+---
+
+### Task 5: Final verification
+
+- [ ] **Step 1: Run full build**
+
+Run: `npm run build`
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm run test`
+
+- [ ] **Step 3: Visual check in dev server**
+
+Run: `npm run dev` — check `/profile` page loads, journal entries display, date groups work, jitter badge shows.
+
+- [ ] **Step 4: Commit any fixes and push**
+
+```bash
+git push origin main
+```

--- a/docs/superpowers/plans/2026-03-31-locals-homepage-redesign.md
+++ b/docs/superpowers/plans/2026-03-31-locals-homepage-redesign.md
@@ -1,0 +1,700 @@
+# Locals Homepage Redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface local list aggregate data in the chalkboard row, redesign the local lists section as menu-style cards, and replace restaurant initial avatars with food category icons.
+
+**Architecture:** New RPC for aggregate data (most-appearing dish/restaurant across lists). New `LocalsAggregate` chalkboard component + gold-frame variant. Rewrite `LocalListsSection` as menu cards. Replace `RestaurantAvatar` internals — same API, new rendering.
+
+**Tech Stack:** React, Supabase RPC, existing design tokens (Amatic SC, Outfit, CSS variables)
+
+**Spec:** `docs/superpowers/specs/2026-03-31-locals-homepage-redesign.md`
+
+---
+
+## File Map
+
+| Action | File | Purpose |
+|--------|------|---------|
+| Create | `supabase/migrations/locals-aggregate.sql` | RPC: get most-appearing dish + restaurant across all local lists |
+| Modify | `src/api/localListsApi.js` | Add `getAggregate()` method |
+| Create | `src/hooks/useLocalsAggregate.js` | React Query hook for aggregate data |
+| Modify | `src/components/home/HomeListMode.jsx` | Add aggregate chalkboards to ChalkboardSection, add locals divider |
+| Modify | `src/components/home/LocalListsSection.jsx` | Full rewrite — menu-style cards |
+| Modify | `src/components/RestaurantAvatar.jsx` | Replace town-colored initials with food category icons |
+| Modify | `src/components/home/index.js` | Export new component if needed |
+
+---
+
+### Task 1: Create the Locals Aggregate RPC
+
+**Files:**
+- Create: `supabase/migrations/locals-aggregate.sql`
+- Modify: `supabase/schema.sql` (add function definition)
+
+- [ ] **Step 1: Write the migration SQL**
+
+```sql
+-- supabase/migrations/locals-aggregate.sql
+-- Returns the dish and restaurant that appear on the most local lists
+
+DROP FUNCTION IF EXISTS get_locals_aggregate();
+
+CREATE OR REPLACE FUNCTION get_locals_aggregate()
+RETURNS TABLE (
+  top_dish_id UUID,
+  top_dish_name TEXT,
+  top_dish_restaurant_name TEXT,
+  top_dish_restaurant_id UUID,
+  top_dish_list_count INT,
+  top_restaurant_id UUID,
+  top_restaurant_name TEXT,
+  top_restaurant_town TEXT,
+  top_restaurant_list_count INT,
+  total_lists INT
+)
+LANGUAGE SQL STABLE
+AS $$
+  WITH list_count AS (
+    SELECT COUNT(DISTINCT ll.id)::INT AS total
+    FROM local_lists ll
+    JOIN local_list_items li ON li.list_id = ll.id
+  ),
+  dish_counts AS (
+    SELECT
+      li.dish_id,
+      d.name AS dish_name,
+      r.name AS restaurant_name,
+      d.restaurant_id,
+      COUNT(DISTINCT ll.id)::INT AS list_count,
+      MAX(d.avg_rating) AS avg_rating
+    FROM local_list_items li
+    JOIN local_lists ll ON ll.id = li.list_id
+    JOIN dishes d ON d.id = li.dish_id
+    JOIN restaurants r ON r.id = d.restaurant_id
+    GROUP BY li.dish_id, d.name, r.name, d.restaurant_id
+    ORDER BY list_count DESC, avg_rating DESC NULLS LAST
+    LIMIT 1
+  ),
+  restaurant_counts AS (
+    SELECT
+      d.restaurant_id,
+      r.name AS restaurant_name,
+      r.town,
+      COUNT(DISTINCT ll.id)::INT AS list_count
+    FROM local_list_items li
+    JOIN local_lists ll ON ll.id = li.list_id
+    JOIN dishes d ON d.id = li.dish_id
+    JOIN restaurants r ON r.id = d.restaurant_id
+    GROUP BY d.restaurant_id, r.name, r.town
+    ORDER BY list_count DESC
+    LIMIT 1
+  )
+  SELECT
+    dc.dish_id AS top_dish_id,
+    dc.dish_name AS top_dish_name,
+    dc.restaurant_name AS top_dish_restaurant_name,
+    dc.restaurant_id AS top_dish_restaurant_id,
+    dc.list_count AS top_dish_list_count,
+    rc.restaurant_id AS top_restaurant_id,
+    rc.restaurant_name AS top_restaurant_name,
+    rc.town AS top_restaurant_town,
+    rc.list_count AS top_restaurant_list_count,
+    lc.total AS total_lists
+  FROM dish_counts dc, restaurant_counts rc, list_count lc;
+$$;
+```
+
+- [ ] **Step 2: Add function to schema.sql**
+
+Add the same function definition to `supabase/schema.sql` after the existing `get_local_lists_for_homepage` function (around line 2465).
+
+- [ ] **Step 3: Run in Supabase SQL Editor**
+
+Run the migration SQL in the Supabase dashboard SQL Editor. Verify with:
+
+```sql
+SELECT * FROM get_locals_aggregate();
+```
+
+Expected: one row with the top dish and top restaurant, or empty if no local lists exist.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/migrations/locals-aggregate.sql supabase/schema.sql
+git commit -m "feat: add get_locals_aggregate RPC for chalkboard cards"
+```
+
+---
+
+### Task 2: API + Hook for Aggregate Data
+
+**Files:**
+- Modify: `src/api/localListsApi.js`
+- Create: `src/hooks/useLocalsAggregate.js`
+
+- [ ] **Step 1: Add getAggregate to localListsApi**
+
+Add this method to the `localListsApi` object in `src/api/localListsApi.js`, after the existing `getForHomepage` method:
+
+```javascript
+  async getAggregate() {
+    try {
+      const { data, error } = await supabase.rpc('get_locals_aggregate')
+      if (error) throw createClassifiedError(error)
+      return data && data.length > 0 ? data[0] : null
+    } catch (error) {
+      logger.error('Failed to fetch locals aggregate:', error)
+      throw error.type ? error : createClassifiedError(error)
+    }
+  },
+```
+
+- [ ] **Step 2: Create the hook**
+
+```javascript
+// src/hooks/useLocalsAggregate.js
+import { useQuery } from '@tanstack/react-query'
+import { localListsApi } from '../api/localListsApi'
+
+export function useLocalsAggregate() {
+  var { data, isLoading } = useQuery({
+    queryKey: ['localsAggregate'],
+    queryFn: function () { return localListsApi.getAggregate() },
+    staleTime: 1000 * 60 * 10, // 10 min — aggregate changes slowly
+  })
+
+  return {
+    aggregate: data || null,
+    loading: isLoading,
+  }
+}
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `npm run build`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/api/localListsApi.js src/hooks/useLocalsAggregate.js
+git commit -m "feat: add useLocalsAggregate hook for chalkboard cards"
+```
+
+---
+
+### Task 3: Add Locals Aggregate Chalkboards to the Editorial Row
+
+**Files:**
+- Modify: `src/components/home/HomeListMode.jsx`
+
+- [ ] **Step 1: Import the hook**
+
+At the top of `HomeListMode.jsx`, add the import alongside the existing ones:
+
+```javascript
+import { useLocalsAggregate } from '../../hooks/useLocalsAggregate'
+```
+
+- [ ] **Step 2: Add gold-frame chalkboard styles**
+
+After the existing `BOARD_SURFACE` constant (line ~214), add these module-level constants:
+
+```javascript
+// Locals chalkboards use the same surface/frame as all other boards — no special treatment
+var BOARD_OUTER_WIDE = { flexShrink: 0, width: '185px' }
+var CHALK_GOLD = { fontFamily: "'Amatic SC', cursive", color: 'var(--color-accent-gold)', fontWeight: 700 }
+var COUNT_BADGE = { fontFamily: "'Outfit', sans-serif", display: 'inline-flex', alignItems: 'center', justifyContent: 'center', background: 'rgba(196, 138, 18, 0.2)', color: 'var(--color-accent-gold)', fontSize: '10px', fontWeight: 700, padding: '2px 8px', borderRadius: '10px', marginTop: '4px' }
+```
+
+- [ ] **Step 3: Create the GoldChalkboardCard component**
+
+Add this function after the existing `ChalkboardCard` component (around line 256):
+
+```javascript
+function LocalsChalkboardCard({ tag, title, titleSize, sub, countText, cta, onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      className="active:scale-[0.97] transition-transform"
+      style={BOARD_OUTER_WIDE}
+    >
+      <div style={BOARD_SURFACE}>
+        <div style={BOARD_FRAME} />
+        <div style={BOARD_DUST} />
+        <div style={BOARD_CONTENT}>
+          <p style={Object.assign({}, CHALK_FAINT, { fontSize: '13px', margin: 0 })}>{tag}</p>
+          <p style={Object.assign({}, CHALK_BIG, { fontSize: titleSize || '30px', fontWeight: 700, lineHeight: 0.95, margin: '2px 0 0' })}>{title}</p>
+          {sub && <p style={Object.assign({}, CHALK_MED, { fontSize: '15px', margin: 0 })}>{sub}</p>}
+          <div style={CHALK_LINE} />
+          {countText && <span style={COUNT_BADGE}>{countText}</span>}
+          {countText && <div style={{ marginTop: '4px' }} />}
+          <p style={Object.assign({}, CHALK_CTA, { fontSize: '18px', fontWeight: 700, margin: 0 })}>{cta}</p>
+        </div>
+      </div>
+    </button>
+  )
+}
+```
+
+- [ ] **Step 4: Wire aggregate data into ChalkboardSection**
+
+Update the `ChalkboardSection` function signature to accept the new props:
+
+```javascript
+function ChalkboardSection({ topRestaurant, mostVotedDish, bestValueMeal, bestIceCream, localsAggregate, onExpandCategory }) {
+```
+
+Then add the two gold chalkboard cards at the END of the row (after the bestIceCream card, before the closing `</div>`):
+
+```javascript
+      {/* Board: Locals Agree — most-appearing dish */}
+      {localsAggregate && localsAggregate.top_dish_id && localsAggregate.total_lists >= 2 && (
+        <LocalsChalkboardCard
+          tag={'\uD83C\uDFC6 locals agree'}
+          title={localsAggregate.top_dish_name}
+          sub={localsAggregate.top_dish_restaurant_name}
+          countText={'On ' + localsAggregate.top_dish_list_count + ' of ' + localsAggregate.total_lists + ' local lists'}
+          cta={'see why \u2192'}
+          onClick={function () { navigate('/dish/' + localsAggregate.top_dish_id) }}
+        />
+      )}
+
+      {/* Board: Island Favorite — most-appearing restaurant */}
+      {localsAggregate && localsAggregate.top_restaurant_id && localsAggregate.total_lists >= 2 && (
+        <LocalsChalkboardCard
+          tag={'\uD83D\uDCCD island favorite'}
+          title={localsAggregate.top_restaurant_name}
+          sub={localsAggregate.top_restaurant_town || ''}
+          countText={localsAggregate.top_restaurant_list_count >= localsAggregate.total_lists ? 'On every local list' : 'On ' + localsAggregate.top_restaurant_list_count + ' of ' + localsAggregate.total_lists + ' local lists'}
+          cta={'see the menu \u2192'}
+          onClick={function () { navigate('/restaurants/' + localsAggregate.top_restaurant_id) }}
+        />
+      )}
+```
+
+- [ ] **Step 5: Pass aggregate data from HomeListMode**
+
+In the `HomeListMode` component, call the hook and pass data to `ChalkboardSection`:
+
+After the existing `useDishSearch` call (around line ~115), add:
+
+```javascript
+  var localsAggregateData = useLocalsAggregate()
+  var localsAggregate = localsAggregateData.aggregate
+```
+
+Then update the `ChalkboardSection` usage (around line 174) to pass the new prop:
+
+```javascript
+            <ChalkboardSection
+              topRestaurant={topRestaurant}
+              mostVotedDish={mostVotedDish}
+              bestValueMeal={bestValueMeal}
+              bestIceCream={bestIceCream}
+              localsAggregate={localsAggregate}
+              onExpandCategory={function (cat) {
+```
+
+- [ ] **Step 6: Verify build**
+
+Run: `npm run build`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/home/HomeListMode.jsx
+git commit -m "feat: add locals aggregate chalkboards with gold frame to editorial row"
+```
+
+---
+
+### Task 4: Rewrite LocalListsSection as Menu Cards
+
+**Files:**
+- Modify: `src/components/home/LocalListsSection.jsx`
+
+- [ ] **Step 1: Rewrite the full component**
+
+Replace the entire content of `src/components/home/LocalListsSection.jsx` with:
+
+```javascript
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../../context/AuthContext'
+import { useLocalLists } from '../../hooks/useLocalLists'
+import { useLocalListDetail } from '../../hooks/useLocalListDetail'
+
+// Menu card styles — module-level constants
+var MENU_CARD = {
+  flexShrink: 0, width: '270px', scrollSnapAlign: 'start',
+  background: '#FFFDF8', borderRadius: '3px', padding: '20px 16px 14px',
+  boxShadow: '0 1px 3px rgba(0,0,0,0.06), 0 6px 20px rgba(0,0,0,0.07)',
+  border: '1px solid rgba(0,0,0,0.04)', position: 'relative',
+}
+var CURATOR_AVATAR = {
+  width: '32px', height: '32px', borderRadius: '50%',
+  display: 'flex', alignItems: 'center', justifyContent: 'center',
+  fontWeight: 700, fontSize: '13px', color: '#fff', flexShrink: 0,
+  boxShadow: '0 2px 6px rgba(0,0,0,0.15)',
+}
+var CURATOR_NAME = { fontFamily: "'Amatic SC', cursive", fontSize: '24px', fontWeight: 700, color: 'var(--color-text-primary)', lineHeight: 1 }
+var CURATOR_TAGLINE = { fontSize: '10px', color: 'var(--color-text-tertiary)', marginTop: '1px', fontStyle: 'italic' }
+var RESTAURANT_HEADER = { fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'var(--color-accent-gold)', letterSpacing: '0.02em', marginBottom: '3px' }
+var DISH_NAME_STYLE = { fontSize: '13px', fontWeight: 500, color: 'var(--color-text-primary)', whiteSpace: 'nowrap' }
+var DISH_DOTS = { flex: 1, borderBottom: '1px dotted var(--color-divider)', minWidth: '12px', alignSelf: 'baseline', marginBottom: '3px' }
+var DISH_RATING_STYLE = { fontSize: '13px', fontWeight: 700, color: 'var(--color-rating)', flexShrink: 0 }
+var MENU_FOOTER = { borderTop: '1px solid var(--color-divider)', paddingTop: '10px', marginTop: '10px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }
+
+// Rotating avatar colors for curators
+var AVATAR_COLORS = ['var(--color-primary)', 'var(--color-accent-gold)', 'var(--color-rating)', '#3B82F6', '#9333EA']
+
+function MenuCard({ list, index }) {
+  var navigate = useNavigate()
+  var { items, loading } = useLocalListDetail(list.user_id)
+
+  var initial = (list.display_name || '?').charAt(0).toUpperCase()
+  var avatarColor = AVATAR_COLORS[index % AVATAR_COLORS.length]
+
+  // Group items by restaurant
+  var groups = []
+  var groupMap = {}
+  if (items && items.length > 0) {
+    items.forEach(function (item) {
+      var rid = item.restaurant_id
+      if (!groupMap[rid]) {
+        groupMap[rid] = { restaurant_name: item.restaurant_name, restaurant_id: rid, dishes: [] }
+        groups.push(groupMap[rid])
+      }
+      groupMap[rid].dishes.push(item)
+    })
+  }
+
+  var restaurantCount = groups.length
+  var dishCount = items ? items.length : (list.item_count || 0)
+
+  return (
+    <div style={MENU_CARD} className="active:scale-[0.98] transition-transform">
+      {/* Curator header */}
+      <div className="flex items-center gap-2.5" style={{ marginBottom: '10px' }}>
+        {list.avatar_url ? (
+          <img src={list.avatar_url} alt="" className="rounded-full" style={{ width: '32px', height: '32px', objectFit: 'cover', flexShrink: 0, boxShadow: '0 2px 6px rgba(0,0,0,0.15)' }} />
+        ) : (
+          <div style={Object.assign({}, CURATOR_AVATAR, { background: avatarColor })}>{initial}</div>
+        )}
+        <div>
+          <p style={CURATOR_NAME}>{list.display_name}</p>
+          {list.curator_tagline && <p style={CURATOR_TAGLINE}>{list.curator_tagline}</p>}
+        </div>
+      </div>
+
+      {/* Divider */}
+      <div style={{ height: '1px', background: 'var(--color-divider)', marginBottom: '10px' }} />
+
+      {/* Restaurant-grouped dishes */}
+      {loading ? (
+        <p style={{ fontSize: '12px', color: 'var(--color-text-tertiary)', textAlign: 'center', padding: '8px 0' }}>Loading...</p>
+      ) : groups.length > 0 ? (
+        groups.slice(0, 3).map(function (group) {
+          return (
+            <div key={group.restaurant_id} style={{ marginBottom: '8px' }}>
+              <button
+                onClick={function (e) { e.stopPropagation(); navigate('/restaurants/' + group.restaurant_id) }}
+                style={RESTAURANT_HEADER}
+              >
+                {group.restaurant_name}
+              </button>
+              {group.dishes.slice(0, 3).map(function (dish) {
+                return (
+                  <button
+                    key={dish.dish_id}
+                    onClick={function (e) { e.stopPropagation(); navigate('/dish/' + dish.dish_id) }}
+                    className="flex items-baseline w-full text-left"
+                    style={{ padding: '2px 0 2px 6px', gap: '6px' }}
+                  >
+                    <span style={DISH_NAME_STYLE}>{dish.dish_name}</span>
+                    <span style={DISH_DOTS} />
+                    <span style={DISH_RATING_STYLE}>{dish.avg_rating ? Number(dish.avg_rating).toFixed(1) : '—'}</span>
+                  </button>
+                )
+              })}
+            </div>
+          )
+        })
+      ) : null}
+
+      {/* Footer */}
+      <div style={MENU_FOOTER}>
+        <span style={{ fontSize: '10px', color: 'var(--color-text-tertiary)', fontWeight: 500 }}>
+          {restaurantCount > 0 ? restaurantCount + ' restaurant' + (restaurantCount === 1 ? '' : 's') + ' \u00B7 ' : ''}{dishCount} dish{dishCount === 1 ? '' : 'es'}
+        </span>
+        <button
+          onClick={function () { navigate('/user/' + list.user_id) }}
+          style={{ fontSize: '13px', fontWeight: 700, color: 'var(--color-primary)' }}
+        >
+          See full list →
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export function LocalListsSection({ onListExpanded }) {
+  var { user } = useAuth()
+  var { lists, loading } = useLocalLists(user ? user.id : null)
+
+  if (loading || lists.length === 0) return null
+
+  return (
+    <div style={{ padding: '8px 0 24px' }}>
+      {/* Section header — centered with flanking lines */}
+      <div className="flex items-center gap-4" style={{ padding: '0 20px', marginBottom: '4px' }}>
+        <div style={{ flex: 1, height: '1px', background: 'var(--color-divider)' }} />
+        <div style={{ textAlign: 'center' }}>
+          <p style={{
+            fontFamily: "'Amatic SC', cursive", fontSize: '26px', fontWeight: 700,
+            color: 'var(--color-text-primary)', whiteSpace: 'nowrap', lineHeight: 1.1,
+          }}>
+            A Local's Guide to <span style={{ color: 'var(--color-primary)' }}>Martha's Vineyard</span>
+          </p>
+        </div>
+        <div style={{ flex: 1, height: '1px', background: 'var(--color-divider)' }} />
+      </div>
+      <p style={{ textAlign: 'center', fontSize: '11px', fontWeight: 500, color: 'var(--color-text-tertiary)', padding: '2px 20px 14px' }}>
+        Curated by people who live here
+      </p>
+
+      {/* Horizontal scroll of menu cards */}
+      <div
+        className="flex overflow-x-auto"
+        style={{
+          gap: '14px', padding: '0 20px 8px',
+          scrollSnapType: 'x mandatory',
+          WebkitOverflowScrolling: 'touch',
+          scrollbarWidth: 'none',
+        }}
+      >
+        {lists.map(function (list, i) {
+          return <MenuCard key={list.list_id} list={list} index={i} />
+        })}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `npm run build`
+Expected: PASS
+
+- [ ] **Step 3: Verify tests**
+
+Run: `npm run test -- --run`
+Expected: All 285 tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/home/LocalListsSection.jsx
+git commit -m "feat: redesign LocalListsSection as restaurant-grouped menu cards"
+```
+
+---
+
+### Task 5: Replace RestaurantAvatar with Food Category Icons
+
+**Files:**
+- Modify: `src/components/RestaurantAvatar.jsx`
+
+- [ ] **Step 1: Rewrite RestaurantAvatar**
+
+Replace the entire content of `src/components/RestaurantAvatar.jsx`:
+
+```javascript
+import { memo } from 'react'
+import { getCategoryNeonImage } from '../constants/categories'
+
+/**
+ * Map restaurant cuisine to category icon.
+ * Falls back to the restaurant's most common dish category,
+ * then to a generic utensils placeholder.
+ */
+var CUISINE_TO_CATEGORY = {
+  'seafood': 'seafood',
+  'pizza': 'pizza',
+  'sushi': 'sushi',
+  'japanese': 'sushi',
+  'mexican': 'tacos',
+  'italian': 'pasta',
+  'chinese': 'asian',
+  'asian': 'asian',
+  'thai': 'asian',
+  'indian': 'curry',
+  'breakfast': 'breakfast',
+  'bakery': 'bakery',
+  'burgers': 'burger',
+  'american': 'burger',
+  'bbq': 'steak',
+  'steakhouse': 'steak',
+}
+
+function getCuisineIcon(cuisine, dishCategory) {
+  // Try cuisine first
+  if (cuisine) {
+    var key = cuisine.toLowerCase().trim()
+    var mapped = CUISINE_TO_CATEGORY[key]
+    if (mapped) {
+      var src = getCategoryNeonImage(mapped)
+      if (src) return src
+    }
+  }
+  // Fall back to dish category
+  if (dishCategory) {
+    var src2 = getCategoryNeonImage(dishCategory)
+    if (src2) return src2
+  }
+  return null
+}
+
+/**
+ * RestaurantAvatar - Shows food category icon for the restaurant
+ * Replaces the old town-colored initial circles
+ */
+export var RestaurantAvatar = memo(function RestaurantAvatar({
+  name,
+  town,
+  cuisine,
+  dishCategory,
+  size = 48,
+  fill = false,
+  className = ''
+}) {
+  var iconSrc = getCuisineIcon(cuisine, dishCategory)
+
+  // Fallback: show first letter if no icon found
+  if (!iconSrc) {
+    var initial = name ? name.charAt(0).toUpperCase() : '?'
+    return (
+      <div
+        className={fill ? '' : 'rounded-lg flex items-center justify-center flex-shrink-0 ' + className}
+        style={fill
+          ? { position: 'absolute', inset: 0, width: '100%', height: '100%', background: 'var(--color-surface)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--color-text-tertiary)', fontSize: (size * 0.4) + 'px', fontWeight: 700 }
+          : { width: size, height: size, background: 'var(--color-surface)', color: 'var(--color-text-tertiary)', fontSize: (size * 0.4) + 'px', fontWeight: 700 }
+        }
+        aria-label={(name || 'Restaurant') + ' icon'}
+      >
+        {initial}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={fill ? '' : 'rounded-lg flex items-center justify-center flex-shrink-0 ' + className}
+      style={fill
+        ? { position: 'absolute', inset: 0, width: '100%', height: '100%', background: 'var(--color-surface)', display: 'flex', alignItems: 'center', justifyContent: 'center' }
+        : { width: size, height: size, background: 'var(--color-surface)' }
+      }
+      aria-label={(name || 'Restaurant') + ' icon'}
+    >
+      <img
+        src={iconSrc}
+        alt=""
+        style={{
+          width: size * 0.7,
+          height: size * 0.7,
+          objectFit: 'contain',
+        }}
+      />
+    </div>
+  )
+})
+
+// Keep getTownStyle export for backwards compat (used by EventCard, SpecialCard)
+// but mark as deprecated — callers should migrate to cuisine-based display
+export function getTownStyle(town) {
+  return { bg: 'var(--color-surface)', text: 'var(--color-text-tertiary)', isGradient: false }
+}
+```
+
+- [ ] **Step 2: Check callers for prop updates**
+
+The callers that import `RestaurantAvatar` are:
+- `src/components/DishListItem.jsx` — passes `name` and `town`. Need to also pass `cuisine` or `dishCategory` where available.
+- `src/components/EventCard.jsx` — passes `name` and `town`.
+- `src/components/SpecialCard.jsx` — passes `name` and `town`.
+
+In `DishListItem.jsx`, the dish object has a `category` field. Update the `RestaurantAvatar` usage to pass it:
+
+Find the `<RestaurantAvatar` usage and add `dishCategory={category}`:
+
+```javascript
+<RestaurantAvatar name={restaurantName} town={restaurantTown} dishCategory={category} size={38} />
+```
+
+For `EventCard.jsx` and `SpecialCard.jsx`, the restaurant cuisine may not be available — the fallback initial letter will display, which is acceptable for now.
+
+- [ ] **Step 3: Verify build**
+
+Run: `npm run build`
+Expected: PASS
+
+- [ ] **Step 4: Verify tests**
+
+Run: `npm run test -- --run`
+Expected: All tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/RestaurantAvatar.jsx src/components/DishListItem.jsx
+git commit -m "feat: replace restaurant initial avatars with food category icons"
+```
+
+---
+
+### Task 6: Final Integration + Verification
+
+**Files:**
+- No new files — verify everything works together
+
+- [ ] **Step 1: Run full build**
+
+Run: `npm run build`
+Expected: PASS with no warnings
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm run test -- --run`
+Expected: All tests pass
+
+- [ ] **Step 3: Visual verification on dev server**
+
+Run: `npm run dev`
+
+Check in browser:
+1. Homepage chalkboard row scrolls to show gold-framed "Locals Agree" and "Island Favorite" cards at the end
+2. Tapping "Locals Agree" card navigates to the dish page
+3. Tapping "Island Favorite" card navigates to the restaurant page
+4. Scrolling to bottom shows "A Local's Guide to Martha's Vineyard" section with flanking lines
+5. Menu cards show curator name, restaurant-grouped dishes with dotted leaders and ratings
+6. Tapping dish name in menu card navigates to dish page
+7. Tapping restaurant name navigates to restaurant page
+8. Restaurant avatars throughout the app show food category icons instead of colored initials
+9. If no local lists exist (< 2), aggregate chalkboards don't appear
+
+- [ ] **Step 4: Commit final state**
+
+```bash
+git add -A
+git commit -m "feat: locals homepage redesign — aggregate chalkboards, menu cards, food icons"
+```
+
+- [ ] **Step 5: Update TASKS.md**
+
+Add completed task entry. Update SPEC.md if the local lists feature description changed.

--- a/docs/superpowers/plans/2026-04-13-h2-sign-in-with-apple.md
+++ b/docs/superpowers/plans/2026-04-13-h2-sign-in-with-apple.md
@@ -1,0 +1,662 @@
+# H2 — Sign in with Apple
+
+**Status:** Ready to implement (revised 2026-04-13 after Codex pressure-test)
+**Effort:** 15-22h (revised up from 13-20.5 after incorporating Apple-specific gaps)
+**Apple rule:** Guideline 4.8 — hard gate
+**Source audit:** Direct code review + Codex gpt-5.4 high pressure-test
+
+> **Why this is required:** WGH offers Google Sign-In (`LoginModal.jsx:231-244`, `Login.jsx:350-364`). Apple rule 4.8: any app with third-party social login must offer Sign in with Apple as an equivalent option. Missing = auto-reject.
+>
+> **Revision notes:** First draft had several wrong assumptions about the Apple identity token (doesn't include name, unlike Google), account linking (Supabase auto-links now), flow type (implicit, not PKCE), and several small plan items. See the revision log at the bottom.
+
+---
+
+## Goal
+
+Add Sign in with Apple as a third auth option alongside Google and email. Works on PWA (web OAuth flow) and iOS Capacitor build (native plugin flow). Handle Apple-specific quirks: Apple doesn't send name in the identity token, relay-email users, first-sign-in name persistence, and 6-month secret rotation.
+
+## Non-goals
+
+- Apple token revocation on sign-out (defer — call on account deletion only, as H1.1 follow-up).
+- Full email-relay configuration at our domain (Apple email source registration is a config task, not code — document, do in Supabase dashboard).
+- Account merge tooling for pre-existing accounts with different verified emails (Supabase auto-links SAME verified email; Apple private-relay may create separate accounts).
+- Single-tap SIWA via Apple JS SDK on web (post-launch).
+
+## Approach
+
+Two flows, same Supabase user:
+
+1. **Web (PWA):** User taps "Sign in with Apple" → Supabase `signInWithOAuth({ provider: 'apple' })` → browser full-page redirect to Apple → user authorizes → Apple redirects back → Supabase validates the ID token and sets session in the browser (the Supabase client uses **implicit flow** by default, per `src/lib/supabase.js:31` — tokens come back in the URL, not via code exchange).
+
+2. **Native (Capacitor iOS):** User taps "Sign in with Apple" → `@capacitor-community/apple-sign-in` community plugin invokes native `ASAuthorizationController` → user authorizes via Touch/Face ID → plugin returns an Apple ID token + first-sign-in name (if shared) → client calls `supabase.auth.signInWithIdToken({ provider: 'apple', token, nonce })` → session is set.
+
+Runtime detection: `Capacitor.isNativePlatform()` returns true only inside the iOS app.
+
+---
+
+## Apple Developer setup (prerequisite)
+
+**Blocked by:** Dan's Apple Developer enrollment (T1 from launch plan).
+
+Once Apple Dev account is active:
+
+- [ ] **Create App ID** (e.g. `com.whatsgoodhere.app`)
+  - Enable capability: **Sign In with Apple**
+
+- [ ] **Create a Services ID** (web-flow client ID)
+  - Example: `com.whatsgoodhere.service`
+  - **Associated Domains** (domains where the SIWA button appears): `whats-good-here.vercel.app` (and any future custom domain)
+  - **Return URL** (OAuth callback — must be Supabase): `https://vpioftosgdkyiwvhxewy.supabase.co/auth/v1/callback`
+  - These are two separate fields in the Apple Services ID config.
+
+- [ ] **Generate Sign in with Apple private key (.p8)**
+  - Download the .p8 file ONCE (not re-downloadable) — store securely (password manager / 1Password vault)
+  - Note the Key ID
+
+- [ ] **Note the Team ID**
+
+- [ ] **Plan secret rotation (mandatory every 6 months)**
+  - Supabase docs: the client secret JWT generated from the .p8 must be rotated every 6 months or auth will fail. Calendar reminder required.
+  - Source: [Supabase Apple auth docs](https://supabase.com/docs/guides/auth/social-login/auth-apple)
+
+**Artifacts Dan needs for Supabase config:**
+- Services ID (e.g. `com.whatsgoodhere.service`)
+- Team ID (10-char string)
+- Key ID (10-char string)
+- .p8 file contents
+
+---
+
+## Supabase config (prerequisite)
+
+In Denis's Supabase dashboard (project `vpioftosgdkyiwvhxewy`):
+
+- [ ] Auth → Providers → Apple → Enable
+- [ ] Client IDs (plural): both the web **Services ID** (for OAuth flow) and the iOS **Bundle ID** (for signInWithIdToken) go here.
+  - The Supabase dashboard field may show "Client IDs" (plural) — add both values; format (comma-separated vs separate fields) is a **verification step in the dashboard**, not a confirmed fact from docs
+- [ ] Team ID
+- [ ] Key ID
+- [ ] Secret Key: paste .p8 contents
+- [ ] Redirect URL for Apple → confirm matches what was set in Services ID config
+
+**Email source registration (optional but recommended):**
+
+Apple's relay delivers forwarded emails through Apple's servers to the user's real inbox. If we send auth emails (magic links at `authApi.js:83`, password resets at `authApi.js:219`) to a relay address, register the WGH sending domain with Apple so emails come from our domain rather than being rejected/spam-filtered. This is a one-time Apple Developer portal config step.
+
+---
+
+## Backend changes
+
+**Profile auto-creation trigger (existing) does NOT auto-fill display_name for Apple users.**
+
+The trigger at `supabase/schema.sql:2923` reads `raw_user_meta_data.full_name` / `name`. Apple's identity token does NOT include name (unlike Google). Supabase docs confirm: for Apple users, the name is delivered ONLY in the first-sign-in plugin/JS response and must be saved manually via `updateUser()`.
+
+**Implication:** Apple users will have `display_name = null` on first sign-in via web OAuth. We handle this via:
+- **Native path:** capture name from plugin response, persist via `persistFirstSignInName()` (see frontend below)
+- **Web path:** display_name stays null; WelcomeModal (updated below) prompts user
+
+**No new tables or Edge Functions required for H2 itself.** (Revocation in H1.1 is a separate Edge Function — see "Account deletion revocation tie-in".)
+
+---
+
+## Frontend — web flow (PWA)
+
+### API method
+
+**File:** `src/api/authApi.js`
+
+Mirror `signInWithGoogle` (line 51). Use `supabase.functions.invoke`-style error handling per repo pattern:
+
+```js
+async signInWithApple(redirectUrl = null) {
+  try {
+    const rateLimit = checkRateLimit('auth', RATE_LIMITS.auth)
+    if (!rateLimit.allowed) throw new Error(rateLimit.message)
+
+    capture('login_started', { method: 'apple' })
+
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'apple',
+      options: { redirectTo: getSafeRedirectUrl(redirectUrl) },
+    })
+    if (error) {
+      capture('login_failed', { method: 'apple', error: error.message })
+      throw createClassifiedError(error)
+    }
+    return { success: true }
+  } catch (error) {
+    logger.error('authApi.signInWithApple failed:', error)
+    throw error.type ? error : createClassifiedError(error)
+  }
+}
+```
+
+**Rate limit caveat:** `checkRateLimit('auth', ...)` uses in-memory storage (`src/lib/rateLimiter.js:6`). Because OAuth is a full-page redirect, the counter resets on return — the limiter only throttles rapid pre-redirect clicks within a single page lifetime. Document as a known limitation; consider server-side rate limiting post-launch (via Supabase RPC, like we do for votes).
+
+### UI — LoginModal.jsx
+
+Add Apple button. Apple HIG says SIWA must be **at least as prominent** as other third-party sign-in options — equal size + comparable placement. Above Google is a safe choice; side-by-side also works. **"Above Google"** is the plan's default.
+
+**Location:** `src/components/Auth/LoginModal.jsx`, before the Google button block.
+
+**Handler:**
+```js
+const handleAppleSignIn = async () => {
+  try {
+    setLoading(true)
+    const redirectUrl = new URL(window.location.href)
+    const pending = getPendingVoteFromStorage()
+    if (pending?.dishId) redirectUrl.searchParams.set('votingDish', pending.dishId)
+    await authApi.signInWithApple(redirectUrl.toString())
+  } catch (error) {
+    setMessage({ type: 'error', text: error.message })
+    setLoading(false)
+  }
+}
+```
+
+**Button — use Apple's official assets:**
+
+Apple's HIG specifies button design requirements:
+- Exact label text: "Sign in with Apple" (case-sensitive)
+- Apple logo at left
+- Official black / white / white-outlined variants only
+- Button height, padding, corner radius follow Apple's specs
+- Source: [Apple HIG / Sign in with Apple buttons](https://developer.apple.com/design/human-interface-guidelines/sign-in-with-apple/overview/buttons/)
+
+**Recommended implementation:** use Apple's provided button assets directly, or import an official SIWA button component. Do NOT hand-author the logo SVG (compliance risk — Apple requires specific proportions/padding).
+
+Option A — download official PNG assets from Apple Developer:
+- `public/apple-signin-black.png` (for light themes)
+- `public/apple-signin-white.png` (for dark themes)
+- Render as a button background image with correct padding
+
+Option B — use a verified npm package like `react-apple-signin-auth` (community-maintained) for just the button styling. But wire up the handler ourselves — don't use the package's auth flow, use Supabase's.
+
+**Dimensions to match Google button exactly:**
+- Width: 100% (w-full)
+- Padding: `px-6 py-4`
+- Border-radius: `rounded-xl` (14px)
+- Font: Outfit (body)
+- Min 44pt tap target (iOS HIG)
+
+**Placement decision:** Put Apple button ABOVE Google — conservative safe default for HIG compliance.
+
+### UI — Login.jsx
+
+Mirror the change in `src/pages/Login.jsx`. Add Apple button above Google button. Same handler pattern.
+
+**Parallel bug to fix (pre-existing, flagged by Codex):** The current Google OAuth flow in `Login.jsx` does not serialize `location.state?.from` into the redirect URL. Post-OAuth return will not preserve where the user came from. Fix for BOTH Apple and Google in this update.
+
+---
+
+## Frontend — native flow (Capacitor)
+
+### Prerequisites (noted — not current state)
+
+The repo currently has NO Capacitor scaffold. No `@capacitor/*` deps in `package.json:21`, no `ios/` directory, no `capacitor.config.*`. The native flow becomes buildable only after the Capacitor scaffold exists (tracked separately).
+
+Once Capacitor is scaffolded:
+
+```bash
+npm install @capacitor-community/apple-sign-in
+npx cap sync ios
+```
+
+Add capability in Xcode: **Signing & Capabilities → + Capability → Sign In with Apple**.
+
+**About the plugin:** `@capacitor-community/apple-sign-in` is a **community-maintained plugin**, NOT an official Capacitor-core plugin. It's actively used but not a first-party solution. Track its maintenance status; reassess if it becomes stale.
+
+### Runtime detection in API method
+
+**File:** `src/api/authApi.js`
+
+```js
+import { Capacitor } from '@capacitor/core'
+
+async signInWithApple(redirectUrl = null) {
+  if (Capacitor.isNativePlatform()) {
+    return this._signInWithAppleNative()
+  }
+  return this._signInWithAppleWeb(redirectUrl)
+}
+```
+
+The existing web code moves into `_signInWithAppleWeb`. Do NOT import the native plugin in the web bundle (webpack tree-shaking may handle this, but be explicit — dynamic import in the native branch).
+
+### Native handler
+
+```js
+async _signInWithAppleNative() {
+  try {
+    const rateLimit = checkRateLimit('auth', RATE_LIMITS.auth)
+    if (!rateLimit.allowed) throw new Error(rateLimit.message)
+
+    capture('login_started', { method: 'apple_native' })
+
+    const { SignInWithApple } = await import('@capacitor-community/apple-sign-in')
+
+    // Generate nonce: raw for Supabase, SHA-256 hashed for Apple
+    const rawNonce = generateNonce()
+    const hashedNonce = await sha256(rawNonce)
+
+    const result = await SignInWithApple.authorize({
+      clientId: IOS_BUNDLE_ID,  // e.g. 'com.whatsgoodhere.app'
+      redirectURI: '<TBD — verify with plugin docs>',  // see open question below
+      scopes: 'email name',
+      state: crypto.randomUUID(),
+      nonce: hashedNonce,
+    })
+
+    const identityToken = result?.response?.identityToken
+    if (!identityToken) throw new Error('Apple sign-in did not return a token')
+
+    const { error } = await supabase.auth.signInWithIdToken({
+      provider: 'apple',
+      token: identityToken,
+      nonce: rawNonce,  // RAW nonce — Supabase verifies against hashed version in the signed token
+    })
+
+    if (error) {
+      capture('login_failed', { method: 'apple_native', error: error.message })
+      throw createClassifiedError(error)
+    }
+
+    // Name is delivered ONLY on first sign-in per user
+    const fullName = result?.response?.givenName
+      ? `${result.response.givenName} ${result.response.familyName || ''}`.trim()
+      : null
+    if (fullName) {
+      await persistFirstSignInName(fullName)
+    }
+
+    capture('login_succeeded', { method: 'apple_native' })
+    return { success: true }
+  } catch (error) {
+    logger.error('authApi.signInWithAppleNative failed:', error)
+    throw error.type ? error : createClassifiedError(error)
+  }
+}
+```
+
+**Open question for plugin `redirectURI`:** The plugin's published type definitions require a `redirectURI` string, but the plan's earlier `redirectURI: ''` was speculative. Verify against the plugin's actual examples before implementation — typical values are the Apple Services ID (web flow) or an intent scheme like `com.whatsgoodhere.app://`. This is not something we should ship without testing on a real device.
+
+### Helper: persistFirstSignInName (with content validation)
+
+**File:** `src/utils/appleAuth.js` (new)
+
+```js
+import { supabase } from '../lib/supabase'
+import { logger } from './logger'
+import { validateUserContent } from '../lib/reviewBlocklist'
+
+export async function persistFirstSignInName(fullName) {
+  try {
+    // Must pass same moderation as any user-set display_name
+    const validationError = validateUserContent(fullName, 'Display name')
+    if (validationError) {
+      logger.warn('Apple-provided name failed validation:', validationError)
+      return  // Fall through — WelcomeModal will prompt user manually
+    }
+
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return
+
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('display_name')
+      .eq('id', user.id)
+      .maybeSingle()
+
+    // Only set if not already set
+    if (!profile?.display_name) {
+      const { error } = await supabase
+        .from('profiles')
+        .update({ display_name: fullName })
+        .eq('id', user.id)
+      if (error) logger.warn('Failed to persist Apple first-sign-in name:', error)
+    }
+  } catch (error) {
+    logger.warn('persistFirstSignInName failed (non-fatal):', error)
+  }
+}
+```
+
+Non-fatal on any failure — user still gets logged in, WelcomeModal catches the missing display_name downstream.
+
+**Uniqueness risk:** `profiles.display_name` has a unique lowercase constraint (`schema.sql:387`). If the Apple-provided name collides with an existing user, this silently fails. The WelcomeModal prompt handles recovery.
+
+### Helper: nonce generation + SHA256
+
+**File:** `src/utils/nonce.js` (new)
+
+```js
+export function generateNonce() {
+  const bytes = new Uint8Array(32)
+  crypto.getRandomValues(bytes)
+  return Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('')
+}
+
+export async function sha256(str) {
+  const buf = new TextEncoder().encode(str)
+  const hash = await crypto.subtle.digest('SHA-256', buf)
+  return Array.from(new Uint8Array(hash), b => b.toString(16).padStart(2, '0')).join('')
+}
+```
+
+Uses Web Crypto — available in Capacitor WKWebView and all modern browsers.
+
+### `IOS_BUNDLE_ID` constant (new)
+
+**File:** `src/constants/app.js`
+
+```js
+export const IOS_BUNDLE_ID = 'com.whatsgoodhere.app'
+```
+
+Must match what gets registered in Apple Developer portal AND what gets configured when Capacitor is scaffolded. Decide value BEFORE Apple Dev portal work.
+
+---
+
+## WelcomeModal fix (covers the no-name edge case)
+
+**File:** `src/components/Auth/WelcomeModal.jsx`
+
+**Current open condition** (`WelcomeModal.jsx:50`):
+```js
+if (user && profile && !profile.has_onboarded) openModal()
+```
+
+**Problem:** a returning user who onboarded in the past but has `display_name = null` (edge case: Apple decline after first onboarding flow was never completed, or manual data edit) gets no prompt, and can't vote (display name is required).
+
+**Fix:** update condition to ALSO open when display_name is missing:
+```js
+if (user && profile && (!profile.has_onboarded || !profile.display_name)) openModal()
+```
+
+This catches:
+- First sign-in users (pre-existing flow)
+- Apple users who skipped the name step on first sign-in
+- Any user in a weird data state
+
+**Pre-existing bug to fix in the same pass:** `completeOnboarding()` at `WelcomeModal.jsx:61` awaits `updateProfile()` but ignores the `{ error }` return. Duplicate display_name unique-constraint errors fail silently. The user sees success but their display_name wasn't saved.
+
+**Fix:**
+```js
+const { error } = await updateProfile(...)
+if (error) {
+  setError(getUserMessage(error, 'setting display name'))
+  return  // Don't close modal on error
+}
+// ...existing close logic
+```
+
+---
+
+## Account linking + duplicate accounts
+
+### Supabase's current behavior (updated from plan v1)
+
+- **Same verified email across providers:** Supabase **auto-links** identities with the same verified email (default behavior, can be configured). So a user with Google `dan@example.com` who signs in with Apple also delivering `dan@example.com` will get ONE auth user with two linked identities.
+- **Private-relay email:** Apple users who pick "Hide My Email" get `random@privaterelay.appleid.com`. This is a DIFFERENT email than their real one → Supabase creates a separate auth user. Can't auto-link.
+- **Manual linking available:** `supabase.auth.linkIdentity()` exists in the installed SDK. Post-launch, could build a "link my Apple account" UI from settings.
+
+**Update Privacy.jsx copy** to reflect this (not two-accounts-always).
+
+### What users see today
+- Google sign-up with real email, then Apple with same real email → single account ✓
+- Google sign-up, then Apple with private-relay → two accounts (document limitation, offer manual link post-launch)
+- Apple sign-up with private-relay, then trying to sign up again with "different" method using same Apple ID → one account under the relay email, which is the canonical record
+
+---
+
+## Copy changes
+
+### Privacy.jsx (line number corrected: 61, not 51)
+
+**Current line 61:**
+```
+If you sign in with Google, we receive your name and email from Google.
+```
+
+**Replace with:**
+```
+If you sign in with Google or Apple, we receive your name (if shared) and
+email (which may be a private-relay address from Apple) from the provider.
+If you use the same verified email across providers, we automatically link
+your accounts.
+```
+
+### Other privacy updates (coordinate with L1 Privacy comprehensive update plan):
+- Disclose Apple's private-relay email behavior
+- Note that auth emails (magic links, resets) may be delivered via Apple's relay
+- Clarify automatic account linking behavior
+
+---
+
+## Testing plan
+
+### Web flow (PWA)
+1. From logged-out, open LoginModal
+2. Tap Apple button → full-page redirect to Apple
+3. Sign in with real Apple ID → return to app → session is set
+4. Profile row exists, `display_name = null`
+5. WelcomeModal opens with name prompt → user sets display name
+6. Sign out + sign in again → same user, no re-prompt (`has_onboarded = true` now)
+
+### Private-relay email
+1. Sign in with Apple, pick "Hide My Email"
+2. Confirm `auth.users.email` ends in `@privaterelay.appleid.com`
+3. Attempt to trigger a password reset (edge case) — Apple forwards via relay
+4. Verify RLS + downstream queries handle the relay email format
+
+### Declined name (first sign-in)
+1. Sign in with Apple, decline name
+2. Confirm display_name is null
+3. WelcomeModal opens → user types a name
+4. Save succeeds, user continues to app
+
+### WelcomeModal handles onboarded-but-null-name case
+1. Create a test user with `has_onboarded = true, display_name = null` (DB manipulation)
+2. Log in → WelcomeModal should still open
+3. Confirm user can set display_name
+
+### Validation on Apple-provided name
+1. Simulate Apple returning name containing banned word
+2. Confirm `persistFirstSignInName` skips the write
+3. Confirm WelcomeModal opens for manual input
+
+### Duplicate display_name collision
+1. Existing user has display_name "Dan"
+2. New Apple user returns "Dan" — persistFirstSignInName silently fails
+3. WelcomeModal opens → user enters a different name → success
+
+### Account linking (Supabase auto-link)
+1. Sign up with Google using real email
+2. Sign out
+3. Sign in with Apple using same real email
+4. Verify ONE auth.users row with two linked identities (inspect `auth.identities` table)
+
+### Private-relay separate account (limitation)
+1. Sign up with Google using real email
+2. Sign out
+3. Sign in with Apple using private-relay
+4. Verify TWO auth.users rows — expected behavior, document
+
+### Native flow (requires Capacitor + iPhone)
+1. Capacitor build installed on physical iPhone
+2. Tap Apple button → native sheet with Touch/Face ID
+3. Authorize → session is set via signInWithIdToken
+4. Name captured on first sign-in, persisted via persistFirstSignInName
+5. Sign out + sign in → no name re-prompt, same user
+
+### Runtime detection
+1. Same code path on web → web flow invoked
+2. Same code path on iOS Capacitor build → native plugin invoked
+
+### Rate limit behavior
+1. Tap Apple sign-in 10 times rapidly before redirect
+2. In-memory limiter throttles attempts beyond threshold (5/5min)
+3. After redirect return, counter is reset (expected limitation)
+
+### UI compliance
+1. Apple button uses official assets or meets exact HIG button spec
+2. Placement: above Google, same width, same padding
+3. Label: exactly "Sign in with Apple"
+4. 44pt minimum tap target
+
+---
+
+## Rollout steps
+
+### Phase 1 — Web only (PWA)
+1. Dan enrolls Apple Developer + creates App ID, Services ID, .p8 key (external)
+2. Configure Supabase Auth → Providers → Apple with both client IDs (web + iOS)
+3. Implement web path:
+   - `authApi.signInWithApple` (web branch only, no native import yet)
+   - Apple button on LoginModal + Login
+   - Fix Google OAuth intent-preservation bug in Login.jsx at the same time
+4. Update WelcomeModal open condition + fix silent error bug
+5. Update Privacy.jsx copy
+6. Deploy to staging → test on real Apple ID (+ private relay)
+7. Deploy to prod
+
+### Phase 2 — Native (after Capacitor scaffold exists)
+1. Install community Apple sign-in plugin
+2. Add SIWA capability in Xcode
+3. Implement native branch in `authApi.signInWithApple`
+4. Verify plugin `redirectURI` param on a real build
+5. Install helpers: `nonce.js`, `appleAuth.js`
+6. Test on physical iPhone via TestFlight
+7. Ship in iOS release
+
+Phase 1 ships independently of Phase 2. The web flow is the Apple HIG baseline.
+
+---
+
+## Rollback
+
+If web flow breaks post-deploy:
+- Feature-flag hide the Apple button. (NOTE: must NOT hide in iOS App Store build — Apple requires SIWA there.)
+
+If native flow breaks in iOS build:
+- Emergency TestFlight patch before App Store submission.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Apple Developer account not enrolled in time | Email/password + Google still work; Apple adds without blocking existing auth |
+| Apple client secret JWT expires (6-month rule) | Calendar reminder; Supabase dashboard makes rotation easy |
+| Services ID / key config mistake | Test on staging before prod; Supabase surfaces clear errors on misconfig |
+| Plugin redirectURI param wrong | Verify on device before marking native flow done |
+| Community plugin goes stale | Monitor; if abandoned, re-evaluate or fork |
+| Apple-provided name fails validation → user sees silent null display_name | WelcomeModal catches this; user sets name manually |
+| Duplicate display_name from Apple collision | WelcomeModal catches + updateProfile returns error (after bug fix) |
+| Private-relay users create duplicate accounts | Document; offer manual link post-launch |
+| Supabase auto-link behavior changes | Monitor Supabase release notes |
+| .p8 private key leakage | Stored only in Supabase (encrypted); never commit to git |
+| iCloud Keychain flakiness on simulator | Test on physical device, not simulator |
+| Apple revocation endpoint complexity | Defer to H1.1 (see below); document as known post-launch gap |
+
+---
+
+## Account deletion revocation tie-in (H1.1 — defer)
+
+Apple requires that apps supporting Sign in with Apple **revoke** the user's Apple access when they delete their account. Non-trivial to implement — here's the shape for future work:
+
+### What's needed
+1. **Capture Apple refresh token on sign-in.** Supabase sessions can carry `provider_refresh_token` / `provider_token` (`@supabase/auth-js/src/lib/types.ts:248`), but the current app doesn't persist them.
+2. **Store refresh token in a new table.** Linked to `auth.users.id`, only for Apple-provider users.
+3. **On account deletion**, call Apple's revoke endpoint:
+   - Endpoint: `https://appleid.apple.com/auth/revoke`
+   - Auth: client_secret JWT signed with .p8, valid for < 24h
+   - Payload: `client_id`, `token` (refresh), `token_type_hint: 'refresh_token'`
+4. **Location:** Add to the existing `delete-account` Edge Function (H1), triggered when `user.app_metadata.provider === 'apple'`.
+
+### Why defer
+- Requires persistent token storage design (new table, RLS, encryption-at-rest for tokens)
+- Requires client_secret JWT generation in Edge Function (crypto signing with .p8)
+- Substantial engineering (~6-10h) beyond H2's scope
+- Not blocking App Store submission if we can show Apple we have account deletion (they may accept "user's Apple ID account remains authorized but WGH account is deleted")
+
+### Follow-up spec
+Open a separate H1.1 spec after H1 and H2 ship. Target: before July 4, definitely before Labor Day.
+
+---
+
+## Effort breakdown (revised)
+
+- Apple Developer setup (Dan external): **1-2h**
+- Supabase config: **0.5h**
+- Web: API method + UI + WelcomeModal fix + Privacy copy + Login.jsx intent-preservation bug fix: **4-5h**
+- Native: plugin install + Xcode capability + branch + helpers + plugin redirectURI verification: **5-7h**
+- Edge case handling (validation, relay, uniqueness, onboarded-null-name): **2-3h**
+- Testing (web + native + edge + linking cases): **3-5h**
+
+**Total: 15.5-22.5h.**
+
+---
+
+## Dependencies
+
+**Blocks:** H1.1 (Apple token revocation). Cannot complete iOS submission without SIWA.
+**Blocked by:**
+- Apple Developer account active (Dan external)
+- App ID + Services ID + .p8 created
+- For Phase 2: Capacitor scaffold exists
+
+**Related:**
+- L1 Privacy + ToS update (shared file edit — coordinate)
+- H1 account deletion (revocation hook in delete-account Edge Function is a follow-up)
+- LoginModal + Login.jsx touches (may conflict with feature work)
+
+---
+
+## Open questions for Dan
+
+1. **Bundle ID:** confirm `com.whatsgoodhere.app` for both Apple App ID and Capacitor Xcode project.
+2. **Services ID name:** `com.whatsgoodhere.service` — good?
+3. **Button variant:** black (default), white, or white-outlined? White-outlined might fit the warm light theme best — worth mocking.
+4. **Flow order:** Phase 1 (web) first, Phase 2 (native) once Capacitor scaffolded. OK?
+5. **Secret rotation calendar:** who owns the 6-month Apple secret rotation reminder?
+6. **Email relay source registration:** any hesitation about configuring our domain as an Apple email source?
+
+---
+
+## Revision log
+
+**2026-04-13 v2 (after Codex pressure-test):**
+
+CRITICAL corrections:
+- Apple identity token does NOT contain name (unlike Google) — removed "same path as Google" claim; added explicit first-sign-in name capture via plugin + WelcomeModal fallback for web
+- WelcomeModal open condition was missing `!display_name` case — added fix for edge case of onboarded users with null display_name (e.g., Apple decline)
+- Services ID config clarified: Associated Domains = app domain, Return URL = Supabase callback (both needed)
+
+IMPORTANT corrections:
+- Supabase auto-links same-email identities — rewrote account-linking section
+- Flow is implicit, not PKCE — corrected description
+- In-memory rate limiter resets on redirect — documented limitation
+- Plugin `redirectURI: ''` was speculative — flagged as open question to verify
+- Labeled plugin as "community-maintained"
+- Noted Capacitor scaffold does NOT exist yet
+- Added `validateUserContent` check in `persistFirstSignInName`
+- Flagged pre-existing WelcomeModal bug (silent error) + fix
+- Added 6-month Apple secret rotation requirement
+- Corrected private-relay disclosure (we DO send auth emails)
+- Use official Apple button assets, not hand-drawn SVG
+- Referenced Apple's button spec (not just 44pt)
+- Noted AuthContext has no first-sign-in callback
+- Multi-client-ID Supabase config flagged as dashboard verification
+- Updated Privacy.jsx line reference: 51 → 61
+
+SUGGESTIONS incorporated:
+- Phase 1 (web) strictly web-only (no native imports)
+- Intent-preservation bug fix in Login.jsx Google flow (same file edit)
+- H1 revocation lives in delete-account Edge Function
+- Display-name-required gate broader than onboarding
+
+DEFERRED to H1.1:
+- Apple token revocation design — requires persistent refresh-token storage + JWT client_secret generation + Apple revoke API call. Non-trivial. Shape documented here.

--- a/docs/superpowers/specs/2026-03-27-profile-redesign.md
+++ b/docs/superpowers/specs/2026-03-27-profile-redesign.md
@@ -1,0 +1,64 @@
+# Profile Redesign — Journal + Identity Card
+
+## Summary
+
+Two different profile experiences depending on whose profile you're viewing:
+- **Your own profile** → The Journal (chronological food diary)
+- **Someone else's profile** → The Identity Card (who they are as an eater, at a glance)
+
+## Core Insight
+
+Your own profile is personal — it's YOUR diary, your food life unfolding. Other people's profiles are about quick understanding — who is this person as an eater?
+
+## My Profile — The Journal
+
+**Layout (top to bottom):**
+1. **Minimal header** — "Your Journal" in Amatic SC, small avatar + name + one-line stats ("87 dishes · 14 restaurants · Martha's Vineyard"), thin divider
+2. **Chronological journal entries** — grouped by date markers (Today, Yesterday, 3 days ago, Last week, dates)
+3. **Each entry** — card with category icon (56px), dish name (16px bold), restaurant (11px), review snippet (12px italic, 2-line clamp), rating number (28px bold, right-aligned)
+4. **Pagination** — "Show more" link at bottom
+
+**What's removed:**
+- Dashboard cards (Recent Meals, Highlights) — the journal IS recent meals
+- Shelf filter tabs (Good Here, Heard That's Good, Wasn't Good) — killed per design decision, journal shows all rated dishes chronologically
+- Share My Picks button from hero — move to a menu/action
+
+**What stays:**
+- Jitter trust badge (in the header row, same as current)
+- Display name editing (tap to edit)
+- Follow counts (accessible but not dominant)
+
+## Other Profile — The Identity Card
+
+**Layout (top to bottom):**
+1. **Centered hero** — back arrow, large avatar (80px), name (24px bold), one-line tagline ("Seafood obsessed · Harsh critic · MV local"), Follow button
+2. **Stats strip** — 3-column card: dishes count, restaurants count, avg rating (green)
+3. **Taste match** — "72% taste match with you — you both love seafood and The Bite"
+4. **Their Top Picks** — top 3 rated dishes with rank medals, name, restaurant, rating
+5. **Food Identity tags** — colored badges (Seafood Expert, Harsh Critic, MV Local, Adventurous) derived from their voting data
+6. **Recent activity** — simple rows: dish name, restaurant, time ago, rating
+
+## File Changes
+
+- `src/pages/Profile.jsx` — refactor to journal layout
+- `src/pages/UserProfile.jsx` — refactor to identity card layout
+- `src/components/profile/JournalFeed.jsx` — simplify to pure chronological, remove shelf filtering
+- `src/components/profile/JournalCard.jsx` — redesign to journal entry card
+- `src/components/profile/HeroIdentityCard.jsx` — split into two: minimal journal header (own) vs centered identity hero (other)
+- `src/components/profile/ShelfFilter.jsx` — remove (no longer needed)
+- May need new: `IdentityTags.jsx`, `TasteMatch.jsx`, `TopPicks.jsx`
+
+## Design Tokens
+
+All existing WGH tokens. Key ones:
+- Date markers: `#C48A12` (gold), 10px bold uppercase
+- Journal cards: white on warm stone, 14px border-radius
+- Rating numbers: 28px/800 weight, color from `getRatingColor()`
+- Review text: 12px italic, `--color-text-secondary`
+- Identity tags: colored pills (coral, black, gold, green) with white text
+
+## What's NOT in scope
+- Food Map visualization
+- Badge system
+- Jitter trust display (defer to later)
+- "Heard That's Good" / favorites (removed for now, add back later)

--- a/docs/superpowers/specs/2026-03-31-locals-homepage-redesign.md
+++ b/docs/superpowers/specs/2026-03-31-locals-homepage-redesign.md
@@ -1,0 +1,160 @@
+# Locals Homepage Redesign — Spec
+
+**Date:** March 31, 2026
+**Status:** Draft
+**Mockup:** `.superpowers/brainstorm/9592-1774986699/content/locals-chalkboard-aggregate.html`
+
+---
+
+## Summary
+
+Two changes to the homepage that surface local list data in the editorial chalkboard row and redesign the local lists section at the bottom.
+
+1. **Locals Aggregate Chalkboards** — two new cards at the END of the chalkboard row showing the dish and restaurant that appear most frequently across all local lists
+2. **Local Lists as Menu Cards** — redesign the bottom-of-page local lists section with restaurant-grouped menu-style cards
+
+Plus: remove the color-coded-by-town restaurant initial avatars from restaurant display everywhere.
+
+---
+
+## Part 1: Locals Aggregate Chalkboards
+
+### What
+
+Two new chalkboard cards appended to the end of the existing editorial chalkboard scroll row. They aggregate ALL local lists and surface the consensus picks.
+
+### Card 1: "Locals Agree" (Most-Appearing Dish)
+
+- **Tag:** "🏆 locals agree"
+- **Title:** Name of the dish that appears on the most local lists (e.g., "Lobster Roll")
+- **Subtitle:** Restaurant name (e.g., "Larsen's Fish Market")
+- **Stat badge:** "On 4 of 5 local lists" (count of lists containing this dish / total lists)
+- **CTA:** "see why →"
+- **Tap action:** Navigate to `/dish/:dishId`
+- **Visual distinction:** Same chalkboard frame as all other cards — no special treatment. Slightly wider card (185px vs 155px standard) to fit the count badge.
+
+### Card 2: "Island Favorite" (Most-Appearing Restaurant)
+
+- **Tag:** "📍 island favorite"
+- **Title:** Restaurant name (e.g., "Larsen's")
+- **Subtitle:** Location detail (e.g., "Fish Market · Menemsha")
+- **Stat badge:** "On every local list" or "On 4 of 5 local lists"
+- **CTA:** "see the menu →"
+- **Tap action:** Navigate to `/restaurants/:restaurantId`
+- **Visual distinction:** Same standard chalkboard frame as all other cards. Slightly wider to fit count badge.
+
+### Data Source
+
+Query `local_list_items` joined with `local_lists` to count:
+- Which `dish_id` appears in the most distinct lists → Card 1
+- Which `restaurant_id` appears in the most distinct lists → Card 2
+
+If there are ties, use the highest-rated dish/restaurant as tiebreaker.
+
+If fewer than 2 local lists exist, don't show these cards (not enough data for "locals agree" to mean anything).
+
+### Placement
+
+Appended to the END of the chalkboard row, after all existing editorial cards (time-of-day, highest rated restaurant, chowder debate, most talked about, best value meal, best ice cream).
+
+---
+
+## Part 2: Local Lists as Menu Cards
+
+### What
+
+Redesign the `LocalListsSection` component. Replace the current white expandable card format with restaurant-grouped menu-style cards on cream parchment.
+
+### Section Header
+
+Centered title with flanking horizontal lines (same pattern as "Browse by Category" divider):
+
+```
+——— A Local's Guide to Martha's Vineyard ———
+         Curated by people who live here
+```
+
+- Title in Amatic SC, 26px, bold. "Martha's Vineyard" in `var(--color-primary)`.
+- Lines: 1px `var(--color-divider)`, flex to fill available space.
+- Subtitle: 11px, `var(--color-text-tertiary)`, centered.
+
+### Placement
+
+Below the Top Rated Nearby dish list (at the bottom of the homepage scroll). Above the bottom nav safe area.
+
+### Menu Card Design
+
+Horizontal scroll of cream parchment cards (270px wide, scroll-snap).
+
+Each card contains:
+1. **Curator header:** Avatar circle (32px, colored) + name in Amatic SC 24px + tagline in italic 10px
+2. **Divider line**
+3. **Dishes grouped by restaurant:**
+   - Restaurant name in Amatic SC 18px, `var(--color-accent-gold)`
+   - Each dish row: name (13px, 500 weight) + dotted leader + rating (13px, 700 weight, `var(--color-rating)`)
+4. **Footer:** "N restaurants · N dishes" stats + "See full list →" CTA in `var(--color-primary)`
+
+Card styling:
+- Background: `#FFFDF8` (warm cream)
+- Border: `1px solid rgba(0,0,0,0.04)`
+- Shadow: `0 1px 3px rgba(0,0,0,0.06), 0 6px 20px rgba(0,0,0,0.07)`
+- Border-radius: 3px
+- Subtle paper texture via radial gradients (gold top-right, coral bottom-left at 2% opacity)
+
+### Tap Behavior
+
+- Tap "See full list →" → navigates to `/user/:userId` (curator's profile where full list is visible)
+- Tap a dish row → navigates to `/dish/:dishId`
+- Tap a restaurant name → navigates to `/restaurants/:restaurantId`
+
+### Data
+
+Uses existing `useLocalLists` and `useLocalListDetail` hooks. The restaurant grouping is done client-side: group `local_list_items` by `restaurant_id`, sort groups by the first item's position in the list.
+
+---
+
+## Part 3: Remove Restaurant Initial Avatars
+
+### What
+
+Remove the color-coded-by-town initial circle avatars (e.g., a coral "L" circle for Larsen's) from restaurant display throughout the app.
+
+### Where They Appear
+
+- `RestaurantAvatar` component (if it exists)
+- Restaurant list items on `/restaurants`
+- Restaurant cards in various contexts
+- Curator avatar circles in LocalListsSection can stay (those are people, not restaurants)
+
+### Replacement
+
+Replace initial circles with the **category food icons** from `public/categories/icons/`. Map the restaurant's `cuisine` field to the matching icon:
+
+- Seafood restaurant → `seafood.webp`
+- Pizza place → `pizza.webp`
+- Sushi restaurant → `sushi.webp`
+- General/American → use the restaurant's most-voted dish category icon
+- No cuisine set → use a generic utensils icon or the app logo
+
+Same size as current avatars (~38-48px), rounded square (border-radius: 10px) with `var(--color-surface)` background — matches the dish icon treatment in `DishListItem`. The icon tells you what kind of food the place serves, not what town it's in.
+
+---
+
+## What's NOT Changing
+
+- The existing editorial chalkboard cards (Breakfast, Porto Pizza, Chowder, etc.) — unchanged
+- The "Browse by Category" section — unchanged
+- The "Top Rated Nearby" ranked dish list — unchanged
+- The Map FAB and map mode — unchanged
+- Bottom nav — unchanged
+
+---
+
+## Success Criteria
+
+1. A first-time visitor sees "Locals Agree: [Dish]" in the chalkboard row within their first scroll
+2. Scrolling to the bottom reveals menu-style cards that feel like picking up a local's personal guide
+3. Tapping the aggregate chalkboard takes you directly to the dish/restaurant page
+4. No color-coded initial avatars remain on restaurant display
+5. `npm run build` passes
+6. `npm run test` passes

--- a/supabase/seed/data/menus/el-barco-full-menu.sql
+++ b/supabase/seed/data/menus/el-barco-full-menu.sql
@@ -1,0 +1,64 @@
+-- El Barco - Food Menu Refresh
+-- Source: https://elbarcomv.com/view-menu/ (Food & Drinks PDF, Apr 2026)
+-- Run this in Supabase SQL Editor (project vpioftosgdkyiwvhxewy)
+--
+-- Fixes:
+--   1. is_open was false → true (restaurant is open)
+--   2. town was "West Tisbury" → "Vineyard Haven" (actual: 16 Union St)
+--   3. Section "Street Tacos" → "Tacos" (match actual PDF menu)
+--   4. Burritos were miscategorized as 'taco' → 'burrito'
+--   5. Quesabirria was miscategorized as 'quesadilla' → 'taco'
+--   6. Adds Tres Leches, renames "Chips & Guac" → "Chips & Guacamole", "Pork Carnitas" → "Carnitas"
+--   7. Corrects prices: Taco Salad $12 → $17, Elote $10 → $9, Churros $11 → $12, tacos repriced
+--
+-- Drinks (Margaritas, Cocktails, Frozen Drinks) are LEFT UNTOUCHED.
+
+-- 1. Flip restaurant to open + fix town
+UPDATE restaurants
+SET is_open = true,
+    town = 'Vineyard Haven'
+WHERE name = 'El Barco';
+
+-- 2. Delete only food dishes (keep drinks)
+DELETE FROM dishes
+WHERE restaurant_id = (SELECT id FROM restaurants WHERE name = 'El Barco')
+  AND menu_section IN ('Appetizers', 'Street Tacos', 'Tacos', 'Burritos', 'Dessert');
+
+-- 3. Insert complete food menu (20 items)
+INSERT INTO dishes (restaurant_id, name, category, menu_section, price) VALUES
+-- Appetizers
+((SELECT id FROM restaurants WHERE name = 'El Barco'), 'Chips & Salsa', 'apps', 'Appetizers', 10.00),
+((SELECT id FROM restaurants WHERE name = 'El Barco'), 'Chips & Queso', 'apps', 'Appetizers', 11.00),
+((SELECT id FROM restaurants WHERE name = 'El Barco'), 'Chips & Guacamole', 'apps', 'Appetizers', 12.00),
+((SELECT id FROM restaurants WHERE name = 'El Barco'), 'Chicken Flautas', 'apps', 'Appetizers', 16.00),
+((SELECT id FROM restaurants WHERE name = 'El Barco'), 'Fried Calamari', 'calamari', 'Appetizers', 16.00),
+((SELECT id FROM restaurants WHERE name = 'El Barco'), 'Elote', 'apps', 'Appetizers', 9.00),
+((SELECT id FROM restaurants WHERE name = 'El Barco'), 'El Barco Taco Salad', 'salad', 'Appetizers', 17.00),
+-- Tacos (two 5-inch tacos per order)
+((SELECT id FROM restaurants WHERE name = 'El Barco'), 'Quesabirria', 'taco', 'Tacos', 17.00),
+((SELECT id FROM restaurants WHERE name = 'El Barco'), 'Carnitas', 'taco', 'Tacos', 12.00),
+((SELECT id FROM restaurants WHERE name = 'El Barco'), 'Pollo Asado', 'taco', 'Tacos', 12.00),
+((SELECT id FROM restaurants WHERE name = 'El Barco'), 'El Fish', 'taco', 'Tacos', 16.00),
+((SELECT id FROM restaurants WHERE name = 'El Barco'), 'Smashburger Taco', 'taco', 'Tacos', 14.00),
+((SELECT id FROM restaurants WHERE name = 'El Barco'), 'Blackened Shrimp', 'taco', 'Tacos', 16.00),
+((SELECT id FROM restaurants WHERE name = 'El Barco'), 'Mushroom Al Pastor', 'taco', 'Tacos', 12.00),
+-- Burritos (12" flour tortilla, jack cheese, rice, pinto beans, lettuce, pico)
+((SELECT id FROM restaurants WHERE name = 'El Barco'), 'Birria Steak Burrito', 'burrito', 'Burritos', 17.00),
+((SELECT id FROM restaurants WHERE name = 'El Barco'), 'Mushroom Al Pastor Burrito', 'burrito', 'Burritos', 15.00),
+((SELECT id FROM restaurants WHERE name = 'El Barco'), 'Carnitas Burrito', 'burrito', 'Burritos', 14.00),
+((SELECT id FROM restaurants WHERE name = 'El Barco'), 'Pollo Asado Burrito', 'burrito', 'Burritos', 14.00),
+-- Dessert
+((SELECT id FROM restaurants WHERE name = 'El Barco'), 'Churros', 'dessert', 'Dessert', 12.00),
+((SELECT id FROM restaurants WHERE name = 'El Barco'), 'Tres Leches', 'dessert', 'Dessert', 14.00);
+
+-- 4. Update menu_section_order to match actual menu (food sections first, drinks after)
+UPDATE restaurants
+SET menu_section_order = ARRAY['Appetizers', 'Tacos', 'Burritos', 'Dessert', 'Margaritas', 'Cocktails', 'Frozen Drinks']
+WHERE name = 'El Barco';
+
+-- 5. Verify
+SELECT r.name, r.town, r.is_open, r.menu_section_order,
+       (SELECT COUNT(*) FROM dishes WHERE restaurant_id = r.id) AS total_dishes,
+       (SELECT COUNT(*) FROM dishes WHERE restaurant_id = r.id AND menu_section IN ('Appetizers','Tacos','Burritos','Dessert')) AS food_dishes
+FROM restaurants r
+WHERE r.name = 'El Barco';

--- a/supabase/seed/data/menus/fat-ronnies-full-menu.sql
+++ b/supabase/seed/data/menus/fat-ronnies-full-menu.sql
@@ -1,0 +1,82 @@
+-- Fat Ronnie's Burger Bar - Full Menu
+-- Source: https://fatronniesburgerbar.com/index.php/menu/
+-- Address: 7 Circuit Ave, Oak Bluffs, MA 02557
+-- Run this in Supabase SQL Editor (project vpioftosgdkyiwvhxewy)
+
+-- 1. Open the restaurant + update menu_url to the real menu page
+UPDATE restaurants
+SET is_open = true,
+    menu_url = 'https://fatronniesburgerbar.com/index.php/menu/'
+WHERE name = 'Fat Ronnie''s Burger Bar';
+
+-- 2. Wipe any existing dishes
+DELETE FROM dishes
+WHERE restaurant_id = (SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar');
+
+-- 3. Insert full menu (45 items)
+INSERT INTO dishes (restaurant_id, name, category, menu_section, price) VALUES
+-- Beef Burgers
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Fat Ronnie', 'burger', 'Beef Burgers', 13.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Bacon', 'burger', 'Beef Burgers', 14.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Mushroom', 'burger', 'Beef Burgers', 14.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Caramelized Onion', 'burger', 'Beef Burgers', 14.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Peppers Onions', 'burger', 'Beef Burgers', 14.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Fat Pepper Jack Burger', 'burger', 'Beef Burgers', 13.95),
+-- Non Beef Burgers
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Turkey Burger', 'burger', 'Non Beef Burgers', 12.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Veggie Burger', 'burger', 'Non Beef Burgers', 12.95),
+-- Chicken
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Chicken Sandwich', 'sandwich', 'Chicken', 12.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Chicken Sub', 'sandwich', 'Chicken', 15.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Chicken Wrap', 'wrap', 'Chicken', 15.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Chicken & Chips', 'fried chicken', 'Chicken', 19.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'HBC', 'fried chicken', 'Chicken', 14.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Tenders', 'tendys', 'Chicken', 12.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Wings', 'wings', 'Chicken', 14.95),
+-- Seafood
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Cod Sandwich', 'fish-sandwich', 'Seafood', 13.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Cod Sub', 'fish-sandwich', 'Seafood', 15.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Cod Wrap', 'wrap', 'Seafood', 15.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Fish & Chips', 'fish-and-chips', 'Seafood', 21.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Lobster Roll', 'lobster roll', 'Seafood', 31.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Fat Cod Sandwich', 'fish-sandwich', 'Seafood', 15.95),
+-- Weenies
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Big Dog', 'sandwich', 'Weenies', 8.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Fat Dog', 'sandwich', 'Weenies', 10.95),
+-- Subs & Wraps
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'CGB Sub', 'sandwich', 'Subs & Wraps', 15.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Burger Sub', 'burger', 'Subs & Wraps', 15.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Burger Wrap', 'wrap', 'Subs & Wraps', 15.95),
+-- Salads
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Grilled Chicken Caesar Salad', 'salad', 'Salads', 15.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Cobb Salad', 'salad', 'Salads', 15.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Greek Salad', 'salad', 'Salads', 14.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Thai Salad', 'salad', 'Salads', 15.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Caesar Salad', 'salad', 'Salads', 15.95),
+-- Mac-N-Cheese
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Mac-N-Cheese', 'pasta', 'Mac-N-Cheese', 8.65),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Beef Mac', 'pasta', 'Mac-N-Cheese', 9.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Bacon Mac', 'pasta', 'Mac-N-Cheese', 9.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Buffalo Chicken Mac', 'pasta', 'Mac-N-Cheese', 10.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'BBQ Chicken Mac', 'pasta', 'Mac-N-Cheese', 10.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Lobster Mac', 'pasta', 'Mac-N-Cheese', 15.95),
+-- Sides
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Fries', 'fries', 'Sides', 4.65),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Cheese Fries', 'fries', 'Sides', 5.65),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Sweet Potato Fries', 'fries', 'Sides', 5.65),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Onion Rings', 'onion rings', 'Sides', 5.65),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Fat Fries', 'fries', 'Sides', 9.95),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Potato Salad', 'sides', 'Sides', 5.65),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Coleslaw', 'sides', 'Sides', 5.65),
+((SELECT id FROM restaurants WHERE name = 'Fat Ronnie''s Burger Bar'), 'Corn on the Cob', 'sides', 'Sides', 4.65);
+
+-- 4. Set menu_section_order to match actual menu layout
+UPDATE restaurants
+SET menu_section_order = ARRAY['Beef Burgers', 'Non Beef Burgers', 'Chicken', 'Seafood', 'Weenies', 'Subs & Wraps', 'Salads', 'Mac-N-Cheese', 'Sides']
+WHERE name = 'Fat Ronnie''s Burger Bar';
+
+-- 5. Verify
+SELECT r.name, r.town, r.is_open, r.menu_section_order,
+       (SELECT COUNT(*) FROM dishes WHERE restaurant_id = r.id) AS dish_count
+FROM restaurants r
+WHERE r.name = 'Fat Ronnie''s Burger Bar';


### PR DESCRIPTION
## Summary
- Lands 5 plan docs + 2 spec docs that were sitting untracked from past brainstorming sessions, into their existing folders (`docs/superpowers/plans/`, `docs/superpowers/specs/`). Same date-prefixed naming convention as the 17 plans + 11 specs already there.
- Adds 2 restaurant menu seed SQL files (El Barco, Fat Ronnie's) into `supabase/seed/data/menus/`.

## Why
Working tree on main was carrying ~3.3k lines of untracked planning + seed work for weeks. Friend reviewing the code flagged the messy git tree. This is the docs/seeds bucket of cleanup.

## Test plan
- [ ] No code paths touched — only `.md` and `.sql` files in seed/docs directories
- [ ] Seed SQL is idempotent — verify with `psql` dry-run if running locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)