### PR TITLE
fix(ux): wrap raw error.message in getUserMessage() on admin surfaces

### DIFF
--- a/src/components/restaurant-admin/MenuImportWizard.jsx
+++ b/src/components/restaurant-admin/MenuImportWizard.jsx
@@ -2,6 +2,7 @@ import { useState, useRef } from 'react'
 import { ALL_CATEGORIES } from '../../constants/categories'
 import { restaurantManagerApi } from '../../api/restaurantManagerApi'
 import { logger } from '../../utils/logger'
+import { getUserMessage } from '../../utils/errorHandler'
 
 export function MenuImportWizard({ restaurantName, onBulkAdd, onClose }) {
   const [step, setStep] = useState(1)
@@ -53,7 +54,7 @@ export function MenuImportWizard({ restaurantName, onBulkAdd, onClose }) {
       setStep(3)
     } catch (err) {
       logger.error('Menu parse error:', err)
-      setError(`Parse failed: ${err.message}`)
+      setError(`Parse failed: ${getUserMessage(err, 'parsing menu')}`)
       setStep(1)
     }
   }

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
 import { logger } from '../utils/logger'
+import { getUserMessage } from '../utils/errorHandler'
 import { restaurantsApi } from '../api/restaurantsApi'
 import { adminApi } from '../api/adminApi'
 import { restaurantManagerApi } from '../api/restaurantManagerApi'
@@ -207,7 +208,7 @@ export function Admin() {
       }
     } catch (error) {
       logger.error('Error saving dish:', error)
-      setMessage({ type: 'error', text: `Failed to save dish: ${error.message}` })
+      setMessage({ type: 'error', text: `Failed to save dish: ${getUserMessage(error, 'saving dish')}` })
     } finally {
       setSubmitting(false)
     }
@@ -231,7 +232,7 @@ export function Admin() {
       }
     } catch (error) {
       logger.error('Error deleting dish:', error)
-      setMessage({ type: 'error', text: `Failed to delete: ${error.message}` })
+      setMessage({ type: 'error', text: `Failed to delete: ${getUserMessage(error, 'deleting dish')}` })
     }
   }
 
@@ -248,7 +249,7 @@ export function Admin() {
       setMessage({ type: 'success', text: 'Invite link generated!' })
     } catch (error) {
       logger.error('Error generating invite:', error)
-      setMessage({ type: 'error', text: `Failed to generate invite: ${error.message}` })
+      setMessage({ type: 'error', text: `Failed to generate invite: ${getUserMessage(error, 'generating invite')}` })
     }
   }
 
@@ -278,7 +279,7 @@ export function Admin() {
       setMessage({ type: 'success', text: 'Manager access revoked' })
     } catch (error) {
       logger.error('Error revoking manager:', error)
-      setMessage({ type: 'error', text: `Failed to revoke: ${error.message}` })
+      setMessage({ type: 'error', text: `Failed to revoke: ${getUserMessage(error, 'revoking manager')}` })
     }
   }
 

--- a/src/pages/ManageRestaurant.jsx
+++ b/src/pages/ManageRestaurant.jsx
@@ -4,6 +4,7 @@ import { useAuth } from '../context/AuthContext'
 import { useRestaurantManager } from '../hooks/useRestaurantManager'
 import { restaurantManagerApi } from '../api/restaurantManagerApi'
 import { logger } from '../utils/logger'
+import { getUserMessage } from '../utils/errorHandler'
 import { SpecialsManager, DishesManager, EventsManager, RestaurantInfoEditor } from '../components/restaurant-admin'
 
 export function ManageRestaurant() {
@@ -57,7 +58,7 @@ export function ManageRestaurant() {
       setMessage({ type: 'success', text: 'Special added!' })
     } catch (error) {
       logger.error('Error adding special:', error)
-      setMessage({ type: 'error', text: `Failed to add special: ${error.message}` })
+      setMessage({ type: 'error', text: `Failed to add special: ${getUserMessage(error, 'adding special')}` })
     }
   }
 
@@ -68,7 +69,7 @@ export function ManageRestaurant() {
       setMessage({ type: 'success', text: 'Special updated!' })
     } catch (error) {
       logger.error('Error updating special:', error)
-      setMessage({ type: 'error', text: `Failed to update: ${error.message}` })
+      setMessage({ type: 'error', text: `Failed to update: ${getUserMessage(error, 'updating special')}` })
     }
   }
 
