### PR TITLE
fix(errors): classify Supabase edge-function + wrapped errors correctly

### DIFF
--- a/src/components/AddRestaurantModal.jsx
+++ b/src/components/AddRestaurantModal.jsx
@@ -11,6 +11,7 @@ import { menuImportApi } from '../api'
 import { validateUserContent } from '../lib/reviewBlocklist'
 import { capture } from '../lib/analytics'
 import { logger } from '../utils/logger'
+import { getUserMessage } from '../utils/errorHandler'
 import { LoginModal } from './Auth/LoginModal'
 
 const STEPS = { SEARCH: 'search', DETAILS: 'details' }
@@ -215,8 +216,11 @@ export function AddRestaurantModal({ isOpen, onClose, initialQuery = '' }) {
       setError("Couldn't load full details for this restaurant from Google. Try picking a different result, or add manually.")
       setSubmitting(false)
     } catch (err) {
-      logger.error('Error creating restaurant from Google Places:', err)
-      setError("Couldn't load this restaurant from Google. Try another result, or add manually.")
+      // Could come from placesApi.getDetails OR restaurantsApi.create — don't
+      // blame Google for either. getUserMessage classifies rate-limit, network,
+      // server, auth, etc. into a truthful message.
+      logger.error('Error adding restaurant from Google Places:', err)
+      setError(getUserMessage(err, 'adding this restaurant'))
       setSubmitting(false)
     }
   }

--- a/src/utils/errorHandler.js
+++ b/src/utils/errorHandler.js
@@ -31,8 +31,17 @@ export function classifyError(error) {
     return ErrorTypes.UNKNOWN
   }
 
+  // If already classified (e.g. by createClassifiedError), trust it —
+  // otherwise getUserMessage re-classifies the wrapper and loses the type.
+  if (error.type && Object.prototype.hasOwnProperty.call(ErrorTypes, error.type)) {
+    return error.type
+  }
+
   const message = (error.message || '').toLowerCase()
-  const code = error.code || error.status
+  // Supabase FunctionsHttpError stashes the HTTP status on error.context.status
+  // rather than error.status; check both so edge-function errors classify
+  // correctly (429 → RATE_LIMIT, 401 → AUTH_ERROR, 5xx → SERVER_ERROR).
+  const code = error.code || error.status || error.context?.status
 
   // Network errors
   if (message.includes('network') || message.includes('failed to fetch')) {

--- a/src/utils/errorHandler.test.js
+++ b/src/utils/errorHandler.test.js
@@ -58,6 +58,19 @@ describe('Error Handler Utilities', () => {
       expect(classifyError({})).toBe(ErrorTypes.UNKNOWN)
       expect(classifyError(null)).toBe(ErrorTypes.UNKNOWN)
     })
+
+    it('should honor pre-set .type (createClassifiedError wrapper)', () => {
+      const wrapped = new Error('Edge Function returned a non-2xx status code')
+      wrapped.type = ErrorTypes.RATE_LIMIT
+      expect(classifyError(wrapped)).toBe(ErrorTypes.RATE_LIMIT)
+    })
+
+    it('should classify Supabase FunctionsHttpError via context.status', () => {
+      // Supabase stashes HTTP status on error.context.status, not error.status
+      expect(classifyError({ context: { status: 429 } })).toBe(ErrorTypes.RATE_LIMIT)
+      expect(classifyError({ context: { status: 401 } })).toBe(ErrorTypes.AUTH_ERROR)
+      expect(classifyError({ context: { status: 500 } })).toBe(ErrorTypes.SERVER_ERROR)
+    })
   })
 
   describe('getUserMessage', () => {


### PR DESCRIPTION
## Summary
Codex review of the first commit caught that the call-site change alone wasn't doing anything — `classifyError` was silently dropping every Supabase Edge Function error (and every pre-wrapped API-layer error) to `UNKNOWN`, so `getUserMessage` returned the same generic "Something went wrong" regardless.

Two root-cause fixes in `src/utils/errorHandler.js`:

1. **Honor pre-set `.type`.** Any error already wrapped by `createClassifiedError()` (every API-layer catch block in the app uses this) got re-classified from the wrapper `Error`, which has no status code, and collapsed to `UNKNOWN`. `classifyError` now trusts a pre-set `.type` if it's a valid `ErrorType`.
2. **Read Supabase `error.context.status`.** `FunctionsHttpError` stashes the HTTP status there, not on `error.status`. We only checked the latter — so every Edge Function 429 / 401 / 5xx collapsed to `UNKNOWN`. Now it classifies correctly.

Call-site change in `AddRestaurantModal.handleSelectExternal` stays: use `getUserMessage(err, 'adding this restaurant')` so the catch tells the truth (rate limit, network, auth, server) instead of always blaming Google. The `restaurantsApi.create()` branch especially benefits — it was being blamed on Google even though Places already returned fine.

## Why this matters beyond Add Restaurant
The classifier bug was silent across the whole app. Every Edge Function failure (places, menu-refresh, discover-restaurants, etc.) and every wrapped API error was showing the generic fallback instead of the real classification. This PR fixes that systemically.

## Scope
- `src/utils/errorHandler.js` — classifier fix (+ comments explaining the Supabase + wrapper cases)
- `src/utils/errorHandler.test.js` — 2 new tests (wrapper-trust path, Supabase `context.status` path) so this doesn't regress
- `src/components/AddRestaurantModal.jsx` — swap hardcoded error copy for `getUserMessage()` in the catch

## Test plan
- [x] `npm run build` passes
- [x] `npm run test src/utils/errorHandler.test.js` passes (29/29)
- [ ] Trigger a real rate limit or network failure against `places-details` and verify the toast matches the cause instead of "Couldn't load from Google"
- [ ] Happy path still works (full-data Google pick → restaurant created directly)
- [ ] Incomplete-data path still shows its own accurate Google-specific error (separate branch, unchanged)

## Review notes
- Independent read by Codex (gpt-5.4, xhigh, read-only) caught the classifier bug in the first version of this PR. Commit 2 addresses it.
- Deliberately did **not** split the try into two catches — once classification works, both paths produce a truthful message, and splitting adds code without UX gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)