### PR TITLE
fix(rls): break admins policy recursion causing 500 on every admin check

### DIFF
--- a/supabase/migrations/2026-04-22-admins-rls-no-recursion.sql
+++ b/supabase/migrations/2026-04-22-admins-rls-no-recursion.sql
@@ -1,0 +1,27 @@
+-- Fix infinite RLS recursion on admins table.
+--
+-- The prior policy queried `FROM admins` from inside its own USING clause,
+-- which made Postgres re-apply the policy on the inner SELECT and return
+-- 500 on every `GET /rest/v1/admins` call (caught 2026-04-22 in prod logs
+-- on wghapp.com — admin status check was 500-ing for every logged-in user).
+--
+-- The true invariant the app needs is "a user can check their own admin
+-- status." No caller reads the full admin list. Own-row semantics eliminate
+-- recursion by construction without relying on SECURITY DEFINER as an
+-- escape hatch.
+
+DROP POLICY IF EXISTS "Admins can read admins" ON admins;
+DROP POLICY IF EXISTS "Users can read own admin row" ON admins;
+
+CREATE POLICY "Users can read own admin row" ON admins FOR SELECT USING (
+  (select auth.uid()) = user_id
+);
+
+-- ROLLBACK: re-creates the broken recursive policy. Only use if a downstream
+-- consumer genuinely needs cross-user admin reads AND you have a plan to
+-- avoid the recursion (wrap the lookup in a SECURITY DEFINER function).
+--
+-- DROP POLICY IF EXISTS "Users can read own admin row" ON admins;
+-- CREATE POLICY "Admins can read admins" ON admins FOR SELECT USING (
+--   EXISTS (SELECT 1 FROM admins WHERE user_id = (select auth.uid()))
+-- );

--- a/supabase/migrations/comprehensive_schema_sync.sql
+++ b/supabase/migrations/comprehensive_schema_sync.sql
@@ -534,9 +534,10 @@ CREATE POLICY "Users can insert own favorites" ON favorites FOR INSERT WITH CHEC
 DROP POLICY IF EXISTS "Users can delete own favorites" ON favorites;
 CREATE POLICY "Users can delete own favorites" ON favorites FOR DELETE USING ((select auth.uid()) = user_id);
 
--- admins
+-- admins: each user can read their own admin row (avoids RLS recursion).
 DROP POLICY IF EXISTS "Admins can read admins" ON admins;
-CREATE POLICY "Admins can read admins" ON admins FOR SELECT USING (EXISTS (SELECT 1 FROM admins WHERE user_id = (select auth.uid())));
+DROP POLICY IF EXISTS "Users can read own admin row" ON admins;
+CREATE POLICY "Users can read own admin row" ON admins FOR SELECT USING ((select auth.uid()) = user_id);
 
 -- dish_photos
 DROP POLICY IF EXISTS "Public read access" ON dish_photos;

--- a/supabase/migrations/denis-sync/step-08-rls-policies-drop-if-exists-create.sql
+++ b/supabase/migrations/denis-sync/step-08-rls-policies-drop-if-exists-create.sql
@@ -75,8 +75,10 @@ DROP POLICY IF EXISTS "Users can delete own favorites" ON favorites;
 CREATE POLICY "Users can delete own favorites" ON favorites FOR DELETE USING ((select auth.uid()) = user_id);
 
 -- ---- admins ----
+-- Each user can read their own admin row (avoids RLS recursion).
 DROP POLICY IF EXISTS "Admins can read admins" ON admins;
-CREATE POLICY "Admins can read admins" ON admins FOR SELECT USING (EXISTS (SELECT 1 FROM admins WHERE user_id = (select auth.uid())));
+DROP POLICY IF EXISTS "Users can read own admin row" ON admins;
+CREATE POLICY "Users can read own admin row" ON admins FOR SELECT USING ((select auth.uid()) = user_id);
 
 -- ---- dish_photos ----
 DROP POLICY IF EXISTS "Public read access" ON dish_photos;