@@ -79,7 +80,7 @@ export function ManageRestaurant() {
       setMessage({ type: 'success', text: 'Special deactivated' })
     } catch (error) {
       logger.error('Error deactivating special:', error)
-      setMessage({ type: 'error', text: `Failed to deactivate: ${error.message}` })
+      setMessage({ type: 'error', text: `Failed to deactivate: ${getUserMessage(error, 'deactivating special')}` })
     }
   }
 
@@ -91,7 +92,7 @@ export function ManageRestaurant() {
       setMessage({ type: 'success', text: 'Dish added!' })
     } catch (error) {
       logger.error('Error adding dish:', error)
-      setMessage({ type: 'error', text: `Failed to add dish: ${error.message}` })
+      setMessage({ type: 'error', text: `Failed to add dish: ${getUserMessage(error, 'adding dish')}` })
     }
   }
 
@@ -102,7 +103,7 @@ export function ManageRestaurant() {
       setMessage({ type: 'success', text: 'Dish updated!' })
     } catch (error) {
       logger.error('Error updating dish:', error)
-      setMessage({ type: 'error', text: `Failed to update: ${error.message}` })
+      setMessage({ type: 'error', text: `Failed to update: ${getUserMessage(error, 'updating dish')}` })
     }
   }
 
@@ -114,7 +115,7 @@ export function ManageRestaurant() {
       setMessage({ type: 'success', text: `${newDishes.length} dishes added!` })
     } catch (error) {
       logger.error('Error bulk adding dishes:', error)
-      setMessage({ type: 'error', text: `Failed to add dishes: ${error.message}` })
+      setMessage({ type: 'error', text: `Failed to add dishes: ${getUserMessage(error, 'adding dishes')}` })
     }
   }
 
@@ -126,7 +127,7 @@ export function ManageRestaurant() {
       setMessage({ type: 'success', text: 'Dish removed' })
     } catch (error) {
       logger.error('Error deleting dish:', error)
-      setMessage({ type: 'error', text: `Failed to remove dish: ${error.message}` })
+      setMessage({ type: 'error', text: `Failed to remove dish: ${getUserMessage(error, 'removing dish')}` })
     }
   }
 
@@ -137,7 +138,7 @@ export function ManageRestaurant() {
       setMessage({ type: 'success', text: 'Restaurant info updated!' })
     } catch (error) {
       logger.error('Error updating restaurant info:', error)
-      setMessage({ type: 'error', text: `Failed to update: ${error.message}` })
+      setMessage({ type: 'error', text: `Failed to update: ${getUserMessage(error, 'updating restaurant info')}` })
     }
   }
 
@@ -149,7 +150,7 @@ export function ManageRestaurant() {
       setMessage({ type: 'success', text: 'Event added!' })
     } catch (error) {
       logger.error('Error adding event:', error)
-      setMessage({ type: 'error', text: `Failed to add event: ${error.message}` })
+      setMessage({ type: 'error', text: `Failed to add event: ${getUserMessage(error, 'adding event')}` })
     }
   }
 
@@ -160,7 +161,7 @@ export function ManageRestaurant() {
       setMessage({ type: 'success', text: 'Event updated!' })
     } catch (error) {
       logger.error('Error updating event:', error)
-      setMessage({ type: 'error', text: `Failed to update: ${error.message}` })
+      setMessage({ type: 'error', text: `Failed to update: ${getUserMessage(error, 'updating event')}` })
     }
   }
 
@@ -171,7 +172,7 @@ export function ManageRestaurant() {
       setMessage({ type: 'success', text: 'Event deactivated' })
     } catch (error) {
       logger.error('Error deactivating event:', error)
-      setMessage({ type: 'error', text: `Failed to deactivate: ${error.message}` })
+      setMessage({ type: 'error', text: `Failed to deactivate: ${getUserMessage(error, 'deactivating event')}` })
     }
   }
 


### PR DESCRIPTION
## Summary
- Admin, ManageRestaurant, and MenuImportWizard were rendering raw `error.message` text in toast copy
- Replaced all 16 occurrences with `getUserMessage(error, 'context')` per CLAUDE.md 1.2
- Brings admin/manager surfaces in line with the rest of the app (RestaurantDetail, hooks already use this pattern)

## Why now
App Store prep: raw error strings are the kind of web-in-a-shell tell Apple reviewers (and users) notice immediately. This closes the last known spot in the app where SDK internals could leak into the UI.

## Test plan
- [x] `npm run build` passes
- [ ] Manual smoke: trigger a known-failing action on /admin (e.g. add dish with invalid payload) and confirm toast shows classified copy, not raw Supabase error
- [ ] Same smoke on /manage (add special, update dish, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)