### PR TITLE
fix(carousel): stop tab scrollIntoView from stomping page scroll

### DIFF
--- a/src/components/home/Top10Carousel.jsx
+++ b/src/components/home/Top10Carousel.jsx
@@ -61,14 +61,18 @@ export var Top10Carousel = forwardRef(function Top10Carousel({ dishes, onCategor
     }
   }, [activeIndex, onCategoryChange])
 
-  // Auto-scroll tab bar to keep active tab visible
+  // Auto-scroll tab bar to keep active tab visible.
+  // Scroll tabsRef horizontally ourselves — scrollIntoView with block: 'nearest'
+  // will vertically scroll the outer container when the tab bar is off-screen,
+  // which fights any page-level scroll-to-carousel animation from callers.
   useEffect(function () {
-    if (!tabsRef.current) return
-    var activeTab = tabsRef.current.children[activeIndex]
-    if (activeTab) {
-      var prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-      activeTab.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', inline: 'center', block: 'nearest' })
-    }
+    var tabs = tabsRef.current
+    if (!tabs) return
+    var activeTab = tabs.children[activeIndex]
+    if (!activeTab) return
+    var prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    var targetLeft = activeTab.offsetLeft - (tabs.offsetWidth - activeTab.offsetWidth) / 2
+    tabs.scrollTo({ left: targetLeft, behavior: prefersReducedMotion ? 'auto' : 'smooth' })
   }, [activeIndex])
 
   // Get all dishes for a tab (unsliced)


### PR DESCRIPTION
## Summary
- Chalkboard clicks still weren't scrolling to the Top 10 rankings after #74. Root cause was in \`Top10Carousel\`, not \`HomeListMode\`.
- \`scrollToCategory\` smooth-scrolls the carousel horizontally. That fires \`handleScroll\` → \`setActiveIndex\` repeatedly (~5 times over 500ms as smooth scroll settles). Each \`activeIndex\` change re-ran \`scrollIntoView({ block: 'nearest' })\` on the active tab.
- \`block: 'nearest'\` walks up to the nearest vertical scroll ancestor (\`listScrollRef\`) and scrolls it to bring the tab to the nearest edge. Since the tab bar was below the viewport, it scrolled the page down just far enough to land at the Local Lists row, overriding #74's scroll-to-carousel.
- Fix: scroll \`tabsRef\` horizontally ourselves via \`tabs.scrollTo({ left })\`. Tab-bar centering now only affects the tab bar — no side-effect page scroll.

## Test plan
- [ ] On \`/\`, tap the Lobster Roll chalkboard → page scrolls past Local Lists all the way to the Top 10 carousel, Lobster Roll tab active.
- [ ] Same for Chowder, Breakfast/Pizza (time-of-day), and any category chalkboards.
- [ ] Tapping the in-tab-bar tabs (Near You, Pizza, Burgers, etc.) still centers the active tab in the tab bar — no visual regression.
- [ ] Swiping the carousel horizontally still updates the tab bar and keeps the active tab centered.
- [ ] \`prefers-reduced-motion: reduce\` → tab bar jumps instantly, no smooth animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)