### PR TITLE
fix(deploy): stop serving HTML for missing chunks + retry budget

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,37 +10,19 @@ import { BottomNav } from './components/BottomNav'
 import { ProtectedRoute } from './components/ProtectedRoute'
 import { WelcomeModal } from './components/Auth/WelcomeModal'
 import { RouteProgress } from './components/RouteProgress'
-import { getSessionItem, removeSessionItem, setSessionItem } from './lib/storage'
 import { preloadSounds } from './lib/sounds'
 import { preloadCategoryImages } from './constants/categories'
-
-// Helper to handle chunk load failures after new deploys
-// If a lazy-loaded chunk fails to load (e.g., after deploy), reload the page once
-function isChunkLoadError(error) {
-  const msg = error?.message || ''
-  return (
-    msg.includes('Failed to fetch dynamically imported module') || // Chrome
-    msg.includes('error loading dynamically imported module') ||   // Safari
-    msg.includes('Importing a module script failed') ||            // Firefox
-    msg.includes('Loading chunk') ||                               // Generic bundler
-    msg.includes('Failed to fetch')                                // Network-level
-  )
-}
-
-const RELOAD_KEY = 'wgh_chunk_reload'
+import { isChunkLoadError, tryChunkReload, clearChunkReloadState } from './utils/chunkReload'
 
 function lazyWithRetry(importFn, namedExport) {
   return lazy(() =>
     importFn()
       .then(m => {
-        // Successful load — clear any reload flag
-        removeSessionItem(RELOAD_KEY)
+        clearChunkReloadState()
         return { default: namedExport ? m[namedExport] : m.default }
       })
       .catch((error) => {
-        if (isChunkLoadError(error) && !getSessionItem(RELOAD_KEY)) {
-          setSessionItem(RELOAD_KEY, '1')
-          window.location.reload()
+        if (isChunkLoadError(error) && tryChunkReload()) {
           return { default: () => null }
         }
         throw error

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,5 +1,5 @@
 import { Component } from 'react'
-import { getSessionItem, setSessionItem } from '../lib/storage'
+import { isChunkLoadError, tryChunkReload } from '../utils/chunkReload'
 
 function ErrorFallback({ error, resetError }) {
   return (
@@ -69,20 +69,9 @@ export class ErrorBoundary extends Component {
       componentStack: errorInfo?.componentStack,
     })
 
-    // Auto-reload on chunk load errors (fallback if lazyWithRetry misses it)
-    const msg = error?.message || ''
-    const isChunkError = (
-      msg.includes('Failed to fetch dynamically imported module') ||
-      msg.includes('error loading dynamically imported module') ||
-      msg.includes('Importing a module script failed') ||
-      msg.includes('Loading chunk') ||
-      msg.includes('Failed to fetch')
-    )
-    if (isChunkError && !getSessionItem('wgh_chunk_reload')) {
-      setSessionItem('wgh_chunk_reload', '1')
-      window.location.reload()
-      return
-    }
+    // Auto-reload on chunk load errors (fallback if lazyWithRetry misses it).
+    // Shared attempt counter prevents reload loops across both paths.
+    if (isChunkLoadError(error) && tryChunkReload()) return
 
     // Lazy-load Sentry and report the error
     if (import.meta.env.PROD) {

--- a/src/utils/chunkReload.js
+++ b/src/utils/chunkReload.js
@@ -1,0 +1,62 @@
+import { getSessionItem, setSessionItem, removeSessionItem } from '../lib/storage'
+
+const STATE_KEY = 'wgh_chunk_reload_state'
+const MAX_ATTEMPTS = 2
+const WINDOW_MS = 2 * 60 * 1000
+
+export function isChunkLoadError(error) {
+  const msg = error?.message || ''
+  const name = error?.name || ''
+
+  if (
+    msg.includes('Failed to fetch dynamically imported module') ||
+    msg.includes('error loading dynamically imported module') ||
+    msg.includes('Importing a module script failed') ||
+    msg.includes('Loading chunk') ||
+    msg.includes('Failed to fetch')
+  ) return true
+
+  // Safari when a missing chunk is rewritten to index.html and parsed as JS:
+  // "Unexpected token '<'" (HTML's opening angle bracket) surfaces as a SyntaxError.
+  if (name === 'SyntaxError' && msg.includes("Unexpected token '<'")) return true
+  if (msg.includes('Unable to resolve specifier')) return true
+
+  return false
+}
+
+function readState() {
+  const raw = getSessionItem(STATE_KEY)
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw)
+    if (typeof parsed?.attempts === 'number' && typeof parsed?.firstAttemptAt === 'number') {
+      return parsed
+    }
+  } catch {
+    // Stale or corrupt entry — treat as absent.
+  }
+  return null
+}
+
+export function tryChunkReload(reload = () => window.location.reload()) {
+  const now = Date.now()
+  const state = readState()
+  const withinWindow = state && now - state.firstAttemptAt <= WINDOW_MS
+  const nextAttempt = withinWindow ? state.attempts + 1 : 1
+
+  if (nextAttempt > MAX_ATTEMPTS) return false
+
+  setSessionItem(
+    STATE_KEY,
+    JSON.stringify({
+      attempts: nextAttempt,
+      firstAttemptAt: withinWindow ? state.firstAttemptAt : now,
+    })
+  )
+  reload()
+  return true
+}
+
+export function clearChunkReloadState() {
+  removeSessionItem(STATE_KEY)
+}

--- a/src/utils/chunkReload.test.js
+++ b/src/utils/chunkReload.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { isChunkLoadError, tryChunkReload, clearChunkReloadState } from './chunkReload'
+import { setSessionItem } from '../lib/storage'
+
+describe('isChunkLoadError', () => {
+  it('matches Chrome message', () => {
+    expect(isChunkLoadError({ message: 'Failed to fetch dynamically imported module: /assets/x.js' })).toBe(true)
+  })
+
+  it('matches Safari message', () => {
+    expect(isChunkLoadError({ message: 'error loading dynamically imported module' })).toBe(true)
+  })
+
+  it('matches Firefox message', () => {
+    expect(isChunkLoadError({ message: 'Importing a module script failed.' })).toBe(true)
+  })
+
+  it('matches generic Loading chunk', () => {
+    expect(isChunkLoadError({ message: 'Loading chunk 42 failed.' })).toBe(true)
+  })
+
+  it('matches plain network Failed to fetch', () => {
+    expect(isChunkLoadError({ message: 'Failed to fetch' })).toBe(true)
+  })
+
+  it("matches Safari's HTML-parsed-as-JS SyntaxError", () => {
+    expect(isChunkLoadError({ name: 'SyntaxError', message: "Unexpected token '<'" })).toBe(true)
+  })
+
+  it('does NOT match bare Unexpected token (avoid false positives on user code)', () => {
+    expect(isChunkLoadError({ name: 'SyntaxError', message: 'Unexpected token }' })).toBe(false)
+  })
+
+  it('matches Unable to resolve specifier', () => {
+    expect(isChunkLoadError({ message: 'Unable to resolve specifier "./foo.js"' })).toBe(true)
+  })
+
+  it('returns false for unrelated errors', () => {
+    expect(isChunkLoadError({ message: 'Network request failed: auth' })).toBe(false)
+    expect(isChunkLoadError({ name: 'TypeError', message: 'Cannot read property x of undefined' })).toBe(false)
+    expect(isChunkLoadError(null)).toBe(false)
+    expect(isChunkLoadError(undefined)).toBe(false)
+    expect(isChunkLoadError({})).toBe(false)
+  })
+})
+
+describe('tryChunkReload + clearChunkReloadState', () => {
+  let reload
+
+  beforeEach(() => {
+    sessionStorage.clear()
+    clearChunkReloadState()
+    reload = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    clearChunkReloadState()
+    sessionStorage.clear()
+  })
+
+  it('first call triggers reload and returns true', () => {
+    expect(tryChunkReload(reload)).toBe(true)
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('second call within window triggers reload and returns true', () => {
+    tryChunkReload(reload)
+    expect(tryChunkReload(reload)).toBe(true)
+    expect(reload).toHaveBeenCalledTimes(2)
+  })
+
+  it('third call within window does NOT reload (max 2 attempts)', () => {
+    tryChunkReload(reload)
+    tryChunkReload(reload)
+    expect(tryChunkReload(reload)).toBe(false)
+    expect(reload).toHaveBeenCalledTimes(2)
+  })
+
+  it('attempt counter resets after 2-min window expires', () => {
+    const now = Date.now()
+    vi.spyOn(Date, 'now').mockReturnValue(now)
+    tryChunkReload(reload)
+    tryChunkReload(reload)
+    expect(tryChunkReload(reload)).toBe(false)
+
+    Date.now.mockReturnValue(now + 3 * 60 * 1000)
+    expect(tryChunkReload(reload)).toBe(true)
+    expect(reload).toHaveBeenCalledTimes(3)
+  })
+
+  it('clearChunkReloadState resets the counter', () => {
+    tryChunkReload(reload)
+    tryChunkReload(reload)
+    clearChunkReloadState()
+    expect(tryChunkReload(reload)).toBe(true)
+    expect(reload).toHaveBeenCalledTimes(3)
+  })
+
+  it('corrupt state is treated as absent and retry allowed', () => {
+    setSessionItem('wgh_chunk_reload_state', 'not-json')
+    expect(tryChunkReload(reload)).toBe(true)
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -13,7 +13,7 @@
     { "source": "/logo-concepts.html", "destination": "/logo-concepts.html" },
     { "source": "/profile-redesign.html", "destination": "/profile-redesign.html" },
     { "source": "/profile-soul.html", "destination": "/profile-soul.html" },
-    { "source": "/(.*)", "destination": "/" }
+    { "source": "/((?!.*\\.(?:js|mjs|css|map|png|jpg|jpeg|webp|svg|ico|woff|woff2|ttf|json|txt|xml)$).*)", "destination": "/" }
   ],
   "headers": [
     {


### PR DESCRIPTION
## Summary

Root fix for the "Something went wrong" error mobile Safari users have been hitting after fresh Vercel deploys.

**1. `vercel.json`** — the SPA catch-all `"/(.*)" → "/"` was swallowing missing `/assets/xxx.js` requests and serving `index.html`. Safari then parsed HTML as JS and threw a SyntaxError that didn't match our chunk-load heuristic, so `lazyWithRetry`'s auto-reload never fired. Exclude common static-asset extensions so missing chunks return a real 404 and the dynamic import rejects with a message our heuristic recognizes.

**2. `src/utils/chunkReload.js` (new)** — shared helper. Replaces the duplicated boolean `wgh_chunk_reload` flag in `App.jsx` + `ErrorBoundary.jsx`. The old flag was one-shot per session: once set, any subsequent chunk error in that session fell through to the fallback UI even though another reload would have fixed it. Replaced with an attempt counter (max 2 reloads in a 2-minute window). Cleared on successful chunk load; bounded to avoid reload loops on genuine outages.

**3. Expanded chunk-error heuristic** — adds Safari's `SyntaxError: Unexpected token '<'` (HTML parsed as JS) and `Unable to resolve specifier` as safety nets in case the `vercel.json` fix ever regresses.

## Why

Dan hit this on mobile Safari right after the PKCE deploy: reset password succeeded → navigation to `/` → "Something went wrong" → refresh → works. Pre-existing bug, not caused by the PKCE PR, but every deploy regresses any open mobile tab until we fix it. Pre-launch hygiene.

## Test plan

- [x] `src/utils/chunkReload.test.js` — 15 tests covering the heuristic + retry logic + window reset + corrupt-state recovery
- [x] `npm run test` passes (360 tests across 22 files)
- [x] Lint passes on all touched files
- [x] `npm run build` passes
- [x] `vercel.json` regex tested locally against common paths — `/assets/xxx.js` correctly SKIPs the rewrite, `/dish/abc` correctly MATCHes
- [ ] Deploy to prod, verify a force-deploy + navigate doesn't trigger the error page (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)