### PR TITLE
fix(menu-extraction): dedupe near-duplicate dish names within a menu section

### DIFF
--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -117,7 +117,11 @@ Pick the MOST SPECIFIC category that fits. Prefer "lobster roll" over "seafood",
 4. **Skip condiments** — extra sauce, side of dressing, bread roll
 5. **Skip side dishes** — mashed potatoes, green beans, rice, coleslaw, steamed veggies, etc. NOT rateable.
 6. **EXCEPTION: Fries and onion rings ARE included** — people rate these. Keep them.
-7. **Deduplicate sizes** — keep only the larger/dinner version
+7. **Deduplicate sizes, portions, and near-duplicate names within a menu section**:
+   - **Size/portion variants** (Small/Medium/Large, 10"/14", Cup/Bowl, half/whole, lunch/dinner): output ONE entry per dish. Use the larger/dinner price.
+   - **Near-duplicate names** (same menu_section, same category): if two dishes differ only by a redundant category suffix — "Margherita" vs "Margherita Pizza", "Caesar" vs "Caesar Salad", "Lobster" vs "Lobster Roll" when both are in the pizza / salad / lobster-roll section — they are the SAME dish listed twice. Output ONE entry. Prefer the shorter name (without the redundant category word).
+   - **Genuinely different portions stay separate:** "Half Roast Chicken" vs "Whole Roast Chicken", "Kids Burger" vs "Burger" — output both.
+   - **When in doubt:** if two dishes in the same section have names that a normal human would read as "the same dish at different prices," collapse them. Better to under-count than to duplicate.
 8. **Prices: NEVER INVENT OR GUESS PRICES.** Only set a price if you can see an exact dollar amount next to that specific dish on the source page. If no explicit price is shown for a dish, the price field MUST be \`null\`. Do NOT infer prices from nearby dishes, category averages, or typical market values. Do NOT fill in \`18\` or any default. A null price is always better than a guessed price. If a range is shown (e.g. "$14-18"), use the lower number.
 9. **One category per dish** — pick the most specific match
 


### PR DESCRIPTION
## Summary
Prompt-only fix. Tightens the \`MENU_EXTRACTION_PROMPT\` rule 7 so Sonnet stops emitting the same dish twice when a menu lists it with two name formats.

## Repro (tonight)
Added Lincoln Tavern & Restaurant. The pipeline imported the menu correctly (great — cron is working!) but the pizza section came out with each of 11 pies duplicated: \`"Margherita" $15\` and \`"Margherita Pizza" $14\`, \`"Pepperoni" $16\` and \`"Pepperoni Pizza" $15\`, etc. 22 rows for 11 real dishes. Cleaned up Lincoln manually with a smart-dedupe SQL; this PR prevents it from happening on the next pizzeria.

## What the prompt now says
Old rule 7:
> **Deduplicate sizes** — keep only the larger/dinner version

New rule 7 covers three cases:
1. **Size/portion variants** (Small/Large, 10"/14", Cup/Bowl, half/whole, lunch/dinner) — ONE entry, use larger price
2. **Near-duplicate names** within the same menu_section + category — "Margherita" vs "Margherita Pizza" = same dish, keep the shorter name
3. **Genuinely different portions** ("Half Roast Chicken" vs "Whole Roast Chicken") — stay as separate dishes

Tie-breaker: prefer shorter names without redundant category suffixes. Bias: under-count over duplicate.

## Test plan
- [ ] After merge + redeploy, re-run menu-refresh on Lincoln Tavern (or delete + re-add) and verify only 11 pizza rows
- [ ] Smoke test with another pizzeria that has small/large sizes
- [ ] Spot-check a non-pizza restaurant to make sure the rule doesn't over-collapse legitimate dish variants

## Not in this PR
- No schema change. No code change outside the prompt string.
- Existing duplicates already in the DB are not auto-cleaned — they need a manual sweep (or just wait for the next menu-refresh cycle to overwrite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)