--- a/supabase/migrations/full-schema-sync.sql
+++ b/supabase/migrations/full-schema-sync.sql
@@ -853,8 +853,10 @@ DROP POLICY IF EXISTS "Users can delete own favorites" ON favorites;
 CREATE POLICY "Users can delete own favorites" ON favorites FOR DELETE USING ((select auth.uid()) = user_id);
 
 -- ---- admins ----
+-- Each user can read their own admin row (avoids RLS recursion).
 DROP POLICY IF EXISTS "Admins can read admins" ON admins;
-CREATE POLICY "Admins can read admins" ON admins FOR SELECT USING (EXISTS (SELECT 1 FROM admins WHERE user_id = (select auth.uid())));
+DROP POLICY IF EXISTS "Users can read own admin row" ON admins;
+CREATE POLICY "Users can read own admin row" ON admins FOR SELECT USING ((select auth.uid()) = user_id);
 
 -- ---- dish_photos ----
 DROP POLICY IF EXISTS "Public read access" ON dish_photos;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -539,8 +539,11 @@ CREATE POLICY "Users can read own favorites" ON favorites FOR SELECT USING ((sel
 CREATE POLICY "Users can insert own favorites" ON favorites FOR INSERT WITH CHECK ((select auth.uid()) = user_id);
 CREATE POLICY "Users can delete own favorites" ON favorites FOR DELETE USING ((select auth.uid()) = user_id);
 
--- admins: admins can read
-CREATE POLICY "Admins can read admins" ON admins FOR SELECT USING (EXISTS (SELECT 1 FROM admins WHERE user_id = (select auth.uid())));
+-- admins: each user can read their own admin row.
+-- Never query `FROM admins` inside this policy — doing so triggers infinite
+-- policy recursion and returns 500. No caller needs the full admin list;
+-- clients check their own admin status via adminApi.isAdmin().
+CREATE POLICY "Users can read own admin row" ON admins FOR SELECT USING ((select auth.uid()) = user_id);
 
 -- dish_photos: public read, users manage own
 CREATE POLICY "Public read access" ON dish_photos FOR SELECT USING (true);


### PR DESCRIPTION
## Summary

- Root cause: the \`admins\` RLS policy queried \`FROM admins\` from inside its own \`USING\` clause, causing infinite policy re-entry. Every \`GET /rest/v1/admins\` from a logged-in user returned 500. Caught in prod DevTools on wghapp.com (\`adminApi.isAdmin()\` was erroring on every page).
- Fix: express the true invariant — a user can read their own admin row. \`adminApi.isAdmin()\` is the only caller, and it only ever looks up the current user's own row. No recursion possible by construction; no reliance on \`SECURITY DEFINER\` as an escape hatch (considered Option B and rejected — preserves the semantic mismatch).
- Patched all four locations that carried the broken policy (\`schema.sql\`, \`comprehensive_schema_sync.sql\`, \`full-schema-sync.sql\`, \`denis-sync/step-08\`) so any future schema rebuild can't reintroduce the bug.
- New migration \`2026-04-22-admins-rls-no-recursion.sql\` includes a commented \`-- ROLLBACK:\` block per CLAUDE.md §1.5.

Reviewed by Codex (gpt-5.4, high reasoning) — confirmed Option A is the root fix and flagged the three stale migration files to patch alongside.

## Test plan

- [ ] Paste \`supabase/migrations/2026-04-22-admins-rls-no-recursion.sql\` into the Supabase SQL Editor and run against prod
- [ ] Hit any page as a logged-in user → Network tab shows \`GET /rest/v1/admins\` returns 200 (empty array for non-admins, own row for admins) instead of 500
- [ ] Non-admin users still see non-admin UI; admin-gated UI still appears for admins
- [ ] \`npm run build\` passes (done locally — ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)