### PR TITLE
Add CLAUDE.md hard-rule hook + new-rpc-migration skill

### DIFF
--- a/.claude/hooks/check-hard-rules.sh
+++ b/.claude/hooks/check-hard-rules.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# PreToolUse hook: enforces a subset of CLAUDE.md §1 hard rules (§1.1, §1.3,
+# §1.4, §1.7, §1.8). Reads tool-use JSON on stdin. Exits 2 with reasons on
+# stderr to block Edit/MultiEdit/Write. Scope: files under src/ and
+# supabase/migrations/ (relative or absolute paths). Other paths pass through.
+#
+# Not enforced here: §1.2 (error handling pattern), §1.5 (DB safety), §1.6
+# (auth gates), §1.9 (content safety). Those need semantic review, not grep.
+
+set -euo pipefail
+
+input="$(cat)"
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')"
+
+case "$tool_name" in
+  Write)
+    content="$(printf '%s' "$input" | jq -r '.tool_input.content // empty')"
+    ;;
+  Edit)
+    content="$(printf '%s' "$input" | jq -r '.tool_input.new_string // empty')"
+    ;;
+  MultiEdit)
+    # Concat every edit's new_string with newlines so we can grep them as one.
+    content="$(printf '%s' "$input" | jq -r '.tool_input.edits[]?.new_string // empty')"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+# Match both absolute paths (Claude Code's default) and bare-relative paths.
+case "$file_path" in
+  */src/*|src/*|*/supabase/migrations/*|supabase/migrations/*) ;;
+  *) exit 0 ;;
+esac
+
+violations=()
+
+# §1.1 Browser compatibility — ES2023+ array methods crash Safari <16
+if printf '%s' "$content" | grep -qE '\.(toSorted|toReversed|toSpliced)\('; then
+  violations+=("§1.1 ES2023+ array method (.toSorted/.toReversed/.toSpliced) — crashes Safari <16. Use slice().sort() etc.")
+fi
+if printf '%s' "$content" | grep -qE '\.at\(\s*-?[0-9]'; then
+  violations+=("§1.1 Array.at() — use arr[arr.length - 1] for the last element.")
+fi
+
+# §1.7 Logging — use src/utils/logger.js
+case "$file_path" in
+  *src/utils/logger.js) ;;
+  *)
+    if printf '%s' "$content" | grep -qE 'console\.(log|error|warn|info|debug)\('; then
+      violations+=("§1.7 Direct console.* call — use logger from src/utils/logger.js. logger.error/.warn always log; .info/.debug are dev-only.")
+    fi
+    ;;
+esac
+
+# §1.8 Storage — use src/lib/storage.js helpers
+case "$file_path" in
+  *src/lib/storage.js|*src/lib/supabase.js) ;;
+  *)
+    if printf '%s' "$content" | grep -qE '\blocalStorage\.'; then
+      violations+=("§1.8 Direct localStorage.* call — use getStorageItem/setStorageItem/removeStorageItem from src/lib/storage.js.")
+    fi
+    ;;
+esac
+
+# §1.4 Data access — no direct supabase.* in components OR hooks (CLAUDE.md
+# §1.4: "No direct Supabase calls from components or hooks"). Match both
+# method calls (supabase.from(...)) and chained property access
+# (supabase.auth.getUser(), supabase.storage.from(...), etc.).
+case "$file_path" in
+  *src/pages/*|*src/components/*|*src/hooks/*)
+    if printf '%s' "$content" | grep -qE '\bsupabase\.(from|rpc|auth|storage|functions|channel|removeChannel|getChannels)[.(]'; then
+      violations+=("§1.4 Direct supabase.* in UI/hooks — all data access must go through src/api/ modules. Use hooks (useDish, useVote, etc.) in components.")
+    fi
+    ;;
+esac
+
+# §1.3 Styling — no Tailwind color classes (layout/spacing only).
+# Exemption: rgba overlays (any /N opacity suffix) — §1.3 explicitly permits
+# these. So `bg-black/60`, `bg-neutral-900/40` are allowed; solid forms aren't.
+if printf '%s' "$content" | grep -qE '\b(text|bg|border|ring|divide|from|to|via|placeholder|fill|stroke|shadow|outline|accent|decoration|caret)-(slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(50|100|200|300|400|500|600|700|800|900|950)(\b)([^/]|$)'; then
+  violations+=("§1.3 Tailwind color class — use var(--color-*) CSS variables instead. Tailwind is for layout/spacing only. (rgba overlays like bg-neutral-900/60 are permitted.)")
+fi
+if printf '%s' "$content" | grep -qE '\b(text|bg|border)-(white|black)(\b)([^/]|$)'; then
+  violations+=("§1.3 Tailwind text-white/bg-white/bg-black — use var(--color-surface-elevated), var(--color-text-primary), etc. (Opacity overlays like bg-black/5 are permitted.)")
+fi
+
+if [ ${#violations[@]} -gt 0 ]; then
+  {
+    echo "BLOCKED: CLAUDE.md hard-rule violation(s) in $file_path:"
+    for v in "${violations[@]}"; do
+      echo "  • $v"
+    done
+    echo ""
+    echo "Fix the content and retry. If this is a false positive, ask Dan before bypassing."
+  } >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/check-hard-rules.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/new-rpc-migration/SKILL.md
+++ b/.claude/skills/new-rpc-migration/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: new-rpc-migration
+description: Scaffold a new Supabase migration file with the canonical template — rollback block, ::NUMERIC cast reminder, qualified column-ref reminder, and SQL Editor deploy checklist. Use when adding a new RPC function, schema change, or table modification in this repo.
+disable-model-invocation: true
+---
+
+# new-rpc-migration
+
+Creates a new migration in `supabase/migrations/` pre-loaded with the §1.5 gotcha reminders and a rollback footer, so none of them get forgotten.
+
+## When to invoke
+
+User runs `/new-rpc-migration <short-name-with-dashes>`. Example: `/new-rpc-migration add-dish-variants-index`.
+
+If the user invokes this skill without an argument, ask for the short name first (kebab-case, describes the change in 2–5 words).
+
+## What to do
+
+1. Derive the filename (use UTC consistently to avoid midnight-flip surprises):
+   - `timestamp=$(date -u +%Y%m%d)`
+   - `filename="supabase/migrations/${timestamp}_${name}.sql"`
+   - If a file with that exact name already exists, append an HHMMSS suffix: `${timestamp}$(date -u +%H%M%S)_${name}.sql`.
+
+2. Copy `assets/template.sql` (relative to this skill) to that path using the Write tool. Replace these tokens in the template before writing:
+   - `<NAME>` → the `<short-name-with-dashes>` argument
+   - `<TIMESTAMP>` → ISO-8601 UTC timestamp from `date -u +%Y-%m-%dT%H:%M:%SZ` (e.g. `2026-04-24T17:00:00Z`)
+
+3. After writing, tell the user:
+   - The file path.
+   - Checklist from CLAUDE.md §1.5 that still needs their attention (don't ask; just state):
+     - **`supabase/schema.sql` is the source of truth** — update the schema file first, then mirror the change in this migration.
+     - **Deploy**: run the migration in the Supabase SQL Editor. Adding the file does NOT deploy.
+     - **Verify**: make a test call after deploy.
+     - **Rollback block required** if the migration changes column types, drops/recreates triggers, alters FK strategies, or rewrites policies. Exempt: pure additive `CREATE INDEX IF NOT EXISTS` / `CREATE OR REPLACE FUNCTION`.
+
+4. Do NOT invent SQL content yet. The template's placeholder comments stay until the user fills them in (or asks you to). The skill scaffolds; the user (or a follow-up request) writes the SQL.
+
+## Gotchas the template already bakes in
+
+These are in the template as comment reminders — do not remove them unless the user explicitly says so:
+- `ROUND()` on float expressions needs `::NUMERIC` cast.
+- PL/pgSQL `RETURNS TABLE` columns become variables inside the function body — always qualify as `tablename.column`.
+- Use `.maybeSingle()` in JS for lookups that might return zero rows (not `.single()`).
+- `-- ROLLBACK:` footer block with paste-ready revert SQL (or an explicit "no SQL rollback" note).
+
+## Naming convention
+
+`supabase/migrations/` currently has a mix of formats: numeric prefixes (`025-`, `030-`), date-only (`20260421_`), date-with-time (`20260216120000_`), ISO-style (`2026-04-10-`), and a few non-prefixed files. None is "the" convention.
+
+This skill standardizes on `YYYYMMDD_short-name.sql` (UTC date, `HHMMSS` appended on collision) for new files going forward. Don't use the integer prefixes (`025-`, `026-`) — those are the oldest pattern and would conflict with sort order if they grew further.

--- a/.claude/skills/new-rpc-migration/assets/template.sql
+++ b/.claude/skills/new-rpc-migration/assets/template.sql
@@ -1,0 +1,56 @@
+-- Migration: <NAME>
+-- Created:   <TIMESTAMP>
+-- Purpose:   [Describe WHAT this migration does and WHY — link to CURRENT_FOCUS.md or issue # if relevant]
+--
+-- DEPLOY: Run this file in the Supabase SQL Editor. Adding it to supabase/migrations/
+--         does NOT deploy it. After running, verify with a test call.
+--
+-- SOURCE OF TRUTH: Update supabase/schema.sql first, then mirror the change here.
+
+-- ============================================================================
+-- FORWARD MIGRATION
+-- ============================================================================
+
+-- [Your SQL goes here.]
+--
+-- Reminders from CLAUDE.md §1.5 — delete these comments once you've handled them:
+--
+--   • ROUND() on a float expression needs ::NUMERIC cast, or Postgres errors:
+--        ROUND(avg_rating::NUMERIC, 2)
+--
+--   • In PL/pgSQL functions with RETURNS TABLE (col_name ...), the column
+--     names become local variables inside the function body. Bare references
+--     are ambiguous if a joined table has the same column. ALWAYS qualify:
+--        SELECT votes.dish_id FROM votes   -- correct
+--        SELECT dish_id        FROM votes   -- ambiguous, will bite you
+--
+--   • In JS (src/api/*), use .maybeSingle() for lookups that might return 0
+--     rows. .single() throws on zero results.
+--
+--   • .rpc() function names in JS must exactly match the CREATE FUNCTION name
+--     here. Do not rename based on Postgres hint messages.
+
+
+-- ============================================================================
+-- ROLLBACK
+-- ============================================================================
+-- Required when this migration:
+--   • changes column types
+--   • drops or recreates triggers
+--   • alters FK strategies
+--   • rewrites RLS policies
+--
+-- Exempt (rollback is obvious):
+--   • pure additive CREATE INDEX IF NOT EXISTS
+--   • CREATE OR REPLACE FUNCTION (just re-run the previous version)
+--
+-- If a SQL rollback is not possible (e.g., the migration triggers a data
+-- backfill), say so explicitly:
+--
+--   -- No SQL rollback. Recovery requires restore from <timestamp> backup.
+--
+-- Otherwise, paste the revert SQL below.
+
+-- ROLLBACK:
+--
+-- [Paste-ready SQL to revert the forward migration above.]

--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -104,6 +104,15 @@ export const authApi = {
   },
 
   /**
+   * Subscribe to auth state changes. Synchronous passthrough — returns the
+   * { data: { subscription } } shape directly so callers can call
+   * subscription.unsubscribe() in cleanup.
+   */
+  onAuthStateChange(callback) {
+    return supabase.auth.onAuthStateChange(callback)
+  },
+
+  /**
    * Sign in with Google OAuth
    * @param {string|null} redirectUrl - Optional custom redirect URL (must be same-origin)
    * @returns {Promise<Object>} Auth response

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,5 +1,6 @@
 import { Component } from 'react'
 import { isChunkLoadError, tryChunkReload } from '../utils/chunkReload'
+import { logger } from '../utils/logger'
 
 function ErrorFallback({ error, resetError }) {
   return (
@@ -57,17 +58,10 @@ export class ErrorBoundary extends Component {
   }
 
   componentDidCatch(error, errorInfo) {
-    // Log the real error to console BEFORE anything else — if Sentry's
-    // dynamic import fails (e.g. Capacitor file:// scheme issues), we still
-    // want the truth in the native log. Error objects don't stringify well,
-    // so pull the fields explicitly.
-    console.error('[ErrorBoundary caught]', {
-      message: error?.message,
-      name: error?.name,
-      stack: error?.stack,
-      type: error?.type,
-      componentStack: errorInfo?.componentStack,
-    })
+    // Log first so the truth is in the native log even if Sentry's dynamic
+    // import fails (e.g. Capacitor file:// scheme). logger.error normalizes
+    // Error objects so iOS doesn't show `{}`.
+    logger.error('[ErrorBoundary caught]', error, { componentStack: errorInfo?.componentStack })
 
     // Auto-reload on chunk load errors (fallback if lazyWithRetry misses it).
     // Shared attempt counter prevents reload loops across both paths.
@@ -84,7 +78,7 @@ export class ErrorBoundary extends Component {
           },
         })
       }).catch(sentryErr => {
-        console.error('[ErrorBoundary] Sentry failed to load:', sentryErr?.message || sentryErr)
+        logger.error('[ErrorBoundary] Sentry failed to load:', sentryErr)
       })
     }
   }

--- a/src/components/LocationPicker.jsx
+++ b/src/components/LocationPicker.jsx
@@ -186,7 +186,7 @@ export function LocationPicker({ radius, onRadiusChange }) {
           <button
             onClick={function () { setShowRadiusSheet(true) }}
             aria-label={radius === 0 ? 'Showing dishes everywhere. Tap to change' : 'Search radius: ' + radius + ' miles. Tap to change'}
-            className="flex items-center gap-1.5 px-3 py-2 rounded-full text-sm font-medium border transition-all hover:border-neutral-300"
+            className="flex items-center gap-1.5 px-3 py-2 rounded-full text-sm font-medium border transition-all hover:border-black/10"
             style={{
               background: 'var(--color-surface)',
               borderColor: 'var(--color-divider)',

--- a/src/pages/ResetPassword.jsx
+++ b/src/pages/ResetPassword.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { authApi } from '../api/authApi'
-import { supabase } from '../lib/supabase'
 import { SmileyPin } from '../components/SmileyPin'
 
 export function ResetPassword() {
@@ -34,7 +33,7 @@ export function ResetPassword() {
       setCheckingSession(false)
     }
 
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+    const { data: { subscription } } = authApi.onAuthStateChange((event, session) => {
       if (event === 'PASSWORD_RECOVERY' || event === 'SIGNED_IN') {
         decide(session)
       } else if (event === 'INITIAL_SESSION' && session) {
@@ -46,7 +45,7 @@ export function ResetPassword() {
     // with whatever getSession reports. Guards against silent init failure.
     const timer = setTimeout(async () => {
       if (cancelled || decided) return
-      const { data: { session } } = await supabase.auth.getSession()
+      const { data: { session } } = await authApi.getSession()
       decide(session)
     }, 5000)
 


### PR DESCRIPTION
## Summary

Two pieces of new Claude Code automation, plus the tech debt the new hook flushed out.

### `.claude/` automation

- **PreToolUse hook** (`.claude/hooks/check-hard-rules.sh`) — enforces a subset of `CLAUDE.md` §1 hard rules on every Edit/MultiEdit/Write under `src/` and `supabase/migrations/`:
  - §1.1 ES2023+ array methods (`.toSorted/.toReversed/.toSpliced/.at(-n)`)
  - §1.3 Tailwind solid color classes (rgba overlays with `/N` opacity suffix are explicitly permitted, matching the §1.3 carve-out)
  - §1.4 direct `supabase.*` in `src/pages|components|hooks` (matches both method calls and chained access like `supabase.auth.getUser()`)
  - §1.7 `console.*` outside `src/utils/logger.js`
  - §1.8 `localStorage.*` outside `src/lib/storage.js` and `src/lib/supabase.js`
- Stress-tested across **303 files** in `src/` + `supabase/migrations/` — **0 false positives**.
- Codex-CLI (gpt-5.3-codex, high) reviewed the hook and caught 4 issues that are all fixed in this PR: relative-path scope-filter bypass, `src/hooks/` missing from §1.4 scope, narrow chained-access regex, and MultiEdit not handled.

- **`new-rpc-migration` skill** (`/new-rpc-migration <name>`) — scaffolds a Supabase migration with a rollback footer, `::NUMERIC` cast reminder, qualified column-ref reminder, and SQL Editor deploy checklist. Filename uses UTC `YYYYMMDD_short-name.sql`.

### Tech debt the hook surfaced

Three pre-existing CLAUDE.md violations the new regex flagged. Fixing now means future edits to these files don't get deadlocked on violations they didn't introduce.

- **`ErrorBoundary.jsx`** (§1.7) — 2× `console.error` → `logger.error`. The manual `{ message, stack, name }` extraction was already doing the same thing `logger`'s `normalize()` does. Switching keeps the path consistent, preserves the iOS Capacitor-friendly behavior (where `console.error(err)` prints `{}` because Error properties aren't enumerable), and inherits future logger improvements (Sentry routing) for free.
- **`LocationPicker.jsx`** (§1.3) — replace stray `hover:border-neutral-300` with `hover:border-black/10`. The original button's inline `style.borderColor` was overriding the Tailwind hover anyway, so behavior is unchanged; the new class matches the established `hover:bg-black/5` pattern elsewhere.
- **`ResetPassword.jsx` + `authApi.js`** (§1.4) — route the two direct `supabase.auth.*` calls (`onAuthStateChange`, `getSession`) through `authApi`. Adds a thin `onAuthStateChange` passthrough next to the existing `getSession` passthrough.

### One-time setup

The hook needs Claude Code to be restarted to pick up `.claude/settings.json`. The first Edit/MultiEdit/Write after restart will trigger a permission prompt to allow the hook to run.

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` — only pre-existing `react-refresh/only-export-components` warning, unrelated to these changes
- [x] Hook stress-test against full src/ + supabase/migrations/ — 0 hits
- [x] Hook blocks 6 representative violations (toSorted, console.log in pages, localStorage outside helpers, supabase.from in components, supabase.auth.getUser chained in hooks, Tailwind solid color)
- [x] Hook permits 4 representative legitimate edits (layout-only Tailwind, console.* in logger.js, files outside scope, opacity overlays like `bg-black/60`)
- [x] Hook blocks both Edit (`new_string`) and MultiEdit (`edits[].new_string`)
- [x] Hook handles relative paths (`src/foo.jsx`) and absolute paths
- [ ] Restart Claude Code and verify hook fires on a test Edit (manual step after merge)
- [ ] Manual UI smoke test of the password-reset flow on `ResetPassword.jsx` (the auth subscription path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)