### PR TITLE
fix(add-restaurant): don't poison rows with user GPS when Places lacks coords

### DIFF
--- a/src/components/AddRestaurantModal.jsx
+++ b/src/components/AddRestaurantModal.jsx
@@ -262,12 +262,22 @@ export function AddRestaurantModal({ isOpen, onClose, initialQuery = '' }) {
             setLat(details.lat)
             setLng(details.lng)
           }
-        } catch {
-          // Fall through to GPS
+        } catch (err) {
+          logger.warn('placesApi.getDetails failed for googlePlaceId', { googlePlaceId, err: err?.message || String(err) })
         }
         setSubmitting(false)
+
+        // If a Google Place was selected but we still can't get its coords,
+        // DO NOT silently fall back to the user's GPS — that writes the
+        // user's location onto a restaurant that's somewhere else entirely
+        // (e.g. user on MV adds a Boston restaurant → row gets MV lat/lng).
+        // Surface the error so the user can retry or pick a different match.
+        if (resolvedLat == null || resolvedLng == null) {
+          setError("Couldn't load this restaurant's location from Google. Please search again or pick a different match.")
+          return
+        }
       }
-      // Fall back to device GPS
+      // Pure manual add (no googlePlaceId): GPS is the best signal we have.
       if (resolvedLat == null || resolvedLng == null) {
         if (hasLocation && location) {
           resolvedLat = location.lat


### PR DESCRIPTION
## Summary
- Recurring bug: user on MV adds a Boston restaurant → row gets Boston's address/google_place_id/menu_url but **MV lat/lng** written from the user's device GPS
- Concrete repro just today: Lincoln Tavern & Restaurant (South Boston) stored with lat/lng=41.46,-70.61 (MV)
- Root cause: `handleDetailsNext` in `AddRestaurantModal` silently fell back to `location.lat/lng` when `placesApi.getDetails()` didn't return coords — even when a `googlePlaceId` was selected
- Fix: GPS fallback now applies **only** when there's no `googlePlaceId` (pure manual add). If a Place is selected but coords can't be resolved, surface an error and abort instead of corrupting the row

## Impact
- Prevents further geo-inconsistent restaurant rows from being created
- Doesn't touch the pure-manual-add path (no Place selected) — GPS is still the correct signal there
- Existing bad rows (like Lincoln Tavern) have to be cleaned up separately

## Test plan
- [x] `npm run build` passes
- [ ] Manual: search for an out-of-region restaurant (e.g. a Chicago place while on MV). Pick it. If Places returns coords, the row gets Chicago's. If Places doesn't return coords, the user sees the error instead of an MV-tagged Chicago row.
- [ ] Manual: add a fully manual restaurant (no Place selected). GPS fallback still works.

## Notes
- Codex review was attempted but the background processes got killed while waiting on rate limits. Self-reviewed the diff against all GPS fallback paths in the modal (`handlePlacePick`, `handleManualAdd`, `handleDetailsNext`, `handleSubmit`) — `handleDetailsNext` was the only one with the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)