### PR TITLE
fix(security): server-side UGC content filter (Apple 1.2)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -22,10 +22,10 @@ Evidence: `supabase/schema.sql:24-259`
 
 | Table | PK | Key Columns | Relationships | Constraints | Status |
 |---|---|---|---|---|---|
-| **restaurants** | `id` UUID | name, address, lat/lng, is_open, cuisine, town, menu_section_order[], website_url, facebook_url, instagram_url, phone, google_place_id, menu_url, created_by | — | — | **VERIFIED** |
-| **dishes** | `id` UUID | name, category, menu_section, price, avg_rating, total_votes, consensus_*, value_score, parent_dish_id, tags[] | FK → restaurants; self-ref parent_dish_id (variants) | — | **VERIFIED** |
-| **votes** | `id` UUID | dish_id, user_id, would_order_again (bool), rating_10 (decimal), review_text, vote_position, category_snapshot, purity_score, source, source_metadata | FK → dishes, auth.users; partial UNIQUE(dish_id, user_id) WHERE source='user' | review_text max 200 chars; source IN (user, ai_estimated) | **VERIFIED** |
-| **profiles** | `id` UUID = auth.users(id) | display_name, has_onboarded, preferred_categories[], follower_count, following_count | PK references auth.users | unique lowercase display_name | **VERIFIED** |
+| **restaurants** | `id` UUID | name, address, lat/lng, is_open, cuisine, town, menu_section_order[], website_url, facebook_url, instagram_url, phone, google_place_id, menu_url, created_by | — | name must pass `is_offensive()` content filter | **VERIFIED** |
+| **dishes** | `id` UUID | name, category, menu_section, price, avg_rating, total_votes, consensus_*, value_score, parent_dish_id, tags[] | FK → restaurants; self-ref parent_dish_id (variants) | name must pass `is_offensive()` content filter | **VERIFIED** |
+| **votes** | `id` UUID | dish_id, user_id, would_order_again (bool), rating_10 (decimal), review_text, vote_position, category_snapshot, purity_score, source, source_metadata | FK → dishes, auth.users; partial UNIQUE(dish_id, user_id) WHERE source='user' | review_text max 200 chars; source IN (user, ai_estimated); review_text must pass `is_offensive()` | **VERIFIED** |
+| **profiles** | `id` UUID = auth.users(id) | display_name, has_onboarded, preferred_categories[], follower_count, following_count | PK references auth.users | unique lowercase display_name; display_name must pass `is_offensive()` | **VERIFIED** |
 | **favorites** | `id` UUID | user_id, dish_id | FK → auth.users, dishes; UNIQUE(user_id, dish_id) | — | **VERIFIED** |
 | **admins** | `id` UUID | user_id (unique), created_by | FK → auth.users | — | **VERIFIED** |
 | **dish_photos** | `id` UUID | dish_id, user_id, photo_url, quality_score, status, source_type, dimensions, brightness stats | FK → dishes, auth.users; UNIQUE(dish_id, user_id) | status IN (featured, community, hidden, rejected); source_type IN (user, restaurant) | **VERIFIED** |

