### PR TITLE
feat(moderation): pre-upload Sonnet vision check on dish photos

### DIFF
--- a/src/api/dishPhotosApi.js
+++ b/src/api/dishPhotosApi.js
@@ -91,7 +91,16 @@ export const dishPhotosApi = {
       )
       const isUnsafe = modError || !modResult || modResult.is_unsafe === true || modResult.is_food_photo === false
       if (isUnsafe) {
-        await supabase.storage.from('dish-photos').remove([fileName])
+        // Bucket is public, so a failed delete leaves a rejected photo accessible
+        // by direct URL. Log loudly so monitoring catches the orphan; surface the
+        // user-facing rejection regardless (we can't return success on rejected
+        // content even if cleanup fails).
+        const { error: removeError } = await supabase.storage.from('dish-photos').remove([fileName])
+        if (removeError) {
+          logger.error('photo-moderate: failed to remove rejected photo from storage', {
+            fileName, removeError,
+          })
+        }
         const userMessage = modResult?.reason || "Couldn't verify your photo. Please try again."
         if (modError) logger.error('photo-moderate invoke failed:', modError)
         else logger.warn('photo rejected by moderation:', { reason: modResult.reason })

--- a/src/api/dishPhotosApi.js
+++ b/src/api/dishPhotosApi.js
@@ -81,6 +81,23 @@ export const dishPhotosApi = {
         .from('dish-photos')
         .getPublicUrl(fileName)
 
+      // Pre-display moderation (Apple App Store guideline 1.2 — UGC filtering).
+      // The file is in storage but not yet exposed via the dish_photos row.
+      // If Sonnet vision rejects it, delete from storage and surface a clear
+      // error to the user. Fail closed: any moderation outage rejects the upload.
+      const { data: modResult, error: modError } = await supabase.functions.invoke(
+        'photo-moderate',
+        { body: { photo_url: publicUrl } }
+      )
+      const isUnsafe = modError || !modResult || modResult.is_unsafe === true || modResult.is_food_photo === false
+      if (isUnsafe) {
+        await supabase.storage.from('dish-photos').remove([fileName])
+        const userMessage = modResult?.reason || "Couldn't verify your photo. Please try again."
+        if (modError) logger.error('photo-moderate invoke failed:', modError)
+        else logger.warn('photo rejected by moderation:', { reason: modResult.reason })
+        throw new Error(userMessage)
+      }
+
       // Build record with quality fields if analysis was provided
       const photoRecord = {
         dish_id: dishId,

--- a/src/api/dishPhotosApi.test.js
+++ b/src/api/dishPhotosApi.test.js
@@ -8,8 +8,12 @@ vi.mock('../lib/supabase', () => ({
       getUser: vi.fn(),
     },
     from: vi.fn(),
+    rpc: vi.fn(),
     storage: {
       from: vi.fn(),
+    },
+    functions: {
+      invoke: vi.fn(),
     },
   },
 }))
@@ -297,6 +301,57 @@ describe('Dish Photos API', () => {
           analysisResults: {},
         })
       ).rejects.toThrow('You must be logged in to upload photos')
+    })
+
+    describe('moderation gating', () => {
+      // Helpers to build up the happy-path-up-to-moderation mock chain.
+      function setupUploadUntilModeration() {
+        supabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+        supabase.rpc.mockResolvedValue({ data: { allowed: true }, error: null })
+        const removeMock = vi.fn().mockResolvedValue({ data: null, error: null })
+        supabase.storage.from.mockReturnValue({
+          upload: vi.fn().mockResolvedValue({ data: {}, error: null }),
+          getPublicUrl: vi.fn().mockReturnValue({ data: { publicUrl: 'https://cdn.example.com/user-1/dish-1.jpg' } }),
+          remove: removeMock,
+        })
+        return { removeMock }
+      }
+
+      it('rejects when moderation flags is_unsafe and removes the storage object', async () => {
+        const { removeMock } = setupUploadUntilModeration()
+        supabase.functions.invoke.mockResolvedValueOnce({
+          data: { is_food_photo: true, is_unsafe: true, reason: "This photo isn't allowed." },
+          error: null,
+        })
+        const file = new File(['x'], 'x.jpg', { type: 'image/jpeg' })
+
+        await expect(dishPhotosApi.uploadPhoto({ dishId: 'dish-1', file })).rejects.toThrow("This photo isn't allowed.")
+        expect(removeMock).toHaveBeenCalledWith(['user-1/dish-1.jpg'])
+      })
+
+      it('rejects when moderation says photo is not food', async () => {
+        const { removeMock } = setupUploadUntilModeration()
+        supabase.functions.invoke.mockResolvedValueOnce({
+          data: { is_food_photo: false, is_unsafe: false, reason: 'Please upload a food photo.' },
+          error: null,
+        })
+        const file = new File(['x'], 'x.jpg', { type: 'image/jpeg' })
+
+        await expect(dishPhotosApi.uploadPhoto({ dishId: 'dish-1', file })).rejects.toThrow('Please upload a food photo.')
+        expect(removeMock).toHaveBeenCalled()
+      })
+
+      it('fails closed when the moderation function errors (Anthropic outage / function down)', async () => {
+        const { removeMock } = setupUploadUntilModeration()
+        supabase.functions.invoke.mockResolvedValueOnce({
+          data: null,
+          error: new Error('Function invocation failed'),
+        })
+        const file = new File(['x'], 'x.jpg', { type: 'image/jpeg' })
+
+        await expect(dishPhotosApi.uploadPhoto({ dishId: 'dish-1', file })).rejects.toThrow()
+        expect(removeMock).toHaveBeenCalled()
+      })
     })
   })
 

