### PR TITLE
feat(auth): B1 — web Apple token capture (Flow K)

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -729,3 +729,10 @@ The map interaction pattern (tap list item → fly to pin → pin lights up) is 
 - `src/pages/Discover.jsx` — poster icon import
 
 *Last updated: Feb 25, 2026*
+
+### Apple Vault Keys
+
+- `apple_encryption_master_key_v1` — AES-256-GCM key for `user_apple_tokens.encrypted_refresh_token` and `pending_apple_revocations.encrypted_refresh_token`. Corresponds to `key_version = 'v1'` in those tables.
+- `apple_signing_key_v1` — contents of the `.p8` private key from Apple Developer portal. Used to sign Apple client secret JWTs. Uploaded in B3-activate.
+- `apple_team_id`, `apple_key_id_v1`, `apple_services_id`, `apple_bundle_id` — non-secret identifiers kept in Vault for deployment consistency and single-lookup loading in `_shared/apple.ts`.
+- Key rotation: write a new vault secret `apple_encryption_master_key_v2`, update encryption-write paths to use v2, leave decryption paths reading key by `key_version` column. Re-encryption of existing rows is a background job (post-launch).

--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -387,8 +387,45 @@ export const authApi = {
    * @returns {Promise<{ ok: boolean, code?: string, status?: number }>}
    */
   async persistAppleRefreshToken(providerRefreshToken) {
+    // Local safe side-effect helpers. PostHog and the logger transport can
+    // themselves throw (storage full, network blocked, etc.). Flow K is
+    // contract-bound to never reject, so wrap every side effect.
+    const safeCapture = (event, props) => {
+      try {
+        // Avoid passing undefined — keeps toHaveBeenCalledWith assertions
+        // simple and matches the 1-arg shape existing callsites use.
+        if (props === undefined) capture(event)
+        else capture(event, props)
+      } catch { /* swallow — never block Flow K */ }
+    }
+    const safeWarn = (msg, meta) => {
+      try { logger.warn(msg, meta) } catch { /* swallow */ }
+    }
+
     if (!providerRefreshToken) {
       return { ok: false, reason: 'missing_token' }
+    }
+
+    // Retry-eligibility rule:
+    //   - Server sent structured failure (data.ok === false): respect it.
+    //     Retry ONLY if the body explicitly marks itself transient.
+    //     (Our Edge Function sets `transient: true` on VAULT_UNAVAILABLE,
+    //     TOKEN_LOOKUP_FAILED, UPSERT_FAILED, IDENTITY_LOOKUP_FAILED.)
+    //   - Transport-level error (no structured body, only error.status):
+    //     Retry on 5xx / 504 per APPLE_PERSIST_TRANSIENT_STATUSES.
+    //   - Anything else: no retry.
+    //
+    // Without this guard, a body-only failure like NO_APPLE_IDENTITY (status
+    // defaults to 500 when the SDK doesn't populate it) would incorrectly
+    // hit the transient-retry branch.
+    const isTransient = (data, error) => {
+      if (data && data.ok === false) {
+        return data.transient === true
+      }
+      if (error?.status && APPLE_PERSIST_TRANSIENT_STATUSES.has(error.status)) {
+        return true
+      }
+      return false
     }
 
     for (let attempt = 1; attempt <= 2; attempt++) {
@@ -399,29 +436,29 @@ export const authApi = {
         })
 
         if (!error && data?.ok === true) {
-          capture('apple_token_persisted')
+          safeCapture('apple_token_persisted')
           return { ok: true }
         }
 
-        const status = error?.status ?? 500
+        const status = error?.status ?? null
         const code = data?.code
 
-        if (!APPLE_PERSIST_TRANSIENT_STATUSES.has(status)) {
-          logger.warn('apple-token-persist non-transient failure', { status, code })
+        if (!isTransient(data, error)) {
+          safeWarn('apple-token-persist non-transient failure', { status, code })
           return { ok: false, code, status }
         }
 
         if (attempt === 2) {
-          capture('apple_token_persist_failed', { status, code })
-          logger.warn('apple-token-persist failed after retry', { status, code })
+          safeCapture('apple_token_persist_failed', { status, code })
+          safeWarn('apple-token-persist failed after retry', { status, code })
           return { ok: false, code, status }
         }
 
         await new Promise((r) => setTimeout(r, APPLE_PERSIST_RETRY_DELAY_MS))
       } catch (err) {
         if (attempt === 2) {
-          capture('apple_token_persist_failed', { status: 0, error: err?.message })
-          logger.warn('apple-token-persist threw after retry', err)
+          safeCapture('apple_token_persist_failed', { status: 0, error: err?.message })
+          safeWarn('apple-token-persist threw after retry', err)
           return { ok: false, error: err?.message }
         }
         await new Promise((r) => setTimeout(r, APPLE_PERSIST_RETRY_DELAY_MS))

--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -10,6 +10,10 @@ import { validateUserContent } from '../lib/reviewBlocklist'
  * Auth API - Centralized authentication operations
  */
 
+// Flow K (Apple SIWA provider_refresh_token persistence) retry policy
+const APPLE_PERSIST_TRANSIENT_STATUSES = new Set([500, 502, 503, 504])
+const APPLE_PERSIST_RETRY_DELAY_MS = 1000
+
 /**
  * Validate redirect URL against allowlist to prevent open redirect attacks
  * Only allows same-origin URLs
@@ -370,6 +374,61 @@ export const authApi = {
       logger.error('Error deleting account:', error)
       throw error.type ? error : createClassifiedError(error)
     }
+  },
+
+  /**
+   * POST the Apple provider_refresh_token (from Supabase web OAuth callback)
+   * to the apple-token-persist Edge Function. One retry on transient failure
+   * after 1s. Never throws — Flow K is fire-and-forget from the auth context's
+   * perspective. The token is only in memory briefly after SIGNED_IN; if we
+   * lose it, Case B (unrevokable sentinel) picks up at delete time.
+   *
+   * @param {string|null} providerRefreshToken
+   * @returns {Promise<{ ok: boolean, code?: string, status?: number }>}
+   */
+  async persistAppleRefreshToken(providerRefreshToken) {
+    if (!providerRefreshToken) {
+      return { ok: false, reason: 'missing_token' }
+    }
+
+    for (let attempt = 1; attempt <= 2; attempt++) {
+      try {
+        const { data, error } = await supabase.functions.invoke('apple-token-persist', {
+          method: 'POST',
+          body: { provider_refresh_token: providerRefreshToken },
+        })
+
+        if (!error && data?.ok === true) {
+          capture('apple_token_persisted')
+          return { ok: true }
+        }
+
+        const status = error?.status ?? 500
+        const code = data?.code
+
+        if (!APPLE_PERSIST_TRANSIENT_STATUSES.has(status)) {
+          logger.warn('apple-token-persist non-transient failure', { status, code })
+          return { ok: false, code, status }
+        }
+
+        if (attempt === 2) {
+          capture('apple_token_persist_failed', { status, code })
+          logger.warn('apple-token-persist failed after retry', { status, code })
+          return { ok: false, code, status }
+        }
+
+        await new Promise((r) => setTimeout(r, APPLE_PERSIST_RETRY_DELAY_MS))
+      } catch (err) {
+        if (attempt === 2) {
+          capture('apple_token_persist_failed', { status: 0, error: err?.message })
+          logger.warn('apple-token-persist threw after retry', err)
+          return { ok: false, error: err?.message }
+        }
+        await new Promise((r) => setTimeout(r, APPLE_PERSIST_RETRY_DELAY_MS))
+      }
+    }
+
+    return { ok: false }
   },
 
   /**

--- a/src/api/authApi.test.js
+++ b/src/api/authApi.test.js
@@ -259,5 +259,41 @@ describe('Auth API', () => {
       expect(r.ok).toBe(false)
       expect(supabase.functions.invoke).not.toHaveBeenCalled()
     })
+
+    it('does NOT retry on body-only failure without transient marker', async () => {
+      // Regression guard for the "default status to 500 → retry" bug caught
+      // in Codex review: a structured failure body like NO_APPLE_IDENTITY
+      // without transient:true must NOT be retried, even when error.status is
+      // missing (which is the case for supabase.functions.invoke body-only
+      // failures in some SDK versions).
+      supabase.functions.invoke.mockResolvedValueOnce({
+        data: { ok: false, code: 'NO_APPLE_IDENTITY' },
+        error: null,
+      })
+
+      const r = await authApi.persistAppleRefreshToken('rt.abc')
+
+      expect(r.ok).toBe(false)
+      expect(r.code).toBe('NO_APPLE_IDENTITY')
+      expect(supabase.functions.invoke).toHaveBeenCalledTimes(1)
+    })
+
+    it('retries on body-marked transient failure', async () => {
+      // Inverse of the above — when the Edge Function returns
+      // { ok: false, transient: true } (e.g., VAULT_UNAVAILABLE), we DO retry.
+      supabase.functions.invoke
+        .mockResolvedValueOnce({
+          data: { ok: false, code: 'VAULT_UNAVAILABLE', transient: true },
+          error: null,
+        })
+        .mockResolvedValueOnce({ data: { ok: true }, error: null })
+
+      const promise = authApi.persistAppleRefreshToken('rt.abc')
+      await vi.advanceTimersByTimeAsync(1000)
+      const r = await promise
+
+      expect(r.ok).toBe(true)
+      expect(supabase.functions.invoke).toHaveBeenCalledTimes(2)
+    })
   })
 })

--- a/src/api/authApi.test.js
+++ b/src/api/authApi.test.js
@@ -15,10 +15,31 @@ vi.mock('../lib/supabase', () => ({
         single: vi.fn(),
       })),
     })),
+    functions: {
+      invoke: vi.fn(),
+    },
+  },
+}))
+
+// Mock analytics so we can assert on capture() calls for Flow K
+vi.mock('../lib/analytics', () => ({
+  capture: vi.fn(),
+  identify: vi.fn(),
+  reset: vi.fn(),
+}))
+
+// Mock logger so transient-failure warnings don't spam test output
+vi.mock('../utils/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
   },
 }))
 
 import { supabase } from '../lib/supabase'
+import { capture } from '../lib/analytics'
 
 describe('Auth API', () => {
   beforeEach(() => {
@@ -163,6 +184,80 @@ describe('Auth API', () => {
       const result = await authApi.getUserVoteForDish('dish-1', 'user-1')
 
       expect(result).toBeNull()
+    })
+  })
+
+  describe('persistAppleRefreshToken (Flow K)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('returns ok on 200 + fires PostHog apple_token_persisted', async () => {
+      supabase.functions.invoke.mockResolvedValueOnce({ data: { ok: true }, error: null })
+
+      const r = await authApi.persistAppleRefreshToken('rt.abc')
+
+      expect(r).toEqual({ ok: true })
+      expect(supabase.functions.invoke).toHaveBeenCalledTimes(1)
+      expect(supabase.functions.invoke).toHaveBeenCalledWith('apple-token-persist', {
+        method: 'POST',
+        body: { provider_refresh_token: 'rt.abc' },
+      })
+      expect(capture).toHaveBeenCalledWith('apple_token_persisted')
+    })
+
+    it('retries once on transient 503, then succeeds', async () => {
+      supabase.functions.invoke
+        .mockResolvedValueOnce({ data: null, error: { status: 503 } })
+        .mockResolvedValueOnce({ data: { ok: true }, error: null })
+
+      const promise = authApi.persistAppleRefreshToken('rt.abc')
+      await vi.advanceTimersByTimeAsync(1000)
+      const r = await promise
+
+      expect(r).toEqual({ ok: true })
+      expect(supabase.functions.invoke).toHaveBeenCalledTimes(2)
+    })
+
+    it('does NOT retry on 409 NO_APPLE_IDENTITY', async () => {
+      supabase.functions.invoke.mockResolvedValueOnce({
+        data: { ok: false, code: 'NO_APPLE_IDENTITY' },
+        error: { status: 409 },
+      })
+
+      const r = await authApi.persistAppleRefreshToken('rt.abc')
+
+      expect(r.ok).toBe(false)
+      expect(r.code).toBe('NO_APPLE_IDENTITY')
+      expect(supabase.functions.invoke).toHaveBeenCalledTimes(1)
+    })
+
+    it('fires PostHog failure event after two transient 503s', async () => {
+      supabase.functions.invoke
+        .mockResolvedValueOnce({ data: null, error: { status: 503 } })
+        .mockResolvedValueOnce({ data: null, error: { status: 503 } })
+
+      const promise = authApi.persistAppleRefreshToken('rt.abc')
+      await vi.advanceTimersByTimeAsync(1000)
+      const r = await promise
+
+      expect(r.ok).toBe(false)
+      expect(supabase.functions.invoke).toHaveBeenCalledTimes(2)
+      expect(capture).toHaveBeenCalledWith(
+        'apple_token_persist_failed',
+        expect.objectContaining({ status: 503 })
+      )
+    })
+
+    it('no-ops on missing token', async () => {
+      const r = await authApi.persistAppleRefreshToken(null)
+
+      expect(r.ok).toBe(false)
+      expect(supabase.functions.invoke).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -2,6 +2,7 @@
 import { createContext, useContext, useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../lib/supabase'
+import { authApi } from '../api/authApi'
 import { capture, identify, reset } from '../lib/analytics'
 import { clearPendingVoteStorage, clearCache, removeStorageItem, removeSessionItem, STORAGE_KEYS } from '../lib/storage'
 import { logger } from '../utils/logger'
@@ -60,6 +61,20 @@ export function AuthProvider({ children }) {
           capture('session_expired')
           reset()
         }
+      }
+
+      // Flow K — Apple SIWA refresh token capture (CLAUDE.md §1.4 routes
+      // through authApi.persistAppleRefreshToken). We gate on
+      // session.provider_refresh_token presence only; the server-side
+      // identity lookup decides whether this user's identity is actually
+      // Apple and returns 409 NO_APPLE_IDENTITY otherwise (cheap no-op).
+      // Do NOT gate on !prevUserRef.current — Supabase may fire SIGNED_IN
+      // again if the browser restores session with provider_refresh_token
+      // briefly visible. The Edge Function is idempotent.
+      if (event === 'SIGNED_IN' && session?.provider_refresh_token) {
+        authApi.persistAppleRefreshToken(session.provider_refresh_token).catch((err) => {
+          logger.warn('persistAppleRefreshToken unexpected throw', err)
+        })
       }
 
       setUser(newUser)

--- a/supabase/functions/_shared/apple.test.ts
+++ b/supabase/functions/_shared/apple.test.ts
@@ -1,0 +1,56 @@
+// supabase/functions/_shared/apple.test.ts
+import { assert, assertEquals, assertRejects } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import { decodeIdToken, decryptRefreshToken, encryptRefreshToken } from './apple.ts';
+
+// NOTE: These tests require SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY + the
+// apple_encryption_master_key_v1 vault secret populated. Run against a
+// staging Supabase or the Denis project with the key pre-seeded in B1.2.
+
+Deno.test('encrypt + decrypt roundtrip', async () => {
+  const plaintext = 'rt.AAAApple.sample-refresh-token.xyz';
+  const { ciphertext, keyVersion } = await encryptRefreshToken(plaintext);
+  assert(ciphertext.length > 0, 'ciphertext produced');
+  assertEquals(keyVersion, 'v1');
+  const decrypted = await decryptRefreshToken(ciphertext, keyVersion);
+  assertEquals(decrypted, plaintext);
+});
+
+Deno.test('encrypt produces different ciphertext on identical input (fresh IV)', async () => {
+  const { ciphertext: a } = await encryptRefreshToken('same');
+  const { ciphertext: b } = await encryptRefreshToken('same');
+  assert(a !== b, 'IV must be fresh per call');
+});
+
+Deno.test('decrypt rejects unknown version byte', async () => {
+  // version=99 + 12 zero IV + 32 bytes of fake ciphertext
+  const badBytes = new Uint8Array(1 + 12 + 32);
+  badBytes[0] = 99;
+  const bad = btoa(String.fromCharCode(...badBytes));
+  await assertRejects(
+    () => decryptRefreshToken(bad, 'v1'),
+    Error,
+    'Unsupported ciphertext version',
+  );
+});
+
+Deno.test('decodeIdToken parses sub from a real-shape JWT', () => {
+  // header.payload.signature with payload = {"sub":"000123.abc","iss":"https://appleid.apple.com"}
+  const payload = btoa(JSON.stringify({ sub: '000123.abc', iss: 'https://appleid.apple.com' }))
+    .replace(/=+$/, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+  const jwt = `eyJhbGciOiJIUzI1NiJ9.${payload}.fakesig`;
+  const parsed = decodeIdToken(jwt);
+  assertEquals(parsed.sub, '000123.abc');
+});
+
+Deno.test('decodeIdToken throws on missing sub', () => {
+  const payload = btoa(JSON.stringify({ iss: 'https://appleid.apple.com' })).replace(/=+$/, '');
+  const jwt = `eyJhbGciOiJIUzI1NiJ9.${payload}.fakesig`;
+  try {
+    decodeIdToken(jwt);
+    throw new Error('should have thrown');
+  } catch (e) {
+    assertEquals((e as Error).message, 'JWT missing sub claim');
+  }
+});

--- a/supabase/functions/_shared/apple.ts
+++ b/supabase/functions/_shared/apple.ts
@@ -11,7 +11,6 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
 const KEY_VERSION = 'v1';
-const VAULT_KEY_NAME = `apple_encryption_master_key_${KEY_VERSION}`;
 
 let cachedKey: CryptoKey | null = null;
 let cachedKeyVersion: string | null = null;

--- a/supabase/functions/_shared/apple.ts
+++ b/supabase/functions/_shared/apple.ts
@@ -1,0 +1,128 @@
+// supabase/functions/_shared/apple.ts
+//
+// Shared Apple auth helpers. Imported by apple-token-persist (B1),
+// apple-token-exchange (B3), apple-revocation-retry (B3), delete-account (B3).
+//
+// encryptRefreshToken + decryptRefreshToken wrap AES-256-GCM. The key is
+// pulled from Supabase Vault by `key_version`. Ciphertext is self-contained
+// (IV + tag + payload, base64url) so rows can be copied between tables
+// without needing Vault access at copy time.
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const KEY_VERSION = 'v1';
+const VAULT_KEY_NAME = `apple_encryption_master_key_${KEY_VERSION}`;
+
+let cachedKey: CryptoKey | null = null;
+let cachedKeyVersion: string | null = null;
+
+async function loadMasterKey(keyVersion: string): Promise<CryptoKey> {
+  if (cachedKey && cachedKeyVersion === keyVersion) return cachedKey;
+
+  const supa = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+    { auth: { persistSession: false } },
+  );
+  const { data, error } = await supa
+    .schema('vault')
+    .from('decrypted_secrets')
+    .select('decrypted_secret')
+    .eq('name', `apple_encryption_master_key_${keyVersion}`)
+    .maybeSingle();
+
+  if (error || !data) {
+    throw new Error(`Vault key not available: ${keyVersion}`);
+  }
+
+  const keyBytes = base64ToBytes(data.decrypted_secret as string);
+  if (keyBytes.length !== 32) {
+    throw new Error(`Vault key wrong length: ${keyBytes.length} (expected 32)`);
+  }
+
+  const key = await crypto.subtle.importKey(
+    'raw',
+    keyBytes,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+  cachedKey = key;
+  cachedKeyVersion = keyVersion;
+  return key;
+}
+
+export async function encryptRefreshToken(
+  plaintext: string,
+): Promise<{ ciphertext: string; keyVersion: string }> {
+  const key = await loadMasterKey(KEY_VERSION);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const encrypted = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    new TextEncoder().encode(plaintext),
+  );
+  // Self-contained: version byte + iv + ciphertext+tag.
+  // Version byte future-proofs format changes distinct from key rotation.
+  const versionByte = new Uint8Array([1]);
+  const out = new Uint8Array(
+    versionByte.length + iv.length + encrypted.byteLength,
+  );
+  out.set(versionByte, 0);
+  out.set(iv, 1);
+  out.set(new Uint8Array(encrypted), 1 + iv.length);
+  return { ciphertext: bytesToBase64(out), keyVersion: KEY_VERSION };
+}
+
+export async function decryptRefreshToken(
+  ciphertext: string,
+  keyVersion: string,
+): Promise<string> {
+  const key = await loadMasterKey(keyVersion);
+  const all = base64ToBytes(ciphertext);
+  const version = all[0];
+  if (version !== 1) {
+    throw new Error(`Unsupported ciphertext version: ${version}`);
+  }
+  const iv = all.slice(1, 13);
+  const body = all.slice(13);
+  const plain = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, body);
+  return new TextDecoder().decode(plain);
+}
+
+/**
+ * Parses a JWT and returns the payload. Does NOT verify the signature —
+ * that is Supabase's responsibility on the way in. We only use this to
+ * read `sub` post-Apple-exchange for the sub-binding assertion.
+ */
+export function decodeIdToken(jwt: string): { sub: string; [k: string]: unknown } {
+  const [, payload] = jwt.split('.');
+  if (!payload) throw new Error('Malformed JWT');
+  const json = new TextDecoder().decode(base64UrlToBytes(payload));
+  const parsed = JSON.parse(json);
+  if (typeof parsed.sub !== 'string' || !parsed.sub) {
+    throw new Error('JWT missing sub claim');
+  }
+  return parsed;
+}
+
+// ---- base64 helpers (no deps) ----
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+function base64UrlToBytes(b64url: string): Uint8Array {
+  const b64 = b64url.replace(/-/g, '+').replace(/_/g, '/').padEnd(
+    b64url.length + ((4 - (b64url.length % 4)) % 4),
+    '=',
+  );
+  return base64ToBytes(b64);
+}

--- a/supabase/functions/_shared/apple.ts
+++ b/supabase/functions/_shared/apple.ts
@@ -78,12 +78,15 @@ export async function decryptRefreshToken(
   ciphertext: string,
   keyVersion: string,
 ): Promise<string> {
-  const key = await loadMasterKey(keyVersion);
+  // Version-byte check comes BEFORE Vault load — fail-fast on malformed
+  // ciphertext without burning a Vault round-trip, and keeps the
+  // version-rejection test self-contained (no credentials required).
   const all = base64ToBytes(ciphertext);
   const version = all[0];
   if (version !== 1) {
     throw new Error(`Unsupported ciphertext version: ${version}`);
   }
+  const key = await loadMasterKey(keyVersion);
   const iv = all.slice(1, 13);
   const body = all.slice(13);
   const plain = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, body);
@@ -96,9 +99,11 @@ export async function decryptRefreshToken(
  * read `sub` post-Apple-exchange for the sub-binding assertion.
  */
 export function decodeIdToken(jwt: string): { sub: string; [k: string]: unknown } {
-  const [, payload] = jwt.split('.');
-  if (!payload) throw new Error('Malformed JWT');
-  const json = new TextDecoder().decode(base64UrlToBytes(payload));
+  const parts = jwt.split('.');
+  if (parts.length !== 3 || !parts[0] || !parts[1] || !parts[2]) {
+    throw new Error('Malformed JWT');
+  }
+  const json = new TextDecoder().decode(base64UrlToBytes(parts[1]));
   const parsed = JSON.parse(json);
   if (typeof parsed.sub !== 'string' || !parsed.sub) {
     throw new Error('JWT missing sub claim');

--- a/supabase/functions/_test/harness.ts
+++ b/supabase/functions/_test/harness.ts
@@ -1,0 +1,318 @@
+// supabase/functions/_test/harness.ts
+//
+// Shared Deno test harness for Edge Function integration tests.
+// Used by B1.4 (_shared/apple.ts tests), B1.6 (apple-token-persist tests),
+// and upcoming B3 tests (apple-token-exchange, apple-revocation-retry).
+//
+// Requires env vars at runtime (never hard-coded):
+//   SUPABASE_URL              — e.g. https://vpioftosgdkyiwvhxewy.supabase.co
+//   SUPABASE_SERVICE_ROLE_KEY — service-role JWT (bypasses RLS)
+//   SUPABASE_FUNCTIONS_URL    — optional; defaults to ${SUPABASE_URL}/functions/v1
+//
+// Run integration tests via:
+//   deno test --allow-net --allow-env supabase/functions/<path>.test.ts
+
+import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+// ---------------------------------------------------------------------------
+// Module-scope service-role client — shared across all harness calls so we
+// don't pay the connection overhead on every helper invocation.
+// ---------------------------------------------------------------------------
+
+function getEnv(key: string): string {
+  const val = Deno.env.get(key);
+  if (!val) throw new Error(`[harness] Required env var missing: ${key}`);
+  return val;
+}
+
+const SUPABASE_URL = getEnv('SUPABASE_URL');
+const SERVICE_ROLE_KEY = getEnv('SUPABASE_SERVICE_ROLE_KEY');
+const FUNCTIONS_BASE_URL =
+  Deno.env.get('SUPABASE_FUNCTIONS_URL') ?? `${SUPABASE_URL}/functions/v1`;
+
+// Service-role client: bypasses RLS, can write auth.* tables, can call
+// auth.admin.*. All harness DB operations go through this client.
+const supa: SupabaseClient = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+  auth: { persistSession: false, autoRefreshToken: false },
+});
+
+// ---------------------------------------------------------------------------
+// createTestUser
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a fresh Supabase auth user (email-confirmed, password-auth).
+ * Returns the userId and a valid access JWT obtained via signInWithPassword.
+ *
+ * Email format: test+<uuid>@wgh-test.invalid
+ * Password: a fixed test-only string long enough to satisfy Supabase defaults.
+ */
+export async function createTestUser(): Promise<{ userId: string; jwt: string }> {
+  const uuid = crypto.randomUUID();
+  const email = `test+${uuid}@wgh-test.invalid`;
+  const password = `T3st-${uuid}-pass!`;
+
+  // Create via admin API so we can set email_confirm = true immediately.
+  const { data: createData, error: createErr } = await supa.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+  });
+
+  if (createErr || !createData?.user) {
+    throw new Error(
+      `[harness] createUser failed: ${createErr?.message ?? 'no user returned'}`,
+    );
+  }
+
+  const userId = createData.user.id;
+
+  // Sign in to obtain a real access JWT. The test must present this to the
+  // Edge Function; a manufactured JWT would fail Supabase's getUser() check.
+  const { data: signInData, error: signInErr } = await supa.auth.signInWithPassword({
+    email,
+    password,
+  });
+
+  if (signInErr || !signInData?.session?.access_token) {
+    // Best-effort cleanup before throwing so we don't leak users.
+    await supa.auth.admin.deleteUser(userId).catch(() => {});
+    throw new Error(
+      `[harness] signInWithPassword failed after createUser: ${signInErr?.message ?? 'no session'}`,
+    );
+  }
+
+  return { userId, jwt: signInData.session.access_token };
+}
+
+// ---------------------------------------------------------------------------
+// insertAppleIdentity
+// ---------------------------------------------------------------------------
+
+/**
+ * Inserts a row into auth.identities linking userId to an Apple provider_id
+ * (appleSub). Uses the service-role client to bypass RLS.
+ *
+ * Schema assumptions (Supabase Postgres 15 auth.identities as of 2026-04):
+ *   id            UUID NOT NULL
+ *   user_id       UUID NOT NULL
+ *   provider_id   TEXT NOT NULL   ← appleSub goes here
+ *   provider      TEXT NOT NULL
+ *   identity_data JSONB NOT NULL
+ *   last_sign_in_at TIMESTAMPTZ   ← nullable in Supabase schema; supply NULL
+ *   created_at    TIMESTAMPTZ
+ *   updated_at    TIMESTAMPTZ
+ *
+ * NOTE: Supabase has evolved auth.identities across versions. If you hit a
+ * "column does not exist" error the most likely culprits are:
+ *   - `provider_id` renamed from `id` in older schemas (pre-2023-12)
+ *   - `email` column present in some project configs (derived, not needed here)
+ * If that happens, inspect the live schema:
+ *   SELECT column_name, data_type FROM information_schema.columns
+ *   WHERE table_schema='auth' AND table_name='identities';
+ * and adjust this insert accordingly.
+ */
+export async function insertAppleIdentity(
+  userId: string,
+  appleSub: string,
+): Promise<void> {
+  const identityId = crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  const { error } = await supa.schema('auth').from('identities').insert({
+    id: identityId,
+    user_id: userId,
+    provider_id: appleSub,
+    provider: 'apple',
+    identity_data: { sub: appleSub, email: `${appleSub}@privaterelay.appleid.com` },
+    last_sign_in_at: null,
+    created_at: now,
+    updated_at: now,
+  });
+
+  if (error) {
+    throw new Error(`[harness] insertAppleIdentity failed: ${error.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// invokeFn
+// ---------------------------------------------------------------------------
+
+/**
+ * POSTs to a deployed Edge Function. Returns the raw Response so tests can
+ * inspect status + body independently.
+ *
+ * - If opts.jwt is provided, sends `Authorization: Bearer <jwt>`.
+ * - If opts.body is provided, JSON-encodes it as the request body.
+ * - Always POSTs (even if body is undefined) — Edge Functions expect POST.
+ */
+export async function invokeFn(
+  name: string,
+  opts: { jwt?: string; body?: unknown } = {},
+): Promise<Response> {
+  const url = `${FUNCTIONS_BASE_URL}/${name}`;
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+
+  if (opts.jwt) {
+    headers['Authorization'] = `Bearer ${opts.jwt}`;
+  }
+
+  const bodyStr = opts.body !== undefined ? JSON.stringify(opts.body) : undefined;
+
+  return fetch(url, {
+    method: 'POST',
+    headers,
+    body: bodyStr,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// cleanupUser
+// ---------------------------------------------------------------------------
+
+/**
+ * Deletes the test auth user. Swallows errors — cleanup must not throw and
+ * abort a test's finally block.
+ */
+export async function cleanupUser(userId: string): Promise<void> {
+  try {
+    await supa.auth.admin.deleteUser(userId);
+  } catch {
+    // swallow — test cleanup must not throw
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getAppleTokenRow
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the user_apple_tokens row for userId, or null if none exists.
+ */
+export async function getAppleTokenRow(
+  userId: string,
+): Promise<Record<string, unknown> | null> {
+  const { data, error } = await supa
+    .from('user_apple_tokens')
+    .select('*')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`[harness] getAppleTokenRow failed: ${error.message}`);
+  }
+
+  return data as Record<string, unknown> | null;
+}
+
+// ---------------------------------------------------------------------------
+// createTestPendingRow
+// ---------------------------------------------------------------------------
+
+/**
+ * Inserts a row into pending_apple_revocations and returns its UUID.
+ *
+ * Column semantics:
+ *   apple_sub             — required; identifies the Apple user
+ *   encrypted_refresh_token — ciphertext; null when unrevokable=true
+ *   key_version           — 'v1' default; null when unrevokable=true
+ *   client_id_type        — 'native'|'web'; null when unrevokable=true
+ *   unrevokable           — sentinel flag (no token captured, audit-only)
+ *   locked_at / locked_by — lease fields for FOR UPDATE SKIP LOCKED
+ *   next_attempt_at       — ISO 8601 string; defaults to NOW()
+ *
+ * The table has a CHECK constraint:
+ *   unrevokable OR (encrypted_refresh_token IS NOT NULL AND key_version IS NOT NULL AND client_id_type IS NOT NULL)
+ *
+ * When unrevokable=true this harness sets the three token columns to null
+ * regardless of what was passed, satisfying the CHECK.
+ * When unrevokable=false (default), defaults ensure the CHECK passes without
+ * the caller having to supply all three columns explicitly.
+ */
+export async function createTestPendingRow(row: {
+  apple_sub: string;
+  encrypted_refresh_token?: string | null;
+  key_version?: string | null;
+  client_id_type?: 'native' | 'web' | null;
+  unrevokable?: boolean;
+  locked_at?: string | null;
+  locked_by?: string | null;
+  next_attempt_at?: string;
+}): Promise<string> {
+  const unrevokable = row.unrevokable ?? false;
+
+  const insert: Record<string, unknown> = {
+    apple_sub: row.apple_sub,
+    unrevokable,
+  };
+
+  if (unrevokable) {
+    // CHECK constraint: when unrevokable=true the three token columns must be
+    // null (or absent). Force them regardless of caller input.
+    insert.encrypted_refresh_token = null;
+    insert.key_version = null;
+    insert.client_id_type = null;
+  } else {
+    // Defaults satisfy the CHECK constraint without forcing caller to supply all.
+    insert.encrypted_refresh_token = row.encrypted_refresh_token ?? 'ciphertext-placeholder';
+    insert.key_version = row.key_version ?? 'v1';
+    insert.client_id_type = row.client_id_type ?? 'native';
+  }
+
+  if (row.locked_at !== undefined) insert.locked_at = row.locked_at;
+  if (row.locked_by !== undefined) insert.locked_by = row.locked_by;
+  if (row.next_attempt_at !== undefined) insert.next_attempt_at = row.next_attempt_at;
+
+  const { data, error } = await supa
+    .from('pending_apple_revocations')
+    .insert(insert)
+    .select('id')
+    .single();
+
+  if (error || !data?.id) {
+    throw new Error(`[harness] createTestPendingRow failed: ${error?.message ?? 'no id returned'}`);
+  }
+
+  return data.id as string;
+}
+
+// ---------------------------------------------------------------------------
+// getPendingRow
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the pending_apple_revocations row for id, or null if none exists.
+ */
+export async function getPendingRow(
+  id: string,
+): Promise<Record<string, unknown> | null> {
+  const { data, error } = await supa
+    .from('pending_apple_revocations')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`[harness] getPendingRow failed: ${error.message}`);
+  }
+
+  return data as Record<string, unknown> | null;
+}
+
+// ---------------------------------------------------------------------------
+// cleanupPending
+// ---------------------------------------------------------------------------
+
+/**
+ * Deletes a pending_apple_revocations row by id. Swallows errors.
+ */
+export async function cleanupPending(id: string): Promise<void> {
+  try {
+    await supa.from('pending_apple_revocations').delete().eq('id', id);
+  } catch {
+    // swallow — test cleanup must not throw
+  }
+}

--- a/supabase/functions/_test/harness.ts
+++ b/supabase/functions/_test/harness.ts
@@ -67,12 +67,15 @@ export async function createTestUser(): Promise<{ userId: string; jwt: string }>
 
   const userId = createData.user.id;
 
-  // Sign in to obtain a real access JWT. The test must present this to the
-  // Edge Function; a manufactured JWT would fail Supabase's getUser() check.
-  const { data: signInData, error: signInErr } = await supa.auth.signInWithPassword({
-    email,
-    password,
+  // Sign in to obtain a real access JWT. Use a throwaway client — if we
+  // reused `supa` (the shared service-role client) for signInWithPassword,
+  // its subsequent DB calls would travel as the user's JWT instead of the
+  // service role, silently losing RLS bypass and leaking fixtures.
+  const signInClient = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
   });
+  const { data: signInData, error: signInErr } = await signInClient.auth
+    .signInWithPassword({ email, password });
 
   if (signInErr || !signInData?.session?.access_token) {
     // Best-effort cleanup before throwing so we don't leak users.

--- a/supabase/functions/apple-token-persist/index.test.ts
+++ b/supabase/functions/apple-token-persist/index.test.ts
@@ -8,8 +8,15 @@
 //
 // Tests that don't hit Vault (400/401/409 paths) succeed without credentials
 // as long as the Edge Function is deployed and SUPABASE_URL is reachable.
+//
+// DB-error paths (IDENTITY_LOOKUP_FAILED, TOKEN_LOOKUP_FAILED, UPSERT_FAILED)
+// require fault injection and are not covered by integration tests. If the
+// handler is ever refactored to accept injected dependencies, add unit tests
+// driving those branches directly. For now they're exercised implicitly by
+// the live Postgres error channel.
 
 import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import {
   createTestUser,
   insertAppleIdentity,
@@ -18,11 +25,22 @@ import {
   getAppleTokenRow,
 } from '../_test/harness.ts';
 
+// Service-role admin client for test-only operations the harness doesn't expose
+// (identity deletion, direct auth.identities inserts with null provider_id).
+function adminClient() {
+  return createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+    { auth: { persistSession: false } },
+  );
+}
+
 Deno.test('happy path: JWT + Apple identity + token → 200, row upserted', async () => {
   const { userId, jwt } = await createTestUser();
-  const appleSub = `0001.${crypto.randomUUID()}.000`;
-  await insertAppleIdentity(userId, appleSub);
   try {
+    const appleSub = `0001.${crypto.randomUUID()}.000`;
+    await insertAppleIdentity(userId, appleSub);
+
     const res = await invokeFn('apple-token-persist', {
       jwt,
       body: { provider_refresh_token: 'rt.happy-path' },
@@ -84,6 +102,8 @@ Deno.test('malformed JSON body → 400 MALFORMED_BODY', async () => {
       body: '{not-json',
     });
     assertEquals(res.status, 400);
+    const body = await res.json();
+    assertEquals(body.code, 'MALFORMED_BODY');
   } finally {
     await cleanupUser(userId);
   }
@@ -91,8 +111,8 @@ Deno.test('malformed JSON body → 400 MALFORMED_BODY', async () => {
 
 Deno.test('user without Apple identity → 409 NO_APPLE_IDENTITY', async () => {
   const { userId, jwt } = await createTestUser();
-  // deliberately NO insertAppleIdentity
   try {
+    // deliberately NO insertAppleIdentity
     const res = await invokeFn('apple-token-persist', {
       jwt,
       body: { provider_refresh_token: 'rt.x' },
@@ -105,11 +125,69 @@ Deno.test('user without Apple identity → 409 NO_APPLE_IDENTITY', async () => {
   }
 });
 
+Deno.test('multi Apple identity rows → 500 MULTI_APPLE_IDENTITY', async () => {
+  const { userId, jwt } = await createTestUser();
+  try {
+    // Insert two rows for the same user with provider='apple'. This is a
+    // degraded state Supabase should prevent but the function fails closed.
+    await insertAppleIdentity(userId, `0001.${crypto.randomUUID()}.dup1`);
+    await insertAppleIdentity(userId, `0001.${crypto.randomUUID()}.dup2`);
+
+    const res = await invokeFn('apple-token-persist', {
+      jwt,
+      body: { provider_refresh_token: 'rt.x' },
+    });
+    assertEquals(res.status, 500);
+    const body = await res.json();
+    assertEquals(body.code, 'MULTI_APPLE_IDENTITY');
+  } finally {
+    await cleanupUser(userId);
+  }
+});
+
+Deno.test('Apple identity with null provider_id → 500 IDENTITY_MISSING_SUB', async () => {
+  const { userId, jwt } = await createTestUser();
+  try {
+    // Insert directly with provider_id = NULL to force the degraded branch.
+    // This bypasses harness.insertAppleIdentity which requires an appleSub.
+    const admin = adminClient();
+    const now = new Date().toISOString();
+    const { error: idErr } = await admin.schema('auth').from('identities').insert({
+      id: crypto.randomUUID(),
+      user_id: userId,
+      provider_id: null,
+      provider: 'apple',
+      identity_data: { sub: null },
+      last_sign_in_at: null,
+      created_at: now,
+      updated_at: now,
+    });
+    if (idErr) {
+      // Some Supabase versions have a NOT NULL constraint on provider_id. If
+      // the insert fails, skip the test — the branch is unreachable in that
+      // configuration.
+      console.warn(`skipping IDENTITY_MISSING_SUB test — insert rejected: ${idErr.message}`);
+      return;
+    }
+
+    const res = await invokeFn('apple-token-persist', {
+      jwt,
+      body: { provider_refresh_token: 'rt.x' },
+    });
+    assertEquals(res.status, 500);
+    const body = await res.json();
+    assertEquals(body.code, 'IDENTITY_MISSING_SUB');
+  } finally {
+    await cleanupUser(userId);
+  }
+});
+
 Deno.test('idempotent: second call upserts in place, same user row', async () => {
   const { userId, jwt } = await createTestUser();
-  const appleSub = `0001.${crypto.randomUUID()}.idem`;
-  await insertAppleIdentity(userId, appleSub);
   try {
+    const appleSub = `0001.${crypto.randomUUID()}.idem`;
+    await insertAppleIdentity(userId, appleSub);
+
     const r1 = await invokeFn('apple-token-persist', {
       jwt,
       body: { provider_refresh_token: 'rt.first' },
@@ -138,10 +216,11 @@ Deno.test('APPLE_SUB_MISMATCH: existing row with different apple_sub → 409', a
   // Simulate account-linking drift: row in user_apple_tokens has apple_sub A,
   // but auth.identities now says apple_sub B. Function must refuse to overwrite.
   const { userId, jwt } = await createTestUser();
-  const oldSub = `0001.${crypto.randomUUID()}.old`;
-  const newSub = `0001.${crypto.randomUUID()}.new`;
-  await insertAppleIdentity(userId, oldSub);
   try {
+    const oldSub = `0001.${crypto.randomUUID()}.old`;
+    const newSub = `0001.${crypto.randomUUID()}.new`;
+    await insertAppleIdentity(userId, oldSub);
+
     // First write — establishes the row with oldSub.
     const r1 = await invokeFn('apple-token-persist', {
       jwt,
@@ -150,16 +229,26 @@ Deno.test('APPLE_SUB_MISMATCH: existing row with different apple_sub → 409', a
     assertEquals(r1.status, 200);
 
     // Swap the identity: delete the old row, insert a new one with newSub.
-    // Harness doesn't expose deleteIdentity — do it inline via service-role.
-    const { createClient } = await import('https://esm.sh/@supabase/supabase-js@2');
-    const admin = createClient(
-      Deno.env.get('SUPABASE_URL')!,
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
-      { auth: { persistSession: false } },
-    );
-    await admin.schema('auth').from('identities').delete()
-      .eq('user_id', userId).eq('provider', 'apple');
+    const admin = adminClient();
+    const { error: delErr } = await admin
+      .schema('auth')
+      .from('identities')
+      .delete()
+      .eq('user_id', userId)
+      .eq('provider', 'apple');
+    assert(!delErr, `identity delete must succeed: ${delErr?.message}`);
     await insertAppleIdentity(userId, newSub);
+
+    // Sanity — exactly one Apple identity row for this user.
+    const { data: idsAfter, error: countErr } = await admin
+      .schema('auth')
+      .from('identities')
+      .select('provider_id')
+      .eq('user_id', userId)
+      .eq('provider', 'apple');
+    assert(!countErr, `identity count query failed: ${countErr?.message}`);
+    assertEquals(idsAfter?.length, 1);
+    assertEquals(idsAfter?.[0].provider_id, newSub);
 
     // Second write — should 409 because user_apple_tokens row still has oldSub.
     const r2 = await invokeFn('apple-token-persist', {

--- a/supabase/functions/apple-token-persist/index.test.ts
+++ b/supabase/functions/apple-token-persist/index.test.ts
@@ -1,0 +1,179 @@
+// supabase/functions/apple-token-persist/index.test.ts
+//
+// Integration tests for apple-token-persist. Require live Supabase:
+// SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, and the apple_encryption_master_key_v1
+// Vault secret populated. Run with:
+//
+//   deno test --allow-net --allow-env supabase/functions/apple-token-persist/
+//
+// Tests that don't hit Vault (400/401/409 paths) succeed without credentials
+// as long as the Edge Function is deployed and SUPABASE_URL is reachable.
+
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import {
+  createTestUser,
+  insertAppleIdentity,
+  invokeFn,
+  cleanupUser,
+  getAppleTokenRow,
+} from '../_test/harness.ts';
+
+Deno.test('happy path: JWT + Apple identity + token → 200, row upserted', async () => {
+  const { userId, jwt } = await createTestUser();
+  const appleSub = `0001.${crypto.randomUUID()}.000`;
+  await insertAppleIdentity(userId, appleSub);
+  try {
+    const res = await invokeFn('apple-token-persist', {
+      jwt,
+      body: { provider_refresh_token: 'rt.happy-path' },
+    });
+    assertEquals(res.status, 200);
+    const row = await getAppleTokenRow(userId);
+    assert(row, 'row was written');
+    assertEquals(row!.apple_sub, appleSub);
+    assertEquals(row!.client_id_type, 'web');
+    assert(typeof row!.encrypted_refresh_token === 'string' && (row!.encrypted_refresh_token as string).length > 0);
+    assertEquals(row!.key_version, 'v1');
+  } finally {
+    await cleanupUser(userId);
+  }
+});
+
+Deno.test('missing Authorization header → 401 MISSING_JWT', async () => {
+  const res = await invokeFn('apple-token-persist', {
+    body: { provider_refresh_token: 'rt.x' },
+  });
+  assertEquals(res.status, 401);
+  const body = await res.json();
+  assertEquals(body.code, 'MISSING_JWT');
+});
+
+Deno.test('invalid JWT → 401 INVALID_JWT', async () => {
+  const res = await invokeFn('apple-token-persist', {
+    jwt: 'not.a.valid.jwt',
+    body: { provider_refresh_token: 'rt.x' },
+  });
+  assertEquals(res.status, 401);
+  const body = await res.json();
+  assertEquals(body.code, 'INVALID_JWT');
+});
+
+Deno.test('missing provider_refresh_token → 400 MISSING_TOKEN', async () => {
+  const { userId, jwt } = await createTestUser();
+  try {
+    const res = await invokeFn('apple-token-persist', { jwt, body: {} });
+    assertEquals(res.status, 400);
+    const body = await res.json();
+    assertEquals(body.code, 'MISSING_TOKEN');
+  } finally {
+    await cleanupUser(userId);
+  }
+});
+
+Deno.test('malformed JSON body → 400 MALFORMED_BODY', async () => {
+  const { userId, jwt } = await createTestUser();
+  try {
+    // invokeFn JSON-encodes, so bypass it with raw fetch
+    const url = `${Deno.env.get('SUPABASE_FUNCTIONS_URL') ?? Deno.env.get('SUPABASE_URL') + '/functions/v1'}/apple-token-persist`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${jwt}`,
+      },
+      body: '{not-json',
+    });
+    assertEquals(res.status, 400);
+  } finally {
+    await cleanupUser(userId);
+  }
+});
+
+Deno.test('user without Apple identity → 409 NO_APPLE_IDENTITY', async () => {
+  const { userId, jwt } = await createTestUser();
+  // deliberately NO insertAppleIdentity
+  try {
+    const res = await invokeFn('apple-token-persist', {
+      jwt,
+      body: { provider_refresh_token: 'rt.x' },
+    });
+    assertEquals(res.status, 409);
+    const body = await res.json();
+    assertEquals(body.code, 'NO_APPLE_IDENTITY');
+  } finally {
+    await cleanupUser(userId);
+  }
+});
+
+Deno.test('idempotent: second call upserts in place, same user row', async () => {
+  const { userId, jwt } = await createTestUser();
+  const appleSub = `0001.${crypto.randomUUID()}.idem`;
+  await insertAppleIdentity(userId, appleSub);
+  try {
+    const r1 = await invokeFn('apple-token-persist', {
+      jwt,
+      body: { provider_refresh_token: 'rt.first' },
+    });
+    assertEquals(r1.status, 200);
+    const row1 = await getAppleTokenRow(userId);
+    const first = row1!.encrypted_refresh_token as string;
+
+    const r2 = await invokeFn('apple-token-persist', {
+      jwt,
+      body: { provider_refresh_token: 'rt.second' },
+    });
+    assertEquals(r2.status, 200);
+    const row2 = await getAppleTokenRow(userId);
+    const second = row2!.encrypted_refresh_token as string;
+
+    assert(first !== second, 'ciphertext changed on second write (fresh IV)');
+    assertEquals(row2!.apple_sub, appleSub);
+    assertEquals(row2!.client_id_type, 'web');
+  } finally {
+    await cleanupUser(userId);
+  }
+});
+
+Deno.test('APPLE_SUB_MISMATCH: existing row with different apple_sub → 409', async () => {
+  // Simulate account-linking drift: row in user_apple_tokens has apple_sub A,
+  // but auth.identities now says apple_sub B. Function must refuse to overwrite.
+  const { userId, jwt } = await createTestUser();
+  const oldSub = `0001.${crypto.randomUUID()}.old`;
+  const newSub = `0001.${crypto.randomUUID()}.new`;
+  await insertAppleIdentity(userId, oldSub);
+  try {
+    // First write — establishes the row with oldSub.
+    const r1 = await invokeFn('apple-token-persist', {
+      jwt,
+      body: { provider_refresh_token: 'rt.old' },
+    });
+    assertEquals(r1.status, 200);
+
+    // Swap the identity: delete the old row, insert a new one with newSub.
+    // Harness doesn't expose deleteIdentity — do it inline via service-role.
+    const { createClient } = await import('https://esm.sh/@supabase/supabase-js@2');
+    const admin = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+      { auth: { persistSession: false } },
+    );
+    await admin.schema('auth').from('identities').delete()
+      .eq('user_id', userId).eq('provider', 'apple');
+    await insertAppleIdentity(userId, newSub);
+
+    // Second write — should 409 because user_apple_tokens row still has oldSub.
+    const r2 = await invokeFn('apple-token-persist', {
+      jwt,
+      body: { provider_refresh_token: 'rt.new' },
+    });
+    assertEquals(r2.status, 409);
+    const body = await r2.json();
+    assertEquals(body.code, 'APPLE_SUB_MISMATCH');
+
+    // Verify the row wasn't mutated.
+    const row = await getAppleTokenRow(userId);
+    assertEquals(row!.apple_sub, oldSub);
+  } finally {
+    await cleanupUser(userId);
+  }
+});

