### PR TITLE
fix(add-restaurant): skip confirm-details fallback when Places returns incomplete data

### DIFF
--- a/src/components/AddRestaurantModal.jsx
+++ b/src/components/AddRestaurantModal.jsx
@@ -206,20 +206,18 @@ export function AddRestaurantModal({ isOpen, onClose, initialQuery = '' }) {
         navigate('/restaurants/' + restaurant.id)
         return
       }
-      // Fallback: no lat/lng from Google — show manual form
-      setName(prediction.name)
-      setAddress(prediction.address || '')
-      setGooglePlaceId(prediction.placeId)
+      // Places returned data but not enough to create a trustworthy row
+      // (no coords). Don't fall through to a Confirm Details form — the
+      // user can't fix Google's missing data from there, and submitting
+      // would either error out (post-PR #63) or poison the row with GPS.
+      // Tell them to try a different result.
+      logger.warn('Places returned incomplete data for placeId', { placeId: prediction.placeId, hasDetails: !!details })
+      setError("Couldn't load full details for this restaurant from Google. Try picking a different result, or add manually.")
       setSubmitting(false)
-      setStep(STEPS.DETAILS)
     } catch (err) {
       logger.error('Error creating restaurant from Google Places:', err)
-      // Fallback: show manual form
-      setName(prediction.name)
-      setAddress(prediction.address || '')
-      setGooglePlaceId(prediction.placeId)
+      setError("Couldn't load this restaurant from Google. Try another result, or add manually.")
       setSubmitting(false)
-      setStep(STEPS.DETAILS)
     }
   }
 


### PR DESCRIPTION
## Summary
Remove the Confirm Details form fallback that fired when a Google Place was picked but \`placesApi.getDetails()\` returned no lat/lng (or threw). The form is useless here — the user can't fix Google's missing data, and after PR #63 submitting the form errors anyway. Now we surface the error inline in the search modal and stay on the search step.

## Repro tonight
Added "Fat Baby" (South Boston). Places returned incomplete data → Confirm Details form appeared. Even after the user clicks through, the row ends up broken (or with PR #63 live, errors out). User-visible flow was confusing.

## After this PR
- Pick a Google Place → if Places returns complete data, restaurant created directly (unchanged)
- Pick a Google Place → if Places returns incomplete data, error shown in search modal: *"Couldn't load full details for this restaurant from Google. Try picking a different result, or add manually."*
- Click "Add Manually" → full Confirm Details form, GPS fallback is legitimate here (unchanged)

## Test plan
- [x] \`npm run build\` passes
- [ ] Verify error copy appears when picking Fat Baby (or any Place where getDetails returns empty)
- [ ] Verify happy path still works (pick a Place with full data → restaurant created directly)
- [ ] Verify pure manual add still shows the Confirm Details form

🤖 Generated with [Claude Code](https://claude.com/claude-code)