--- a/supabase/functions/photo-moderate/index.ts
+++ b/supabase/functions/photo-moderate/index.ts
@@ -156,6 +156,18 @@ serve(async (req) => {
       headers: { ...cors, 'Content-Type': 'application/json' },
     })
   }
+  // Allowlist: only URLs from THIS project's dish-photos bucket. Without this,
+  // any authenticated user could burn the Anthropic budget asking us to moderate
+  // arbitrary internet images. JWT auth alone scopes WHO can call; this scopes
+  // WHAT they can ask us to moderate.
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') || ''
+  const allowedPrefix = supabaseUrl ? `${supabaseUrl}/storage/v1/object/public/dish-photos/` : ''
+  if (!allowedPrefix || !photoUrl.startsWith(allowedPrefix)) {
+    return new Response(JSON.stringify({ error: 'photo_url must point to the dish-photos bucket' }), {
+      status: 400,
+      headers: { ...cors, 'Content-Type': 'application/json' },
+    })
+  }
 
   const result = await moderate(photoUrl)
 

--- a/supabase/functions/photo-moderate/index.ts
+++ b/supabase/functions/photo-moderate/index.ts
@@ -1,0 +1,165 @@
+import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { corsHeaders } from '../_shared/cors.ts'
+
+/**
+ * Photo Moderation Edge Function
+ *
+ * Required for Apple App Store submission (Guideline 1.2 — UGC moderation).
+ * Called from dishPhotosApi.uploadPhoto AFTER the file is in storage but BEFORE
+ * the dish_photos row is inserted (which is what makes the photo visible to
+ * other users).
+ *
+ * Sonnet vision evaluates the image and returns:
+ *   { is_food_photo: bool, is_unsafe: bool, reason: string }
+ *
+ * Caller is responsible for deleting the storage object if rejected.
+ *
+ * Behavior on degraded service (Anthropic down, key unset, parse failure):
+ * fail CLOSED — return is_unsafe=true with a "couldn't verify" reason. Better
+ * to block legit users for a few minutes than let bad content through during
+ * an outage. Apple compliance requires good-faith filtering, not 100% uptime.
+ */
+
+const ANTHROPIC_API_KEY = Deno.env.get('ANTHROPIC_API_KEY')
+
+const MODERATION_PROMPT = `You are reviewing a photo uploaded to the dish-photo section of a food discovery app. Users are supposed to upload photos of the dish they're rating, the restaurant they ate at, or food-related context (table setting, menu, restaurant interior).
+
+Evaluate the image and return ONLY valid JSON (no markdown, no fences):
+{
+  "is_food_photo": boolean,
+  "is_unsafe": boolean,
+  "reason": "short explanation under 80 chars"
+}
+
+is_food_photo: TRUE if the photo shows food, a dish, a drink, a meal context, a menu, a restaurant interior or exterior, or food packaging. FALSE if the photo is unrelated content (selfies without food, pets, scenery without food, screenshots, memes, blank/test images).
+
+is_unsafe: TRUE if the photo contains: nudity, sexually suggestive content, violence, gore, weapons, hate symbols, drugs, alcohol abuse imagery, or any content unsafe for general audiences. FALSE for normal food/restaurant content (a glass of wine on a table is fine; a person clearly intoxicated is not).
+
+reason: brief, user-facing explanation (under 80 chars). Examples: "Please upload a food photo." / "This photo isn't allowed." / "Looks good!"
+
+If you can't tell what the image is (corrupted, blank, ambiguous), set is_food_photo=false with reason "Couldn't read this photo. Please try a clearer image."`
+
+interface ModerationResult {
+  is_food_photo: boolean
+  is_unsafe: boolean
+  reason: string
+}
+
+function failClosed(reason: string): ModerationResult {
+  return { is_food_photo: false, is_unsafe: true, reason }
+}
+
+async function moderate(photoUrl: string): Promise<ModerationResult> {
+  if (!ANTHROPIC_API_KEY) {
+    console.error('photo-moderate: ANTHROPIC_API_KEY not configured')
+    return failClosed("Couldn't verify photo. Please try again.")
+  }
+
+  let response: Response
+  try {
+    response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: 'claude-sonnet-4-6',
+        max_tokens: 256,
+        messages: [{
+          role: 'user',
+          content: [
+            { type: 'image', source: { type: 'url', url: photoUrl } },
+            { type: 'text', text: 'Moderate this photo per the system instructions.' },
+          ],
+        }],
+        system: MODERATION_PROMPT,
+      }),
+    })
+  } catch (err) {
+    console.error('photo-moderate: fetch failed', err)
+    return failClosed("Couldn't verify photo. Please try again.")
+  }
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '<unreadable>')
+    console.error(`photo-moderate: Anthropic ${response.status} — ${text.slice(0, 500)}`)
+    return failClosed("Couldn't verify photo. Please try again.")
+  }
+
+  let raw: string
+  try {
+    const data = await response.json()
+    raw = data.content?.[0]?.text || ''
+  } catch (err) {
+    console.error('photo-moderate: response.json() failed', err)
+    return failClosed("Couldn't verify photo. Please try again.")
+  }
+
+  const jsonMatch = raw.match(/\{[\s\S]*\}/)
+  if (!jsonMatch) {
+    console.error('photo-moderate: no JSON in Sonnet output:', raw.slice(0, 500))
+    return failClosed("Couldn't verify photo. Please try again.")
+  }
+
+  let parsed: Record<string, unknown>
+  try {
+    parsed = JSON.parse(jsonMatch[0])
+  } catch (err) {
+    console.error('photo-moderate: JSON parse failed', err, raw.slice(0, 500))
+    return failClosed("Couldn't verify photo. Please try again.")
+  }
+
+  return {
+    is_food_photo: parsed.is_food_photo === true,
+    is_unsafe: parsed.is_unsafe === true,
+    reason: typeof parsed.reason === 'string' ? parsed.reason.slice(0, 200) : '',
+  }
+}
+
+serve(async (req) => {
+  const cors = corsHeaders(req)
+
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: cors })
+  }
+
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { ...cors, 'Content-Type': 'application/json' },
+    })
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = await req.json()
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+      headers: { ...cors, 'Content-Type': 'application/json' },
+    })
+  }
+
+  const photoUrl = typeof body.photo_url === 'string' ? body.photo_url : ''
+  if (!photoUrl) {
+    return new Response(JSON.stringify({ error: 'photo_url required' }), {
+      status: 400,
+      headers: { ...cors, 'Content-Type': 'application/json' },
+    })
+  }
+  // Sonnet image URL source requires HTTPS — same constraint we hit in menu-refresh.
+  if (!photoUrl.startsWith('https://')) {
+    return new Response(JSON.stringify({ error: 'photo_url must be https' }), {
+      status: 400,
+      headers: { ...cors, 'Content-Type': 'application/json' },
+    })
+  }
+
+  const result = await moderate(photoUrl)
+
+  return new Response(JSON.stringify(result), {
+    headers: { ...cors, 'Content-Type': 'application/json' },
+  })
+})