--- a/supabase/functions/apple-token-persist/index.ts
+++ b/supabase/functions/apple-token-persist/index.ts
@@ -1,0 +1,144 @@
+// supabase/functions/apple-token-persist/index.ts
+//
+// Web path for Apple refresh-token capture (Flow K in the spec).
+//
+// Client flow:
+//   Supabase web OAuth callback → onAuthStateChange fires SIGNED_IN with
+//   session.provider_refresh_token present → authApi.persistAppleRefreshToken
+//   POSTs here with { provider_refresh_token } and the user's JWT in
+//   Authorization.
+//
+// This function never calls Apple. It only encrypts + upserts. The token
+// itself came from Supabase's own OAuth callback and is already validated.
+//
+// Auth: Bearer JWT (user JWT from Supabase). We derive user_id from claims
+// and look up apple_sub from auth.identities. Client-supplied apple_sub or
+// user_id is ignored.
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { encryptRefreshToken } from '../_shared/apple.ts';
+
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+function json(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...CORS },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response(null, { headers: CORS });
+  if (req.method !== 'POST') return json(405, { ok: false, code: 'METHOD_NOT_ALLOWED' });
+
+  // 1. Authenticate caller
+  const authHeader = req.headers.get('authorization') ?? '';
+  const jwt = authHeader.toLowerCase().startsWith('bearer ')
+    ? authHeader.slice(7).trim()
+    : '';
+  if (!jwt) return json(401, { ok: false, code: 'MISSING_JWT' });
+
+  const supa = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+    { auth: { persistSession: false } },
+  );
+  const { data: userData, error: userErr } = await supa.auth.getUser(jwt);
+  if (userErr || !userData.user) {
+    return json(401, { ok: false, code: 'INVALID_JWT' });
+  }
+  const userId = userData.user.id;
+
+  // 2. Parse body
+  let body: { provider_refresh_token?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return json(400, { ok: false, code: 'MALFORMED_BODY' });
+  }
+  const providerRefreshToken = typeof body?.provider_refresh_token === 'string'
+    ? body.provider_refresh_token
+    : '';
+  if (!providerRefreshToken) {
+    return json(400, { ok: false, code: 'MISSING_TOKEN' });
+  }
+
+  // 3. Derive apple_sub from auth.identities (server-side only — never trust client)
+  const { data: identities, error: idErr } = await supa
+    .schema('auth')
+    .from('identities')
+    .select('provider_id, provider')
+    .eq('user_id', userId)
+    .eq('provider', 'apple');
+
+  if (idErr) {
+    return json(500, { ok: false, code: 'IDENTITY_LOOKUP_FAILED', transient: true });
+  }
+  if (!identities || identities.length === 0) {
+    return json(409, { ok: false, code: 'NO_APPLE_IDENTITY' });
+  }
+  if (identities.length > 1) {
+    // Degraded state — fail closed. Mirror apple-token-exchange behavior.
+    console.error(JSON.stringify({
+      event: 'apple_token_persist_multi_identity',
+      user_hash: await hashUserId(userId),
+    }));
+    return json(500, { ok: false, code: 'MULTI_APPLE_IDENTITY' });
+  }
+  const appleSub = identities[0].provider_id;
+  if (!appleSub) {
+    return json(500, { ok: false, code: 'IDENTITY_MISSING_SUB' });
+  }
+
+  // 4. Encrypt + upsert
+  let encrypted: { ciphertext: string; keyVersion: string };
+  try {
+    encrypted = await encryptRefreshToken(providerRefreshToken);
+  } catch (e) {
+    console.error(JSON.stringify({
+      event: 'apple_token_persist_encrypt_failed',
+      user_hash: await hashUserId(userId),
+    }));
+    return json(503, { ok: false, code: 'VAULT_UNAVAILABLE', transient: true });
+  }
+
+  // Web path — this is always client_id_type = 'web' because the refresh
+  // token came from Supabase's OAuth callback using the Services ID.
+  const { error: upsertErr } = await supa
+    .from('user_apple_tokens')
+    .upsert(
+      {
+        user_id: userId,
+        apple_sub: appleSub,
+        encrypted_refresh_token: encrypted.ciphertext,
+        key_version: encrypted.keyVersion,
+        client_id_type: 'web',
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id' },
+    );
+  if (upsertErr) {
+    // Structured, scrubbed — never log the raw error object (may contain query fragments).
+    console.error(JSON.stringify({
+      event: 'apple_token_persist_upsert_failed',
+      user_hash: await hashUserId(userId),
+      pg_code: (upsertErr as Record<string, unknown>)?.code ?? null,
+    }));
+    return json(500, { ok: false, code: 'UPSERT_FAILED', transient: true });
+  }
+
+  return json(200, { ok: true });
+});
+
+async function hashUserId(userId: string): Promise<string> {
+  const bytes = new TextEncoder().encode(userId);
+  const hash = await crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+    .slice(0, 16);
+}

