### PR TITLE
fix(places-details): disable gateway JWT verify so the new anon key works

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -16,3 +16,12 @@ verify_jwt = false
 # {restaurant_id} (must match an existing row), or {} — no arbitrary URL injection.
 [functions.menu-refresh]
 verify_jwt = false
+
+# places-details is called from the browser with the publishable anon key. The
+# Supabase Functions gateway rejects the new-format sb_publishable_* key as
+# "UNAUTHORIZED_INVALID_JWT_FORMAT" because it checks JWT shape. The function
+# itself does no DB mutation — it proxies Google Places Details with the server's
+# GOOGLE_PLACES_API_KEY and returns public place data. Same gating exception as
+# places-autocomplete (which is already open and serving from production).
+[functions.places-details]
+verify_jwt = false


### PR DESCRIPTION
## Summary
Supabase Functions gateway was rejecting **every** \`places-details\` call with \`UNAUTHORIZED_INVALID_JWT_FORMAT\` because the new-format \`sb_publishable_*\` anon key isn't shaped like a JWT. This silently broke the entire Add Restaurant flow — Places details returned nothing → AddRestaurantModal fell through to the Confirm Details form → GPS fallback fired → every row got the user's location written onto it regardless of where the restaurant actually was (the Lincoln Tavern / Fat Baby bug).

Same gateway-level class of bug we fixed for \`menu-refresh\` earlier tonight.

## Change
One config.toml entry: \`[functions.places-details] verify_jwt = false\`.

Already deployed to live project (\`vpioftosgdkyiwvhxewy\`) via \`supabase functions deploy places-details\`. Verified with a live curl against Fat Baby's place_id — now returns full data including real Boston coords, address, website URL, phone.

## Why it's safe
- Function is already de facto public: the in-code auth is explicitly optional ("guest path")
- Returns only public Google Places data; no DB writes; no user data
- Matches \`places-autocomplete\`'s config (it's been open this whole time — that's why autocomplete worked and details didn't)
- Same gating-only pattern already applied to \`menu-refresh\` and \`delete-account\`

## Follow-up (not blocking)
Rate-limiting / shared-secret protection for places-details + places-autocomplete to cap Google API spend if someone tries to abuse the endpoints. Same concern exists on autocomplete today; this PR doesn't make it worse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)