### PR TITLE
fix(home): scroll chalkboard clicks to Top 10 carousel

### DIFF
--- a/src/components/home/HomeListMode.jsx
+++ b/src/components/home/HomeListMode.jsx
@@ -40,14 +40,15 @@ export const HomeListMode = memo(function HomeListMode({
       carouselRef.current.scrollToCategory(cat)
     }
     setTimeout(function () {
+      var container = listScrollRef && listScrollRef.current
       var el = document.getElementById('top10-carousel')
-      if (el) {
+      if (container && el) {
         var prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-        var offset = el.getBoundingClientRect().top + window.scrollY - 8
-        window.scrollTo({ top: offset, behavior: prefersReducedMotion ? 'auto' : 'smooth' })
+        var target = el.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop - 8
+        container.scrollTo({ top: target, behavior: prefersReducedMotion ? 'auto' : 'smooth' })
       }
     }, 100)
-  }, [onExpandedCategoryChange])
+  }, [onExpandedCategoryChange, listScrollRef])
 
   return (
     <div
@@ -181,20 +182,7 @@ export const HomeListMode = memo(function HomeListMode({
               bestValueMeal={bestValueMeal}
               bestIceCream={bestIceCream}
               localsAggregate={localsAggregate}
-              onExpandCategory={function (cat) {
-                onExpandedCategoryChange(cat)
-                if (carouselRef.current) {
-                  carouselRef.current.scrollToCategory(cat)
-                }
-                setTimeout(function () {
-                  var el = document.getElementById('top10-carousel')
-                  if (el) {
-                    var prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-                    var offset = el.getBoundingClientRect().top + window.scrollY - 8
-                    window.scrollTo({ top: offset, behavior: prefersReducedMotion ? 'auto' : 'smooth' })
-                  }
-                }, 100)
-              }}
+              onExpandCategory={handleCategorySelect}
             />
 
             {/* Local Lists — horizontal scroll above the food icon tabs */}


### PR DESCRIPTION
## Summary
- Chalkboard clicks (Lobster Roll, Chowder, etc.) were scrolling with `window.scrollTo`, but the page is `fixed inset-0` and the real scroll container is the inner `listScrollRef` div — `window.scrollY` was always 0, so clicks felt like they stopped at the Local Lists row instead of landing on the Top 10 rankings.
- Fix: scroll `listScrollRef.current` using the bounding-rect delta plus `container.scrollTop`, preserving the existing `-8` top offset and reduced-motion handling.
- Collapsed the duplicated inline handler into the existing `handleCategorySelect`.

## Test plan
- [ ] On `/`, tap the Lobster Roll chalkboard → page scrolls past Local Lists to the Top 10 carousel, with Lobster Roll active.
- [ ] Same for Chowder, Breakfast, Pizza, and any locals-agree/island-favorite boards that route to `/dish/...` or `/restaurants/...` (unchanged — only category boards scroll).
- [ ] With `prefers-reduced-motion: reduce`, the scroll is instant, not smooth.
- [ ] Search + empty states still render (no regressions in the non-chalkboard paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)