### PR TITLE
fix: post-login ErrorBoundary crash on iOS — Rules of Hooks violation in useRestaurantManager

### DIFF
--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -57,6 +57,18 @@ export class ErrorBoundary extends Component {
   }
 
   componentDidCatch(error, errorInfo) {
+    // Log the real error to console BEFORE anything else — if Sentry's
+    // dynamic import fails (e.g. Capacitor file:// scheme issues), we still
+    // want the truth in the native log. Error objects don't stringify well,
+    // so pull the fields explicitly.
+    console.error('[ErrorBoundary caught]', {
+      message: error?.message,
+      name: error?.name,
+      stack: error?.stack,
+      type: error?.type,
+      componentStack: errorInfo?.componentStack,
+    })
+
     // Auto-reload on chunk load errors (fallback if lazyWithRetry misses it)
     const msg = error?.message || ''
     const isChunkError = (
@@ -82,6 +94,8 @@ export class ErrorBoundary extends Component {
             },
           },
         })
+      }).catch(sentryErr => {
+        console.error('[ErrorBoundary] Sentry failed to load:', sentryErr?.message || sentryErr)
       })
     }
   }

--- a/src/hooks/useRestaurantManager.js
+++ b/src/hooks/useRestaurantManager.js
@@ -14,18 +14,26 @@ export function useRestaurantManager() {
     staleTime: 1000 * 60 * 5, // 5 minutes — manager status rarely changes
   })
 
+  // Rules of Hooks: all hook calls must run every render in the same order.
+  // The early-return MUST come AFTER the last hook, not before. Previously
+  // useEffect was below the `if (!user) return`, so hook count changed
+  // from 1 → 2 the moment user signed in, and React's reconciler crashed
+  // with `undefined is not an object (evaluating 'e.length')` in
+  // areHookInputsEqual. Crash was iOS/Capacitor-only because fresh-launch
+  // starts with user=null briefly; on web, session restore from
+  // localStorage made user truthy from the first render.
+  useEffect(() => {
+    if (user && result === undefined && !loading) {
+      logger.error('Unexpected null result from getMyRestaurant')
+    }
+  }, [user, result, loading])
+
   if (!user) {
     return { isManager: false, restaurant: null, loading: false }
   }
 
   const isManager = !!result?.restaurant
   const restaurant = result?.restaurant ?? null
-
-  useEffect(() => {
-    if (result === undefined && !loading) {
-      logger.error('Unexpected null result from getMyRestaurant')
-    }
-  }, [result, loading])
 
   return { isManager, restaurant, loading }
 }

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -6,19 +6,37 @@
 
 const isDev = import.meta.env.DEV
 
+// Error/Error-like objects stringify to `{}` because their properties aren't
+// enumerable. Capacitor's console bridge then shows `[error] - {}` which
+// hides the actual problem. Serialize defensively so native logs always
+// surface .message + .stack + any classified .type.
+function normalize(arg) {
+  if (arg instanceof Error || (arg && typeof arg === 'object' && 'message' in arg && 'stack' in arg)) {
+    return {
+      message: arg.message,
+      stack: arg.stack,
+      name: arg.name,
+      ...(arg.type ? { type: arg.type } : {}),
+      ...(arg.code ? { code: arg.code } : {}),
+      ...(arg.status ? { status: arg.status } : {}),
+    }
+  }
+  return arg
+}
+
 export const logger = {
   /**
    * Log errors - always logged, sent to Sentry in production
    */
   error(message, ...args) {
-    console.error(message, ...args)
+    console.error(message, ...args.map(normalize))
   },
 
   /**
    * Log warnings - always logged
    */
   warn(message, ...args) {
-    console.warn(message, ...args)
+    console.warn(message, ...args.map(normalize))
   },
 
   /**


### PR DESCRIPTION
## Summary
Root-caused the post-login `Something went wrong` ErrorBoundary crash Dan reproduced tonight on iOS simulator.

**Root cause:** `useRestaurantManager` had an early-return between two hooks.

```js
useQuery(...)            // hook 1
if (!user) return {...}  // EARLY RETURN — hook count differs between renders
useEffect(...)           // hook 2 — only runs when user is truthy
```

When user goes from `null` → signed-in, the hook count changes 1 → 2. React's reconciler corrupts → `areHookInputsEqual` crashes with `TypeError: undefined is not an object (evaluating 'e.length')` on the next render.

**Why only iOS:** on web, Supabase restores the session from localStorage synchronously enough that user is truthy on the very first render — hook count never changes. On native Capacitor, initial render has user=null before auth restores → count changes on login → crash.

## Fix
Move the early-return **after** the `useEffect` so both hooks always run every render. Added `user &&` guard to the effect's inner condition to preserve prior behavior.

## How I found it (two-commit PR)

**Commit 1 — observability fix.** The Capacitor log only showed `⚡️ [error] - {}` because `Error` objects have non-enumerable properties and `componentDidCatch` didn't log before attempting Sentry's dynamic import. Patched:
- `logger.error` / `logger.warn` to normalize Error-like args, extracting message/stack/name/type/code/status
- `ErrorBoundary.componentDidCatch` to log a structured payload BEFORE Sentry import, and catch Sentry import failures

Result: next rebuild surfaced the real error + full componentStack in Xcode console.

**Commit 2 — the actual bug fix.** Decoded the minified stack: the crashing function was React's internal `areHookInputsEqual`; the component was `SettingsDropdown` (which calls `useRestaurantManager` via `{isManager}`). Traced to the hook violation above.

## Test plan
- [x] `npm run build` passes
- [x] `npm run cap:sync` succeeds
- [x] **Dan verified on iOS simulator — no more ErrorBoundary crash on login**
- [ ] Prod web regression check (should be no-op — web was already working for this flow)

## Bonus
The observability instrumentation is permanent and now protects every future ErrorBoundary crash — we'll never see `{}` again; the real message, stack, and componentStack will always be in the log. Worth keeping even though we've root-caused this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)