### PR TITLE
fix(menu-refresh): upgrade http:// asset URLs to https:// for Sonnet API

### DIFF
--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -424,6 +424,34 @@ function mergeCandidates(a: MenuCandidate[], b: MenuCandidate[]): MenuCandidate[
 }
 
 /**
+ * Anthropic's image and document URL sources require HTTPS — they reject http:// with
+ * "Only HTTPS URLs are supported." Many restaurant sites still list assets at http://.
+ * Most CDNs/hosts serve the same asset over https, so upgrade the protocol before sending.
+ * URLs that aren't http/https (data:, file:, mailto:, etc.) are dropped — the extractors
+ * can't use them anyway. Output is deduped to avoid double-charging when both protocols
+ * appeared in the source.
+ */
+function toHttpsUrls(urls: string[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const u of urls) {
+    if (!u) continue
+    let upgraded: string
+    if (u.startsWith('https://')) {
+      upgraded = u
+    } else if (u.startsWith('http://')) {
+      upgraded = 'https://' + u.slice('http://'.length)
+    } else {
+      continue
+    }
+    if (seen.has(upgraded)) continue
+    seen.add(upgraded)
+    out.push(upgraded)
+  }
+  return out
+}
+
+/**
  * Extract dishes from menu text using Claude
  */
 async function extractMenuWithClaude(content: string, restaurantName: string): Promise<MenuExtractionResult> {
@@ -485,16 +513,17 @@ async function extractMenuFromImagesWithClaude(
   imageUrls: string[],
   restaurantName: string
 ): Promise<MenuExtractionResult> {
-  if (imageUrls.length === 0) return { dishes: [], menu_section_order: [] }
+  const httpsUrls = toHttpsUrls(imageUrls)
+  if (httpsUrls.length === 0) return { dishes: [], menu_section_order: [] }
 
-  const content: Array<Record<string, unknown>> = imageUrls.map(url => ({
+  const content: Array<Record<string, unknown>> = httpsUrls.map(url => ({
     type: 'image',
     source: { type: 'url', url },
   }))
 
   content.push({
     type: 'text',
-    text: `Extract the full menu from "${restaurantName}" from the ${imageUrls.length === 1 ? 'attached image' : `${imageUrls.length} attached images`}. The images are page-ordered. If different images represent different services (breakfast, lunch, dinner), preserve those as menu sections.`,
+    text: `Extract the full menu from "${restaurantName}" from the ${httpsUrls.length === 1 ? 'attached image' : `${httpsUrls.length} attached images`}. The images are page-ordered. If different images represent different services (breakfast, lunch, dinner), preserve those as menu sections.`,
   })
 
   const response = await fetch('https://api.anthropic.com/v1/messages', {
@@ -546,11 +575,12 @@ async function extractMenuFromPdfsWithClaude(
   pdfUrls: string[],
   restaurantName: string
 ): Promise<MenuExtractionResult> {
-  if (pdfUrls.length === 0) return { dishes: [], menu_section_order: [] }
+  const httpsUrls = toHttpsUrls(pdfUrls)
+  if (httpsUrls.length === 0) return { dishes: [], menu_section_order: [] }
 
   // Use URL source instead of base64 — Sonnet fetches the PDFs server-side,
   // avoiding memory pressure on the Edge Function runtime.
-  const content: Array<Record<string, unknown>> = pdfUrls.map(url => ({
+  const content: Array<Record<string, unknown>> = httpsUrls.map(url => ({
     type: 'document',
     source: {
       type: 'url',
@@ -560,7 +590,7 @@ async function extractMenuFromPdfsWithClaude(
 
   content.push({
     type: 'text',
-    text: `Extract the full menu from "${restaurantName}" from the ${pdfUrls.length === 1 ? 'attached PDF' : `${pdfUrls.length} attached PDFs`}. Combine all dishes into a single output. If different PDFs represent different meal services (breakfast, lunch, dinner), preserve those as menu sections.`,
+    text: `Extract the full menu from "${restaurantName}" from the ${httpsUrls.length === 1 ? 'attached PDF' : `${httpsUrls.length} attached PDFs`}. Combine all dishes into a single output. If different PDFs represent different meal services (breakfast, lunch, dinner), preserve those as menu sections.`,
   })
 
   const response = await fetch('https://api.anthropic.com/v1/messages', {


### PR DESCRIPTION
## Summary

After deploying the candidate-scoring layer (#82) and sub-page fallback (#83), several restaurants that DID have menu candidates discovered (top_score 4-5) still failed with:

```
Claude image API error: 400 - Only HTTPS URLs are supported.
Claude PDF API error: 400 - Only HTTPS URLs are supported.
```

Anthropic's image and document URL sources require `https://`. Many restaurant websites still list asset URLs under `http://` even though the CDN serves them fine over `https://`.

New `toHttpsUrls()` helper:
- Upgrades `http://` → `https://`
- Drops anything that isn't http/https (data:, file:, mailto:)
- Dedupes (sites occasionally list the same asset at both protocols)

Applied in both `extractMenuFromImagesWithClaude` and `extractMenuFromPdfsWithClaude`.

## Affected restaurants

Currently dead with this exact error — should unlock after deploy + revive:
- Among The Flowers Cafe (PDF)
- Nat's Nook (image)
- The Seafood Shanty (image)
- TigerHawk Sandwich Company (different error — file 404; not fixed by this PR)

## Deployment status

**Code-only.** Edge Function redeploy required:
```bash
supabase functions deploy menu-refresh --project-ref vpioftosgdkyiwvhxewy
```

Then revive dead jobs:
```sql
UPDATE menu_import_jobs
SET status='pending', attempt_count=0, run_after=now(),
    error_code=null, error_message=null, lock_expires_at=null
WHERE error_code = 'no_dishes' AND status = 'dead';
```

## Test plan

- [ ] `npm run test` passes (403/403 green locally)
- [ ] Deploy + revive
- [ ] Among The Flowers Cafe — expect `winning_strategy: pdf` (was: "Only HTTPS URLs are supported")
- [ ] Nat's Nook — expect `winning_strategy: image`
- [ ] Verify Shy Bird still works (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)