### PR TITLE
feat(menu-refresh): score-ranked candidate extraction (PDFs + images)

### DIFF
--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -2,6 +2,7 @@ import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { detectCms, cmsRequiresRender } from './cms-detect.ts'
 import { fetchRenderedHtml, BrowserlessError } from './browserless.ts'
+import { discoverMenuCandidates, type MenuCandidate } from './menu-candidates.ts'
 
 /**
  * Menu Refresh Edge Function
@@ -391,30 +392,28 @@ async function fetchMenuContent(url: string): Promise<string> {
   return extractMenuTextFromHtml(html)
 }
 
-/**
- * Extract PDF URLs from HTML that look like menu documents.
- * Returns absolute URLs. Skips PDFs that clearly aren't menus (gift cards, terms, etc).
- */
-function extractPdfMenuUrls(html: string, baseUrl: string): string[] {
-  const base = new URL(baseUrl)
-  // Match href="..."pdf and src="..."pdf
-  const pdfRegex = /(?:href|src)=["']([^"']*\.pdf[^"']*)["']/gi
-  const found = new Set<string>()
-  let match
-  while ((match = pdfRegex.exec(html)) !== null) {
-    try {
-      const url = new URL(match[1], base).href
-      // Skip obvious non-menu PDFs
-      const lower = url.toLowerCase()
-      if (/\b(terms|privacy|policy|giftcard|gift-card|application|job|employment|contract|waiver|rules)\b/.test(lower)) {
-        continue
-      }
-      found.add(url)
-    } catch {
-      // Invalid URL, skip
-    }
+interface ExtractionAttempt {
+  strategy: 'image' | 'pdf' | 'html'
+  url_count: number
+  top_score?: number
+  dishes_found: number
+  error?: string
+}
+
+// Caps per strategy. Vision is per-pixel-token expensive — keep image batches small.
+const MAX_IMAGE_CANDIDATES = 3
+const MAX_PDF_CANDIDATES = 6
+
+// Merge two candidate lists by URL (last-write-wins on score), then re-sort.
+// Used when Browserless renders surface JS-injected assets that weren't in the raw HTML.
+function mergeCandidates(a: MenuCandidate[], b: MenuCandidate[]): MenuCandidate[] {
+  const byUrl = new Map<string, MenuCandidate>()
+  for (const c of a) byUrl.set(c.url, c)
+  for (const c of b) {
+    const existing = byUrl.get(c.url)
+    if (!existing || c.score > existing.score) byUrl.set(c.url, c)
   }
-  return Array.from(found).slice(0, 6) // Cap at 6 PDFs per restaurant
+  return Array.from(byUrl.values()).sort((x, y) => y.score - x.score)
 }
 
 /**
@@ -457,6 +456,67 @@ async function extractMenuWithClaude(content: string, restaurantName: string): P
   const parsed = JSON.parse(jsonMatch[0])
 
   // Validate categories
+  const validDishes = (Array.isArray(parsed.dishes) ? parsed.dishes : [])
+    .filter((d: ExtractedDish) => d.name && d.category)
+    .map((d: ExtractedDish) => ({
+      ...d,
+      category: VALID_CATEGORIES.includes(d.category) ? d.category : 'entree',
+    }))
+
+  return {
+    dishes: validDishes,
+    menu_section_order: Array.isArray(parsed.menu_section_order) ? parsed.menu_section_order : [],
+  }
+}
+
+/**
+ * Extract dishes from one or more menu IMAGES (PNG/JPG/WEBP) using Sonnet vision.
+ * Images are passed by URL so Sonnet fetches them server-side (no Edge Function OOM).
+ * Vision is more expensive than document blocks per token — keep batches small (≤3).
+ */
+async function extractMenuFromImagesWithClaude(
+  imageUrls: string[],
+  restaurantName: string
+): Promise<MenuExtractionResult> {
+  if (imageUrls.length === 0) return { dishes: [], menu_section_order: [] }
+
+  const content: Array<Record<string, unknown>> = imageUrls.map(url => ({
+    type: 'image',
+    source: { type: 'url', url },
+  }))
+
+  content.push({
+    type: 'text',
+    text: `Extract the full menu from "${restaurantName}" from the ${imageUrls.length === 1 ? 'attached image' : `${imageUrls.length} attached images`}. The images are page-ordered. If different images represent different services (breakfast, lunch, dinner), preserve those as menu sections.`,
+  })
+
+  const response = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': ANTHROPIC_API_KEY!,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 8192,
+      messages: [{ role: 'user', content }],
+      system: MENU_EXTRACTION_PROMPT,
+    }),
+  })
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    throw new Error(`Claude image API error: ${response.status} - ${errorText}`)
+  }
+
+  const data = await response.json()
+  const text = data.content?.[0]?.text || '{}'
+
+  const jsonMatch = text.match(/\{[\s\S]*\}/)
+  if (!jsonMatch) return { dishes: [], menu_section_order: [] }
+
+  const parsed = JSON.parse(jsonMatch[0])
   const validDishes = (Array.isArray(parsed.dishes) ? parsed.dishes : [])
     .filter((d: ExtractedDish) => d.name && d.category)
     .map((d: ExtractedDish) => ({
@@ -752,10 +812,10 @@ serve(async (req) => {
               dbUpdates.menu_url = menuUrl
             } else {
               // Ephemeral fallback for THIS run only. Many restaurants link the
-              // menu as a PDF (e.g. /wp-content/uploads/*.pdf) only from the
-              // homepage — paths findMenuUrl's probe list misses. Letting the
-              // downstream pipeline see the homepage gives extractPdfMenuUrls a
-              // chance to find those links and Sonnet a shot at the homepage
+              // menu as a PDF or image (e.g. /wp-content/uploads/*.pdf) only from
+              // the homepage — paths findMenuUrl's probe list misses. Letting the
+              // downstream pipeline see the homepage gives discoverMenuCandidates
+              // a chance to find those links and Sonnet a shot at the homepage
               // HTML. We do NOT persist this to dbUpdates.menu_url — that would
               // lock the restaurant into the homepage forever and prevent
               // future discovery of a real /menu URL.
@@ -816,10 +876,14 @@ serve(async (req) => {
           let renderError: string | null = null
           let renderedTextLen: number | null = null
 
-          // Detect PDF menu links in the HTML (many Wix/Squarespace sites embed menus as PDFs)
-          const pdfUrls = extractPdfMenuUrls(rawHtml, menuUrl)
-          let pdfsUsed = false
-          let pdfsDownloaded = 0
+          // Discover all menu candidates (PDFs + images) and rank by score.
+          // Score combines URL keywords (+menu/+dinner/-beverage/-logo) with
+          // anchor/alt context. Highest-scoring asset wins, regardless of format.
+          // `let` because Browserless renders below may surface JS-injected
+          // candidates that need to merge into this pool.
+          let candidates = discoverMenuCandidates(rawHtml, menuUrl)
+          const attempts: ExtractionAttempt[] = []
+          const triedUrls = new Set<string>()
 
           // Fast path: compute raw hash BEFORE any Sonnet/render call.
           // If the raw HTML shell hasn't changed since last successful run, skip everything.
@@ -855,6 +919,9 @@ serve(async (req) => {
               if (renderedText.length >= 50) {
                 extractionContent = renderedText
                 renderSucceeded = true
+                // Re-discover candidates from the rendered HTML — JS-injected menu
+                // PDFs/images are invisible in raw HTML.
+                candidates = mergeCandidates(candidates, discoverMenuCandidates(renderedHtml, menuUrl))
               }
             } catch (renderErr) {
               renderError = renderErr instanceof Error ? renderErr.message : String(renderErr)
@@ -881,9 +948,7 @@ serve(async (req) => {
                 render_succeeded: renderSucceeded,
                 render_error: renderError,
                 rendered_text_len: renderedTextLen,
-                pdf_urls_found: pdfUrls.length,
-                pdfs_downloaded: pdfsDownloaded,
-                pdfs_used: pdfsUsed,
+                candidates_found: candidates.length,
               },
               lock_expires_at: null,
               updated_at: new Date().toISOString(),
@@ -912,21 +977,62 @@ serve(async (req) => {
             }
           }
 
-          // Extract with Sonnet — PDFs take priority if detected, else use text extraction
-          // PDFs are passed as URL sources so Sonnet fetches them server-side (avoids Edge Function OOM)
-          let extracted: MenuExtractionResult
-          if (pdfUrls.length > 0) {
-            console.log(`${restaurant.name}: found ${pdfUrls.length} PDF menu(s), sending URLs to Sonnet`)
-            pdfsDownloaded = pdfUrls.length  // all URLs passed through (no download on our side)
-            try {
-              extracted = await extractMenuFromPdfsWithClaude(pdfUrls, restaurant.name)
-              pdfsUsed = true
-            } catch (pdfExtractErr) {
-              console.error(`${restaurant.name}: PDF extraction failed:`, pdfExtractErr)
-              extracted = await extractMenuWithClaude(extractionContent, restaurant.name)
+          // Extract with Sonnet. Try strategies in score order:
+          // image batch (if highest-scoring candidates are images) → pdf batch → html text.
+          // First non-empty result wins. Stop early to avoid extra Sonnet calls.
+          let extracted: MenuExtractionResult = { dishes: [], menu_section_order: [] }
+
+          const tryAssetExtraction = async (cands: MenuCandidate[]): Promise<void> => {
+            const fresh = cands.filter(c => !triedUrls.has(c.url))
+            const images = fresh.filter(c => c.type === 'image').slice(0, MAX_IMAGE_CANDIDATES)
+            const pdfs = fresh.filter(c => c.type === 'pdf').slice(0, MAX_PDF_CANDIDATES)
+            const imageMaxScore = images[0]?.score ?? -Infinity
+            const pdfMaxScore = pdfs[0]?.score ?? -Infinity
+            const tryImagesFirst = images.length > 0 && imageMaxScore >= pdfMaxScore
+            const ordered: Array<{ type: 'image' | 'pdf'; cands: MenuCandidate[] }> = []
+            if (tryImagesFirst) {
+              if (images.length > 0) ordered.push({ type: 'image', cands: images })
+              if (pdfs.length > 0) ordered.push({ type: 'pdf', cands: pdfs })
+            } else {
+              if (pdfs.length > 0) ordered.push({ type: 'pdf', cands: pdfs })
+              if (images.length > 0) ordered.push({ type: 'image', cands: images })
             }
-          } else {
-            extracted = await extractMenuWithClaude(extractionContent, restaurant.name)
+
+            for (const group of ordered) {
+              const urls = group.cands.map(c => c.url)
+              urls.forEach(u => triedUrls.add(u))
+              const topScore = group.cands[0].score
+              try {
+                console.log(`${restaurant.name}: trying ${group.type} batch (${urls.length} urls, top score ${topScore})`)
+                const result = group.type === 'image'
+                  ? await extractMenuFromImagesWithClaude(urls, restaurant.name)
+                  : await extractMenuFromPdfsWithClaude(urls, restaurant.name)
+                attempts.push({ strategy: group.type, url_count: urls.length, top_score: topScore, dishes_found: result.dishes.length })
+                if (result.dishes.length > 0) {
+                  extracted = result
+                  return
+                }
+              } catch (err) {
+                const message = err instanceof Error ? err.message : String(err)
+                console.error(`${restaurant.name}: ${group.type} extraction failed:`, message)
+                attempts.push({ strategy: group.type, url_count: urls.length, top_score: topScore, dishes_found: 0, error: message })
+              }
+            }
+          }
+
+          await tryAssetExtraction(candidates)
+
+          // Fallback: extract from page text if no asset-based strategy yielded dishes
+          if (extracted.dishes.length === 0) {
+            try {
+              const result = await extractMenuWithClaude(extractionContent, restaurant.name)
+              attempts.push({ strategy: 'html', url_count: 0, dishes_found: result.dishes.length })
+              if (result.dishes.length > 0) extracted = result
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err)
+              console.error(`${restaurant.name}: html extraction failed:`, message)
+              attempts.push({ strategy: 'html', url_count: 0, dishes_found: 0, error: message })
+            }
           }
 
           // Render fallback #2: zero dishes AND CMS requires rendering AND we haven't rendered yet
@@ -961,7 +1067,17 @@ serve(async (req) => {
                     continue
                   }
                 }
-                extracted = await extractMenuWithClaude(extractionContent, restaurant.name)
+                // Re-discover candidates from rendered HTML — JS-injected PDF/image
+                // menus that were invisible in raw HTML may be present now.
+                candidates = mergeCandidates(candidates, discoverMenuCandidates(renderedHtml, menuUrl))
+                await tryAssetExtraction(candidates)
+                if (extracted.dishes.length === 0) {
+                  // No new asset candidates worked either — fall back to text extraction
+                  // on the rendered page.
+                  const result = await extractMenuWithClaude(extractionContent, restaurant.name)
+                  attempts.push({ strategy: 'html', url_count: 0, dishes_found: result.dishes.length })
+                  if (result.dishes.length > 0) extracted = result
+                }
               }
             } catch (renderErr) {
               renderError = renderErr instanceof Error ? renderErr.message : String(renderErr)
@@ -988,9 +1104,8 @@ serve(async (req) => {
                 render_succeeded: renderSucceeded,
                 render_error: renderError,
                 rendered_text_len: renderedTextLen,
-                pdf_urls_found: pdfUrls.length,
-                pdfs_downloaded: pdfsDownloaded,
-                pdfs_used: pdfsUsed,
+                candidates_found: candidates.length,
+                attempts,
               },
               lock_expires_at: null,
               updated_at: new Date().toISOString(),
@@ -1011,6 +1126,8 @@ serve(async (req) => {
             menu_content_hash: rawHash,
           }).eq('id', restaurant.id)
 
+          const winningStrategy = attempts.find(a => a.dishes_found > 0)?.strategy ?? 'html'
+
           await supabase.from('menu_import_jobs').update({
             status: 'completed',
             completed_at: new Date().toISOString(),
@@ -1028,9 +1145,9 @@ serve(async (req) => {
               render_succeeded: renderSucceeded,
               render_error: renderError,
               rendered_text_len: renderedTextLen,
-              pdf_urls_found: pdfUrls.length,
-              pdfs_downloaded: pdfsDownloaded,
-              pdfs_used: pdfsUsed,
+              candidates_found: candidates.length,
+              winning_strategy: winningStrategy,
+              attempts,
             },
             lock_expires_at: null,
             updated_at: new Date().toISOString(),
@@ -1040,7 +1157,7 @@ serve(async (req) => {
             job_id: job.id, status: 'success', restaurant: restaurant.name,
             dishes: extracted.dishes.length, inserted: stats.inserted, updated: stats.updated,
             rendered: renderSucceeded,
-            pdfs_used: pdfsUsed,
+            strategy: winningStrategy,
           })
 
         } catch (err) {

--- a/supabase/functions/menu-refresh/menu-candidates.test.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest'
+import { discoverMenuCandidates, scoreCandidate } from './menu-candidates.ts'
+
+describe('scoreCandidate', () => {
+  it('positive: menu in URL', () => {
+    expect(scoreCandidate('https://x.com/menu.pdf').score).toBeGreaterThan(0)
+  })
+
+  it('positive: dinner in URL', () => {
+    expect(scoreCandidate('https://x.com/dinner-menu.png').score).toBeGreaterThan(8)
+  })
+
+  it('negative: beverage cancels menu', () => {
+    expect(scoreCandidate('https://x.com/beverage-menu.pdf').score).toBeLessThan(0)
+  })
+
+  it('negative: drinks alone is negative', () => {
+    expect(scoreCandidate('https://x.com/drinks.pdf').score).toBeLessThan(0)
+  })
+
+  it('negative: gift card is strongly negative', () => {
+    expect(scoreCandidate('https://x.com/gift-card.pdf').score).toBeLessThan(-5)
+  })
+
+  it('negative: logo image filtered', () => {
+    expect(scoreCandidate('https://x.com/logo.png', 'site logo').score).toBeLessThan(0)
+  })
+
+  it('decodes URL-encoded paths so filename keywords still score', () => {
+    const url = 'https://media-cdn.getbento.com/accounts/abc/media/CLy6aXCpTZ6Z87bGaqWr_Dinner%20Menu%20-%20Digital.png'
+    expect(scoreCandidate(url).score).toBeGreaterThan(8)
+  })
+
+  it('uses anchor text context for plain URLs', () => {
+    expect(scoreCandidate('https://x.com/123.png', 'Click here for our dinner menu').score).toBeGreaterThan(8)
+  })
+
+  it('returns 0 with no signal in URL or context', () => {
+    expect(scoreCandidate('https://x.com/abc123.png', 'some random thing').score).toBe(0)
+  })
+
+  it('alt-text "drinks menu" stays negative', () => {
+    expect(scoreCandidate('https://x.com/x.png', 'drinks menu').score).toBeLessThan(0)
+  })
+})
+
+describe('discoverMenuCandidates', () => {
+  it('returns empty for HTML with no asset links', () => {
+    const html = '<html><body><h1>Hello</h1></body></html>'
+    expect(discoverMenuCandidates(html, 'https://x.com/')).toEqual([])
+  })
+
+  it('finds <a href> PDFs and scores them', () => {
+    const html = '<a href="/dinner-menu.pdf">Dinner</a>'
+    const out = discoverMenuCandidates(html, 'https://x.com/')
+    expect(out).toHaveLength(1)
+    expect(out[0].type).toBe('pdf')
+    expect(out[0].url).toBe('https://x.com/dinner-menu.pdf')
+    expect(out[0].score).toBeGreaterThan(0)
+  })
+
+  it('finds <img src> PNGs and scores by alt text', () => {
+    const html = '<img src="/abc.png" alt="Dinner Menu">'
+    const out = discoverMenuCandidates(html, 'https://x.com/')
+    expect(out).toHaveLength(1)
+    expect(out[0].type).toBe('image')
+    expect(out[0].score).toBeGreaterThan(0)
+  })
+
+  it('filters out negative-score candidates (beverage menus)', () => {
+    const html = `
+      <a href="/dinner.pdf">Dinner Menu</a>
+      <a href="/beverages.pdf">Beverage Menu</a>
+    `
+    const out = discoverMenuCandidates(html, 'https://x.com/')
+    const urls = out.map(c => c.url)
+    expect(urls).toContain('https://x.com/dinner.pdf')
+    expect(urls).not.toContain('https://x.com/beverages.pdf')
+  })
+
+  it('sorts by descending score', () => {
+    const html = `
+      <a href="/menu.pdf">Menu</a>
+      <a href="/dinner-menu.pdf">Dinner Menu</a>
+    `
+    const out = discoverMenuCandidates(html, 'https://x.com/')
+    expect(out[0].url).toBe('https://x.com/dinner-menu.pdf')
+    expect(out[1].url).toBe('https://x.com/menu.pdf')
+  })
+
+  it('deduplicates URLs found by multiple selectors', () => {
+    const html = `
+      <a href="/menu.pdf">Menu</a>
+      <link rel="prefetch" href="/menu.pdf">
+    `
+    const out = discoverMenuCandidates(html, 'https://x.com/')
+    expect(out.filter(c => c.url === 'https://x.com/menu.pdf')).toHaveLength(1)
+  })
+
+  it('Shy Bird real-world: image food menus outscore beverage PDF', () => {
+    const html = `
+      <a href="https://media-cdn.getbento.com/accounts/abc/media/yGGY2X4eQHG1mz1l441A_Dinner%20Menu%20-%20Digital.png">Dinner</a>
+      <a href="https://media-cdn.getbento.com/accounts/abc/media/0hW3PfLyTSGLoZnhYcC0_Lunch%20-%20Digital.png">Lunch</a>
+      <a href="https://media-cdn.getbento.com/accounts/abc/media/8VYcmfBrThSgH1GvgO9Y_Breakfast%20-%20Digital.png">Breakfast</a>
+      <a href="https://media-cdn.getbento.com/accounts/abc/media/vmoiHQlDQJak4Cn6RUXr_Brunch%20Menu%20-%20Digital.png">Brunch</a>
+      <a href="https://media-cdn.getbento.com/accounts/abc/media/C1MEz39SP6vj2niFa3h3_SBSB%20Beverage%20Menu%202025.pdf">Beverage</a>
+    `
+    const out = discoverMenuCandidates(html, 'https://www.shybird.com/menus')
+    // Beverage PDF is filtered out (negative score)
+    expect(out.find(c => c.url.includes('Beverage'))).toBeUndefined()
+    // Image food menus all score positive
+    const images = out.filter(c => c.type === 'image')
+    expect(images.length).toBe(4)
+    expect(images.every(c => c.score > 0)).toBe(true)
+  })
+
+  it('absolutizes relative URLs', () => {
+    const html = '<a href="files/menu.pdf">Menu</a>'
+    const out = discoverMenuCandidates(html, 'https://x.com/about/')
+    expect(out[0].url).toBe('https://x.com/about/files/menu.pdf')
+  })
+
+  it('ignores non-pdf/non-image links (CSS, JS, HTML pages)', () => {
+    const html = `
+      <link href="/menu.css">
+      <script src="/menu.js"></script>
+      <a href="/menu">Menu Page</a>
+    `
+    const out = discoverMenuCandidates(html, 'https://x.com/')
+    expect(out).toEqual([])
+  })
+
+  it('handles srcset by capturing every URL with shared alt context', () => {
+    const html = '<img srcset="/dinner-menu-320w.png 320w, /dinner-menu-640w.png 640w" alt="Dinner Menu">'
+    const out = discoverMenuCandidates(html, 'https://x.com/')
+    const urls = out.filter(c => c.type === 'image').map(c => c.url)
+    expect(urls).toContain('https://x.com/dinner-menu-320w.png')
+    expect(urls).toContain('https://x.com/dinner-menu-640w.png')
+  })
+
+  it('handles data-src with alt context from same img tag', () => {
+    // Hash-only filename — only the alt carries the menu signal
+    const html = '<img data-src="/abc123.png" src="placeholder.gif" alt="Dinner Menu">'
+    const out = discoverMenuCandidates(html, 'https://x.com/')
+    expect(out.some(c => c.url === 'https://x.com/abc123.png' && c.score > 0)).toBe(true)
+  })
+
+  it('regression: opaque PDF URLs (no keyword) still pass the filter', () => {
+    // Old code took every PDF except obvious negatives — preserve that recall.
+    const html = '<a href="/wp-content/uploads/abc-83fa.pdf">Download</a>'
+    const out = discoverMenuCandidates(html, 'https://x.com/')
+    expect(out).toHaveLength(1)
+    expect(out[0].type).toBe('pdf')
+    expect(out[0].score).toBe(0)
+  })
+
+  it('opaque image URLs (no keyword) are dropped (vision cost)', () => {
+    const html = '<img src="/abc123.png" alt="">'
+    const out = discoverMenuCandidates(html, 'https://x.com/')
+    expect(out).toEqual([])
+  })
+
+  it('preserves query strings on signed URLs', () => {
+    const html = '<object data="/menu.pdf?token=abc&exp=123" type="application/pdf"></object>'
+    const out = discoverMenuCandidates(html, 'https://x.com/')
+    expect(out.some(c => c.url === 'https://x.com/menu.pdf?token=abc&exp=123')).toBe(true)
+  })
+
+  it('strongly negative PDFs are still dropped', () => {
+    const html = `
+      <a href="/dinner.pdf">Dinner Menu</a>
+      <a href="/giftcard.pdf">Gift Card Form</a>
+      <a href="/allergens.pdf">Allergens</a>
+    `
+    const out = discoverMenuCandidates(html, 'https://x.com/')
+    const urls = out.map(c => c.url)
+    expect(urls).toContain('https://x.com/dinner.pdf')
+    expect(urls).not.toContain('https://x.com/giftcard.pdf')
+    expect(urls).not.toContain('https://x.com/allergens.pdf')
+  })
+
+  it('legal/HR PDFs are dropped (matches old extractPdfMenuUrls reject set)', () => {
+    const html = `
+      <a href="/privacy-policy.pdf">Privacy</a>
+      <a href="/terms-of-service.pdf">Terms</a>
+      <a href="/job-application.pdf">Apply</a>
+      <a href="/employment-contract.pdf">Contract</a>
+      <a href="/liability-waiver.pdf">Waiver</a>
+      <a href="/house-rules.pdf">Rules</a>
+    `
+    const out = discoverMenuCandidates(html, 'https://x.com/')
+    expect(out.map(c => c.url)).toEqual([])
+  })
+})

--- a/supabase/functions/menu-refresh/menu-candidates.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.ts
@@ -1,0 +1,238 @@
+/**
+ * Menu Candidate Discovery + Scoring
+ *
+ * Find every asset on a page that COULD be a food menu, score by how likely
+ * it is to be one, and let the extractor try the best candidates first
+ * regardless of format. This avoids hard-coding "PDFs before images" — when
+ * a restaurant puts food menus as PNGs and only beverage menus as PDFs
+ * (e.g. Shy Bird), the image score wins and food extraction succeeds.
+ *
+ * Scoring: positive keywords (menu/food/dinner/lunch/brunch/breakfast)
+ * combine additively with negative keywords (drinks/beverage/cocktail/
+ * wine/allergen/giftcard/logo/banner). URLs are decoded before scoring so
+ * randomized CDN prefixes still expose the human filename
+ * (e.g. /CLy6aX..._Dinner%20Menu%20-%20Digital.png → "Dinner Menu Digital").
+ */
+
+export type CandidateType = 'pdf' | 'image'
+
+export interface MenuCandidate {
+  url: string
+  type: CandidateType
+  score: number
+  source: 'href' | 'src' | 'srcset' | 'data-src' | 'generic'
+  evidence: string
+}
+
+interface KeywordWeight {
+  pattern: RegExp
+  weight: number
+}
+
+const POSITIVE_KEYWORDS: KeywordWeight[] = [
+  { pattern: /\bmenus?\b/i, weight: 5 },
+  { pattern: /\bdinner\b/i, weight: 4 },
+  { pattern: /\blunch\b/i, weight: 4 },
+  { pattern: /\bbreakfast\b/i, weight: 4 },
+  { pattern: /\bbrunch\b/i, weight: 4 },
+  { pattern: /\bfood\b/i, weight: 3 },
+  { pattern: /\ball[\s-]?day\b/i, weight: 3 },
+  { pattern: /\bentrees?\b/i, weight: 2 },
+  { pattern: /\bseafood\b/i, weight: 2 },
+  { pattern: /\braw[\s-]?bar\b/i, weight: 2 },
+  { pattern: /\bappetizers?\b/i, weight: 2 },
+]
+
+const NEGATIVE_KEYWORDS: KeywordWeight[] = [
+  { pattern: /\ballergens?\b/i, weight: -8 },
+  { pattern: /\bnutrition(al)?\b/i, weight: -6 },
+  { pattern: /\bgift[\s-]?cards?\b/i, weight: -8 },
+  { pattern: /\bgiftcards?\b/i, weight: -8 },
+  { pattern: /\bdrinks?\b/i, weight: -6 },
+  { pattern: /\bbeverages?\b/i, weight: -6 },
+  { pattern: /\bcocktails?\b/i, weight: -6 },
+  { pattern: /\bwines?\b/i, weight: -5 },
+  { pattern: /\bbeers?\b/i, weight: -5 },
+  { pattern: /\bspirits?\b/i, weight: -5 },
+  { pattern: /\bcatering\b/i, weight: -4 },
+  { pattern: /\bprivate[\s-]?events?\b/i, weight: -6 },
+  { pattern: /\bevents?\b/i, weight: -2 },
+  { pattern: /\bkids?\b/i, weight: -2 },
+  // Legal / HR docs — old extractPdfMenuUrls hard-rejected these. Keep them
+  // strongly negative so /privacy-policy.pdf, /job-application.pdf, etc. fail
+  // the score >= 0 PDF gate.
+  { pattern: /\bterms\b/i, weight: -10 },
+  { pattern: /\bprivacy\b/i, weight: -10 },
+  { pattern: /\bpolicy\b/i, weight: -8 },
+  { pattern: /\bapplication\b/i, weight: -8 },
+  { pattern: /\bemployment\b/i, weight: -10 },
+  { pattern: /\bjob\b/i, weight: -8 },
+  { pattern: /\bcontract\b/i, weight: -8 },
+  { pattern: /\bwaiver\b/i, weight: -10 },
+  { pattern: /\brules\b/i, weight: -6 },
+  // Filename noise — these never name a food menu
+  { pattern: /\blogo\b/i, weight: -10 },
+  { pattern: /\bfavicon\b/i, weight: -10 },
+  { pattern: /\bicon\b/i, weight: -8 },
+  { pattern: /\bheader\b/i, weight: -8 },
+  { pattern: /\bbanner\b/i, weight: -8 },
+  { pattern: /\bhero\b/i, weight: -8 },
+  { pattern: /\bavatar\b/i, weight: -8 },
+  { pattern: /\bthumbnail\b/i, weight: -6 },
+  { pattern: /\bgallery\b/i, weight: -6 },
+  { pattern: /\bpress\b/i, weight: -4 },
+]
+
+const PDF_EXT = /\.pdf(\?|#|$)/i
+const IMAGE_EXT = /\.(png|jpe?g|webp)(\?|#|$)/i
+
+function classifyType(url: string): CandidateType | null {
+  if (PDF_EXT.test(url)) return 'pdf'
+  if (IMAGE_EXT.test(url)) return 'image'
+  return null
+}
+
+function safeDecode(s: string): string {
+  try {
+    return decodeURIComponent(s)
+  } catch {
+    return s
+  }
+}
+
+// CDN filenames glue words with `_` (e.g. `..._Dinner_Menu_Digital.png`).
+// Underscore is a regex word-char, so `\bdinner\b` won't match between `_D`.
+// Normalizing to spaces lets the keyword regexes work naturally.
+function normalize(s: string): string {
+  return safeDecode(s).replace(/_/g, ' ')
+}
+
+export function scoreCandidate(url: string, context: string = ''): { score: number; evidence: string } {
+  const decoded = `${normalize(url)} ${normalize(context)}`
+  let score = 0
+  const hits: string[] = []
+  for (const { pattern, weight } of POSITIVE_KEYWORDS) {
+    if (pattern.test(decoded)) {
+      score += weight
+      hits.push(`+${weight}:${pattern.source}`)
+    }
+  }
+  for (const { pattern, weight } of NEGATIVE_KEYWORDS) {
+    if (pattern.test(decoded)) {
+      score += weight
+      hits.push(`${weight}:${pattern.source}`)
+    }
+  }
+  return { score, evidence: hits.join(' ') }
+}
+
+interface RawMatch {
+  url: string
+  source: MenuCandidate['source']
+  context: string
+}
+
+function absolutize(url: string, base: URL): string | null {
+  try {
+    return new URL(url, base).href
+  } catch {
+    return null
+  }
+}
+
+function stripTags(s: string): string {
+  return s.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()
+}
+
+function collectInnerAlt(innerHtml: string): string {
+  const alts: string[] = []
+  const altRegex = /\salt=["']([^"']*)["']/gi
+  let m
+  while ((m = altRegex.exec(innerHtml)) !== null) {
+    if (m[1]) alts.push(m[1])
+  }
+  return alts.join(' ')
+}
+
+function extractRawMatches(html: string, baseUrl: string): RawMatch[] {
+  const base = new URL(baseUrl)
+  const seen = new Set<string>()
+  const matches: RawMatch[] = []
+
+  const push = (url: string | null, source: MenuCandidate['source'], context: string) => {
+    if (!url) return
+    if (seen.has(url)) return
+    seen.add(url)
+    matches.push({ url, source, context })
+  }
+
+  // <a href> — anchor text + alt of any inner <img> contribute context.
+  // Captures full href attribute (preserves ?query and #hash for signed URLs).
+  const anchorRegex = /<a\b[^>]*\shref=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi
+  let m
+  while ((m = anchorRegex.exec(html)) !== null) {
+    const text = stripTags(m[2]).slice(0, 200)
+    const innerAlt = collectInnerAlt(m[2]).slice(0, 200)
+    push(absolutize(m[1], base), 'href', `${text} ${innerAlt}`.trim())
+  }
+
+  // <img> — parse whole tag once. alt/title carry the human label and apply
+  // to all URLs in the tag (src, data-src, every srcset entry).
+  const imgRegex = /<img\b[^>]*?>/gi
+  while ((m = imgRegex.exec(html)) !== null) {
+    const tag = m[0]
+    const alt = tag.match(/\salt=["']([^"']*)["']/i)?.[1] || ''
+    const title = tag.match(/\stitle=["']([^"']*)["']/i)?.[1] || ''
+    const context = `${alt} ${title}`.trim()
+    const src = tag.match(/\ssrc=["']([^"']+)["']/i)?.[1]
+    const dataSrc = tag.match(/\sdata-src=["']([^"']+)["']/i)?.[1]
+    const srcset = tag.match(/\ssrcset=["']([^"']+)["']/i)?.[1]
+    if (src) push(absolutize(src, base), 'src', context)
+    if (dataSrc) push(absolutize(dataSrc, base), 'data-src', context)
+    if (srcset) {
+      // srcset format: "url1 1x, url2 2x" or "url1 320w, url2 640w"
+      for (const entry of srcset.split(',')) {
+        const url = entry.trim().split(/\s+/)[0]
+        if (url) push(absolutize(url, base), 'srcset', context)
+      }
+    }
+  }
+
+  // Catch-all for href/src/data attributes outside <a> and <img> (<link>, <object>,
+  // <source>, JS strings). Capture the FULL attribute value so query strings and
+  // anchors survive (signed URLs need ?token= preserved to be fetchable).
+  const generic = /(?:href|src|data)=["']([^"']+\.(?:pdf|png|jpe?g|webp)[^"']*)["']/gi
+  while ((m = generic.exec(html)) !== null) {
+    push(absolutize(m[1], base), 'generic', '')
+  }
+
+  return matches
+}
+
+/**
+ * Discover and score every menu candidate on the page, sorted by descending score.
+ *
+ * Threshold is asymmetric by type:
+ * - PDFs pass with score >= 0 (PDFs on restaurant sites are mostly menus; the old
+ *   path took every PDF except obvious negatives like terms/giftcards). This keeps
+ *   us from regressing on opaque CDN URLs like /uploads/menu-83fa.pdf.
+ * - Images require score > 0 (vision is per-pixel-token expensive; without a real
+ *   menu signal we'd burn budget on logos/heroes/galleries).
+ *
+ * Caller decides per-type caps.
+ */
+export function discoverMenuCandidates(html: string, baseUrl: string): MenuCandidate[] {
+  const raw = extractRawMatches(html, baseUrl)
+  const candidates: MenuCandidate[] = []
+  for (const r of raw) {
+    const type = classifyType(r.url)
+    if (!type) continue
+    const { score, evidence } = scoreCandidate(r.url, r.context)
+    const passes = type === 'pdf' ? score >= 0 : score > 0
+    if (!passes) continue
+    candidates.push({ url: r.url, type, score, source: r.source, evidence })
+  }
+  // Sort by score desc; for tie-breaks (e.g. multiple score-0 PDFs) preserve order.
+  candidates.sort((a, b) => b.score - a.score)
+  return candidates
+}


### PR DESCRIPTION
## Summary

The old `extractPdfMenuUrls` only matched `.pdf`, so restaurants whose food menus are PNG images (Shy Bird and many getbento.com / Wix sites) failed import — Sonnet only ever saw beverage PDFs and correctly skipped them per the drinks-exclusion prompt.

This PR replaces the PDF-only path with a **score-ranked candidate layer**, turning each new failure into vocabulary the cron knows to try.

- **`discoverMenuCandidates()`** — finds every PDF/image asset (`href`, `src`, `data-src`, `srcset`, generic) and scores by URL+anchor/alt keywords. Positive: menu/dinner/lunch/brunch/breakfast/food. Negative: drinks/beverage/cocktail/allergen/giftcard/terms/privacy/policy/employment/waiver/logo/banner/hero/gallery.
- **Asymmetric threshold** — PDFs pass at score >= 0 (preserves old broad PDF recall on opaque CDN URLs); images require score > 0 (vision is per-pixel-token expensive).
- **Strategy ordering by max score** — picks images-first or PDFs-first based on which group has the highest-scoring candidate. HTML text is the final fallback.
- **Render-aware** — after either Browserless render fallback succeeds, candidates are re-discovered from the rendered HTML and merged. JS-injected menu links no longer get missed. `triedUrls` tracks what's been sent to Sonnet so we don't pay twice.
- **Structured `attempts[]` in `error_context`** — turns the dead-job table into a debuggable case library (which strategy ran, how many URLs, top score, dishes found, error).

## Review trail

3 Codex review rounds (gpt-5.4 + high). Caught and fixed: opaque-PDF regression, srcset/data-src losing alt context, query-string truncation on signed URLs, missing JS-render re-discovery, missing legal/HR PDF rejects. Final pass: "Ship it."

## Deployment status

**Code-only PR.** Edge Function needs `supabase functions deploy menu-refresh` to Denis's project (`vpioftosgdkyiwvhxewy`) for the change to take effect. After deploy, revive existing dead jobs that died on `no_dishes`:

```sql
UPDATE menu_import_jobs
SET status='pending', attempt_count=0, run_after=now(),
    error_code=null, error_message=null, lock_expires_at=null
WHERE error_code = 'no_dishes' AND status = 'dead';
```

No DB migration. No schema change. `error_context` is JSONB — shape change is non-breaking.

## Test plan

- [ ] `npm run test` passes (394/394 green locally)
- [ ] Deploy Edge Function: `supabase functions deploy menu-refresh --project-ref vpioftosgdkyiwvhxewy`
- [ ] Re-add Shy Bird via the modal — menu should populate within ~60s
- [ ] Verify a Squarespace/WordPress restaurant (PDF-based menu) still imports correctly — regression check
- [ ] Run the SQL helper above to revive dead jobs and check `menu_import_jobs.error_context.winning_strategy` for the case library entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)