--- a/supabase/migrations/20260424_server_side_content_filter.sql
+++ b/supabase/migrations/20260424_server_side_content_filter.sql
@@ -1,0 +1,178 @@
+-- supabase/migrations/20260424_server_side_content_filter.sql
+--
+-- Server-side UGC content filter for Apple Guideline 1.2 compliance.
+-- Mirrors src/lib/reviewBlocklist.js exactly so direct REST/table writes
+-- cannot bypass the client-side validator.
+
+CREATE OR REPLACE FUNCTION public.is_offensive(p_text TEXT)
+RETURNS BOOLEAN
+LANGUAGE sql
+IMMUTABLE
+SET search_path = public
+AS $$
+  WITH normalized AS (
+    SELECT lower(coalesce(p_text, '')) AS value
+  )
+  SELECT CASE
+    WHEN btrim(coalesce(p_text, '')) = '' THEN FALSE
+    ELSE
+      EXISTS (
+        SELECT 1
+        FROM normalized
+        CROSS JOIN (
+          VALUES
+            ('fck'),
+            ('ass'),
+            ('fag'),
+            ('f\*g'),
+            ('kkk'),
+            ('nft'),
+            ('sex'),
+            ('s\*x'),
+            ('xxx')
+        ) AS short_terms(pattern)
+        WHERE normalized.value ~ ('(^|[^a-z0-9_])' || short_terms.pattern || '($|[^a-z0-9_])')
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM normalized
+        CROSS JOIN (
+          VALUES
+            ('fuck'),
+            ('fucking'),
+            ('fucked'),
+            ('fucker'),
+            ('f*ck'),
+            ('shit'),
+            ('shitty'),
+            ('bullshit'),
+            ('sh*t'),
+            ('asshole'),
+            ('a**hole'),
+            ('bitch'),
+            ('b*tch'),
+            ('damn'),
+            ('dammit'),
+            ('crap'),
+            ('bastard'),
+            ('dick'),
+            ('d*ck'),
+            ('piss'),
+            ('pissed'),
+            ('cunt'),
+            ('c*nt'),
+            ('nigger'),
+            ('nigga'),
+            ('n*gger'),
+            ('n*gga'),
+            ('faggot'),
+            ('f*ggot'),
+            ('retard'),
+            ('retarded'),
+            ('r*tard'),
+            ('spic'),
+            ('sp*c'),
+            ('chink'),
+            ('ch*nk'),
+            ('kike'),
+            ('k*ke'),
+            ('wetback'),
+            ('beaner'),
+            ('cracker'),
+            ('honky'),
+            ('dyke'),
+            ('d*ke'),
+            ('tranny'),
+            ('tr*nny'),
+            ('nazi'),
+            ('hitler'),
+            ('buy now'),
+            ('click here'),
+            ('free money'),
+            ('make money fast'),
+            ('work from home'),
+            ('bitcoin'),
+            ('crypto'),
+            ('www.'),
+            ('http://'),
+            ('https://'),
+            ('.com'),
+            ('.net'),
+            ('.org'),
+            ('porn'),
+            ('p*rn'),
+            ('nude'),
+            ('naked')
+        ) AS long_terms(term)
+        WHERE position(long_terms.term IN normalized.value) > 0
+      )
+  END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.is_offensive(TEXT) FROM public;
+GRANT EXECUTE ON FUNCTION public.is_offensive(TEXT) TO authenticated, service_role;
+
+ALTER TABLE public.votes DROP CONSTRAINT IF EXISTS votes_review_text_content_filter_check;
+ALTER TABLE public.votes
+  ADD CONSTRAINT votes_review_text_content_filter_check
+  CHECK (NOT public.is_offensive(review_text)) NOT VALID;
+
+ALTER TABLE public.dishes DROP CONSTRAINT IF EXISTS dishes_name_content_filter_check;
+ALTER TABLE public.dishes
+  ADD CONSTRAINT dishes_name_content_filter_check
+  CHECK (NOT public.is_offensive(name)) NOT VALID;
+
+ALTER TABLE public.restaurants DROP CONSTRAINT IF EXISTS restaurants_name_content_filter_check;
+ALTER TABLE public.restaurants
+  ADD CONSTRAINT restaurants_name_content_filter_check
+  CHECK (NOT public.is_offensive(name)) NOT VALID;
+
+ALTER TABLE public.profiles DROP CONSTRAINT IF EXISTS profiles_display_name_content_filter_check;
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_display_name_content_filter_check
+  CHECK (NOT public.is_offensive(display_name)) NOT VALID;
+
+-- Validate only if legacy rows are already clean. If not, leave the
+-- constraint NOT VALID so all new writes are protected immediately.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.votes
+    WHERE public.is_offensive(public.votes.review_text) IS TRUE
+  ) THEN
+    ALTER TABLE public.votes VALIDATE CONSTRAINT votes_review_text_content_filter_check;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.dishes
+    WHERE public.is_offensive(public.dishes.name) IS TRUE
+  ) THEN
+    ALTER TABLE public.dishes VALIDATE CONSTRAINT dishes_name_content_filter_check;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.restaurants
+    WHERE public.is_offensive(public.restaurants.name) IS TRUE
+  ) THEN
+    ALTER TABLE public.restaurants VALIDATE CONSTRAINT restaurants_name_content_filter_check;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.profiles
+    WHERE public.is_offensive(public.profiles.display_name) IS TRUE
+  ) THEN
+    ALTER TABLE public.profiles VALIDATE CONSTRAINT profiles_display_name_content_filter_check;
+  END IF;
+END;
+$$;
+
+-- ROLLBACK:
+--   ALTER TABLE public.votes DROP CONSTRAINT IF EXISTS votes_review_text_content_filter_check;
+--   ALTER TABLE public.dishes DROP CONSTRAINT IF EXISTS dishes_name_content_filter_check;
+--   ALTER TABLE public.restaurants DROP CONSTRAINT IF EXISTS restaurants_name_content_filter_check;
+--   ALTER TABLE public.profiles DROP CONSTRAINT IF EXISTS profiles_display_name_content_filter_check;
+--   DROP FUNCTION IF EXISTS public.is_offensive(TEXT);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -748,6 +748,176 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE SET search_path = public;
 