--- a/supabase/functions/apple-token-persist/index.ts
+++ b/supabase/functions/apple-token-persist/index.ts
@@ -91,14 +91,37 @@ Deno.serve(async (req) => {
   }
   const appleSub = identities[0].provider_id;
   if (!appleSub) {
+    console.error(JSON.stringify({
+      event: 'apple_token_persist_null_provider_id',
+      user_hash: await hashUserId(userId),
+    }));
     return json(500, { ok: false, code: 'IDENTITY_MISSING_SUB' });
   }
 
-  // 4. Encrypt + upsert
+  // 4. Refuse to overwrite a row whose apple_sub differs from the identity
+  // we just derived — defense against account-linking edge cases where the
+  // stored row drifted from auth.identities. Spec Flow K: 409 + alert.
+  const { data: existing, error: existingErr } = await supa
+    .from('user_apple_tokens')
+    .select('apple_sub')
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (existingErr) {
+    return json(500, { ok: false, code: 'TOKEN_LOOKUP_FAILED', transient: true });
+  }
+  if (existing && existing.apple_sub !== appleSub) {
+    console.error(JSON.stringify({
+      event: 'apple_token_persist_sub_mismatch',
+      user_hash: await hashUserId(userId),
+    }));
+    return json(409, { ok: false, code: 'APPLE_SUB_MISMATCH' });
+  }
+
+  // 5. Encrypt + upsert
   let encrypted: { ciphertext: string; keyVersion: string };
   try {
     encrypted = await encryptRefreshToken(providerRefreshToken);
-  } catch (e) {
+  } catch {
     console.error(JSON.stringify({
       event: 'apple_token_persist_encrypt_failed',
       user_hash: await hashUserId(userId),

--- a/supabase/migrations/20260421_user_apple_tokens.sql
+++ b/supabase/migrations/20260421_user_apple_tokens.sql
@@ -1,0 +1,49 @@
+-- supabase/migrations/20260421_user_apple_tokens.sql
+--
+-- Per-user Apple refresh-token storage for App Store compliance with
+-- guideline 5.1.1(v) — account deletion must revoke Apple consent.
+--
+-- encrypted_refresh_token is self-contained ciphertext (not a Vault reference)
+-- so rows can be copied byte-for-byte into pending_apple_revocations during
+-- account deletion without needing Vault access at copy time.
+
+CREATE TABLE IF NOT EXISTS public.user_apple_tokens (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  apple_sub TEXT NOT NULL,
+  encrypted_refresh_token TEXT NOT NULL,
+  key_version TEXT NOT NULL,
+  -- client_id_type determines which Apple client_id was used when the token
+  -- was issued. Revocation MUST use the same client_id — 'native' = bundle id
+  -- (com.whatsgoodhere.app), 'web' = services id (com.whatsgoodhere.service).
+  -- Mixing these causes Apple to reject the revoke with invalid_client.
+  client_id_type TEXT NOT NULL CHECK (client_id_type IN ('native', 'web')),
+  -- Idempotency: code_hash + code_hash_seen_at together identify the most
+  -- recent authorization_code. Duplicate submission within 60s returns 409
+  -- without re-calling Apple. code_hash_seen_at is NOT the same as updated_at
+  -- (which is bumped by non-exchange writes like web token re-captures).
+  code_hash TEXT,
+  code_hash_seen_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_exchange_at TIMESTAMPTZ,
+  revoked_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS user_apple_tokens_apple_sub_idx
+  ON public.user_apple_tokens (apple_sub);
+
+ALTER TABLE public.user_apple_tokens ENABLE ROW LEVEL SECURITY;
+
+-- No policies for authenticated role = deny all. Service role bypasses RLS.
+
+COMMENT ON TABLE public.user_apple_tokens IS
+  'Apple refresh tokens for SIWA revocation compliance. Service-role only. encrypted_refresh_token is self-contained ciphertext (not a Vault ref).';
+COMMENT ON COLUMN public.user_apple_tokens.code_hash IS
+  'SHA-256 of last Apple authorization_code consumed. Paired with code_hash_seen_at for duplicate-submission 409 response.';
+COMMENT ON COLUMN public.user_apple_tokens.client_id_type IS
+  'Which Apple client_id issued this refresh token. Revocation must use same client_id.';
+COMMENT ON COLUMN public.user_apple_tokens.key_version IS
+  'Versioned label for the Vault encryption key used on encrypted_refresh_token. Allows rotation without re-encrypting.';
+
+-- ROLLBACK:
+--   DROP TABLE IF EXISTS public.user_apple_tokens CASCADE;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -322,6 +322,35 @@ CREATE TABLE IF NOT EXISTS events (
   created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL
 );
 
+-- 1w. user_apple_tokens
+-- Per-user Apple refresh-token storage for App Store compliance with
+-- guideline 5.1.1(v) — account deletion must revoke Apple consent.
+--
+-- encrypted_refresh_token is self-contained ciphertext (not a Vault reference)
+-- so rows can be copied byte-for-byte into pending_apple_revocations during
+-- account deletion without needing Vault access at copy time.
+CREATE TABLE IF NOT EXISTS user_apple_tokens (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  apple_sub TEXT NOT NULL,
+  encrypted_refresh_token TEXT NOT NULL,
+  key_version TEXT NOT NULL,
+  -- client_id_type determines which Apple client_id was used when the token
+  -- was issued. Revocation MUST use the same client_id — 'native' = bundle id
+  -- (com.whatsgoodhere.app), 'web' = services id (com.whatsgoodhere.service).
+  -- Mixing these causes Apple to reject the revoke with invalid_client.
+  client_id_type TEXT NOT NULL CHECK (client_id_type IN ('native', 'web')),
+  -- Idempotency: code_hash + code_hash_seen_at together identify the most
+  -- recent authorization_code. Duplicate submission within 60s returns 409
+  -- without re-calling Apple. code_hash_seen_at is NOT the same as updated_at
+  -- (which is bumped by non-exchange writes like web token re-captures).
+  code_hash TEXT,
+  code_hash_seen_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_exchange_at TIMESTAMPTZ,
+  revoked_at TIMESTAMPTZ
+);
+
 -- 1v. category_median_prices (view)
 -- SECURITY INVOKER ensures this runs with the querying user's permissions, not the creator's
 CREATE OR REPLACE VIEW category_median_prices
@@ -452,6 +481,9 @@ CREATE INDEX IF NOT EXISTS idx_events_active_upcoming ON events(event_date, is_p
 CREATE INDEX IF NOT EXISTS idx_events_type ON events(event_type) WHERE is_active = true;
 -- Audit 2026-04-16: FK index on events.created_by.
 CREATE INDEX IF NOT EXISTS idx_events_created_by ON events(created_by);
+
+-- user_apple_tokens
+CREATE INDEX IF NOT EXISTS user_apple_tokens_apple_sub_idx ON user_apple_tokens (apple_sub);
 
 -- jitter_samples (keep only last 30 samples per user, rolling window)
 CREATE INDEX IF NOT EXISTS idx_jitter_samples_user ON jitter_samples (user_id, collected_at DESC);
@@ -607,6 +639,9 @@ CREATE POLICY "Admin or manager update events" ON events FOR UPDATE
   USING (is_admin() OR is_restaurant_manager(restaurant_id))
   WITH CHECK (is_admin() OR is_restaurant_manager(restaurant_id));
 CREATE POLICY "Admin or manager delete events" ON events FOR DELETE USING (is_admin() OR is_restaurant_manager(restaurant_id));
+
+-- user_apple_tokens: service-role only. No policies for authenticated role = deny all.
+ALTER TABLE user_apple_tokens ENABLE ROW LEVEL SECURITY;
 
 -- jitter_profiles + jitter_samples: users can read own profile, insert own samples, service role manages all
 ALTER TABLE jitter_profiles ENABLE ROW LEVEL SECURITY;

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -11,6 +11,13 @@ export default defineConfig({
       'e2e/**',
       'whats-good-here-soul/**',
       'node_modules/**',
+      // Deno-native tests — these use `https://deno.land/std/...` + `https://esm.sh/...`
+      // URL imports that Node's ESM loader rejects. Run them with:
+      //   deno test --allow-net --allow-env <path>
+      // Other supabase/functions/*.test.ts files are pure vitest (import from 'vitest')
+      // and stay included by default — only list the Deno-specific ones here.
+      'supabase/functions/_shared/apple.test.ts',
+      'supabase/functions/apple-token-persist/index.test.ts',
     ],
   },
 })


### PR DESCRIPTION
## Summary
Ships Flow K end-to-end: when a user signs in with Apple on the web, Supabase exposes `session.provider_refresh_token` briefly on the post-callback `SIGNED_IN` event. We POST it to a new `apple-token-persist` Edge Function which encrypts it (AES-256-GCM via Supabase Vault) and upserts it into `user_apple_tokens` with `client_id_type='web'`. Prerequisite for App Store guideline 5.1.1(v) compliance.

Plan: `docs/superpowers/plans/2026-04-21-oauth-native-plan-b.md` (B1 of 5 PRs).
Spec: `docs/superpowers/specs/2026-04-20-oauth-native-and-apple-revocation-design.md`.

## What's in the diff
- `supabase/migrations/20260421_user_apple_tokens.sql` + `supabase/schema.sql` append — table with `client_id_type`, `code_hash`, `code_hash_seen_at`, deny-all RLS
- `supabase/functions/_shared/apple.ts` — `encryptRefreshToken`, `decryptRefreshToken`, `decodeIdToken` (version-byte check before Vault load)
- `supabase/functions/_test/harness.ts` — Deno integration-test harness (isolated sign-in client to preserve service-role bypass)
- `supabase/functions/apple-token-persist/` — Edge Function + 10 integration tests, with `APPLE_SUB_MISMATCH` guard against account-linking drift
- `src/api/authApi.js` — `persistAppleRefreshToken` with transient-marker retry policy (not default-500 retry), safe side-effect wrappers, never-throws contract
- `src/context/AuthContext.jsx` — Flow K hook gated only on `session.provider_refresh_token` (server decides Apple vs non-Apple)
- `NOTES.md` — Apple Vault key convention

## Codex review
Four per-task Codex passes (gpt-5.4 / high) + one final holistic pass. All MUST-FIX findings triaged and applied inline; final pass returned **READY TO MERGE** with zero must-fixes. Trail:

| Pass | Must-fix findings | Applied |
|---|---|---|
| Post-B1.4 batch | Version-byte check before Vault load; harness signIn isolation | ✓ commit `4535491` |
| B1.5 apple-token-persist | `APPLE_SUB_MISMATCH` pre-check, structured log hygiene | ✓ commit `f8d3664` |
| B1.6 integration tests | Fixture leak in seed-then-try; MULTI/NULL identity tests missing | ✓ commit `9080d1f` |
| B1.7 Flow K + authApi | Body-only 500 default → wrong retry; unsafe PostHog/logger | ✓ commit `a3b2480` |
| Final holistic | None; unused `VAULT_KEY_NAME` constant (nice-to-have) | ✓ commit `96a142e` |

## Test plan
- [x] `npm run build` clean
- [x] `npx vitest run src/api/authApi.test.js` → 18/18
- [x] `deno test --allow-net --allow-env supabase/functions/_shared/apple.test.ts` → 3/5 pass without credentials (version-byte + JWT decode tests run clean; crypto roundtrip tests require Vault)
- [ ] **Dan-side unblocks before the feature runtime-lights-up:**
  - [ ] Run `supabase/migrations/20260421_user_apple_tokens.sql` in SQL Editor
  - [ ] `openssl rand -base64 32` → `SELECT vault.create_secret(<key>, 'apple_encryption_master_key_v1', ...)`
  - [ ] Deploy Edge Function: `SUPABASE_ACCESS_TOKEN=<token> npx supabase functions deploy apple-token-persist --project-ref vpioftosgdkyiwvhxewy`
  - [ ] Verify `auth.identities.provider_id` column exists (quick `SELECT 1 FROM information_schema.columns WHERE ...`)
  - [ ] Web smoke: sign in with Apple → check for a `user_apple_tokens` row with `client_id_type='web'`

## Intentional non-goals (for later PRs)
- Native iOS Google + Apple via Capgo → B2
- Apple token exchange backend + revocation retry + delete-account extension → B3-code
- Apple Dev credentials upload + Supabase provider config + prod feature-flag flip → B3-activate
- Universal links + AASA → B4
- SIWA Xcode capability + TestFlight → B5

## Known nice-to-have follow-ups (not blocking merge)
- Flow K fires on any `SIGNED_IN` with `provider_refresh_token`; non-Apple users get a cheap `409 NO_APPLE_IDENTITY`. Codex called this "minor spec drift" but safe.
- DB-error branches (`IDENTITY_LOOKUP_FAILED`, `TOKEN_LOOKUP_FAILED`, `UPSERT_FAILED`, `VAULT_UNAVAILABLE`) are not covered by integration tests — would need fault injection or a handler-factory refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)