### PR DESCRIPTION
## Summary

**Apple App Store guideline 1.2 blocker** — UGC apps must filter objectionable material before posting.

Today, a user uploads a dish photo → file goes straight to public Supabase Storage → dish_photos row makes it visible to every user immediately. No filtering. Someone could upload anything.

This PR adds a Sonnet vision moderation gate between storage upload and the dish_photos insert. If the photo is unsafe or not food-related, it's deleted and the user gets a clear rejection message.

## How it works

1. Client uploads to storage (unchanged)
2. **NEW:** Client calls `photo-moderate` edge function with the public URL
3. Function calls Sonnet vision: `{is_food_photo, is_unsafe, reason}`
4. If rejected: storage object is removed, user sees clear error
5. If approved: dish_photos row is inserted (existing flow)

**Fail closed:** any moderation outage rejects the upload. Apple compliance requires good-faith filtering, not 100% uptime.

## Security hardening (Codex review fixes in second commit)

- **URL allowlist on the function** — only URLs from `${SUPABASE_URL}/storage/v1/object/public/dish-photos/` are accepted, so authenticated users can't spam arbitrary internet images and burn Anthropic budget
- **Storage delete error logged** — bucket is public, so a failed cleanup would leave a rejected photo accessible by direct URL; now logged for monitoring

## Cost / latency

- ~$0.005 per upload (Sonnet vision)
- 1-3s added to upload flow (acceptable for the compliance gate)

## Deployment

```bash
supabase functions deploy photo-moderate --project-ref vpioftosgdkyiwvhxewy
```

`ANTHROPIC_API_KEY` already set on the project (used by menu-refresh).

## What this DOES NOT cover (deferred per Codex)

- **Reviews moderation** — review text still uses the existing `validateUserContent` blocklist; Sonnet moderation of review text is a follow-up
- **Admin reports queue UI** — `get_open_reports()` RPC exists; needs an Admin.jsx tab. Apple requires "timely response" so this is the next blocker
- **Auto-hide on N reports** — punted; manual moderation is enough for MVP

## Test plan

- [ ] `npm run test` passes (417/418 locally; 1 pre-existing nativeAuth failure unrelated)
- [ ] Deploy edge function
- [ ] Upload a normal dish photo from the app — should succeed in 1-3s
- [ ] Upload a non-food photo (selfie / scenery) — should reject with clear message
- [ ] Verify storage object is removed on rejection (check Supabase dashboard)
- [ ] Verify URL allowlist: `curl -X POST .../photo-moderate -d '{"photo_url":"https://google.com/x.jpg"}'` returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)