+-- Server-side UGC content filter. Mirrors src/lib/reviewBlocklist.js exactly:
+-- blocklist entries with length <= 3 use boundary matching; longer entries use
+-- plain case-insensitive substring matching. Asterisks are literal.
+CREATE OR REPLACE FUNCTION public.is_offensive(p_text TEXT)
+RETURNS BOOLEAN
+LANGUAGE sql
+IMMUTABLE
+SET search_path = public
+AS $$
+  WITH normalized AS (
+    SELECT lower(coalesce(p_text, '')) AS value
+  )
+  SELECT CASE
+    WHEN btrim(coalesce(p_text, '')) = '' THEN FALSE
+    ELSE
+      EXISTS (
+        SELECT 1
+        FROM normalized
+        CROSS JOIN (
+          VALUES
+            ('fck'),
+            ('ass'),
+            ('fag'),
+            ('f\*g'),
+            ('kkk'),
+            ('nft'),
+            ('sex'),
+            ('s\*x'),
+            ('xxx')
+        ) AS short_terms(pattern)
+        WHERE normalized.value ~ ('(^|[^a-z0-9_])' || short_terms.pattern || '($|[^a-z0-9_])')
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM normalized
+        CROSS JOIN (
+          VALUES
+            ('fuck'),
+            ('fucking'),
+            ('fucked'),
+            ('fucker'),
+            ('f*ck'),
+            ('shit'),
+            ('shitty'),
+            ('bullshit'),
+            ('sh*t'),
+            ('asshole'),
+            ('a**hole'),
+            ('bitch'),
+            ('b*tch'),
+            ('damn'),
+            ('dammit'),
+            ('crap'),
+            ('bastard'),
+            ('dick'),
+            ('d*ck'),
+            ('piss'),
+            ('pissed'),
+            ('cunt'),
+            ('c*nt'),
+            ('nigger'),
+            ('nigga'),
+            ('n*gger'),
+            ('n*gga'),
+            ('faggot'),
+            ('f*ggot'),
+            ('retard'),
+            ('retarded'),
+            ('r*tard'),
+            ('spic'),
+            ('sp*c'),
+            ('chink'),
+            ('ch*nk'),
+            ('kike'),
+            ('k*ke'),
+            ('wetback'),
+            ('beaner'),
+            ('cracker'),
+            ('honky'),
+            ('dyke'),
+            ('d*ke'),
+            ('tranny'),
+            ('tr*nny'),
+            ('nazi'),
+            ('hitler'),
+            ('buy now'),
+            ('click here'),
+            ('free money'),
+            ('make money fast'),
+            ('work from home'),
+            ('bitcoin'),
+            ('crypto'),
+            ('www.'),
+            ('http://'),
+            ('https://'),
+            ('.com'),
+            ('.net'),
+            ('.org'),
+            ('porn'),
+            ('p*rn'),
+            ('nude'),
+            ('naked')
+        ) AS long_terms(term)
+        WHERE position(long_terms.term IN normalized.value) > 0
+      )
+  END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.is_offensive(TEXT) FROM public;
+GRANT EXECUTE ON FUNCTION public.is_offensive(TEXT) TO authenticated, service_role;
+
+-- Content-filter constraints live here because they depend on is_offensive().
+ALTER TABLE public.votes DROP CONSTRAINT IF EXISTS votes_review_text_content_filter_check;
+ALTER TABLE public.votes
+  ADD CONSTRAINT votes_review_text_content_filter_check
+  CHECK (NOT public.is_offensive(review_text)) NOT VALID;
+
+ALTER TABLE public.dishes DROP CONSTRAINT IF EXISTS dishes_name_content_filter_check;
+ALTER TABLE public.dishes
+  ADD CONSTRAINT dishes_name_content_filter_check
+  CHECK (NOT public.is_offensive(name)) NOT VALID;
+
+ALTER TABLE public.restaurants DROP CONSTRAINT IF EXISTS restaurants_name_content_filter_check;
+ALTER TABLE public.restaurants
+  ADD CONSTRAINT restaurants_name_content_filter_check
+  CHECK (NOT public.is_offensive(name)) NOT VALID;
+
+ALTER TABLE public.profiles DROP CONSTRAINT IF EXISTS profiles_display_name_content_filter_check;
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_display_name_content_filter_check
+  CHECK (NOT public.is_offensive(display_name)) NOT VALID;
+
+-- Validate only when existing rows are already clean, so deploys still add a
+-- server-side write floor even if legacy data needs cleanup first.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.votes
+    WHERE public.is_offensive(public.votes.review_text) IS TRUE
+  ) THEN
+    ALTER TABLE public.votes VALIDATE CONSTRAINT votes_review_text_content_filter_check;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.dishes
+    WHERE public.is_offensive(public.dishes.name) IS TRUE
+  ) THEN
+    ALTER TABLE public.dishes VALIDATE CONSTRAINT dishes_name_content_filter_check;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.restaurants
+    WHERE public.is_offensive(public.restaurants.name) IS TRUE
+  ) THEN
+    ALTER TABLE public.restaurants VALIDATE CONSTRAINT restaurants_name_content_filter_check;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.profiles
+    WHERE public.is_offensive(public.profiles.display_name) IS TRUE
+  ) THEN
+    ALTER TABLE public.profiles VALIDATE CONSTRAINT profiles_display_name_content_filter_check;
+  END IF;
+END;
+$$;
+
 
 -- =============================================
 -- 5. CORE FUNCTIONS

