### PR TITLE
feat(auth): migrate web flow to PKCE (Plan A)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,9 +50,6 @@ blob-report/
 # Auto-generated build artifacts
 public/bundle-stats.html
 
-# Alternate codebase checkout (separate project, not part of this repo)
-whats-good-here-soul/
-
 # Claude Code scheduled tasks
 .claude/scheduled_tasks.lock
 

--- a/CURRENT_FOCUS.md
+++ b/CURRENT_FOCUS.md
@@ -2,49 +2,69 @@
 
 *Dan (or any Claude session starting work) updates this file at session start. Every other Claude session reads it first to avoid collisions.*
 
-**Last updated:** 2026-04-17
+**Last updated:** 2026-04-20 (end of night)
 
 ---
 
 ## Active handoff
 
-<!-- Fill this in BEFORE touching files. Clear it when done.
-     This is the collision-prevention surface — if it's stale, the whole
-     system weakens. Keep it honest. -->
-
-- **Owner / session:** _(Dan's terminal | Dan's other Claude | Denis's Claude | scheduled agent name)_
-- **Branch:** _(e.g., audit/supabase-2026-04-16 — or `main` if directly committing)_
-- **Files / modules claimed:** _(e.g., `src/api/votesApi.js`, `supabase/schema.sql §votes`, `src/pages/Profile.jsx`)_
-- **Safe for others to continue:** _(what parts of the repo are NOT touched and open for parallel work)_
-- **Do not duplicate:** _(specific tasks already in-flight — PR numbers, migration filenames, feature names)_
+**No active sessions.** Xcode-simulator phase wrapped tonight. Dan is stopping here.
 
 ---
 
-## This session — the goal
+## Where we are
 
-<!-- One paragraph. What are we actually shipping this session?
-     Skip the long context — CLAUDE.md + SPEC.md provide that. -->
+Went from Capacitor scaffold → working native iOS app in one session. Six PRs merged to main (#67–#72), all on simulator:
 
-_(stub)_
+- #67 `places-details` — disable gateway JWT verify so new anon key works
+- #68 `add-restaurant` — surface real error (catch block was swallowing it)
+- #69 `BottomNav` — don't crush icons under iOS home-indicator safe area
+- #70 `edge-fns` — allowlist Capacitor origins so native iOS reaches Places + parse-menu
+- #71 `ios` — radius sheet bottom clipping + `NSLocationWhenInUseUsageDescription`
+- #72 `useRestaurantManager` — Rules of Hooks fix (early return after `useEffect`); ErrorBoundary + logger now surface real errors
 
-## Blockers / waiting on
+What works on simulator: app boot, Add Restaurant end-to-end, sign-in (email), location permission, safe-area handling everywhere, clean icons, real error reporting.
 
-<!-- Anything held up on Denis, Apple review, a design decision, etc.
-     Claude should NOT quietly start work that's waiting on someone else. -->
+## Next session — real-device testing
 
-- _(nothing)_
+Plug in a real iPhone, pick it from Xcode's device selector, run. Simulator ≠ device for:
+
+- Haptics
+- Push notifications
+- Deep links / universal links
+- Real network conditions
+- Actual GPS (not simulated Cupertino)
+- Camera / photo picker
+
+Fix anything that breaks on device that didn't break in simulator.
+
+## Known launch risks (not tonight)
+
+- **OAuth on native is probably broken.** `LoginModal.buildOAuthRedirect()` uses `window.location.href`, which in Capacitor is `capacitor://localhost/...`. Google won't redirect back to a custom scheme. Fix is `@capacitor/browser` + deep-link return, or native Google Sign-In plugin. Dan signed in with email tonight — verify Google path before launch.
+- **Google Places TOS deferrals** (per memory `project_google_places_compliance`): Leaflet map showing Places pins, and missing `attributions` field from Places Details. Both flagged for pre-submission.
+- **Virtual business address** not set up yet — Privacy/Terms ship with email-only for now.
+- **2026-04-30 checkpoint:** if no TestFlight build + account deletion live by then, flip to PWA-primary per the App Store launch memory.
+
+## App Store path (rough order)
+
+1. Confirm certs + provisioning profiles in Xcode Signing & Capabilities
+2. Real-device run
+3. Fix OAuth-on-native
+4. Resolve Google Places deferrals
+5. App Store Connect setup (screenshots, description, privacy, age rating)
+6. TestFlight build + internal testers
+7. Submit
 
 ## Not this session
 
-<!-- Stuff explicitly parked. Claude: don't pick this up even if it looks tempting. -->
-
-- _(nothing)_
+- Menu-refresh 401 fix (still open per memory)
+- Post-launch features deferred: scoring history, Ask WGH, FriendsFeed, TastePersonalityCard
 
 ---
 
 ## Protocol
 
 - **Update BEFORE touching files.** If you skip the update, you are the collision.
-- **Clear the "Active handoff" block when the session ends** (commit or stash, then reset this section). A stale handoff is worse than none — the next session will assume it's accurate.
-- **If `Last updated` is >24h old, treat the whole file as stale** — ask Dan what's current before assuming anything.
-- **One active handoff per surface.** Two sessions can run in parallel if their scopes don't overlap — append a second handoff block, clearly labeled. But never two sessions on the same files at the same time.
+- **Clear the "Active handoff" block when the session ends.** Stale handoff is worse than none.
+- **If `Last updated` is >24h old, treat the file as stale** — ask Dan what's current.
+- **One active handoff per surface.** Parallel sessions OK if scopes don't overlap; append a second handoff block.

--- a/LAUNCH-READINESS.md
+++ b/LAUNCH-READINESS.md
@@ -39,7 +39,7 @@ Any Claude session (Dan's, Denis's, mine, a future one) can check items off as w
 ## iOS native (Capacitor)
 
 - [ ] Apple Developer account active (individual now, LLC transfer post-launch)
-- [ ] Capacitor shell builds locally
+- [x] Capacitor shell builds locally — simulator smoke passed 2026-04-20 (#62, #67–#72)
 - [ ] App Store review passed
 - [ ] Sign In with Apple wired
 

--- a/docs/superpowers/plans/2026-04-20-plan-a-web-pkce-migration.md
+++ b/docs/superpowers/plans/2026-04-20-plan-a-web-pkce-migration.md
@@ -1,0 +1,473 @@
+# Plan A — Web PKCE Migration
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the Supabase web auth flow from implicit to PKCE so OAuth callbacks and email links use `?code=...` exchanges instead of `#access_token=...` URL fragments.
+
+**Architecture:** Set `flowType: 'pkce'` on the Supabase client. Keep `detectSessionInUrl: true` so Supabase auto-exchanges the code on both `/login` and `/reset-password` entry points. Adjust the one place in `Login.jsx` that sniffs `window.location.hash` for `type=signup` — under PKCE, `type` arrives as a query param, not a hash fragment. Ship behind no feature flag; it is a near-drop-in change with transparent fallback (Supabase handles legacy `#access_token=` URLs during the transition window).
+
+**Tech Stack:** React 19, Vite 7, Supabase JS v2, Vitest, Playwright (existing).
+
+**Spec reference:** `docs/superpowers/specs/2026-04-20-oauth-native-and-apple-revocation-design.md` — Phase 2 (Web PKCE migration). Part 1 of 3; Plans B (server Apple infra) and C (native + universal links) follow.
+
+**Branch:** `feat/plan-a-pkce-migration`
+
+---
+
+### Task 1: Create feature branch
+
+**Files:**
+- No code changes. Git only.
+
+- [ ] **Step 1: Verify current branch is main and up to date**
+
+Run:
+```bash
+git branch --show-current && git status --short
+```
+Expected:
+```
+main
+```
+(no uncommitted changes besides already-tracked `.gitignore` if present). If not on main, STOP and ask Dan.
+
+- [ ] **Step 2: Create and switch to feature branch**
+
+Run:
+```bash
+git checkout -b feat/plan-a-pkce-migration
+```
+Expected: `Switched to a new branch 'feat/plan-a-pkce-migration'`
+
+- [ ] **Step 3: Verify clean branch state**
+
+Run:
+```bash
+git branch --show-current
+```
+Expected: `feat/plan-a-pkce-migration`
+
+---
+
+### Task 2: Add `flowType: 'pkce'` to Supabase client
+
+**Files:**
+- Modify: `src/lib/supabase.js:30-38`
+
+- [ ] **Step 1: Read current Supabase client config**
+
+The file currently looks like this (lines 27-39):
+```js
+export const supabase = createClient(
+  supabaseUrl || '',
+  supabaseAnonKey || '',
+  {
+    auth: {
+      persistSession: true,
+      storage: typeof window !== 'undefined' ? window.localStorage : undefined,
+      storageKey: 'whats-good-here-auth',
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+    }
+  }
+)
+```
+
+- [ ] **Step 2: Add `flowType: 'pkce'` to the auth config**
+
+Use Edit to change:
+```js
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+    }
+```
+to:
+```js
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+      flowType: 'pkce',
+    }
+```
+
+- [ ] **Step 3: Verify the file compiles**
+
+Run:
+```bash
+npx eslint src/lib/supabase.js
+```
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+Run:
+```bash
+git add src/lib/supabase.js
+git commit -m "feat(auth): migrate Supabase web flow to PKCE
+
+flowType: 'pkce' on the client. detectSessionInUrl: true stays on so
+Supabase auto-exchanges ?code= on /login and /reset-password. No
+manual exchangeCodeForSession in page components.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+Expected: commit succeeds.
+
+---
+
+### Task 3: Extract post-confirmation URL check to a testable helper
+
+**Files:**
+- Create: `src/utils/authUrlType.js`
+- Create: `src/utils/authUrlType.test.js`
+
+`Login.jsx:21` currently does `window.location.hash.includes('type=signup')`. Under PKCE, `type` arrives as a query param. We want a single helper that reads both hash and query so the detection works during the transition period and going forward.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/utils/authUrlType.test.js` with:
+```js
+import { describe, it, expect } from 'vitest'
+import { getAuthUrlType } from './authUrlType'
+
+describe('getAuthUrlType', () => {
+  it('returns null for a plain URL', () => {
+    expect(getAuthUrlType('https://app.example/login')).toBe(null)
+  })
+
+  it('returns the type from a query param (PKCE)', () => {
+    expect(getAuthUrlType('https://app.example/login?code=abc&type=signup')).toBe('signup')
+    expect(getAuthUrlType('https://app.example/login?type=email&code=abc')).toBe('email')
+    expect(getAuthUrlType('https://app.example/reset-password?code=abc&type=recovery')).toBe('recovery')
+  })
+
+  it('returns the type from a hash fragment (legacy implicit)', () => {
+    expect(getAuthUrlType('https://app.example/login#access_token=xxx&type=signup')).toBe('signup')
+    expect(getAuthUrlType('https://app.example/login#type=email&access_token=xxx')).toBe('email')
+  })
+
+  it('prefers query over hash if both present', () => {
+    expect(getAuthUrlType('https://app.example/login?type=signup#type=email')).toBe('signup')
+  })
+
+  it('returns null for malformed URLs (no throw)', () => {
+    expect(getAuthUrlType('not a url')).toBe(null)
+    expect(getAuthUrlType('')).toBe(null)
+    expect(getAuthUrlType(null)).toBe(null)
+  })
+
+  it('returns null for unrecognized type values', () => {
+    // We only care about signup/email/recovery/magiclink
+    expect(getAuthUrlType('https://app.example/login?type=unknown')).toBe(null)
+  })
+
+  it('recognizes magiclink type', () => {
+    expect(getAuthUrlType('https://app.example/login?code=xxx&type=magiclink')).toBe('magiclink')
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+```bash
+npx vitest run src/utils/authUrlType.test.js
+```
+Expected: FAIL with "Cannot find module './authUrlType'" or similar.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `src/utils/authUrlType.js`:
+```js
+const KNOWN_TYPES = new Set(['signup', 'email', 'recovery', 'magiclink'])
+
+/**
+ * Extracts Supabase auth URL type ('signup' | 'email' | 'recovery' | 'magiclink')
+ * from either the query string (PKCE) or the hash fragment (legacy implicit).
+ * Returns null if no recognized type is present or the URL is malformed.
+ */
+export function getAuthUrlType(urlString) {
+  if (!urlString || typeof urlString !== 'string') return null
+  let url
+  try {
+    url = new URL(urlString)
+  } catch {
+    return null
+  }
+
+  const queryType = url.searchParams.get('type')
+  if (queryType && KNOWN_TYPES.has(queryType)) return queryType
+
+  const hash = url.hash.startsWith('#') ? url.hash.slice(1) : url.hash
+  const hashParams = new URLSearchParams(hash)
+  const hashType = hashParams.get('type')
+  if (hashType && KNOWN_TYPES.has(hashType)) return hashType
+
+  return null
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```bash
+npx vitest run src/utils/authUrlType.test.js
+```
+Expected: all 7 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+Run:
+```bash
+git add src/utils/authUrlType.js src/utils/authUrlType.test.js
+git commit -m "feat(auth): add getAuthUrlType helper for PKCE + legacy detection
+
+Reads Supabase auth type param from both ?type= (PKCE) and
+#type= (legacy implicit). Known types: signup, email, recovery,
+magiclink. Returns null for anything else, including malformed URLs.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+Expected: commit succeeds.
+
+---
+
+### Task 4: Use `getAuthUrlType` in Login.jsx
+
+**Files:**
+- Modify: `src/pages/Login.jsx:1-26`
+
+- [ ] **Step 1: Read current state**
+
+The current lines 1-26 of `src/pages/Login.jsx` look like:
+```jsx
+import { useState, useEffect } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import { authApi } from '../api/authApi'
+import { useAuth } from '../context/AuthContext'
+import { logger } from '../utils/logger'
+import { CameraIcon } from '../components/CameraIcon'
+import { SmileyPin } from '../components/SmileyPin'
+import { FEATURES } from '../constants/features'
+
+// SECURITY: Email is NOT persisted to storage to prevent XSS exposure of PII
+
+export function Login() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { user } = useAuth()
+  const [loading, setLoading] = useState(false)
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [username, setUsername] = useState('')
+  // If user arrives with confirmation hash params, go straight to sign-in
+  const isPostConfirmation = window.location.hash.includes('type=signup') || window.location.hash.includes('type=email')
+  const [message, setMessage] = useState(
+    isPostConfirmation ? { type: 'success', text: 'Email verified! Sign in to get started.' } : null
+  )
+  const [showLogin, setShowLogin] = useState(isPostConfirmation) // Controls welcome vs login view
+  const [mode, setMode] = useState(isPostConfirmation ? 'signin' : 'options') // 'options' | 'signin' | 'signup' | 'forgot'
+```
+
+- [ ] **Step 2: Add the import**
+
+Use Edit to change:
+```jsx
+import { FEATURES } from '../constants/features'
+```
+to:
+```jsx
+import { FEATURES } from '../constants/features'
+import { getAuthUrlType } from '../utils/authUrlType'
+```
+
+- [ ] **Step 3: Replace the hash-only check with the helper**
+
+Use Edit to change:
+```jsx
+  // If user arrives with confirmation hash params, go straight to sign-in
+  const isPostConfirmation = window.location.hash.includes('type=signup') || window.location.hash.includes('type=email')
+```
+to:
+```jsx
+  // If user arrives with confirmation params (PKCE query or legacy hash), go straight to sign-in
+  const authUrlType = getAuthUrlType(window.location.href)
+  const isPostConfirmation = authUrlType === 'signup' || authUrlType === 'email'
+```
+
+- [ ] **Step 4: Verify eslint passes**
+
+Run:
+```bash
+npx eslint src/pages/Login.jsx
+```
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+Run:
+```bash
+git add src/pages/Login.jsx
+git commit -m "fix(auth): detect post-confirmation type from query OR hash
+
+Under PKCE, Supabase email-confirmation links put type= in the query
+string (?type=signup) instead of the hash fragment. Swap the hash-only
+check in Login.jsx for getAuthUrlType, which handles both shapes.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+Expected: commit succeeds.
+
+---
+
+### Task 5: Full test + build verification
+
+**Files:**
+- No changes.
+
+- [ ] **Step 1: Run the full unit test suite**
+
+Run:
+```bash
+npm run test -- --run
+```
+Expected: all tests PASS. If any fail, investigate — a regression from the PKCE change is possible if another test mocks `window.location.hash` directly.
+
+- [ ] **Step 2: Run lint on the full src tree**
+
+Run:
+```bash
+npm run lint
+```
+Expected: no errors (warnings OK if pre-existing).
+
+- [ ] **Step 3: Run production build**
+
+Run:
+```bash
+npm run build
+```
+Expected: build succeeds with no errors. No ES2023+ methods in output (project rule per CLAUDE.md §1.1).
+
+- [ ] **Step 4: If all three green, nothing to commit — proceed to Task 6**
+
+No commit needed — this task only verifies.
+
+---
+
+### Task 6: Manual smoke on dev server
+
+**Files:**
+- No changes.
+
+This is a manual verification step. Must pass before opening the PR.
+
+- [ ] **Step 1: Start the dev server**
+
+Run (in a separate terminal, keep it running for the rest of this task):
+```bash
+npm run dev
+```
+Expected: Vite dev server on `http://localhost:5173`.
+
+- [ ] **Step 2: Smoke — existing email/password sign-in still works**
+
+1. Open `http://localhost:5173/login`
+2. Sign in with an existing email/password test account from `SMOKE-TEST.md`
+3. Expected: lands on home, `useAuth()` user is populated.
+4. Sign out.
+
+- [ ] **Step 3: Smoke — Google OAuth still works on web (no PKCE regression)**
+
+1. Open `http://localhost:5173/login`
+2. Click "Continue with Google"
+3. Complete Google auth
+4. Expected: returns to the app, signed in. URL no longer contains `?code=...` after Supabase has exchanged it.
+
+- [ ] **Step 4: Smoke — password reset end-to-end**
+
+1. In the app, trigger "Forgot password?" for a test account
+2. Open the email (inbox or Supabase dashboard → Logs → Auth)
+3. Click the reset link
+4. Expected: lands on `/reset-password` with a valid recovery session; "Set new password" form is visible (not the "invalid or expired" error)
+5. Set a new password, sign in with it. Expected: works.
+
+- [ ] **Step 5: Smoke — email confirmation success message still shows**
+
+This verifies the `getAuthUrlType` helper is working in production shape.
+
+1. Sign up a new test account with a real inbox you can access.
+2. Click the email confirmation link.
+3. Expected: lands on `/login` with a green success banner "Email verified! Sign in to get started." and the form pre-switched to sign-in mode.
+4. If the URL is `...?code=xxx&type=signup` or `...#type=signup&access_token=xxx`, the helper must detect either shape.
+
+- [ ] **Step 6: No commit — if all four smoke steps pass, move to Task 7**
+
+If any step fails, investigate and fix before proceeding. Likely culprits: Supabase redirect URL allow-list missing `localhost:5173`, or Supabase email template stale.
+
+---
+
+### Task 7: Open pull request
+
+**Files:**
+- No code changes. Git/GitHub only.
+
+- [ ] **Step 1: Push the branch**
+
+Run:
+```bash
+git push -u origin feat/plan-a-pkce-migration
+```
+Expected: new branch on origin, PR link printed.
+
+- [ ] **Step 2: Create the PR**
+
+Run:
+```bash
+gh pr create --title "feat(auth): migrate web flow to PKCE (Plan A)" --body "$(cat <<'EOF'
+## Summary
+- Sets \`flowType: 'pkce'\` on the Supabase web client.
+- \`detectSessionInUrl: true\` stays on so Supabase auto-exchanges \`?code=\` on \`/login\` and \`/reset-password\` entry points. No manual \`exchangeCodeForSession\` in page components.
+- New \`src/utils/authUrlType.js\` reads Supabase auth type param from both \`?type=\` (PKCE) and \`#type=\` (legacy implicit). \`Login.jsx\` uses it in place of the hash-only check for post-confirmation detection.
+
+## Why
+First of three plans implementing the OAuth-on-native-iOS + Apple-token-revocation design (spec: \`docs/superpowers/specs/2026-04-20-oauth-native-and-apple-revocation-design.md\`). Plan A is the web-side security upgrade that unblocks Plans B + C. PKCE is the 2026 industry default and removes tokens-in-URL-fragment risk.
+
+## Test plan
+- [x] Unit: \`src/utils/authUrlType.test.js\` — 7 tests, covers PKCE query, legacy hash, both, malformed, unknown types, magiclink
+- [x] \`npm run test\` passes
+- [x] \`npm run lint\` passes
+- [x] \`npm run build\` passes (no ES2023+ regressions)
+- [x] Manual smoke on localhost:5173:
+  - [x] Existing email/password sign-in still works
+  - [x] Google OAuth still works (no PKCE regression)
+  - [x] Password reset end-to-end lands on valid recovery session
+  - [x] Email confirmation success banner still shows on \`/login\` with both PKCE query and legacy hash shapes
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+Expected: PR created, URL printed.
+
+- [ ] **Step 3: Report the PR URL back to Dan**
+
+Share the PR URL so Dan can review and merge.
+
+---
+
+## Out of scope for Plan A
+
+Intentionally deferred to later plans in the series:
+- **Plan B** — Apple server infrastructure (Edge Functions, migrations, retry cron)
+- **Plan C** — Native Capacitor wiring, universal links, AASA, iOS capabilities, AuthLifecycle, apple-token-persist client wiring
+
+Already shipped and NOT in Plan A:
+- `WelcomeModal.jsx` open condition + silent-error fix (already merged, verified at `src/components/Auth/WelcomeModal.jsx:60` and `src/components/Auth/WelcomeModal.jsx:80-85`)
+- `Login.jsx` OAuth redirect `location.state?.from` serialization (already correct at `src/pages/Login.jsx:72-80`)
+
+## Rollback
+
+If PKCE migration breaks email confirmation or password reset post-merge:
+1. Revert the merge commit: `git revert -m 1 <merge_sha>`
+2. Investigate via Supabase Auth logs which URL shape the email is actually delivering.
+3. If the issue is limited to one URL shape, extend `getAuthUrlType` test coverage and re-land.

--- a/docs/superpowers/plans/2026-04-20-plan-a-web-pkce-migration.md
+++ b/docs/superpowers/plans/2026-04-20-plan-a-web-pkce-migration.md
@@ -319,6 +319,175 @@ Expected: commit succeeds.
 
 ---
 
+### Task 4.5: Harden ResetPassword.jsx against PKCE race
+
+**Why this task exists:** `ResetPassword.jsx:16-33` currently does a single `authApi.getSession()` on mount and renders "Invalid or expired reset link" if it returns `null`. Under **implicit** flow this was fine — the hash token was parsed synchronously during client init. Under **PKCE**, Supabase does an async HTTP POST to `/token` to exchange `?code=`. On slow networks the React `useEffect` can run before the exchange completes → valid links show as expired. The spec v3 (line 101) claims this page needs no edit because it already reads from `onAuthStateChange`, but that is inaccurate for the current code. This task closes the real gap.
+
+Event-handling approach (confirmed with Codex second opinion):
+- Subscribe to `onAuthStateChange`.
+- Resolve as valid on: `PASSWORD_RECOVERY` with session (primary), `SIGNED_IN` with session (compat), or `INITIAL_SESSION` with **truthy** session (fast path for already-signed-in user, and for PKCE exchange that completes before subscription).
+- Do NOT treat `INITIAL_SESSION` with null session as failure (ordering is `INITIAL_SESSION` → `PASSWORD_RECOVERY` in current supabase-js).
+- 5s timeout fallback: call `getSession()` once; if still null, show the invalid-link message. Prevents an indefinite spinner on silent failure.
+- Use a closure `decided` flag (not React state) so multiple racing async paths resolve exactly once.
+
+**Files:**
+- Modify: `src/pages/ResetPassword.jsx:1-33`
+
+- [ ] **Step 1: Read the current state**
+
+Lines 1-33 currently read:
+```jsx
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { authApi } from '../api/authApi'
+import { SmileyPin } from '../components/SmileyPin'
+
+export function ResetPassword() {
+  const navigate = useNavigate()
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [message, setMessage] = useState(null)
+  const [isValidSession, setIsValidSession] = useState(false)
+  const [checkingSession, setCheckingSession] = useState(true)
+
+  // Check if we have a valid recovery session
+  useEffect(() => {
+    const checkSession = async () => {
+      // Supabase automatically handles the recovery token from the URL
+      const { data: { session } } = await authApi.getSession()
+
+      if (session) {
+        setIsValidSession(true)
+      } else {
+        setMessage({
+          type: 'error',
+          text: 'Invalid or expired reset link. Please request a new one.'
+        })
+      }
+      setCheckingSession(false)
+    }
+
+    checkSession()
+  }, [])
+```
+
+- [ ] **Step 2: Add the `supabase` import**
+
+Use Edit to change:
+```jsx
+import { authApi } from '../api/authApi'
+import { SmileyPin } from '../components/SmileyPin'
+```
+to:
+```jsx
+import { authApi } from '../api/authApi'
+import { supabase } from '../lib/supabase'
+import { SmileyPin } from '../components/SmileyPin'
+```
+
+- [ ] **Step 3: Replace the useEffect body**
+
+Use Edit to change:
+```jsx
+  // Check if we have a valid recovery session
+  useEffect(() => {
+    const checkSession = async () => {
+      // Supabase automatically handles the recovery token from the URL
+      const { data: { session } } = await authApi.getSession()
+
+      if (session) {
+        setIsValidSession(true)
+      } else {
+        setMessage({
+          type: 'error',
+          text: 'Invalid or expired reset link. Please request a new one.'
+        })
+      }
+      setCheckingSession(false)
+    }
+
+    checkSession()
+  }, [])
+```
+to:
+```jsx
+  // Check for a valid recovery session. Under PKCE, Supabase exchanges
+  // ?code= asynchronously, so we subscribe to auth events instead of
+  // relying on a single getSession() read that can fire before the
+  // exchange completes.
+  useEffect(() => {
+    let decided = false
+    let cancelled = false
+
+    const decide = (session) => {
+      if (cancelled || decided) return
+      decided = true
+      if (session) {
+        setIsValidSession(true)
+      } else {
+        setMessage({
+          type: 'error',
+          text: 'Invalid or expired reset link. Please request a new one.'
+        })
+      }
+      setCheckingSession(false)
+    }
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === 'PASSWORD_RECOVERY' || event === 'SIGNED_IN') {
+        decide(session)
+      } else if (event === 'INITIAL_SESSION' && session) {
+        decide(session)
+      }
+    })
+
+    // Fallback: if no recovery/signed-in event arrives within 5s, resolve
+    // with whatever getSession reports. Guards against silent init failure.
+    const timer = setTimeout(async () => {
+      if (cancelled || decided) return
+      const { data: { session } } = await supabase.auth.getSession()
+      decide(session)
+    }, 5000)
+
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+      subscription.unsubscribe()
+    }
+  }, [])
+```
+
+- [ ] **Step 4: Verify eslint passes**
+
+Run:
+```bash
+npx eslint src/pages/ResetPassword.jsx
+```
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+Run:
+```bash
+git add src/pages/ResetPassword.jsx
+git commit -m "fix(auth): wait for auth events on password reset under PKCE
+
+ResetPassword previously called getSession() once on mount. Under
+implicit flow the hash token was parsed synchronously so this worked.
+Under PKCE the ?code= exchange is async — a slow exchange made valid
+reset links show 'Invalid or expired' before the session landed.
+
+Subscribe to onAuthStateChange (PASSWORD_RECOVERY, SIGNED_IN, plus
+INITIAL_SESSION-with-session as a fast path). Keep a 5s fallback to
+getSession so silent init failure doesn't strand the user on a spinner.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+Expected: commit succeeds.
+
+---
+
 ### Task 5: Full test + build verification
 
 **Files:**
@@ -428,6 +597,7 @@ gh pr create --title "feat(auth): migrate web flow to PKCE (Plan A)" --body "$(c
 - Sets \`flowType: 'pkce'\` on the Supabase web client.
 - \`detectSessionInUrl: true\` stays on so Supabase auto-exchanges \`?code=\` on \`/login\` and \`/reset-password\` entry points. No manual \`exchangeCodeForSession\` in page components.
 - New \`src/utils/authUrlType.js\` reads Supabase auth type param from both \`?type=\` (PKCE) and \`#type=\` (legacy implicit). \`Login.jsx\` uses it in place of the hash-only check for post-confirmation detection.
+- \`ResetPassword.jsx\` now subscribes to \`onAuthStateChange\` (PASSWORD_RECOVERY / SIGNED_IN / INITIAL_SESSION-with-session) instead of a one-shot \`getSession()\`. Closes a real PKCE race where a slow \`?code=\` exchange made valid recovery links show as expired. 5s \`getSession()\` fallback guards silent init failure.
 
 ## Why
 First of three plans implementing the OAuth-on-native-iOS + Apple-token-revocation design (spec: \`docs/superpowers/specs/2026-04-20-oauth-native-and-apple-revocation-design.md\`). Plan A is the web-side security upgrade that unblocks Plans B + C. PKCE is the 2026 industry default and removes tokens-in-URL-fragment risk.

--- a/docs/superpowers/specs/2026-04-20-oauth-native-and-apple-revocation-design.md
+++ b/docs/superpowers/specs/2026-04-20-oauth-native-and-apple-revocation-design.md
@@ -1,0 +1,583 @@
+# OAuth on Native iOS + Apple Token Revocation — Design
+
+**Status:** Approved design, ready for implementation plan
+**Date:** 2026-04-20
+**Author:** Dan Walsh (with Claude Opus 4.7 + Codex gpt-5.4/high)
+**Blocks:** TestFlight build, App Store submission
+**Supersedes (partially):** `docs/superpowers/plans/2026-04-13-h2-sign-in-with-apple.md` (H2 plan — stale assumptions about Capacitor scaffold + implicit flow)
+
+---
+
+## Goal
+
+Make native iOS auth work properly for App Store submission. Root-cause fix, not a band-aid.
+
+Concretely: Google login currently breaks in the Capacitor shell (redirects to a scheme Google refuses). Sign in with Apple doesn't exist (Apple rule 4.8 auto-rejects). Email verification and password reset links on iOS open Safari instead of the app. Apple requires us to revoke the Apple-ID consent server-side when a user deletes their account (guideline 5.1.1(v)), and we have no infrastructure for that.
+
+This spec closes all four gaps with one coherent architecture.
+
+## Non-goals
+
+- Android native auth. Same architecture will port (both plugins are cross-platform) but out of scope for v1.
+- Account linking UI (merging a Google-only account with an Apple private-relay account). Supabase auto-links same-email identities; private-relay edge cases are a post-launch feature.
+- Apple server-to-server notifications (consent-revoked, account-deleted). Post-launch hardening.
+- First-party Swift bridge. The thin-adapter design means we can swap from the Capgo community plugin to a custom bridge later without changing callers.
+
+---
+
+## Architecture
+
+Three layers, one mental model.
+
+### Layer 1 — Web PWA (one security upgrade, no UX change)
+
+- Keep `supabase.auth.signInWithOAuth` for Google and Apple on web.
+- Migrate Supabase client from implicit flow to **PKCE flow** (`flowType: 'pkce'` in `src/lib/supabase.js`). Industry standard in 2026; removes tokens-in-URL-fragment risk.
+- **PKCE is not a one-line change.** `src/pages/Login.jsx` currently reads `window.location.hash` for post-confirmation state (email confirm, password recovery). PKCE changes callback shape from `#access_token=...` to `?code=...`, requiring rework of the entry handler to call `supabase.auth.exchangeCodeForSession(code)`.
+- Transitional handling for legacy `#access_token=` URLs (users with old email links in their inbox) for one release.
+
+### Layer 2 — iOS native (the root fix)
+
+- Both Google and Apple use platform-native SDKs via `@capgo/capacitor-social-login` (actively maintained, one plugin for both providers; replaces abandoned `@codetrix-studio/capacitor-google-auth`).
+- Google: native iOS Google Sign-In SDK returns `{ idToken, accessToken }` → `supabase.auth.signInWithIdToken({ provider: 'google', token: idToken, access_token: accessToken })`.
+- Apple: native `ASAuthorizationController` returns `{ identityToken, authorizationCode, givenName, familyName, user = apple_sub }` → `supabase.auth.signInWithIdToken({ provider: 'apple', token: identityToken, nonce: rawNonce })`. First-sign-in extras trigger server-side `authorizationCode` exchange for refresh-token storage.
+- No browser redirect, no deep-link dance, no custom scheme for OAuth.
+
+### Layer 3 — Thin auth bridge (isolation guarantee)
+
+- One module, `src/lib/nativeAuth.js`, is the **only** place that imports `@capgo/capacitor-social-login`.
+- Exposes `signInWithGoogleNative()` and `signInWithAppleNative()` with normalized return shapes and WGH-coded errors.
+- `Capacitor.isNativePlatform()` branches live inside the API layer (`src/api/authApi.js`), not scattered across UI.
+- **Boundary rule:** no plugin-native object shape ever escapes the bridge. All errors map to the canonical WGH set before throwing. If a plugin goes stale, it's a one-file swap.
+
+### Apple revocation infrastructure
+
+Apple's guideline 5.1.1(v) requires apps supporting SIWA to revoke Apple's consent on account deletion. This needs:
+
+- **`user_apple_tokens`** table (per-user, refresh token ciphertext + key version + apple_sub). RLS: deny-all to authenticated role. Service-role only.
+- **`pending_apple_revocations`** table (no FK to users — survives cascade delete). Columns include `next_attempt_at` to drive aggressive-then-decaying retry cadence.
+- **`apple-token-exchange`** Edge Function: exchanges `authorizationCode` for refresh token on first Apple sign-in.
+- **`delete-account`** Edge Function (extended): queues the revocation BEFORE cascading delete. Queue insert is mandatory — failure blocks deletion.
+- **`apple-revocation-retry`** Edge Function: invoked by `pg_cron` every 15 minutes, retries pending revocations per backoff schedule.
+- **Supabase Vault** for encryption key and `.p8` private key. Not raw `pgcrypto`.
+
+### Universal links (canonical domain)
+
+- `whatsgoodhere.app` is the canonical launch domain (owned, DNS not yet pointed at Vercel as of 2026-04-20).
+- `public/.well-known/apple-app-site-association` declares universal-link paths.
+- Xcode "Associated Domains" capability registers `applinks:whatsgoodhere.app`.
+- Email verification, password reset, and magic-link URLs from Supabase resolve to the app shell, not Safari.
+- Cross-device PKCE failure (signup on desktop, link tapped on phone) surfaces a friendly "Send new link to this device" affordance rather than an opaque error.
+
+### Lifecycle hooks
+
+- `@capacitor/app` `appStateChange` listener → on foreground, call `supabase.auth.getSession()` to reconcile. Don't trust WebView timer refresh.
+- `@capacitor/app` `appUrlOpen` listener → hand off to `authUrl.parse(url)` → `supabase.auth.exchangeCodeForSession(code)`.
+- Both listeners mount inside `AuthLifecycle` component under `AuthProvider`, not in `App.jsx`. Keeps auth state mutations near the auth client.
+
+---
+
+## Components
+
+### New client modules
+
+| File | Purpose | Est. size |
+|---|---|---|
+| `src/lib/nativeAuth.js` | Thin adapter for Capgo plugin. Nonce generation (raw + SHA-256 for Apple). Normalizes success payloads and errors to WGH codes. Runtime validator for bridge contract. | 120–150 |
+| `src/utils/nonce.js` | `generateNonce()` (64-char hex from 32 crypto-random bytes) + `sha256(str)` (Web Crypto). | 15 |
+| `src/lib/authUrl.js` | Parser for auth-return universal links. Returns `{ code, type: 'recovery' \| 'confirm' \| 'magiclink' }` or `null`. Ignores non-auth deep links. | 25 |
+| `src/components/Auth/AuthLifecycle.jsx` | Mounted inside `AuthProvider`. Owns `appStateChange` + `appUrlOpen` listeners. | 40 |
+
+### Edited client modules
+
+| File | Change | Est. added lines |
+|---|---|---|
+| `src/api/authApi.js` | Add `Capacitor.isNativePlatform()` branches in `signInWithGoogle` and `signInWithApple`. Native branch calls bridge → `supabase.auth.signInWithIdToken`. On Apple native with `authorizationCode`, invoke `apple-token-exchange` (client body: `{ authorization_code }` only — no `apple_sub` or `user_id`). Apply nonce dance for Apple. Normalize errors. Add `signOut()` native branch that also calls Capgo's `logout()` to clear Google account picker. | 80–120 |
+| `src/lib/supabase.js` | Add `flowType: 'pkce'`. | 1 |
+| `src/pages/Login.jsx` | Handle both `?code=` (PKCE) and legacy `#access_token=` (one-release transition). Call `supabase.auth.exchangeCodeForSession()`. Fix existing `location.state?.from` intent-preservation bug. Activate Apple button. | 40 |
+| `src/components/Auth/LoginModal.jsx` | Activate pre-wired Apple button with official SIWA asset. | 15 |
+| `src/components/Auth/WelcomeModal.jsx` | Open condition: `(!profile.has_onboarded \|\| !profile.display_name)`. Fix existing silent-error-on-duplicate-display_name bug (from H2 plan). | 10 |
+| `src/App.jsx` | Mount `AuthLifecycle` inside `AuthProvider`. No auth logic directly in App.jsx. | 5 |
+| `src/pages/Privacy.jsx` + `src/pages/Terms.jsx` | Copy updates for Apple sign-in, private-relay email behavior, account linking, canonical domain `whatsgoodhere.app`. | 25 |
+
+### iOS native config
+
+| File / capability | Change |
+|---|---|
+| `ios/App/App/Info.plist` | Add `CFBundleURLTypes` for custom scheme (fallback only — universal links primary). |
+| Xcode Signing & Capabilities | Add "Sign In with Apple". Add "Associated Domains" with `applinks:whatsgoodhere.app`. |
+| `ios/App/App.entitlements` | Associated Domains entry. |
+| `PrivacyInfo.xcprivacy` | Audit after plugin install. Capgo may ship its own; we add/override only what's missing. |
+
+### Universal-link artifact
+
+| File | Purpose |
+|---|---|
+| `public/.well-known/apple-app-site-association` | JSON declaring `applinks` with `TEAMID.com.whatsgoodhere.app` appID and path patterns for `/auth/*`. Vercel serves with `Content-Type: application/json`. **Deferred until DNS wired.** Shipped in same PR that wires the DNS. |
+
+### New server modules
+
+| File | Purpose | Est. size |
+|---|---|---|
+| `supabase/migrations/20260420_user_apple_tokens.sql` | Create `user_apple_tokens` table: `user_id UUID PK REFERENCES auth.users(id) ON DELETE CASCADE`, `apple_sub TEXT NOT NULL`, `encrypted_refresh_token TEXT NOT NULL`, `key_version TEXT NOT NULL`, `created_at`, `updated_at`, `last_exchange_at`, `revoked_at`. RLS: deny all to authenticated role. Index on `apple_sub`. Includes `-- ROLLBACK:` block. | 30 |
+| `supabase/migrations/20260420_pending_apple_revocations.sql` | Create `pending_apple_revocations` table (no FK to users). `apple_sub`, `encrypted_refresh_token`, `key_version`, `attempts INT DEFAULT 0`, `last_attempt_at`, `next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`, `created_at`, `dead_letter BOOLEAN DEFAULT FALSE`. RLS: deny all. Index on `next_attempt_at WHERE attempts < MAX_ATTEMPTS AND NOT dead_letter`. | 25 |
+| `supabase/functions/_shared/apple.ts` | Shared Apple helper: `signClientSecretJWT()` (signs with `.p8` from Vault, 5-min TTL), `exchangeAuthorizationCode()` (POST `/auth/token`), `revokeToken()` (POST `/auth/revoke`), `decodeIdToken()` (parses `sub` and claims without external deps), shared error mapping. | 150 |
+| `supabase/functions/apple-token-exchange/index.ts` | Receives `{ authorization_code }` with `Authorization: Bearer <JWT>`. `getClaims()` → user_id. Looks up `auth.identities` for `apple_sub`. Calls `_shared/apple.exchangeAuthorizationCode()`. **Verifies decoded `id_token.sub` === stored `provider_id`** (security binding — without this, a stolen code could be bound to another user). Encrypts via Vault. UPSERTs `user_apple_tokens` (fresh code for existing user updates token; narrow idempotency window rejects same-event duplicates). Returns structured response with HTTP status. | 180–250 |
+| `supabase/functions/delete-account/index.ts` (edit) | Before existing cascade: query `auth.identities WHERE user_id = ? AND provider = 'apple'`. If Apple identity exists: fetch `user_apple_tokens` row, INSERT INTO `pending_apple_revocations` (mandatory — queue failure returns 500, blocks delete). Try inline revoke via `_shared/apple.revokeToken()`. Success → DELETE pending row. Failure → leave row for cron. Proceed with cascade regardless of revoke outcome. | 40 |
+| `supabase/functions/apple-revocation-retry/index.ts` | Invoked by `pg_cron` every 15min. SELECTs pending rows where `next_attempt_at <= NOW() AND attempts < MAX_ATTEMPTS AND NOT dead_letter`. For each: call `_shared/apple.revokeToken()`. Success → DELETE row. Apple 5xx/timeout → `attempts += 1`, `next_attempt_at = NOW() + backoff(attempts)` where backoff is `[15min, 1hr, 6hr, 24hr, 24hr, 24hr…]`. Apple 4xx → mark `dead_letter = true` (NOT retryable), Sentry event. Past MAX_ATTEMPTS → mark `dead_letter`, PostHog `apple_revoke_failed_final`. | 100 |
+
+### Config
+
+- Supabase Vault: store `.p8` contents, Apple Team ID, Key ID, Services ID, Apple encryption master key.
+- Supabase Auth → Providers → Apple: enabled, Client IDs = Bundle ID + Services ID, Team ID, Key ID, .p8 contents. Redirect allow-list includes `whatsgoodhere.app`.
+- Apple Developer portal: App ID `com.whatsgoodhere.app` + SIWA capability; Services ID `com.whatsgoodhere.service` + Associated Domains `whatsgoodhere.app` + Return URL `https://vpioftosgdkyiwvhxewy.supabase.co/auth/v1/callback`; .p8 key.
+- Google Cloud Console: iOS client ID for bundle `com.whatsgoodhere.app`. Verify existing web client ID still matches Supabase config.
+- Vercel project domain: add `whatsgoodhere.app`, provision Let's Encrypt cert, update DNS at registrar.
+- `pg_cron` schedule: `*/15 * * * *` invokes `apple-revocation-retry`.
+
+**Boundary rule (explicit):** `nativeAuth.js` is the only module importing `@capgo/capacitor-social-login`. No plugin-shaped objects escape. `authApi.js` pattern-matching on plugin error strings = boundary leak, fix it.
+
+---
+
+## Data flow
+
+### Flow A — Native Google sign-in
+
+```
+Tap Google → authApi.signInWithGoogle()
+  → isNativePlatform() === true → nativeAuth.signInWithGoogleNative()
+  → Capgo plugin opens iOS Google Sign-In sheet
+  → plugin returns { idToken, accessToken }
+  → supabase.auth.signInWithIdToken({ provider: 'google', token: idToken, access_token: accessToken })
+  → onAuthStateChange → AuthContext updates
+```
+No nonce dance. No `authorizationCode`. No server round-trip.
+
+### Flow B — Native Apple first sign-in
+
+```
+Tap Apple → authApi.signInWithApple()
+  → isNativePlatform() === true → nativeAuth.signInWithAppleNative()
+  → nonce.generateNonce() (raw, 64 hex chars) + sha256(raw) (hashed)
+  → Capgo plugin invokes ASAuthorizationController with scopes 'email name', hashed nonce
+  → Touch/Face ID → plugin returns { identityToken, authorizationCode, givenName, familyName, user = apple_sub }
+  → supabase.auth.signInWithIdToken({ provider: 'apple', token: identityToken, nonce: rawNonce })
+    → fails → abort, surface error, do NOT attempt server-side recovery
+    → succeeds → session set → onAuthStateChange fires
+  → persistFirstSignInName(givenName + familyName) runs INDEPENDENTLY of exchange
+  → if authorizationCode present:
+       POST apple-token-exchange (Bearer JWT, body: { authorization_code })
+       → Edge Function:
+            getClaims() → user_id
+            SELECT provider_id FROM auth.identities WHERE user_id=? AND provider='apple' → storedAppleSub
+            _shared/apple.signClientSecretJWT() (from Vault .p8)
+            _shared/apple.exchangeAuthorizationCode(code, client_id: BUNDLE_ID)
+              → Apple returns { refresh_token, id_token }
+            decodeIdToken(id_token) → decodedSub
+            ASSERT decodedSub === storedAppleSub → else 403 + Sentry
+            encrypt refresh_token via Vault → UPSERT user_apple_tokens (apple_sub from storedAppleSub, key_version, timestamps)
+            return 200
+       → on failure: log, surface metric, continue (Flow H heals later)
+```
+**Apple sub binding** (assert decodedSub === storedAppleSub) prevents a stolen code from being bound to an unrelated user's account.
+
+### Flow C — Native Apple returning sign-in
+
+```
+Same through signInWithIdToken.
+authorizationCode may or may not be present (Apple docs do NOT restrict to first time).
+Client posts to apple-token-exchange iff code present.
+Edge Function UPSERTs on matching apple_sub — fresh code = token refresh; same-event duplicate (same authorization_code hash) within ~60s window = 409.
+```
+Idempotent by design. No double-exchange problem.
+
+### Flow D — Email auth return (universal link)
+
+```
+Tap email-confirmation or password-reset link in iOS Mail
+  → iOS resolves applinks:whatsgoodhere.app
+  → /.well-known/apple-app-site-association authorizes the path
+  → iOS opens WGH app (not Safari)
+  → @capacitor/app appUrlOpen fires with URL containing ?code=... AND ?type=recovery|confirm|magiclink
+  → AuthLifecycle → authUrl.parse(url)
+  → supabase.auth.exchangeCodeForSession(code)
+    → success: route by type (recovery → reset page, confirm → welcome, magiclink → home)
+    → failure (code verifier not found = cross-device PKCE):
+        show message "Open this link on the device where you signed up, or request a new link here."
+        button: "Send new link to <email>" → triggers Supabase magic link
+```
+
+### Flow E — App foreground reconciliation
+
+```
+Return from background → @capacitor/app appStateChange fires isActive:true
+  → AuthLifecycle calls supabase.auth.getSession()
+  → Supabase re-reads storage + refreshes if expired
+  → onAuthStateChange fires on state change
+```
+
+### Flow F — Account deletion (Apple user)
+
+```
+Tap Delete → authApi.deleteAccount() → POST delete-account (Bearer JWT)
+  → Edge Function:
+       getClaims() → user_id
+       SELECT FROM auth.identities WHERE user_id=? AND provider='apple'
+       IF Apple identity:
+            SELECT FROM user_apple_tokens WHERE user_id=?
+            INSERT INTO pending_apple_revocations (apple_sub, encrypted_refresh_token, key_version, attempts=0)
+              → INSERT FAILS → return 500, BLOCK CASCADE (mandatory queue)
+              → INSERT OK → try _shared/apple.revokeToken()
+                   → success: DELETE pending row
+                   → failure: leave row, log, continue
+       Existing cascade: delete user data, auth.admin.deleteUser(user_id)
+       user_apple_tokens row cascades via FK
+       pending_apple_revocations row survives (no FK)
+       return 200
+```
+
+### Flow G — Apple revocation retry cron
+
+```
+pg_cron every 15min → apple-revocation-retry Edge Function
+  → SELECT FROM pending_apple_revocations
+       WHERE next_attempt_at <= NOW() AND attempts < MAX_ATTEMPTS AND NOT dead_letter
+  → For each row:
+       _shared/apple.revokeToken(row.encrypted_refresh_token, row.key_version)
+         → success: DELETE row, PostHog apple_revoke_succeeded
+         → Apple 5xx / timeout: UPDATE attempts += 1, next_attempt_at = NOW() + backoff(attempts)
+             backoff schedule (attempt → wait): [1→15min, 2→1hr, 3→6hr, 4→24hr, 5+→24hr]
+             MAX_ATTEMPTS = 10 (row dead-lettered ~9 days after first failure)
+         → Apple 4xx (invalid_grant, etc.): UPDATE dead_letter = true, Sentry event, PostHog apple_revoke_failed_final
+  → attempts past MAX_ATTEMPTS → UPDATE dead_letter = true, Sentry event once
+```
+
+### Flow H — Later Apple sign-in healing
+
+```
+User has Apple identity but no stored refresh token (earlier exchange failed or pre-existing user).
+Fresh Apple sign-in returns authorizationCode.
+apple-token-exchange sees no existing row → INSERT. Self-heals.
+```
+
+### Flow I — Provider logout
+
+```
+User signs out
+  → supabase.auth.signOut()
+  → if isNativePlatform(): nativeAuth.logout() → Capgo plugin clears native Google account picker cache
+```
+Without this, next Google tap silently reuses the same account. Problematic on shared devices.
+
+### Flow J — Cross-device PKCE failure (handled in Flow D)
+
+Same-device-only constraint from Supabase PKCE. Signup on desktop + email on phone → exchange fails with "code verifier not found". Friendly recovery: "Send new link to this device" button.
+
+**Invariants across all flows:**
+- Web bundle never imports Capacitor plugin symbols (dynamic import inside `nativeAuth.js`, gated on `isNativePlatform()`)
+- No auth state lives outside `supabase.auth.*` — `onAuthStateChange` is single source of truth
+- Bridge is the only module knowing plugin identity
+- Apple refresh tokens never reach the client after exchange
+- Deletion is never blocked by Apple API availability; it's blocked only by failure to durably queue the retry
+- Apple sub binding is asserted server-side before persisting tokens
+
+---
+
+## Error handling
+
+### Canonical top-level client codes (UI-facing)
+
+| Code | Meaning | UI behavior |
+|---|---|---|
+| `AUTH_USER_CANCELLED` | User dismissed native sheet | Silent, no toast. Modal stays open. |
+| `AUTH_NETWORK` | Transient network failure | Retry button, "Check your connection" |
+| `AUTH_RATE_LIMITED` | 429 from Apple/Google/Supabase | "Too many attempts. Please wait a moment and try again." |
+| `AUTH_CONFIG` | Deterministic misconfig | "Sign in unavailable — try email for now." Disable the offending button. |
+| `AUTH_SECURITY` | Nonce mismatch, invalid token, audience mismatch, apple sub mismatch | Generic "Sign in failed — please try again." Never leak specifics. |
+| `AUTH_UNKNOWN` | Catch-all | Generic copy + Sentry event. |
+
+### Internal subcodes (telemetry only)
+
+- `apple_invalid_client`, `apple_invalid_grant`, `apple_rate_limited`, `apple_unavailable`, `apple_sub_mismatch`
+- `google_plugin_init_failed`, `google_sdk_missing_clientid`
+- `supabase_provider_disabled`, `supabase_rate_limited`, `supabase_auth_500`
+- `nonce_mismatch`, `token_audience_mismatch`, `id_token_invalid`
+
+Errors carry `{ code: <top-level>, subcode: <fine-grained>, cause?: string }`. UI reads `code`; Sentry/PostHog read `subcode`.
+
+### Error shape
+
+**Client bridge (`nativeAuth.js`):** throws `{ code, subcode?, cause? }` — no plugin-native objects escape.
+
+**API layer (`authApi.js`):** catches bridge + Supabase errors, wraps with `createClassifiedError()` per CLAUDE.md §1.2. Returns `{ success: false, cancelled: true, code: 'AUTH_USER_CANCELLED' }` on cancel (does not throw). Throws classified error otherwise.
+
+**UI layer:** reads `error.message` via `getUserMessage(error, 'signing in')`. Never renders raw error objects (CLAUDE.md §1.2).
+
+**Edge Function response:** proper HTTP status code + flat JSON body `{ ok: true } | { ok: false, code, message, transient, subcode? }`.
+
+| Status | Meaning |
+|---|---|
+| 200 | Success |
+| 400 | Malformed request body |
+| 401 | JWT missing or invalid (client should sign out) |
+| 403 | Apple sub mismatch (security — never retry) |
+| 409 | Narrow idempotency conflict (same-event duplicate submission) |
+| 422 | Apple rejected the code (expired, already used) |
+| 429 | Rate limited (Apple or Supabase) |
+| 500 | Server bug, Vault unreachable (and ciphertext cannot be queued), misconfig |
+| 502 | Apple endpoint 5xx / timeout — transient |
+
+### Specific error mapping
+
+**`apple-token-exchange`:**
+- Apple `invalid_grant` → `422 { code: 'APPLE_CODE_INVALID', subcode: 'apple_invalid_grant', transient: false }`. Client logs, moves on. Flow H heals next sign-in.
+- Apple `invalid_client` / `unauthorized_client` → `500 { code: 'APPLE_CONFIG', subcode: 'apple_invalid_client', transient: false }` + Sentry page.
+- Apple 5xx / timeout → `502 { code: 'APPLE_UNAVAILABLE', subcode: 'apple_unavailable', transient: true }`. Client logs, doesn't block login.
+- Apple sub mismatch → `403 { code: 'AUTH_SECURITY', subcode: 'apple_sub_mismatch' }` + Sentry (hashed user_id, never raw sub).
+- JWT `getClaims()` fails → `401`. Client forces sign-out.
+- Vault inaccessible AND row cannot be persisted as queue ciphertext → `500`.
+
+**`delete-account`:**
+- Queue insert fails → `500 { code: 'DELETE_QUEUE_FAILED', transient: true }`. **No cascade.** User sees retry copy.
+- Revoke inline fails → still returns `200`. Cron owns it.
+- Vault inaccessible: if queue insert succeeded with raw ciphertext, return `200` (cron decrypts later when Vault recovers). If queue insert itself can't persist retryable material, return `500`.
+
+**`apple-revocation-retry`:**
+- Apple `invalid_grant` on retry → `dead_letter = true` immediately (not transient). Sentry event once.
+- Apple 5xx/timeout → `attempts += 1`, schedule next retry per backoff.
+
+### Observability
+
+- `AUTH_CONFIG` + `AUTH_SECURITY` errors → Sentry breadcrumb of provider + subcode.
+- `apple-token-exchange` failures tagged with **hashed** user_id and subcode. **Never `apple_sub`, `authorizationCode`, `accessToken`, `refresh_token`, or `idToken` in breadcrumbs.**
+- Per-session in-memory counter (not localStorage) for client-side network errors — fire one Sentry event after N ≥ 3 same-class failures.
+- `pending_apple_revocations` rows transitioning to `dead_letter = true` emit single Sentry event + PostHog `apple_revoke_failed_final`.
+
+**PostHog events:**
+- `login_started` (existing), `login_succeeded` (existing), `login_failed` (existing)
+- `apple_token_exchanged`, `apple_token_persisted`, `apple_token_exchange_failed`
+- `apple_revoke_queued`, `apple_revoke_succeeded`, `apple_revoke_failed_final`
+- `auth_cancelled`
+
+### Explicit non-goals
+
+- No automatic retry on security errors. Nonce mismatch or invalid token = refuse.
+- No client-side retry on Apple endpoint failures. Flow G owns that.
+- No generic "something went wrong" popups. Every surfaced error either has actionable copy or sends the user to a working alternative (email).
+- No Sentry breadcrumbs containing provider tokens, auth codes, or raw Apple identifiers. Forbidden list enforced via negative tests.
+
+---
+
+## Testing
+
+### Unit tests (Vitest)
+
+**`src/utils/nonce.test.js`** — `generateNonce()` format + uniqueness; `sha256()` matches RFC 6234 test vector.
+
+**`src/lib/nativeAuth.test.js`** (mock Capgo plugin) — Google/Apple success contracts; cancel → `AUTH_USER_CANCELLED`; network → `AUTH_NETWORK`; plugin init failure → `AUTH_CONFIG`; unknown → `AUTH_UNKNOWN`. Runtime validator asserts output/error shape conforms to strict allowed-keys schema. No plugin-native object escapes (boundary test).
+
+**`src/lib/authUrl.test.js`** — recovery/confirm/magiclink types; non-auth URL → `null`; malformed → `null` (no throw); missing code → `null`.
+
+**`src/api/authApi.test.js`** (mock supabase + nativeAuth) — web Google/Apple → `signInWithOAuth`; native Google → bridge then `signInWithIdToken` with `token` + `access_token`; native Apple first sign-in → `signInWithIdToken` then exchange invoked, `persistFirstSignInName` fires independently; native Apple returning → exchange OK (idempotent); `signInWithIdToken` failure → abort, no exchange; cancel returns structured result.
+
+### Integration tests (Vitest + Supabase test harness, mocked Apple/Google endpoints)
+
+**`apple-token-exchange`:** happy path; missing/invalid JWT → 401; token already exists + fresh code → UPDATE; duplicate submission within window → 409; Apple `invalid_grant` → 422; Apple `invalid_client` → 500 + Sentry; Apple 500 → 502 (transient); **Apple sub mismatch → 403 (security binding, critical)**; Vault unavailable → 500 when ciphertext cannot be persisted; JWT signing failure → 500; **client-supplied `apple_sub` in body is ignored** (derived server-side only).
+
+**`delete-account`:** non-Apple user → cascade only; Apple user + Apple 200 → pending inserted → revoke ok → pending deleted → cascade; Apple user + Apple 500 → pending survives → cascade still completes; Apple user + queue insert fails → 500, NO cascade; Apple user + Vault unavailable with queue OK → cascade proceeds (cron handles decrypt later); linked Google + Apple identities → pending for Apple side, both cleared.
+
+**`apple-revocation-retry`:** no pending → no-op; Apple 200 → row deleted, PostHog; Apple 5xx → `attempts += 1`, `next_attempt_at` per backoff; Apple `invalid_grant` → `dead_letter = true` immediately; past MAX_ATTEMPTS → `dead_letter`, Sentry once; `next_attempt_at > NOW()` skipped.
+
+### E2E tests (Playwright, staging on `whatsgoodhere.app`)
+
+**PR CI runs mocked provider callbacks**, not real Google/Apple (brittle, rate-limited). Real providers run on staging and real-device smoke only.
+
+- Web Google happy path (stubbed callback, Supabase service-role-created session)
+- Web Apple happy path (same pattern)
+- Password reset: request → follow mock email → land on reset page with valid session → sign in succeeds
+- **Cross-context PKCE failure:** start flow in one browser context, open callback URL in fresh clean context (no verifier) → friendly failure UI appears with "Send new link" affordance. Tests the real failure mode, not true cross-device.
+- Account deletion: full flow, verify `auth.users` row deleted, `profiles` cascaded, `pending_apple_revocations` empty or present as expected.
+
+### Real-device smoke (pre-TestFlight gate, 60–90 min total)
+
+Manual on real iPhone. Two passes:
+
+**Auth pass (~30 min):**
+- Native Google fresh, signed out
+- Native Google after sign-out (account picker works — doesn't auto-pick)
+- Native Apple first-time: name captured, display_name populated
+- Native Apple returning: server logs show single exchange OR 409 on second
+- Apple with Hide My Email: sign-in succeeds, relay email in profile, auth emails arrive
+- Sign out → next Google tap shows account picker, not auto-pick
+- Background → foreground: session stays valid after 30 min
+
+**Account + email + backend pass (~30–60 min):**
+- Password reset: request in app → open email in iOS Mail → tap link → app opens (not Safari) → reset → sign in
+- Email confirmation: new sign-up, same iOS Mail flow
+- Account deletion on Apple user (online): via direct DB, verify `pending_apple_revocations` empty after
+- Account deletion on Apple user (offline — airplane mode mid-delete): verify `pending_apple_revocations` row present with `attempts = 0`
+- Airplane mode during sign-in → clear network error UI, retry button works
+
+Backend visibility: direct Supabase SQL Editor. No dev-only public endpoints.
+
+### Security tests
+
+**Automated:**
+- Nonce mismatch rejects session (mock Supabase returning nonce-mismatch, verify generic security copy in UI).
+- `user_apple_tokens` RLS: authenticated role SELECT returns zero rows.
+- `pending_apple_revocations` RLS: authenticated role SELECT returns zero rows.
+- `apple-token-exchange` without Bearer JWT → 401.
+- **Apple sub binding test:** mock Apple response with mismatched `sub` → 403, no row written.
+- Negative observability: mock Sentry transport, trigger error paths, inspect fully serialized event payload, assert **none** of `apple_sub` / `authorizationCode` / `accessToken` / `refresh_token` / `idToken` / Bearer tokens / JWT-shaped regex appear. Run both client and server.
+
+**Manual (one-time pre-launch):**
+- Network capture during native Apple sign-in — verify `authorization_code` goes only to our `apple-token-exchange` endpoint over HTTPS.
+- Vault key rotation: rotate, verify old `pending_apple_revocations` rows decrypt via `key_version` lookup, verify new writes use new key. CI covers via fake crypto adapter with seeded multi-version keys; staging does one real E2E rotation per quarter.
+
+### AASA validation in CI
+
+- Fetch `https://whatsgoodhere.app/.well-known/apple-app-site-association`
+- Assert: 200 status, no redirects, `Content-Type: application/json`, valid JSON, schema includes `applinks` with appID `TEAMID.com.whatsgoodhere.app`, paths array non-empty
+- Real universal-link behavior validated on-device during smoke
+
+### Rollout gates
+
+**Before TestFlight upload:**
+- Unit + integration + E2E in CI passing
+- Real-device smoke fully green
+- `whatsgoodhere.app` resolves with valid Let's Encrypt cert
+- AASA file CI check passes
+- Apple Dev verification complete, SIWA capability enabled in App ID
+- Privacy manifest audit passed (Capgo plugin declares data collection)
+
+**Before App Store submission:**
+- All the above, plus:
+- One round of TestFlight internal testing (min 3 days)
+- Security test suite green on latest main
+- Key rotation dry-run successful in staging
+
+### Explicit non-goals
+
+- Real Apple/Google endpoints in CI (mock only — rate-limited, flaky).
+- Capgo plugin internals (test the contract, not the implementation).
+- Simulator Apple Sign-In (documented flaky — real-device only).
+
+---
+
+## Rollout
+
+### Phase 1 — Prerequisites (Dan-external, parallelizable)
+
+- Apple Developer account verification completes (external, waiting on Apple)
+- Apple Dev portal: App ID with SIWA capability, Services ID with `whatsgoodhere.app` associated domain, .p8 key generated
+- Google Cloud Console: iOS client ID for bundle `com.whatsgoodhere.app`
+- Vercel: point `whatsgoodhere.app` DNS at Vercel, provision cert
+
+### Phase 2 — Web PKCE migration (ship alone, low-risk)
+
+- `flowType: 'pkce'` in supabase.js
+- Rework `Login.jsx` hash → code handling + intent-preservation bug fix
+- Transitional fallback for legacy `#access_token` URLs
+- Fix `WelcomeModal` silent-error bug + open condition
+- Deploy, verify email confirmation and password reset still work on web
+
+### Phase 3 — Native auth + exchange + revocation (main ship)
+
+- Install `@capgo/capacitor-social-login`, `@capacitor/app`
+- Build `nativeAuth.js`, `nonce.js`, `authUrl.js`, `AuthLifecycle.jsx`
+- Supabase migrations: `user_apple_tokens`, `pending_apple_revocations`
+- `_shared/apple.ts` + `apple-token-exchange` + `apple-revocation-retry` Edge Functions
+- Extend `delete-account` with mandatory queue + revocation
+- Supabase Vault config (`.p8`, keys)
+- Supabase Auth → Providers → Apple enabled
+- Xcode: SIWA + Associated Domains capabilities
+- `pg_cron` schedule for `apple-revocation-retry`
+- AASA file shipped in same PR as DNS wiring
+- Unit + integration + E2E green in CI
+- Real-device smoke green
+- Merge, deploy to staging, TestFlight upload
+
+### Phase 4 — TestFlight + App Store submission
+
+- Internal testers for 3 days minimum
+- Address any feedback
+- Final security suite + key rotation drill
+- Submit to App Store review
+
+### Rollback
+
+- **Web PKCE issues post-deploy:** revert `flowType: 'pkce'`. Email links break for one day while migration queues; hash-mode resumes.
+- **Native Google issues in TestFlight:** feature-flag hide Google button on native (keeps Apple + email working). Ship patch.
+- **Apple SIWA issues in TestFlight:** must NOT hide Apple button if Google is shown (Apple 4.8). If Apple is unshippable, hide both Google and Apple → email-only until fix.
+- **`pending_apple_revocations` backlog grows:** temporarily run cron more aggressively (every 5 min). Dead-letter triage via direct SQL.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Apple Dev verification delayed | Web PKCE migration is independent — ships alone. Native work stays in a branch. |
+| Capgo plugin abandoned | Thin-bridge design means one-file swap. Reassess quarterly. |
+| Apple key/cert rotation mishandled | `key_version` column + tested rotation path. Staging drill quarterly. |
+| Private-relay users create duplicate accounts | Documented limitation. Manual account-link UI is post-launch. |
+| PKCE cross-device email flow confuses users | Friendly error + "Send new link here" affordance. Telemetry on failure rate post-launch. |
+| Apple sub binding check too strict (edge case where stored sub differs) | Fail loudly with Sentry, investigate per-case. Don't silently accept mismatch. |
+| `apple-token-exchange` fails after session set | Flow H self-heals on next sign-in. Non-blocking. |
+| Vault outage during delete | Queue stores opaque ciphertext, cron decrypts when Vault recovers. Delete proceeds. |
+| Universal link collision with existing paths | AASA `paths` array is explicit — only `/auth/*` subtree claims. |
+| Apple CDN caches old AASA | Apple documentation (TN3155) has debugging guidance; test on-device after changes. |
+| Google SDK privacy manifest requirements change | Audit after plugin install; override `PrivacyInfo.xcprivacy` if needed. |
+| Codex knowledge cutoff misses a 2026 change | Multiple review rounds + sources cited for every claim. |
+
+---
+
+## Dependencies
+
+**Blocks:**
+- TestFlight build
+- App Store submission
+- Resuming H2 plan (superseded in part by this spec)
+
+**Blocked by:**
+- Apple Developer account verification (external, waiting)
+- `whatsgoodhere.app` DNS → Vercel (Dan, ~15 min)
+- Google Cloud Console iOS client ID (Dan, one-time)
+
+**Related:**
+- L1 Privacy + Terms copy updates (coordinate with this spec)
+- Virtual business address decision (`project_business_address` memory) — independent, not blocked by this
+- Google Places TOS deferrals (`project_google_places_compliance`) — independent, not blocked by this
+
+---
+
+## Estimates
+
+| Area | Hours |
+|---|---|
+| Apple Developer + Google Cloud + Vercel config (Dan) | 2–3 |
+| Web PKCE migration (Phase 2) | 3–5 |
+| Bridge + native auth wiring | 6–10 |
+| `user_apple_tokens` + `_shared/apple.ts` + `apple-token-exchange` | 8–12 |
+| `delete-account` extension + `pending_apple_revocations` + cron | 6–10 |
+| Supabase Vault setup | 1–2 |
+| Xcode capabilities + AASA + Info.plist | 2–3 |
+| WelcomeModal + Privacy/Terms copy | 1–2 |
+| Unit + integration tests | 6–10 |
+| E2E + security tests | 4–6 |
+| Real-device smoke execution | 1–2 |
+
+**Total: 40–65 hours.**
+
+Against 2026-04-30 TestFlight checkpoint (10 days): tight but achievable if Phase 2 ships in parallel with Phase 1 external work. Against 2026-05-12 submission target: comfortable with room for TestFlight iteration.
+
+---
+
+## Revision log
+
+**2026-04-20 v1:** Drafted. Four pressure-test rounds with Codex gpt-5.4/high integrated. Corrections incorporated:
+- Architecture: replaced archived `@codetrix-studio/capacitor-google-auth` with `@capgo/capacitor-social-login` (covers both providers); moved auth lifecycle listeners out of `App.jsx` into `AuthLifecycle`; added `authUrl.js` parser; added `_shared/apple.ts` server helper; dropped `APPLE_SERVICES_ID` from client constants; deferred AASA until DNS wired.
+- Flows: made Apple code-exchange idempotent (not first-time-only); removed client-supplied `apple_sub`; made PKCE same-device limitation explicit with recovery UX; made delete-account queue insert mandatory; added Flow H (later sign-in healing) and Flow I (provider logout); tightened retry cadence from daily to aggressive-then-decaying.
+- Errors: added `AUTH_RATE_LIMITED`; separated top-level UI codes from internal subcodes; Apple 4xx is NOT transient; Vault outage doesn't block delete if ciphertext queue-able; explicit forbidden-in-Sentry list.
+- Tests: moved real provider OAuth out of PR CI to staging/manual; added Apple sub binding security test; changed 409 TOKEN_EXISTS to UPDATE semantics; expanded device smoke to 60–90min; added negative observability tests; AASA validated in CI.
+- Missed earlier and added: server-side Apple sub binding before persistence (prevents stolen-code attack).

--- a/docs/superpowers/specs/2026-04-20-oauth-native-and-apple-revocation-design.md
+++ b/docs/superpowers/specs/2026-04-20-oauth-native-and-apple-revocation-design.md
@@ -29,18 +29,19 @@ This spec closes all four gaps with one coherent architecture.
 
 Three layers, one mental model.
 
-### Layer 1 — Web PWA (one security upgrade, no UX change)
+### Layer 1 — Web PWA (security upgrade + Apple token capture)
 
 - Keep `supabase.auth.signInWithOAuth` for Google and Apple on web.
 - Migrate Supabase client from implicit flow to **PKCE flow** (`flowType: 'pkce'` in `src/lib/supabase.js`). Industry standard in 2026; removes tokens-in-URL-fragment risk.
-- **PKCE is not a one-line change.** `src/pages/Login.jsx` currently reads `window.location.hash` for post-confirmation state (email confirm, password recovery). PKCE changes callback shape from `#access_token=...` to `?code=...`, requiring rework of the entry handler to call `supabase.auth.exchangeCodeForSession(code)`.
-- Transitional handling for legacy `#access_token=` URLs (users with old email links in their inbox) for one release.
+- **PKCE callback ownership:** keep Supabase's `detectSessionInUrl: true` enabled (default). Supabase auto-handles the `?code=...` exchange on BOTH `/login` and `/reset-password` returns — no manual `exchangeCodeForSession()` in these entry points. Manual exchange lives ONLY in the Capacitor `appUrlOpen` handler, where Supabase's URL detection doesn't fire.
+- Old `#access_token=...` links from user inboxes: `detectSessionInUrl` continues to handle these transparently for one release. No dedicated fallback code needed in page components.
+- **Web Apple token capture (new):** a user who signs up via web Apple OAuth and never uses native still needs a revocation-capable refresh token stored server-side. On `onAuthStateChange` → `SIGNED_IN` with Apple identity and `session.provider_refresh_token` present, the client POSTs to a new `apple-token-persist` Edge Function that encrypts + stores it in `user_apple_tokens` with matching `apple_sub`. Supabase exposes `provider_refresh_token` briefly after web OAuth callback — we catch it there or lose it.
 
 ### Layer 2 — iOS native (the root fix)
 
 - Both Google and Apple use platform-native SDKs via `@capgo/capacitor-social-login` (actively maintained, one plugin for both providers; replaces abandoned `@codetrix-studio/capacitor-google-auth`).
 - Google: native iOS Google Sign-In SDK returns `{ idToken, accessToken }` → `supabase.auth.signInWithIdToken({ provider: 'google', token: idToken, access_token: accessToken })`.
-- Apple: native `ASAuthorizationController` returns `{ identityToken, authorizationCode, givenName, familyName, user = apple_sub }` → `supabase.auth.signInWithIdToken({ provider: 'apple', token: identityToken, nonce: rawNonce })`. First-sign-in extras trigger server-side `authorizationCode` exchange for refresh-token storage.
+- Apple: native `ASAuthorizationController` returns `{ identityToken, authorizationCode, givenName, familyName, user = apple_sub }` → `supabase.auth.signInWithIdToken({ provider: 'apple', token: identityToken, nonce: rawNonce })`. `authorizationCode` is NOT first-sign-in-only — Apple documents it as present on any successful auth. When present, client POSTs to `apple-token-exchange`; Edge Function UPSERTs (fresh code updates the stored refresh token; same-code duplicate within a 60s window is a 409).
 - No browser redirect, no deep-link dance, no custom scheme for OAuth.
 
 ### Layer 3 — Thin auth bridge (isolation guarantee)
@@ -54,11 +55,12 @@ Three layers, one mental model.
 
 Apple's guideline 5.1.1(v) requires apps supporting SIWA to revoke Apple's consent on account deletion. This needs:
 
-- **`user_apple_tokens`** table (per-user, refresh token ciphertext + key version + apple_sub). RLS: deny-all to authenticated role. Service-role only.
-- **`pending_apple_revocations`** table (no FK to users — survives cascade delete). Columns include `next_attempt_at` to drive aggressive-then-decaying retry cadence.
-- **`apple-token-exchange`** Edge Function: exchanges `authorizationCode` for refresh token on first Apple sign-in.
-- **`delete-account`** Edge Function (extended): queues the revocation BEFORE cascading delete. Queue insert is mandatory — failure blocks deletion.
-- **`apple-revocation-retry`** Edge Function: invoked by `pg_cron` every 15 minutes, retries pending revocations per backoff schedule.
+- **`user_apple_tokens`** table (per-user, refresh token ciphertext + `key_version` + `apple_sub` + `code_hash` for idempotency). RLS: deny-all to authenticated role. Service-role only. **Ciphertext is self-contained** — not a Vault reference handle — so the row can be copied byte-for-byte without needing Vault access at copy time.
+- **`pending_apple_revocations`** table (no FK to users — survives cascade delete). Columns include `next_attempt_at` (retry cadence), `locked_at` + `locked_by` (row leasing for concurrency safety), `unrevokable BOOLEAN` (sentinel for Apple identities we never captured a token for — tracked for audit but not retried).
+- **`apple-token-exchange`** Edge Function: native path. Exchanges `authorizationCode` whenever present (not first-sign-in-only). UPSERTs on matching `apple_sub` (fresh code = token refresh; duplicate within idempotency window = 409).
+- **`apple-token-persist`** Edge Function (new): web path. Receives `session.provider_refresh_token` from client on post-Apple-signin AuthStateChange. Encrypts + stores. Idempotent — duplicate submissions for same user no-op.
+- **`delete-account`** Edge Function (extended): queues the revocation BEFORE cascading delete. Queue insert is mandatory — failure blocks deletion. If Apple identity exists but no token row: insert sentinel row with `unrevokable = TRUE`, proceed with cascade.
+- **`apple-revocation-retry`** Edge Function: invoked by `pg_cron` every 15 minutes. Uses `FOR UPDATE SKIP LOCKED` with `locked_at` leasing to prevent concurrent workers from racing on the same row. Stale locks (> 10 min) auto-recoverable.
 - **Supabase Vault** for encryption key and `.p8` private key. Not raw `pgcrypto`.
 
 ### Universal links (canonical domain)
@@ -92,9 +94,11 @@ Apple's guideline 5.1.1(v) requires apps supporting SIWA to revoke Apple's conse
 
 | File | Change | Est. added lines |
 |---|---|---|
-| `src/api/authApi.js` | Add `Capacitor.isNativePlatform()` branches in `signInWithGoogle` and `signInWithApple`. Native branch calls bridge → `supabase.auth.signInWithIdToken`. On Apple native with `authorizationCode`, invoke `apple-token-exchange` (client body: `{ authorization_code }` only — no `apple_sub` or `user_id`). Apply nonce dance for Apple. Normalize errors. Add `signOut()` native branch that also calls Capgo's `logout()` to clear Google account picker. | 80–120 |
-| `src/lib/supabase.js` | Add `flowType: 'pkce'`. | 1 |
-| `src/pages/Login.jsx` | Handle both `?code=` (PKCE) and legacy `#access_token=` (one-release transition). Call `supabase.auth.exchangeCodeForSession()`. Fix existing `location.state?.from` intent-preservation bug. Activate Apple button. | 40 |
+| `src/api/authApi.js` | Add `Capacitor.isNativePlatform()` branches in `signInWithGoogle` and `signInWithApple`. Native branch calls bridge → `supabase.auth.signInWithIdToken`. On Apple with `authorizationCode` present (any sign-in), invoke `apple-token-exchange` (client body: `{ authorization_code }` only — no `apple_sub` or `user_id`). Apply nonce dance for Apple. Normalize errors. Add `signOut()` native branch that also calls Capgo's `logout()` to clear Google account picker. | 80–120 |
+| `src/lib/supabase.js` | Add `flowType: 'pkce'`. Keep `detectSessionInUrl: true` (default) — Supabase auto-handles `?code=` return on web. | 2 |
+| `src/context/AuthContext.jsx` (edit) | On `onAuthStateChange` → `SIGNED_IN` event: if identity is Apple AND `session.provider_refresh_token` is present, POST to `apple-token-persist` (web-path token capture). Fire-and-forget; failure is logged but non-blocking. | 15 |
+| `src/pages/Login.jsx` | Fix existing `location.state?.from` intent-preservation bug. Activate Apple button. (No manual `exchangeCodeForSession` — `detectSessionInUrl` handles it.) | 25 |
+| `src/pages/ResetPassword.jsx` (no edit needed) | `detectSessionInUrl` handles `?code=` automatically; existing logic reads session from `onAuthStateChange` once set. Verified during PKCE migration QA. | 0 |
 | `src/components/Auth/LoginModal.jsx` | Activate pre-wired Apple button with official SIWA asset. | 15 |
 | `src/components/Auth/WelcomeModal.jsx` | Open condition: `(!profile.has_onboarded \|\| !profile.display_name)`. Fix existing silent-error-on-duplicate-display_name bug (from H2 plan). | 10 |
 | `src/App.jsx` | Mount `AuthLifecycle` inside `AuthProvider`. No auth logic directly in App.jsx. | 5 |
@@ -119,12 +123,13 @@ Apple's guideline 5.1.1(v) requires apps supporting SIWA to revoke Apple's conse
 
 | File | Purpose | Est. size |
 |---|---|---|
-| `supabase/migrations/20260420_user_apple_tokens.sql` | Create `user_apple_tokens` table: `user_id UUID PK REFERENCES auth.users(id) ON DELETE CASCADE`, `apple_sub TEXT NOT NULL`, `encrypted_refresh_token TEXT NOT NULL`, `key_version TEXT NOT NULL`, `created_at`, `updated_at`, `last_exchange_at`, `revoked_at`. RLS: deny all to authenticated role. Index on `apple_sub`. Includes `-- ROLLBACK:` block. | 30 |
-| `supabase/migrations/20260420_pending_apple_revocations.sql` | Create `pending_apple_revocations` table (no FK to users). `apple_sub`, `encrypted_refresh_token`, `key_version`, `attempts INT DEFAULT 0`, `last_attempt_at`, `next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`, `created_at`, `dead_letter BOOLEAN DEFAULT FALSE`. RLS: deny all. Index on `next_attempt_at WHERE attempts < MAX_ATTEMPTS AND NOT dead_letter`. | 25 |
+| `supabase/migrations/20260420_user_apple_tokens.sql` | Create `user_apple_tokens` table: `user_id UUID PK REFERENCES auth.users(id) ON DELETE CASCADE`, `apple_sub TEXT NOT NULL`, `encrypted_refresh_token TEXT NOT NULL` (**self-contained ciphertext**, not a Vault reference), `key_version TEXT NOT NULL`, `code_hash TEXT` (SHA-256 of last `authorization_code` for idempotency), `created_at`, `updated_at`, `last_exchange_at`, `revoked_at`. RLS: deny all to authenticated role. Index on `apple_sub`. Unique index on `(user_id, code_hash)` for idempotency checks. Includes `-- ROLLBACK:` block. | 35 |
+| `supabase/migrations/20260420_pending_apple_revocations.sql` | Create `pending_apple_revocations` table (no FK to users — survives cascade). `apple_sub`, `encrypted_refresh_token`, `key_version`, `attempts INT DEFAULT 0`, `last_attempt_at`, `next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`, `locked_at TIMESTAMPTZ`, `locked_by TEXT`, `unrevokable BOOLEAN DEFAULT FALSE` (sentinel — Apple identity existed but no token was ever captured), `created_at`, `dead_letter BOOLEAN DEFAULT FALSE`. RLS: deny all. Index on `next_attempt_at WHERE attempts < MAX_ATTEMPTS AND NOT dead_letter AND NOT unrevokable`. | 35 |
 | `supabase/functions/_shared/apple.ts` | Shared Apple helper: `signClientSecretJWT()` (signs with `.p8` from Vault, 5-min TTL), `exchangeAuthorizationCode()` (POST `/auth/token`), `revokeToken()` (POST `/auth/revoke`), `decodeIdToken()` (parses `sub` and claims without external deps), shared error mapping. | 150 |
-| `supabase/functions/apple-token-exchange/index.ts` | Receives `{ authorization_code }` with `Authorization: Bearer <JWT>`. `getClaims()` → user_id. Looks up `auth.identities` for `apple_sub`. Calls `_shared/apple.exchangeAuthorizationCode()`. **Verifies decoded `id_token.sub` === stored `provider_id`** (security binding — without this, a stolen code could be bound to another user). Encrypts via Vault. UPSERTs `user_apple_tokens` (fresh code for existing user updates token; narrow idempotency window rejects same-event duplicates). Returns structured response with HTTP status. | 180–250 |
-| `supabase/functions/delete-account/index.ts` (edit) | Before existing cascade: query `auth.identities WHERE user_id = ? AND provider = 'apple'`. If Apple identity exists: fetch `user_apple_tokens` row, INSERT INTO `pending_apple_revocations` (mandatory — queue failure returns 500, blocks delete). Try inline revoke via `_shared/apple.revokeToken()`. Success → DELETE pending row. Failure → leave row for cron. Proceed with cascade regardless of revoke outcome. | 40 |
-| `supabase/functions/apple-revocation-retry/index.ts` | Invoked by `pg_cron` every 15min. SELECTs pending rows where `next_attempt_at <= NOW() AND attempts < MAX_ATTEMPTS AND NOT dead_letter`. For each: call `_shared/apple.revokeToken()`. Success → DELETE row. Apple 5xx/timeout → `attempts += 1`, `next_attempt_at = NOW() + backoff(attempts)` where backoff is `[15min, 1hr, 6hr, 24hr, 24hr, 24hr…]`. Apple 4xx → mark `dead_letter = true` (NOT retryable), Sentry event. Past MAX_ATTEMPTS → mark `dead_letter`, PostHog `apple_revoke_failed_final`. | 100 |
+| `supabase/functions/apple-token-exchange/index.ts` | **Native path.** Receives `{ authorization_code }` with `Authorization: Bearer <JWT>`. `getClaims()` → user_id. Looks up `auth.identities` for `apple_sub`. **Fail-closed if: no Apple identity row, multiple Apple identity rows, or `provider_id` null — all return 409/500 with Sentry.** Calls `_shared/apple.exchangeAuthorizationCode()`. **Verifies decoded `id_token.sub` === stored `provider_id`** (security binding). Hashes `authorization_code` (SHA-256) → `code_hash`. If existing row with same `code_hash` within 60s → 409 (duplicate submission). Else UPSERT — fresh code updates `encrypted_refresh_token`, `key_version`, `code_hash`, `updated_at`, `last_exchange_at`. Encrypts via Vault. Returns structured response with HTTP status. | 180–250 |
+| `supabase/functions/apple-token-persist/index.ts` (new) | **Web path.** Receives `{ provider_refresh_token }` with `Authorization: Bearer <JWT>`. `getClaims()` → user_id. Looks up `auth.identities` for `apple_sub`. Encrypts token via Vault. UPSERTs `user_apple_tokens` (idempotent — if row exists with same `apple_sub`, UPDATE; else INSERT). Does NOT call Apple endpoints (the token came from Supabase's own OAuth callback, already validated). Returns 200 on success, 400 if token missing, 401 if JWT invalid. | 80–100 |
+| `supabase/functions/delete-account/index.ts` (edit) | Before existing cascade: query `auth.identities WHERE user_id = ? AND provider = 'apple'`. If Apple identity exists: SELECT `user_apple_tokens` row. **Three cases:** (a) token row found → INSERT INTO `pending_apple_revocations` with full credential (mandatory — queue failure returns 500, blocks delete), try inline revoke, success → DELETE pending. (b) token row NOT found (web Apple who never synced, or prior exchange failed) → INSERT sentinel row with `apple_sub` + `unrevokable = TRUE` (mandatory for audit trail). (c) queue insert fails → 500, NO cascade. Proceed with cascade regardless of revoke outcome (case a/b both allow cascade). | 60 |
+| `supabase/functions/apple-revocation-retry/index.ts` | Invoked by `pg_cron` every 15min. Acquires row leases via `SELECT ... FOR UPDATE SKIP LOCKED` filtered by `next_attempt_at <= NOW() AND attempts < MAX_ATTEMPTS AND NOT dead_letter AND NOT unrevokable`. Stamps `locked_at = NOW()`, `locked_by = function_instance_id`. For each leased row: call `_shared/apple.revokeToken()`. Success → DELETE row. Apple 5xx/timeout → `attempts += 1`, `next_attempt_at = NOW() + backoff(attempts)` where backoff is `[1→15min, 2→1hr, 3→6hr, 4→24hr, 5+→24hr]`. Apple 4xx → mark `dead_letter = true` (NOT retryable), Sentry event. Past MAX_ATTEMPTS (=10) → mark `dead_letter`. Clears `locked_at` on exit. Stale leases (> 10min old) auto-recoverable on next cron tick. | 120 |
 
 ### Config
 
@@ -225,32 +230,52 @@ Tap Delete → authApi.deleteAccount() → POST delete-account (Bearer JWT)
        SELECT FROM auth.identities WHERE user_id=? AND provider='apple'
        IF Apple identity:
             SELECT FROM user_apple_tokens WHERE user_id=?
-            INSERT INTO pending_apple_revocations (apple_sub, encrypted_refresh_token, key_version, attempts=0)
-              → INSERT FAILS → return 500, BLOCK CASCADE (mandatory queue)
-              → INSERT OK → try _shared/apple.revokeToken()
-                   → success: DELETE pending row
-                   → failure: leave row, log, continue
+            CASE A — token row found:
+                 INSERT INTO pending_apple_revocations (apple_sub, encrypted_refresh_token, key_version, attempts=0)
+                   → INSERT FAILS → return 500, BLOCK CASCADE (mandatory queue)
+                   → INSERT OK → try _shared/apple.revokeToken()
+                        → success: DELETE pending row
+                        → failure: leave row, log, continue (cron handles retry)
+            CASE B — token row NOT found (web Apple never synced, or earlier exchange failed):
+                 INSERT INTO pending_apple_revocations (apple_sub, unrevokable=TRUE)
+                   → INSERT FAILS → return 500, BLOCK CASCADE (audit trail is mandatory)
+                   → INSERT OK → skip revoke attempt (no token to revoke)
+                   → PostHog apple_revoke_unrevokable (separate from revoke_failed)
        Existing cascade: delete user data, auth.admin.deleteUser(user_id)
        user_apple_tokens row cascades via FK
        pending_apple_revocations row survives (no FK)
        return 200
 ```
+Case B is honest — we can't revoke what we never captured. The sentinel row surfaces in health metrics so we see the volume and can tighten the web-capture path if it happens often.
 
 ### Flow G — Apple revocation retry cron
 
 ```
 pg_cron every 15min → apple-revocation-retry Edge Function
+  → BEGIN
   → SELECT FROM pending_apple_revocations
-       WHERE next_attempt_at <= NOW() AND attempts < MAX_ATTEMPTS AND NOT dead_letter
-  → For each row:
+       WHERE next_attempt_at <= NOW()
+         AND attempts < MAX_ATTEMPTS
+         AND NOT dead_letter
+         AND NOT unrevokable
+         AND (locked_at IS NULL OR locked_at < NOW() - INTERVAL '10 minutes')
+       FOR UPDATE SKIP LOCKED
+       LIMIT N
+  → For each leased row:
+       UPDATE locked_at = NOW(), locked_by = <function_instance_id>
        _shared/apple.revokeToken(row.encrypted_refresh_token, row.key_version)
          → success: DELETE row, PostHog apple_revoke_succeeded
-         → Apple 5xx / timeout: UPDATE attempts += 1, next_attempt_at = NOW() + backoff(attempts)
+         → Apple 5xx / timeout: UPDATE attempts += 1,
+             next_attempt_at = NOW() + backoff(attempts),
+             locked_at = NULL
              backoff schedule (attempt → wait): [1→15min, 2→1hr, 3→6hr, 4→24hr, 5+→24hr]
              MAX_ATTEMPTS = 10 (row dead-lettered ~9 days after first failure)
-         → Apple 4xx (invalid_grant, etc.): UPDATE dead_letter = true, Sentry event, PostHog apple_revoke_failed_final
-  → attempts past MAX_ATTEMPTS → UPDATE dead_letter = true, Sentry event once
+         → Apple 4xx (invalid_grant, etc.): UPDATE dead_letter = true,
+             locked_at = NULL, Sentry event, PostHog apple_revoke_failed_final
+  → attempts past MAX_ATTEMPTS → UPDATE dead_letter = true, locked_at = NULL, Sentry event once
+  → COMMIT
 ```
+`FOR UPDATE SKIP LOCKED` + `locked_at` lease prevents two cron invocations (or cron racing inline delete-flow revoke) from both grabbing the same row. Stale locks > 10min old are reclaimed automatically. `unrevokable` sentinels are never retried — they exist only for audit.
 
 ### Flow H — Later Apple sign-in healing
 
@@ -272,6 +297,31 @@ Without this, next Google tap silently reuses the same account. Problematic on s
 ### Flow J — Cross-device PKCE failure (handled in Flow D)
 
 Same-device-only constraint from Supabase PKCE. Signup on desktop + email on phone → exchange fails with "code verifier not found". Friendly recovery: "Send new link to this device" button.
+
+### Flow K — Web Apple token capture (first signin on web)
+
+```
+User signs in with Apple on web (PWA, not native)
+  → supabase.auth.signInWithOAuth({ provider: 'apple' }) → Supabase callback → session set
+  → onAuthStateChange fires SIGNED_IN with session.provider_refresh_token present (briefly, only on first post-callback event)
+  → AuthContext detects:
+       - provider is 'apple'
+       - session.provider_refresh_token is non-null
+       - identity row has apple_sub
+  → POST apple-token-persist (Bearer JWT, body: { provider_refresh_token })
+       → Edge Function:
+            getClaims() → user_id
+            SELECT provider_id FROM auth.identities WHERE user_id=? AND provider='apple' → apple_sub
+            encrypt provider_refresh_token via Vault
+            UPSERT user_apple_tokens (user_id, apple_sub, encrypted_refresh_token, key_version)
+              → fresh capture: INSERT
+              → existing row: UPDATE (idempotent — user may have re-authed Apple on web multiple times)
+            return 200
+  → client: fire-and-forget (logged failure is non-blocking; user is signed in)
+```
+**Why this flow exists:** Supabase exposes `provider_refresh_token` briefly after web OAuth callback. If we don't catch it there, it's gone — we can't get it back later without the user re-authorizing. A web-only Apple user who deletes their account would have no refresh token to revoke. This flow closes that compliance gap.
+
+**Timing sensitivity:** `onAuthStateChange` fires multiple times during session lifecycle; only the post-callback event carries `provider_refresh_token`. AuthContext tracks whether this user's row already has a stored token via a lightweight RPC check (or lets `apple-token-persist` handle idempotency). Either way, we don't lose the capture window.
 
 **Invariants across all flows:**
 - Web bundle never imports Capacitor plugin symbols (dynamic import inside `nativeAuth.js`, gated on `isNativePlatform()`)
@@ -338,9 +388,18 @@ Errors carry `{ code: <top-level>, subcode: <fine-grained>, cause?: string }`. U
 - Vault inaccessible AND row cannot be persisted as queue ciphertext → `500`.
 
 **`delete-account`:**
-- Queue insert fails → `500 { code: 'DELETE_QUEUE_FAILED', transient: true }`. **No cascade.** User sees retry copy.
+- Queue insert fails (either case A or case B sentinel) → `500 { code: 'DELETE_QUEUE_FAILED', transient: true }`. **No cascade.** User sees retry copy.
 - Revoke inline fails → still returns `200`. Cron owns it.
-- Vault inaccessible: if queue insert succeeded with raw ciphertext, return `200` (cron decrypts later when Vault recovers). If queue insert itself can't persist retryable material, return `500`.
+- Vault inaccessible: ciphertext in `user_apple_tokens` is self-contained (not a Vault reference), so the queue copy doesn't need Vault access. Return `200`, cron decrypts later when Vault recovers.
+- Apple identity exists but no token row → Case B sentinel path. Returns `200` with `unrevokable: true` flag internally (not exposed to client).
+- Multiple Apple identities for one user (shouldn't happen, Supabase dedupes) → fail-closed, `500`, Sentry page.
+
+**`apple-token-persist`:**
+- Missing `provider_refresh_token` → `400`.
+- JWT invalid → `401`.
+- No Apple identity row for user → `409 { code: 'NO_APPLE_IDENTITY' }`. Client silently drops — user may have signed in with a non-Apple provider; AuthContext's detection logic should have prevented this call.
+- Vault unavailable → `503 { transient: true }`. Client retries on next sign-in (the `provider_refresh_token` is gone after this session, but AuthContext can check a stored-token RPC on next login and prompt re-auth if missing — post-launch hardening).
+- Existing row for user with same `apple_sub` → UPDATE (idempotent).
 
 **`apple-revocation-retry`:**
 - Apple `invalid_grant` on retry → `dead_letter = true` immediately (not transient). Sentry event once.
@@ -382,11 +441,13 @@ Errors carry `{ code: <top-level>, subcode: <fine-grained>, cause?: string }`. U
 
 ### Integration tests (Vitest + Supabase test harness, mocked Apple/Google endpoints)
 
-**`apple-token-exchange`:** happy path; missing/invalid JWT → 401; token already exists + fresh code → UPDATE; duplicate submission within window → 409; Apple `invalid_grant` → 422; Apple `invalid_client` → 500 + Sentry; Apple 500 → 502 (transient); **Apple sub mismatch → 403 (security binding, critical)**; Vault unavailable → 500 when ciphertext cannot be persisted; JWT signing failure → 500; **client-supplied `apple_sub` in body is ignored** (derived server-side only).
+**`apple-token-exchange`:** happy path; missing/invalid JWT → 401; **no Apple identity for user → 409 fail-closed + Sentry**; **multiple Apple identities → 500 fail-closed + Sentry**; **apple_sub null on identity row → 500 fail-closed + Sentry**; token already exists + fresh code → UPDATE with new `code_hash`; duplicate submission within 60s (same `code_hash`) → 409; Apple `invalid_grant` → 422; Apple `invalid_client` → 500 + Sentry; Apple 500 → 502 (transient); **Apple sub mismatch (decoded id_token.sub ≠ stored provider_id) → 403 (security binding, critical)**; Vault unavailable → 500 when ciphertext cannot be persisted; JWT signing failure → 500; **client-supplied `apple_sub` in body is ignored** (derived server-side only).
 
-**`delete-account`:** non-Apple user → cascade only; Apple user + Apple 200 → pending inserted → revoke ok → pending deleted → cascade; Apple user + Apple 500 → pending survives → cascade still completes; Apple user + queue insert fails → 500, NO cascade; Apple user + Vault unavailable with queue OK → cascade proceeds (cron handles decrypt later); linked Google + Apple identities → pending for Apple side, both cleared.
+**`delete-account`:** non-Apple user → cascade only; Apple user + token row + Apple 200 → pending inserted → revoke ok → pending deleted → cascade (Case A happy); Apple user + token row + Apple 500 → pending survives → cascade still completes (Case A degraded); Apple user + queue insert fails → 500, NO cascade; Apple user + Vault unavailable + queue OK → cascade proceeds (cron decrypts later); **Apple user + NO token row → unrevokable sentinel inserted, cascade proceeds (Case B)**; **Apple user + NO token row + sentinel insert fails → 500, NO cascade**; linked Google + Apple identities → pending for Apple side, both identities cleared by cascade.
 
-**`apple-revocation-retry`:** no pending → no-op; Apple 200 → row deleted, PostHog; Apple 5xx → `attempts += 1`, `next_attempt_at` per backoff; Apple `invalid_grant` → `dead_letter = true` immediately; past MAX_ATTEMPTS → `dead_letter`, Sentry once; `next_attempt_at > NOW()` skipped.
+**`apple-token-persist`:** happy path (valid JWT + provider_refresh_token + Apple identity exists) → encrypted + upserted + 200; missing body → 400; invalid JWT → 401; no Apple identity → 409 `NO_APPLE_IDENTITY`; Vault unavailable → 503 transient; existing row same apple_sub → UPDATE, 200; existing row different apple_sub (edge case: account-link shenanigans) → 409, Sentry page.
+
+**`apple-revocation-retry`:** no pending → no-op; Apple 200 → row deleted, PostHog; Apple 5xx → `attempts += 1`, `next_attempt_at` per backoff; Apple `invalid_grant` → `dead_letter = true` immediately; past MAX_ATTEMPTS → `dead_letter`, Sentry once; `next_attempt_at > NOW()` skipped; **unrevokable sentinel rows are never selected**; **concurrency test: two workers run in parallel against the same pending row — one acquires lease via FOR UPDATE SKIP LOCKED, the other skips; no double-revoke; stale lease (locked_at > 10min old) is reclaimed on next tick**.
 
 ### E2E tests (Playwright, staging on `whatsgoodhere.app`)
 
@@ -405,8 +466,9 @@ Manual on real iPhone. Two passes:
 **Auth pass (~30 min):**
 - Native Google fresh, signed out
 - Native Google after sign-out (account picker works — doesn't auto-pick)
-- Native Apple first-time: name captured, display_name populated
-- Native Apple returning: server logs show single exchange OR 409 on second
+- Native Apple first-time: name captured, display_name populated, `user_apple_tokens` row present with `code_hash` set
+- Native Apple returning: server logs show exchange hits UPDATE path (not INSERT), `code_hash` changes, `last_exchange_at` advances; rapid double-tap within 60s returns 409 once
+- Web Apple first sign-in: `apple-token-persist` endpoint called, `user_apple_tokens` row present after page refresh (verifies Flow K end-to-end)
 - Apple with Hide My Email: sign-in succeeds, relay email in profile, auth emails arrive
 - Sign out → next Google tap shows account picker, not auto-pick
 - Background → foreground: session stays valid after 30 min
@@ -414,8 +476,9 @@ Manual on real iPhone. Two passes:
 **Account + email + backend pass (~30–60 min):**
 - Password reset: request in app → open email in iOS Mail → tap link → app opens (not Safari) → reset → sign in
 - Email confirmation: new sign-up, same iOS Mail flow
-- Account deletion on Apple user (online): via direct DB, verify `pending_apple_revocations` empty after
-- Account deletion on Apple user (offline — airplane mode mid-delete): verify `pending_apple_revocations` row present with `attempts = 0`
+- Account deletion on Apple user WITH token (Case A, online): via direct DB, verify `pending_apple_revocations` empty after (inline revoke succeeded + DELETE)
+- Account deletion on Apple user WITH token (Case A, offline — airplane mode mid-delete): verify `pending_apple_revocations` row present with `attempts = 0`, `unrevokable = FALSE`, cron picks it up later
+- Account deletion on Apple user WITHOUT token (Case B — web Apple who never synced): simulate by deleting token row before delete, verify sentinel row present with `unrevokable = TRUE`, cascade completed
 - Airplane mode during sign-in → clear network error UI, retry button works
 
 Backend visibility: direct Supabase SQL Editor. No dev-only public endpoints.
@@ -555,25 +618,45 @@ Backend visibility: direct Supabase SQL Editor. No dev-only public endpoints.
 
 | Area | Hours |
 |---|---|
-| Apple Developer + Google Cloud + Vercel config (Dan) | 2–3 |
+| Apple Developer + Google Cloud + Vercel DNS config (Dan) | 2–3 |
 | Web PKCE migration (Phase 2) | 3–5 |
 | Bridge + native auth wiring | 6–10 |
-| `user_apple_tokens` + `_shared/apple.ts` + `apple-token-exchange` | 8–12 |
-| `delete-account` extension + `pending_apple_revocations` + cron | 6–10 |
-| Supabase Vault setup | 1–2 |
-| Xcode capabilities + AASA + Info.plist | 2–3 |
-| WelcomeModal + Privacy/Terms copy | 1–2 |
-| Unit + integration tests | 6–10 |
+| `user_apple_tokens` + `code_hash` + `_shared/apple.ts` + `apple-token-exchange` (with fail-closed identity checks + apple_sub binding) | 10–14 |
+| `apple-token-persist` Edge Function + AuthContext web-capture wiring (new) | 4–6 |
+| `delete-account` extension (Case A + Case B sentinel) + `pending_apple_revocations` with `locked_at`/`locked_by`/`unrevokable` | 7–11 |
+| `apple-revocation-retry` with `FOR UPDATE SKIP LOCKED` + concurrency tests | 5–7 |
+| Supabase Vault setup + self-contained ciphertext verification | 1–2 |
+| Xcode capabilities + AASA + Info.plist (after DNS wired) | 2–3 |
+| WelcomeModal + Privacy/Terms copy + canonical domain sweep | 1–2 |
+| Unit + integration tests (including concurrency + negative observability + Case B + Flow K) | 8–12 |
 | E2E + security tests | 4–6 |
-| Real-device smoke execution | 1–2 |
+| Real-device smoke execution (60–90 min/pass, expect 2 passes) | 2–3 |
 
-**Total: 40–65 hours.**
+**Total: 55–84 hours.**
 
-Against 2026-04-30 TestFlight checkpoint (10 days): tight but achievable if Phase 2 ships in parallel with Phase 1 external work. Against 2026-05-12 submission target: comfortable with room for TestFlight iteration.
+Against 2026-04-30 TestFlight checkpoint (10 days): tight. Phase 2 (web PKCE, ~3–5h) can ship in parallel with Phase 1 external Dan tasks. Phase 3 native + revocation work is the long pole. Against 2026-05-12 submission target: achievable with disciplined sequencing and one TestFlight iteration round.
+
+**Critical-path dependencies:**
+- `whatsgoodhere.app` DNS → Vercel → cert provisioned MUST happen before AASA + universal-link testing can begin.
+- Apple Dev verification MUST complete before SIWA capability enable + Services ID config + .p8 generation.
+- Supabase Vault key + `.p8` upload MUST happen before `apple-token-exchange` can be tested against a staged Apple environment.
+- None of these three are coding tasks — they gate but don't consume engineering time.
 
 ---
 
 ## Revision log
+
+**2026-04-20 v2 (end-to-end review with Codex gpt-5.4/high):**
+- Added web Apple token capture path: new `apple-token-persist` Edge Function + AuthContext wiring + Flow K. Closes compliance gap where web-only Apple users had no revocation-capable refresh token.
+- PKCE callback ownership resolved: `detectSessionInUrl: true` stays on; manual `exchangeCodeForSession()` only lives in Capacitor `appUrlOpen` handler. Supabase auto-handles `?code=` on `/login` AND `/reset-password` returns; no dedicated legacy-hash fallback code needed in page components.
+- `pending_apple_revocations` gains `locked_at`, `locked_by`, `unrevokable` columns. Retry cron uses `FOR UPDATE SKIP LOCKED` with 10-min stale-lease reclamation. Prevents double-revoke from concurrent workers or cron-racing-inline-delete-revoke.
+- `user_apple_tokens` gains `code_hash` (SHA-256 of last authorization_code) with unique `(user_id, code_hash)` index. Persistent idempotency check for 60s-window duplicate submissions; fresh codes UPDATE.
+- Flow F Case B sentinel path: Apple identity exists but no token row → insert `unrevokable = TRUE` row for audit, proceed with cascade. Honest about what we can't revoke.
+- `apple-token-exchange` gains fail-closed checks: no Apple identity / multiple identities / null `provider_id` → 409/500 + Sentry. Prevents corrupted-state silent accepts.
+- Swept "first sign-in" wording across architecture and overview sections to align with "authorizationCode may be present on any Apple sign-in; fresh code UPDATES."
+- Ciphertext self-containment made explicit in migration comments: `encrypted_refresh_token` is real ciphertext + `key_version`, not a Vault reference handle. Enables Vault-outage-tolerant queue copies during delete.
+- Smoke checklist updated: verifies UPDATE path (not INSERT) on returning Apple, Case B simulation for web-Apple-no-token, Flow K end-to-end.
+- Estimates revised 40–65h → 55–84h for concurrency hardening, web capture path, additional tests.
 
 **2026-04-20 v1:** Drafted. Four pressure-test rounds with Codex gpt-5.4/high integrated. Corrections incorporated:
 - Architecture: replaced archived `@codetrix-studio/capacitor-google-auth` with `@capgo/capacitor-social-login` (covers both providers); moved auth lifecycle listeners out of `App.jsx` into `AuthLifecycle`; added `authUrl.js` parser; added `_shared/apple.ts` server helper; dropped `APPLE_SERVICES_ID` from client constants; deferred AASA until DNS wired.

--- a/docs/superpowers/specs/2026-04-20-oauth-native-and-apple-revocation-design.md
+++ b/docs/superpowers/specs/2026-04-20-oauth-native-and-apple-revocation-design.md
@@ -231,22 +231,31 @@ Tap Delete → authApi.deleteAccount() → POST delete-account (Bearer JWT)
        IF Apple identity:
             SELECT FROM user_apple_tokens WHERE user_id=?
             CASE A — token row found:
-                 INSERT INTO pending_apple_revocations (apple_sub, encrypted_refresh_token, key_version, attempts=0)
+                 INSERT INTO pending_apple_revocations (
+                   apple_sub, encrypted_refresh_token, key_version, attempts=0,
+                   locked_at=NOW(), locked_by='delete-account:<request_id>'
+                 )
                    → INSERT FAILS → return 500, BLOCK CASCADE (mandatory queue)
-                   → INSERT OK → try _shared/apple.revokeToken()
-                        → success: DELETE pending row
-                        → failure: leave row, log, continue (cron handles retry)
+                   → INSERT OK → row is LEASED to this request — cron cannot pick it up
+                        → try _shared/apple.revokeToken()
+                            → success: DELETE pending row
+                            → failure: UPDATE locked_at=NULL, locked_by=NULL (releases lease for cron pickup), log, continue
             CASE B — token row NOT found (web Apple never synced, or earlier exchange failed):
                  INSERT INTO pending_apple_revocations (apple_sub, unrevokable=TRUE)
                    → INSERT FAILS → return 500, BLOCK CASCADE (audit trail is mandatory)
                    → INSERT OK → skip revoke attempt (no token to revoke)
                    → PostHog apple_revoke_unrevokable (separate from revoke_failed)
+            AUTH.IDENTITIES DEGRADED STATES (fail-closed, mirror apple-token-exchange):
+                 → multiple Apple identity rows for one user → 500, Sentry page, NO cascade
+                 → Apple identity row with null provider_id → 500, Sentry page, NO cascade
        Existing cascade: delete user data, auth.admin.deleteUser(user_id)
        user_apple_tokens row cascades via FK
        pending_apple_revocations row survives (no FK)
        return 200
 ```
 Case B is honest — we can't revoke what we never captured. The sentinel row surfaces in health metrics so we see the volume and can tighten the web-capture path if it happens often.
+
+**Concurrency guarantee:** Case A's pending row is inserted ALREADY LEASED (`locked_at = NOW()`, `locked_by = 'delete-account:<request_id>'`). This makes the row invisible to the retry cron (which filters `locked_at IS NULL OR locked_at < NOW() - 10min`) until either (a) inline revoke succeeds and deletes the row, or (b) inline revoke fails and explicitly clears the lease for cron pickup. Eliminates the double-revoke race between inline revoke and cron.
 
 ### Flow G — Apple revocation retry cron
 
@@ -298,7 +307,7 @@ Without this, next Google tap silently reuses the same account. Problematic on s
 
 Same-device-only constraint from Supabase PKCE. Signup on desktop + email on phone → exchange fails with "code verifier not found". Friendly recovery: "Send new link to this device" button.
 
-### Flow K — Web Apple token capture (first signin on web)
+### Flow K — Web Apple token capture (on any web Apple sign-in with provider_refresh_token present)
 
 ```
 User signs in with Apple on web (PWA, not native)
@@ -309,6 +318,8 @@ User signs in with Apple on web (PWA, not native)
        - session.provider_refresh_token is non-null
        - identity row has apple_sub
   → POST apple-token-persist (Bearer JWT, body: { provider_refresh_token })
+       → on transient failure (network, 5xx, 503): retry ONCE after 1s while provider_refresh_token is still in memory
+       → on second failure: log + PostHog apple_token_persist_failed, continue (user is signed in; residual misses fall into Case B at delete time)
        → Edge Function:
             getClaims() → user_id
             SELECT provider_id FROM auth.identities WHERE user_id=? AND provider='apple' → apple_sub
@@ -317,11 +328,10 @@ User signs in with Apple on web (PWA, not native)
               → fresh capture: INSERT
               → existing row: UPDATE (idempotent — user may have re-authed Apple on web multiple times)
             return 200
-  → client: fire-and-forget (logged failure is non-blocking; user is signed in)
 ```
-**Why this flow exists:** Supabase exposes `provider_refresh_token` briefly after web OAuth callback. If we don't catch it there, it's gone — we can't get it back later without the user re-authorizing. A web-only Apple user who deletes their account would have no refresh token to revoke. This flow closes that compliance gap.
+**Why this flow exists:** Supabase exposes `provider_refresh_token` briefly after web OAuth callback. If we don't catch it there, it's gone — we can't get it back later without the user re-authorizing. A web-only Apple user who deletes their account would have no refresh token to revoke. This flow captures the token on the normal web path; Case B (delete-time sentinel) covers residual misses.
 
-**Timing sensitivity:** `onAuthStateChange` fires multiple times during session lifecycle; only the post-callback event carries `provider_refresh_token`. AuthContext tracks whether this user's row already has a stored token via a lightweight RPC check (or lets `apple-token-persist` handle idempotency). Either way, we don't lose the capture window.
+**Timing sensitivity:** `onAuthStateChange` fires multiple times during session lifecycle; only the post-callback event carries `provider_refresh_token`. AuthContext tracks whether this user's row already has a stored token via a lightweight RPC check (or lets `apple-token-persist` handle idempotency). Either way, the retry-once-in-session policy reduces Case B to transient-network edge cases.
 
 **Invariants across all flows:**
 - Web bundle never imports Capacitor plugin symbols (dynamic import inside `nativeAuth.js`, gated on `isNativePlatform()`)
@@ -538,26 +548,30 @@ Backend visibility: direct Supabase SQL Editor. No dev-only public endpoints.
 
 ### Phase 2 — Web PKCE migration (ship alone, low-risk)
 
-- `flowType: 'pkce'` in supabase.js
-- Rework `Login.jsx` hash → code handling + intent-preservation bug fix
-- Transitional fallback for legacy `#access_token` URLs
-- Fix `WelcomeModal` silent-error bug + open condition
-- Deploy, verify email confirmation and password reset still work on web
+- `flowType: 'pkce'` in `src/lib/supabase.js` (keep `detectSessionInUrl: true` — Supabase auto-handles `?code=` return on both `/login` and `/reset-password`)
+- Fix existing `location.state?.from` intent-preservation bug in `Login.jsx`
+- Fix `WelcomeModal` silent-error-on-duplicate-display_name bug + extend open condition to `!display_name`
+- Deploy, verify email confirmation and password reset still work on web (including users hitting old `#access_token=` URLs — Supabase handles the transition window transparently)
+- No manual `exchangeCodeForSession()` calls in page components. That logic belongs only in Capacitor `appUrlOpen` handler, which ships in Phase 3.
 
-### Phase 3 — Native auth + exchange + revocation (main ship)
+### Phase 3 — Native auth + exchange + revocation + web Apple capture (main ship)
 
 - Install `@capgo/capacitor-social-login`, `@capacitor/app`
 - Build `nativeAuth.js`, `nonce.js`, `authUrl.js`, `AuthLifecycle.jsx`
-- Supabase migrations: `user_apple_tokens`, `pending_apple_revocations`
-- `_shared/apple.ts` + `apple-token-exchange` + `apple-revocation-retry` Edge Functions
-- Extend `delete-account` with mandatory queue + revocation
-- Supabase Vault config (`.p8`, keys)
-- Supabase Auth → Providers → Apple enabled
+- **Wire `apple-token-persist` capture path in `AuthContext`** — detect web Apple sign-in with `session.provider_refresh_token` on `onAuthStateChange` → `SIGNED_IN`, POST with one retry on transient failure (1s delay) to reduce Case B rate, fire-and-forget on final failure
+- Supabase migrations: `user_apple_tokens` (with `code_hash`), `pending_apple_revocations` (with `locked_at`, `locked_by`, `unrevokable`)
+- `_shared/apple.ts` helper
+- `apple-token-exchange` Edge Function (native path, with fail-closed identity checks + apple_sub binding)
+- **`apple-token-persist` Edge Function (web path, for captured provider_refresh_token)**
+- `apple-revocation-retry` Edge Function with `FOR UPDATE SKIP LOCKED` + lease reclamation
+- Extend `delete-account` with pre-leased pending row (Case A) + unrevokable sentinel (Case B) + fail-closed on Apple identity degraded states
+- Supabase Vault config (`.p8`, encryption master key)
+- Supabase Auth → Providers → Apple enabled with redirect allow-list for `whatsgoodhere.app`
 - Xcode: SIWA + Associated Domains capabilities
-- `pg_cron` schedule for `apple-revocation-retry`
+- `pg_cron` schedule for `apple-revocation-retry` (every 15 min)
 - AASA file shipped in same PR as DNS wiring
-- Unit + integration + E2E green in CI
-- Real-device smoke green
+- Unit + integration + E2E green in CI (including concurrency, Flow K, Case B, negative observability)
+- Real-device smoke green (60–90 min/pass, both auth + account passes)
 - Merge, deploy to staging, TestFlight upload
 
 ### Phase 4 — TestFlight + App Store submission
@@ -645,6 +659,14 @@ Against 2026-04-30 TestFlight checkpoint (10 days): tight. Phase 2 (web PKCE, ~3
 ---
 
 ## Revision log
+
+**2026-04-20 v3 (post-v2 Codex confirmation pass):**
+- **Blocker fix:** `delete-account` Case A inline revoke was racing the cron. Fix: INSERT the pending row ALREADY LEASED (`locked_at = NOW()`, `locked_by = 'delete-account:<request_id>'`). Row is invisible to cron until inline revoke completes or explicitly releases the lease.
+- Delete flow gains explicit fail-closed branches for Apple identity degraded states (multiple identities, null provider_id), mirroring `apple-token-exchange`.
+- Phase 2 rollout text rewritten: no manual `exchangeCodeForSession` in `Login.jsx`/`ResetPassword.jsx` — `detectSessionInUrl: true` handles both.
+- Phase 3 rollout text gains explicit `apple-token-persist` + AuthContext web-capture entries (was architecturally present but not in the ship list).
+- Flow K adds an immediate in-session retry (1s delay, one attempt) before giving up on `apple-token-persist`, reducing Case B fallback rate. "Closes the gap" softened to "captures on normal path; Case B covers residual misses."
+- Flow K header renamed from "first signin on web" to "on any web Apple sign-in with provider_refresh_token present" to match UPSERT semantics.
 
 **2026-04-20 v2 (end-to-end review with Codex gpt-5.4/high):**
 - Added web Apple token capture path: new `apple-token-persist` Edge Function + AuthContext wiring + Flow K. Closes compliance gap where web-only Apple users had no revocation-capable refresh token.

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -34,6 +34,7 @@ export const supabase = createClient(
       storageKey: 'whats-good-here-auth',
       autoRefreshToken: true,
       detectSessionInUrl: true,
+      flowType: 'pkce',
     }
   }
 )

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -6,6 +6,7 @@ import { logger } from '../utils/logger'
 import { CameraIcon } from '../components/CameraIcon'
 import { SmileyPin } from '../components/SmileyPin'
 import { FEATURES } from '../constants/features'
+import { getAuthUrlType } from '../utils/authUrlType'
 
 // SECURITY: Email is NOT persisted to storage to prevent XSS exposure of PII
 
@@ -17,8 +18,9 @@ export function Login() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [username, setUsername] = useState('')
-  // If user arrives with confirmation hash params, go straight to sign-in
-  const isPostConfirmation = window.location.hash.includes('type=signup') || window.location.hash.includes('type=email')
+  // If user arrives with confirmation params (PKCE query or legacy hash), go straight to sign-in
+  const authUrlType = getAuthUrlType(window.location.href)
+  const isPostConfirmation = authUrlType === 'signup' || authUrlType === 'email'
   const [message, setMessage] = useState(
     isPostConfirmation ? { type: 'success', text: 'Email verified! Sign in to get started.' } : null
   )

--- a/src/pages/ResetPassword.jsx
+++ b/src/pages/ResetPassword.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { authApi } from '../api/authApi'
+import { supabase } from '../lib/supabase'
 import { SmileyPin } from '../components/SmileyPin'
 
 export function ResetPassword() {
@@ -12,12 +13,16 @@ export function ResetPassword() {
   const [isValidSession, setIsValidSession] = useState(false)
   const [checkingSession, setCheckingSession] = useState(true)
 
-  // Check if we have a valid recovery session
+  // Under PKCE, Supabase exchanges ?code= asynchronously, so we subscribe
+  // to auth events instead of relying on a single getSession() read that
+  // can fire before the exchange completes.
   useEffect(() => {
-    const checkSession = async () => {
-      // Supabase automatically handles the recovery token from the URL
-      const { data: { session } } = await authApi.getSession()
+    let decided = false
+    let cancelled = false
 
+    const decide = (session) => {
+      if (cancelled || decided) return
+      decided = true
       if (session) {
         setIsValidSession(true)
       } else {
@@ -29,7 +34,27 @@ export function ResetPassword() {
       setCheckingSession(false)
     }
 
-    checkSession()
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === 'PASSWORD_RECOVERY' || event === 'SIGNED_IN') {
+        decide(session)
+      } else if (event === 'INITIAL_SESSION' && session) {
+        decide(session)
+      }
+    })
+
+    // Fallback: if no recovery/signed-in event arrives within 5s, resolve
+    // with whatever getSession reports. Guards against silent init failure.
+    const timer = setTimeout(async () => {
+      if (cancelled || decided) return
+      const { data: { session } } = await supabase.auth.getSession()
+      decide(session)
+    }, 5000)
+
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+      subscription.unsubscribe()
+    }
   }, [])
 
   const handleSubmit = async (e) => {

--- a/src/utils/authUrlType.js
+++ b/src/utils/authUrlType.js
@@ -1,0 +1,28 @@
+const KNOWN_TYPES = new Set([
+  'signup',
+  'email',
+  'recovery',
+  'magiclink',
+  'invite',
+  'email_change',
+])
+
+export function getAuthUrlType(urlString) {
+  if (!urlString || typeof urlString !== 'string') return null
+  let url
+  try {
+    url = new URL(urlString)
+  } catch {
+    return null
+  }
+
+  const queryType = url.searchParams.get('type')
+  if (queryType && KNOWN_TYPES.has(queryType)) return queryType
+
+  const hash = url.hash.startsWith('#') ? url.hash.slice(1) : url.hash
+  const hashParams = new URLSearchParams(hash)
+  const hashType = hashParams.get('type')
+  if (hashType && KNOWN_TYPES.has(hashType)) return hashType
+
+  return null
+}

--- a/src/utils/authUrlType.test.js
+++ b/src/utils/authUrlType.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { getAuthUrlType } from './authUrlType'
+
+describe('getAuthUrlType', () => {
+  it('returns null for a plain URL', () => {
+    expect(getAuthUrlType('https://app.example/login')).toBe(null)
+  })
+
+  it('returns the type from a query param (PKCE)', () => {
+    expect(getAuthUrlType('https://app.example/login?code=abc&type=signup')).toBe('signup')
+    expect(getAuthUrlType('https://app.example/login?type=email&code=abc')).toBe('email')
+    expect(getAuthUrlType('https://app.example/reset-password?code=abc&type=recovery')).toBe('recovery')
+  })
+
+  it('returns the type from a hash fragment (legacy implicit)', () => {
+    expect(getAuthUrlType('https://app.example/login#access_token=xxx&type=signup')).toBe('signup')
+    expect(getAuthUrlType('https://app.example/login#type=email&access_token=xxx')).toBe('email')
+  })
+
+  it('prefers query over hash if both present', () => {
+    expect(getAuthUrlType('https://app.example/login?type=signup#type=email')).toBe('signup')
+  })
+
+  it('returns null for malformed URLs (no throw)', () => {
+    expect(getAuthUrlType('not a url')).toBe(null)
+    expect(getAuthUrlType('')).toBe(null)
+    expect(getAuthUrlType(null)).toBe(null)
+  })
+
+  it('returns null for unrecognized type values', () => {
+    expect(getAuthUrlType('https://app.example/login?type=unknown')).toBe(null)
+  })
+
+  it('recognizes magiclink type', () => {
+    expect(getAuthUrlType('https://app.example/login?code=xxx&type=magiclink')).toBe('magiclink')
+  })
+
+  it('recognizes invite and email_change types', () => {
+    expect(getAuthUrlType('https://app.example/login?code=xxx&type=invite')).toBe('invite')
+    expect(getAuthUrlType('https://app.example/login?code=xxx&type=email_change')).toBe('email_change')
+  })
+
+  it('is case-sensitive (only accepts lowercase Supabase values)', () => {
+    expect(getAuthUrlType('https://app.example/login?type=Signup')).toBe(null)
+    expect(getAuthUrlType('https://app.example/login?type=EMAIL')).toBe(null)
+  })
+})


### PR DESCRIPTION
## Summary
- Sets `flowType: 'pkce'` on the Supabase web client.
- `detectSessionInUrl: true` stays on so Supabase auto-exchanges `?code=` on `/login` and `/reset-password` entry points. No manual `exchangeCodeForSession` in page components (that's Plan C's Capacitor `appUrlOpen` handler).
- New `src/utils/authUrlType.js` reads Supabase auth type param from both `?type=` (PKCE) and `#type=` (legacy implicit). Allowlist covers `signup`, `email`, `recovery`, `magiclink`, `invite`, `email_change` for completeness; `Login.jsx` currently only consumes `signup` / `email`. Strict lowercase match.
- `ResetPassword.jsx` now subscribes to `onAuthStateChange` (`PASSWORD_RECOVERY` / `SIGNED_IN` / `INITIAL_SESSION`-with-session) instead of a one-shot `getSession()`. Closes a real PKCE race where a slow `?code=` exchange made valid recovery links show as expired. 5s `getSession()` fallback guards silent init failure.

## Why
First of three plans implementing the OAuth-on-native-iOS + Apple-token-revocation design (spec: `docs/superpowers/specs/2026-04-20-oauth-native-and-apple-revocation-design.md`). Plan A is the web-side security upgrade that unblocks Plans B + C. PKCE is the 2026 industry default and removes tokens-in-URL-fragment risk.

## Test plan

**Automated (green):**
- [x] Unit: `src/utils/authUrlType.test.js` — 9 tests, PKCE query / legacy hash / both / malformed / unknown / magiclink / invite / email_change / case sensitivity
- [x] `npm run test` passes (345 tests across 21 files)
- [x] Lint passes on all touched files (pre-existing lint debt in unrelated files unchanged)
- [x] `npm run build` passes; grep confirmed no `toSorted` / `toReversed` / `toSpliced` in `dist/` (CLAUDE.md §1.1)

**Manual smoke — pending on Vercel preview URL (OAuth + email links must hit the real callback domain):**
- [ ] Existing email/password sign-in still works
- [ ] Google OAuth on web still works (no PKCE regression)
- [ ] Password reset end-to-end lands on valid recovery session (exercises the Task 4.5 fix)
- [ ] Email confirmation success banner still shows on `/login` (covers both PKCE `?type=signup` and legacy `#type=signup` from existing inbox links)

Draft until smoke is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)