### PR TITLE
feat(menu-refresh): sub-page nav + broader render trigger (case lib v2)

### DIFF
--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -2,7 +2,7 @@ import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { detectCms, cmsRequiresRender } from './cms-detect.ts'
 import { fetchRenderedHtml, BrowserlessError } from './browserless.ts'
-import { discoverMenuCandidates, type MenuCandidate } from './menu-candidates.ts'
+import { discoverMenuCandidates, findSubMenuPages, type MenuCandidate } from './menu-candidates.ts'
 
 /**
  * Menu Refresh Edge Function
@@ -393,16 +393,23 @@ async function fetchMenuContent(url: string): Promise<string> {
 }
 
 interface ExtractionAttempt {
-  strategy: 'image' | 'pdf' | 'html'
+  strategy: 'image' | 'pdf' | 'html' | 'sub-page'
   url_count: number
   top_score?: number
   dishes_found: number
   error?: string
+  url?: string  // for sub-page attempts, which sub-URL was tried
 }
 
 // Caps per strategy. Vision is per-pixel-token expensive — keep image batches small.
 const MAX_IMAGE_CANDIDATES = 3
 const MAX_PDF_CANDIDATES = 6
+const MAX_SUB_PAGES = 4
+// Render fallback #2 fires more broadly than fallback #1: even on plain HTML
+// sites without a CMS signature, if everything else returned 0 dishes the page
+// might just be a JS-loaded shell. One Browserless call per failed job is cheap
+// insurance vs. another dead-letter restaurant.
+const SPARSE_TEXT_THRESHOLD = 2000
 
 // Merge two candidate lists by URL (last-write-wins on score), then re-sort.
 // Used when Browserless renders surface JS-injected assets that weren't in the raw HTML.
@@ -1035,8 +1042,62 @@ serve(async (req) => {
             }
           }
 
-          // Render fallback #2: zero dishes AND CMS requires rendering AND we haven't rendered yet
-          if (extracted.dishes.length === 0 && cmsRequiresRender(cms) && !rendererAttempted) {
+          // Sub-page fallback (Pattern 1): when /menu is just a navigation page
+          // linking to /brunch /lunch /dinner /breakfast (Webflow / WordPress /
+          // multi-service restaurants split the menu across pages). Fetch each
+          // sub-page, run extraction on each, merge results.
+          if (extracted.dishes.length === 0) {
+            const subPages = findSubMenuPages(rawHtml, menuUrl, MAX_SUB_PAGES)
+            if (subPages.length > 0) {
+              console.log(`${restaurant.name}: trying ${subPages.length} sub-menu pages`)
+              // Dedupe across sub-pages by (lowercased name, lowercased section).
+              // Many restaurants list the same dish on /lunch and /dinner; without
+              // deduping we'd report inflated dishes_found, and even though
+              // upsertDishes coalesces by name later, keeping the merged result
+              // honest matters for telemetry and for pages that genuinely share
+              // sections (e.g. desserts).
+              const seenDishes = new Set<string>()
+              const mergedDishes: typeof extracted.dishes = []
+              const mergedSections: string[] = []
+              for (const subUrl of subPages) {
+                try {
+                  const subHtml = await fetchRawHtml(subUrl)
+                  const subText = extractMenuTextFromHtml(subHtml)
+                  if (subText.length < 50) {
+                    attempts.push({ strategy: 'sub-page', url_count: 1, dishes_found: 0, url: subUrl, error: 'page_too_short' })
+                    continue
+                  }
+                  const subResult = await extractMenuWithClaude(subText, restaurant.name)
+                  attempts.push({ strategy: 'sub-page', url_count: 1, dishes_found: subResult.dishes.length, url: subUrl })
+                  for (const dish of subResult.dishes) {
+                    const key = `${dish.name.toLowerCase()}|${(dish.menu_section || '').toLowerCase()}`
+                    if (seenDishes.has(key)) continue
+                    seenDishes.add(key)
+                    mergedDishes.push(dish)
+                  }
+                  for (const sec of subResult.menu_section_order) {
+                    if (!mergedSections.includes(sec)) mergedSections.push(sec)
+                  }
+                } catch (err) {
+                  const message = err instanceof Error ? err.message : String(err)
+                  console.error(`${restaurant.name}: sub-page ${subUrl} failed:`, message)
+                  attempts.push({ strategy: 'sub-page', url_count: 1, dishes_found: 0, url: subUrl, error: message })
+                }
+              }
+              if (mergedDishes.length > 0) {
+                extracted = { dishes: mergedDishes, menu_section_order: mergedSections }
+              }
+            }
+          }
+
+          // Render fallback #2: zero dishes AND not yet rendered AND the site
+          // either matches a known JS CMS OR has sparse raw text. The sparse-text
+          // gate catches custom React/Vue restaurants that don't carry a CMS
+          // signature — Quitsa-class sites. Without the gate we'd burn Browserless
+          // on every 0-dish failure, including restaurants that legitimately have
+          // no menu we can extract.
+          const looksJsRendered = cmsRequiresRender(cms) || rawTextLen < SPARSE_TEXT_THRESHOLD
+          if (extracted.dishes.length === 0 && !rendererAttempted && looksJsRendered) {
             console.log(`${restaurant.name}: Sonnet found 0 dishes in ${cms} site, attempting render fallback`)
             rendererAttempted = true  // mark ATTEMPTED regardless of outcome
             try {

--- a/supabase/functions/menu-refresh/menu-candidates.test.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { discoverMenuCandidates, scoreCandidate } from './menu-candidates.ts'
+import { discoverMenuCandidates, findSubMenuPages, scoreCandidate } from './menu-candidates.ts'
 
 describe('scoreCandidate', () => {
   it('positive: menu in URL', () => {
@@ -190,5 +190,90 @@ describe('discoverMenuCandidates', () => {
     `
     const out = discoverMenuCandidates(html, 'https://x.com/')
     expect(out.map(c => c.url)).toEqual([])
+  })
+})
+
+describe('findSubMenuPages', () => {
+  it('finds /brunch /lunch /dinner /breakfast nav links', () => {
+    const html = `
+      <nav>
+        <a href="/brunch">Brunch</a>
+        <a href="/lunch">Lunch</a>
+        <a href="/dinner">Dinner</a>
+        <a href="/breakfast">Breakfast</a>
+      </nav>
+    `
+    const out = findSubMenuPages(html, 'https://otwnantucket.com/menu')
+    expect(out).toEqual([
+      'https://otwnantucket.com/brunch',
+      'https://otwnantucket.com/lunch',
+      'https://otwnantucket.com/dinner',
+      'https://otwnantucket.com/breakfast',
+    ])
+  })
+
+  it('matches /brunch-menu and /our-dinner', () => {
+    const html = `
+      <a href="/brunch-menu">Brunch Menu</a>
+      <a href="/our-dinner">Dinner</a>
+    `
+    const out = findSubMenuPages(html, 'https://x.com/')
+    expect(out).toContain('https://x.com/brunch-menu')
+    expect(out).toContain('https://x.com/our-dinner')
+  })
+
+  it('skips false positives like /brunch-recipes /lunch-club', () => {
+    const html = `
+      <a href="/brunch-recipes">Recipes</a>
+      <a href="/lunch-club">Lunch Club</a>
+    `
+    const out = findSubMenuPages(html, 'https://x.com/')
+    expect(out).toEqual([])
+  })
+
+  it('skips external links (different origin)', () => {
+    const html = `
+      <a href="/brunch">Internal</a>
+      <a href="https://other.com/dinner">External</a>
+    `
+    const out = findSubMenuPages(html, 'https://x.com/')
+    expect(out).toEqual(['https://x.com/brunch'])
+  })
+
+  it('skips self-links (the page we are already fetching)', () => {
+    const html = '<a href="/menu">Menu</a><a href="/dinner">Dinner</a>'
+    const out = findSubMenuPages(html, 'https://x.com/menu')
+    expect(out).toEqual(['https://x.com/dinner'])
+  })
+
+  it('skips self-links even when the link has a different query/hash', () => {
+    const html = '<a href="/menu?tab=dinner">Dinner Tab</a><a href="/menu#brunch">Brunch Anchor</a><a href="/lunch">Lunch</a>'
+    const out = findSubMenuPages(html, 'https://x.com/menu')
+    expect(out).toEqual(['https://x.com/lunch'])
+  })
+
+  it('caps at max (default 4)', () => {
+    const html = `
+      <a href="/brunch">B</a>
+      <a href="/lunch">L</a>
+      <a href="/dinner">D</a>
+      <a href="/breakfast">Bk</a>
+      <a href="/menu-1">M1</a>
+      <a href="/menu-2">M2</a>
+    `
+    const out = findSubMenuPages(html, 'https://x.com/')
+    expect(out).toHaveLength(4)
+  })
+
+  it('dedupes URLs that differ only by query/hash', () => {
+    const html = '<a href="/brunch?ref=nav">B1</a><a href="/brunch#section">B2</a>'
+    const out = findSubMenuPages(html, 'https://x.com/')
+    expect(out).toEqual(['https://x.com/brunch'])
+  })
+
+  it('returns empty when no menu nav links exist', () => {
+    const html = '<a href="/about">About</a><a href="/contact">Contact</a>'
+    const out = findSubMenuPages(html, 'https://x.com/')
+    expect(out).toEqual([])
   })
 })

--- a/supabase/functions/menu-refresh/menu-candidates.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.ts
@@ -209,6 +209,50 @@ function extractRawMatches(html: string, baseUrl: string): RawMatch[] {
   return matches
 }
 
+// Path patterns that name a sub-menu page (Webflow / WordPress sites often
+// split their menu across /brunch, /lunch, /dinner, etc.). Anchor regex lets
+// us match `/brunch`, `/our-brunch`, `/brunch-menu`, but not `/brunch-recipes`.
+const SUB_MENU_PATH_PATTERNS = [
+  /\/(?:[\w-]*-)?brunch(?:-menu)?\/?$/i,
+  /\/(?:[\w-]*-)?lunch(?:-menu)?\/?$/i,
+  /\/(?:[\w-]*-)?dinner(?:-menu)?\/?$/i,
+  /\/(?:[\w-]*-)?breakfast(?:-menu)?\/?$/i,
+  /\/(?:[\w-]*-)?menu(?:-\d+)?\/?$/i,  // /menu-1, /our-menu — but only as standalone path
+]
+
+/**
+ * Find sub-menu page URLs on a parent menu page. Used as Pattern 1 fallback
+ * when the menu page itself yielded no dishes — many restaurants split their
+ * menu across /brunch, /lunch, /dinner instead of putting it all on /menu.
+ *
+ * Same-origin only (don't follow external links). Capped to keep cost bounded.
+ */
+export function findSubMenuPages(html: string, baseUrl: string, max = 4): string[] {
+  const base = new URL(baseUrl)
+  const baseNormalized = base.origin + base.pathname  // strip query/hash for self-link check
+  const found = new Set<string>()
+  const out: string[] = []
+  const anchorRegex = /<a\b[^>]*\shref=["']([^"']+)["']/gi
+  let m
+  while ((m = anchorRegex.exec(html)) !== null) {
+    let absolute: URL
+    try {
+      absolute = new URL(m[1], base)
+    } catch {
+      continue
+    }
+    if (absolute.origin !== base.origin) continue
+    const normalized = absolute.origin + absolute.pathname  // drop ?query #hash
+    if (normalized === baseNormalized) continue  // skip self-links (compare normalized)
+    if (!SUB_MENU_PATH_PATTERNS.some(p => p.test(absolute.pathname))) continue
+    if (found.has(normalized)) continue
+    found.add(normalized)
+    out.push(normalized)
+    if (out.length >= max) break
+  }
+  return out
+}
+
 /**
  * Discover and score every menu candidate on the page, sorted by descending score.
  *


### PR DESCRIPTION
## Summary

Two new patterns added to the menu importer's case library, both targeting restaurants we tried to add and got `no_dishes`.

**Pattern 1 — Multi-page menu navigation** (Or, The Whale-class)
Webflow / WordPress restaurants split their menu across `/brunch`, `/lunch`, `/dinner`, `/breakfast` with `/menu` as just a nav hub. New `findSubMenuPages()` follows those links (cap 4, same-origin only), runs extraction on each, merges deduped by `(name, menu_section)`.

**Pattern 4 — Broader render trigger** (Quitsa Kitchen-class)
Render fallback #2 was gated on `cmsRequiresRender(cms)`. Now also fires when raw text < 2000 chars (sparse = JS shell). Catches custom React/Vue restaurants that don't carry a CMS signature. Still bounded by `rendererAttempted` so we don't double-pay.

Both patterns run only after every prior strategy returned 0 dishes — existing successful paths (Shy Bird, La Choza, Highlands) are unaffected.

## Review trail

Single Codex round (gpt-5.4 + high). Caught: missing dish dedupe across sub-pages (lunch/dinner overlap inflated counts), self-link skip used raw `href` (broke when link had `?query`/`#hash`). Both fixed. Final pass: "Ship it."

## Deployment status

**Code-only PR.** Edge Function needs redeploy:
```bash
supabase functions deploy menu-refresh --project-ref vpioftosgdkyiwvhxewy
```

After deploy, revive the still-dead jobs to test the new strategies:
```sql
UPDATE menu_import_jobs
SET status='pending', attempt_count=0, run_after=now(),
    error_code=null, error_message=null, lock_expires_at=null
WHERE error_code = 'no_dishes' AND status = 'dead';
```

## Test plan

- [ ] `npm run test` passes (403/403 green locally)
- [ ] Deploy + revive
- [ ] Or, The Whale — should now extract via `sub-page` strategy (check `error_context.attempts`)
- [ ] Quitsa Kitchen — should now hit Browserless render via the broader trigger
- [ ] Shy Bird — re-verify still works via `image` strategy (regression check)
- [ ] La Choza — re-verify still works via `html` (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)