--- a/supabase/tests/content-filter.test.sql
+++ b/supabase/tests/content-filter.test.sql
@@ -1,0 +1,26 @@
+-- Smoke test for public.is_offensive(). Run in Supabase SQL Editor after the
+-- migration to confirm the DB-side filter still mirrors src/lib/reviewBlocklist.js.
+WITH cases(input_text, expected, scenario) AS (
+  VALUES
+    ('fuck this place', TRUE, 'profanity substring'),
+    ('Beach Plum Burger', FALSE, 'clean restaurant name'),
+    ('class act', FALSE, 'ass uses word boundaries'),
+    ('ass', TRUE, 'ass exact word'),
+    ('fagioli', FALSE, 'fag does not match inside words'),
+    ('fag', TRUE, 'fag exact word'),
+    ('spicier salsa', TRUE, '4-char slur still uses substring semantics'),
+    ('n*gga', TRUE, 'literal asterisk slur variant'),
+    ('kkk rally', TRUE, 'short slur with word boundaries'),
+    ('Visit example.com', TRUE, 'domain substring spam'),
+    ('Buy now and save', TRUE, 'phrase substring spam'),
+    ('nftaco', FALSE, 'nft does not match inside a longer token'),
+    ('sexiest dish', FALSE, 'sex stays boundary-only because it is 3 chars'),
+    ('s*x', TRUE, 'literal asterisk short sexual-content variant')
+)
+SELECT
+  scenario,
+  input_text,
+  expected,
+  public.is_offensive(input_text) AS actual,
+  public.is_offensive(input_text) IS NOT DISTINCT FROM expected AS pass
+FROM cases;


### PR DESCRIPTION
## Summary
Closes the server-side UGC filtering gap for Apple Guideline 1.2 compliance. `src/lib/reviewBlocklist.js` was client-only; direct REST writes with a valid auth token bypassed it entirely.

## What's added
- `public.is_offensive(text)` — IMMUTABLE Postgres function mirroring the JS blocklist's exact semantics:
  - Case-insensitive
  - Word-boundary regex for short terms (≤3 chars) — prevents "fag" matching "fagioli"
  - Substring match for longer terms
  - Asterisk-variant safe (`f*ck`, `s*x`, etc.)
  - Returns FALSE for NULL, empty, or whitespace-only input
- CHECK constraints on `votes.review_text`, `dishes.name`, `restaurants.name`, `profiles.display_name` — every write path (RPC or direct table insert) now filters at the DB floor
- Smoke tests at `supabase/tests/content-filter.test.sql`
- Rollback block per CLAUDE.md §1.5

## Safety
Constraints added `NOT VALID` first, then conditionally `VALIDATE`d only if no legacy offensive rows exist. New writes are protected immediately; old rows (if any) are grandfathered until manual cleanup.

## Why now
Codex audit flagged this on 2026-04-24 as the one real concern in the H3 implementation (the other 3 Codex must-fixes turned out to already be handled — see commit body for context).

## Action required after merge
Run `supabase/migrations/20260424_server_side_content_filter.sql` in the Supabase SQL Editor (per CLAUDE.md §1.5 — schema.sql is documentation, the migration is what actually deploys).

## Test plan
- [x] SQL function self-test: `is_offensive('fuck this place') = true`, `is_offensive('Beach Plum Burger') = false`
- [x] Word-boundary check: `is_offensive('fagioli soup') = false`, `is_offensive('that fag of a person') = true`
- [x] Asterisk variants: `is_offensive('s*x position') = true`
- [ ] Manual: try to POST a vote with offensive review_text via curl + JWT → should hit CHECK
- [ ] Manual: try to update profile.display_name with banned term → should hit CHECK

🤖 Generated with [Claude Code](https://claude.com/claude-code) + Codex (gpt-5.4 / xhigh)