### PR TITLE
feat(curator+share): prep curator Top 10s + playlists for hand-out

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.0.0",
       "dependencies": {
         "@capacitor/app": "^8.1.0",
+        "@capacitor/browser": "^8.0.3",
         "@capacitor/cli": "^8.3.1",
         "@capacitor/core": "^8.3.1",
         "@capacitor/ios": "^8.3.1",
+        "@capacitor/share": "^8.0.1",
         "@capgo/capacitor-social-login": "^8.3.20",
         "@sentry/react": "^10.34.0",
         "@supabase/supabase-js": "^2.89.0",
@@ -1676,6 +1678,15 @@
         "@capacitor/core": ">=8.0.0"
       }
     },
+    "node_modules/@capacitor/browser": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/browser/-/browser-8.0.3.tgz",
+      "integrity": "sha512-WJWPHEPbweiFoHYmVlCbZf5yrqJ2Rchx2Xvbmd+3Lf+Zkpq3nXBThThY2CF69lYEg1NINGF9BcHThIOEU1gZlQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
     "node_modules/@capacitor/cli": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.3.1.tgz",
@@ -1769,6 +1780,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.3.0"
+      }
+    },
+    "node_modules/@capacitor/share": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/share/-/share-8.0.1.tgz",
+      "integrity": "sha512-3cSBKBCJVon54rKDROP2rqGyeGks4pBh9TbaEk9S375Kbek/ZHe72N50zIa0Vn9Eac/SuhwgehO/mmA4CsUOiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capgo/capacitor-social-login": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
   },
   "dependencies": {
     "@capacitor/app": "^8.1.0",
+    "@capacitor/browser": "^8.0.3",
     "@capacitor/cli": "^8.3.1",
     "@capacitor/core": "^8.3.1",
     "@capacitor/ios": "^8.3.1",
+    "@capacitor/share": "^8.0.1",
     "@capgo/capacitor-social-login": "^8.3.20",
     "@sentry/react": "^10.34.0",
     "@supabase/supabase-js": "^2.89.0",

--- a/src/api/adminApi.js
+++ b/src/api/adminApi.js
@@ -169,6 +169,21 @@ export const adminApi = {
   },
 
   /**
+   * Mint a curator invite link (admin-only RPC).
+   * @returns {Promise<{ success: boolean, token?: string, expires_at?: string, error?: string }>}
+   */
+  async createCuratorInvite() {
+    try {
+      const { data, error } = await supabase.rpc('create_curator_invite')
+      if (error) throw createClassifiedError(error)
+      return data
+    } catch (error) {
+      logger.error('Error minting curator invite:', error)
+      throw error.type ? error : createClassifiedError(error)
+    }
+  },
+
+  /**
    * Search dishes by name
    * @param {string} query - Search query
    * @param {number} limit - Max results

--- a/src/pages/AcceptCuratorInvite.jsx
+++ b/src/pages/AcceptCuratorInvite.jsx
@@ -47,7 +47,7 @@ export function AcceptCuratorInvite() {
     try {
       var result = await localListsApi.acceptCuratorInvite(token)
       if (result.success) {
-        navigate('/my-list')
+        navigate('/my-list', { state: { justAcceptedCuratorInvite: true } })
       } else {
         setError(result.error || 'Failed to accept invite')
       }

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -29,6 +29,11 @@ export function Admin() {
   // Edit mode state
   const [editingDishId, setEditingDishId] = useState(null)
 
+  // Curator invite state
+  const [curatorInviteLink, setCuratorInviteLink] = useState('')
+  const [curatorInviteExpires, setCuratorInviteExpires] = useState('')
+  const [mintingCuratorInvite, setMintingCuratorInvite] = useState(false)
+
   // Restaurant manager state
   const [inviteRestaurantId, setInviteRestaurantId] = useState('')
   const [inviteLink, setInviteLink] = useState('')
@@ -234,6 +239,68 @@ export function Admin() {
       logger.error('Error deleting dish:', error)
       setMessage({ type: 'error', text: `Failed to delete: ${getUserMessage(error, 'deleting dish')}` })
     }
+  }
+
+  async function handleMintCuratorInvite() {
+    setMintingCuratorInvite(true)
+    try {
+      const result = await adminApi.createCuratorInvite()
+      if (!result?.success || !result?.token) {
+        setMessage({ type: 'error', text: result?.error || 'Failed to mint invite' })
+        return
+      }
+      const link = `${window.location.origin}/curator-invite/${result.token}`
+      setCuratorInviteLink(link)
+      setCuratorInviteExpires(result.expires_at || '')
+
+      const ta = document.createElement('textarea')
+      ta.value = link
+      ta.style.position = 'fixed'
+      ta.style.left = '-9999px'
+      document.body.appendChild(ta)
+      ta.focus()
+      ta.select()
+      let copied = false
+      try {
+        copied = document.execCommand('copy')
+      } catch {
+        copied = false
+      }
+      document.body.removeChild(ta)
+
+      const expiresText = result.expires_at
+        ? ` — expires ${new Date(result.expires_at).toLocaleDateString()}`
+        : ''
+      setMessage({
+        type: 'success',
+        text: copied
+          ? `Curator invite copied${expiresText}`
+          : `Invite minted${expiresText} — copy the link below`,
+      })
+    } catch (error) {
+      logger.error('Error minting curator invite:', error)
+      setMessage({ type: 'error', text: `Failed to mint invite: ${getUserMessage(error, 'minting curator invite')}` })
+    } finally {
+      setMintingCuratorInvite(false)
+    }
+  }
+
+  function handleCopyCuratorInvite() {
+    if (!curatorInviteLink) return
+    const ta = document.createElement('textarea')
+    ta.value = curatorInviteLink
+    ta.style.position = 'fixed'
+    ta.style.left = '-9999px'
+    document.body.appendChild(ta)
+    ta.focus()
+    ta.select()
+    try {
+      document.execCommand('copy')
+      setMessage({ type: 'success', text: 'Link copied!' })
+    } catch {
+      setMessage({ type: 'error', text: 'Copy failed — please select and copy manually' })
+    }
+    document.body.removeChild(ta)
   }
 
   async function handleGenerateInvite() {
@@ -776,6 +843,53 @@ export function Admin() {
                   No managers assigned yet
                 </p>
               )}
+            </div>
+          )}
+        </div>
+
+        {/* Local Curator Invites */}
+        <div className="mt-8 pt-8 border-t" style={{ borderColor: 'var(--color-divider)' }}>
+          <h2 className="text-lg font-semibold mb-2" style={{ color: 'var(--color-text-primary)' }}>
+            Local Curator Invites
+          </h2>
+          <p className="text-sm mb-4" style={{ color: 'var(--color-text-secondary)' }}>
+            Mint a single-use link for someone you want to invite as a local curator (their Top 10 dishes show on the homepage).
+          </p>
+
+          <button
+            onClick={handleMintCuratorInvite}
+            disabled={mintingCuratorInvite}
+            className="px-4 py-2 rounded-lg font-medium transition-all text-sm disabled:opacity-60"
+            style={{ background: 'var(--color-primary)', color: 'var(--color-text-on-primary)' }}
+          >
+            {mintingCuratorInvite ? 'Minting…' : 'Mint invite link'}
+          </button>
+
+          {curatorInviteLink && (
+            <div className="mt-3 p-3 rounded-lg border" style={{ background: 'var(--color-bg)', borderColor: 'var(--color-divider)' }}>
+              <p className="text-xs font-medium mb-1" style={{ color: 'var(--color-text-tertiary)' }}>
+                Invite link
+                {curatorInviteExpires && ` (expires ${new Date(curatorInviteExpires).toLocaleDateString()})`}:
+              </p>
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  readOnly
+                  value={curatorInviteLink}
+                  className="flex-1 px-2 py-1 border rounded text-xs"
+                  style={{ borderColor: 'var(--color-divider)', background: 'var(--color-surface)' }}
+                />
+                <button
+                  onClick={handleCopyCuratorInvite}
+                  className="px-3 py-1 rounded text-xs font-medium"
+                  style={{ background: 'var(--color-primary)', color: 'var(--color-text-on-primary)' }}
+                >
+                  Copy
+                </button>
+              </div>
+              <p className="text-xs mt-2" style={{ color: 'var(--color-text-tertiary)' }}>
+                Single-use — once they accept, mint a new one for the next curator.
+              </p>
             </div>
           )}
         </div>

--- a/src/pages/MyList.jsx
+++ b/src/pages/MyList.jsx
@@ -1,46 +1,112 @@
-import { useState, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useState, useEffect, useMemo } from 'react'
+import { useNavigate, useLocation, useBlocker } from 'react-router-dom'
 import { useMyLocalList } from '../hooks/useMyLocalList'
 import { useDishSearch } from '../hooks/useDishSearch'
 import { getCategoryEmoji } from '../constants/categories'
 import { logger } from '../utils/logger'
 
+function snapshot(tagline, items) {
+  return JSON.stringify({
+    tagline: tagline || '',
+    items: (items || []).map(function (item) {
+      return {
+        dish_id: item.dish_id,
+        note: item.note || '',
+      }
+    }),
+  })
+}
+
 export function MyList() {
   var navigate = useNavigate()
-  var { listMeta, dishes, loading, saveList, saving } = useMyLocalList()
+  var location = useLocation()
+  var { listMeta, dishes, loading, error, saveList, saving } = useMyLocalList()
 
-  // Local state for editing
   var [tagline, setTagline] = useState('')
   var [items, setItems] = useState([])
   var [searchQuery, setSearchQuery] = useState('')
   var [showSearch, setShowSearch] = useState(false)
   var [saveMessage, setSaveMessage] = useState(null)
-  var [initialized, setInitialized] = useState(false)
+  var [hydrated, setHydrated] = useState(false)
+  var [serverSnapshot, setServerSnapshot] = useState('')
+  var [welcomeDismissed, setWelcomeDismissed] = useState(false)
 
   var { results: searchResults } = useDishSearch(searchQuery, 20)
 
-  // Initialize from server data (once)
+  // Hydrate once we have a server response — even if dishes is empty,
+  // so brand-new curators get listMeta.curatorTagline synced.
   useEffect(function () {
-    if (initialized) return
-    if (dishes.length > 0) {
-      setItems(dishes.map(function (d) {
-        return {
-          dish_id: d.dish_id,
-          dish_name: d.dish_name,
-          restaurant_name: d.restaurant_name,
-          category: d.category,
-          note: d.note || '',
-        }
-      }))
-      setInitialized(true)
-    }
-    if (listMeta && listMeta.curatorTagline) {
-      setTagline(listMeta.curatorTagline)
-    }
-  }, [dishes, listMeta, initialized])
+    if (hydrated || loading) return
+    if (!listMeta) return
+    var initialItems = dishes.map(function (d) {
+      return {
+        dish_id: d.dish_id,
+        dish_name: d.dish_name,
+        restaurant_name: d.restaurant_name,
+        category: d.category,
+        note: d.note || '',
+      }
+    })
+    var initialTagline = listMeta.curatorTagline || ''
+    setItems(initialItems)
+    setTagline(initialTagline)
+    setServerSnapshot(snapshot(initialTagline, initialItems))
+    setHydrated(true)
+  }, [hydrated, loading, listMeta, dishes])
 
-  // Not a curator — no list found
-  if (!loading && !listMeta) {
+  var currentSnapshot = useMemo(function () {
+    return snapshot(tagline, items)
+  }, [tagline, items])
+  var isDirty = hydrated && currentSnapshot !== serverSnapshot
+
+  // beforeunload — only while dirty. Removed on cleanup or when clean.
+  useEffect(function () {
+    if (!isDirty) return undefined
+    function handler(e) {
+      e.preventDefault()
+      e.returnValue = ''
+      return ''
+    }
+    window.addEventListener('beforeunload', handler)
+    return function () { window.removeEventListener('beforeunload', handler) }
+  }, [isDirty])
+
+  // In-app navigation block while dirty.
+  var blocker = useBlocker(function (args) {
+    return isDirty && args.currentLocation.pathname !== args.nextLocation.pathname
+  })
+
+  // Loading and error states (must come before the !listMeta gate so a
+  // failed fetch doesn't masquerade as "you're not a curator").
+  if (loading && !hydrated) {
+    return (
+      <div className="min-h-screen flex items-center justify-center" style={{ background: 'var(--color-bg)' }}>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2" style={{ borderColor: 'var(--color-primary)' }} />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center px-6" style={{ background: 'var(--color-bg)' }}>
+        <div style={{ fontSize: 64 }}>⚠️</div>
+        <h1 style={{ fontFamily: "'Amatic SC', cursive", fontSize: 32, marginTop: 12, color: 'var(--color-text-primary)' }}>
+          Couldn't load your list
+        </h1>
+        <p style={{ color: 'var(--color-text-secondary)', marginTop: 8, textAlign: 'center' }}>
+          {error?.message || 'Please try again.'}
+        </p>
+        <button
+          onClick={function () { window.location.reload() }}
+          style={{ color: 'var(--color-accent-gold)', marginTop: 16, background: 'none', border: 'none', fontWeight: 700 }}
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  if (!listMeta) {
     return (
       <div className="min-h-screen flex items-center justify-center" style={{ background: 'var(--color-bg)' }}>
         <div className="text-center px-6">
@@ -59,14 +125,6 @@ export function MyList() {
             Go Home
           </button>
         </div>
-      </div>
-    )
-  }
-
-  if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center" style={{ background: 'var(--color-bg)' }}>
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2" style={{ borderColor: 'var(--color-primary)' }} />
       </div>
     )
   }
@@ -141,6 +199,7 @@ export function MyList() {
       var result = await saveList(payload)
       if (result.success) {
         setSaveMessage('Saved! ' + (items.length > 0 ? 'Your list is live.' : 'List unpublished.'))
+        setServerSnapshot(snapshot(tagline, items))
       } else {
         setSaveMessage('Error: ' + (result.error || 'Failed to save'))
       }
@@ -156,6 +215,16 @@ export function MyList() {
   var filteredResults = searchResults.filter(function (dish) {
     return !addedIds[dish.dish_id || dish.id]
   })
+
+  var showWelcome = !welcomeDismissed
+    && location.state
+    && location.state.justAcceptedCuratorInvite
+    && items.length === 0
+
+  function dismissWelcome() {
+    setWelcomeDismissed(true)
+    navigate(location.pathname, { replace: true, state: null })
+  }
 
   return (
     <div style={{ background: 'var(--color-bg)', minHeight: '100vh', paddingBottom: '100px' }}>
@@ -173,6 +242,46 @@ export function MyList() {
           Pick up to 10 dishes visitors should try
         </p>
       </div>
+
+      {/* Welcome banner (just-accepted curator) */}
+      {showWelcome && (
+        <div
+          className="mx-4 mb-3 rounded-xl"
+          style={{
+            background: 'var(--color-surface-elevated)',
+            border: '1px solid var(--color-primary)',
+            padding: '12px 14px',
+            display: 'flex',
+            gap: '10px',
+            alignItems: 'flex-start',
+          }}
+        >
+          <div style={{ flex: 1 }}>
+            <p style={{ fontSize: '14px', fontWeight: 700, color: 'var(--color-text-primary)', marginBottom: '4px' }}>
+              You&rsquo;re a Local Curator 🎉
+            </p>
+            <p style={{ fontSize: '12px', color: 'var(--color-text-secondary)', lineHeight: 1.4 }}>
+              Pick up to 10 dishes visitors should try, add a tagline, and hit
+              {' '}<strong>Save &amp; Publish</strong>. Your list shows up on the homepage.
+            </p>
+          </div>
+          <button
+            onClick={dismissWelcome}
+            aria-label="Dismiss welcome"
+            style={{
+              background: 'none',
+              border: 'none',
+              fontSize: '18px',
+              color: 'var(--color-text-tertiary)',
+              cursor: 'pointer',
+              padding: '0 4px',
+              lineHeight: 1,
+            }}
+          >
+            ×
+          </button>
+        </div>
+      )}
 
       {/* Tagline */}
       <div className="px-4 mb-4">
@@ -455,9 +564,20 @@ export function MyList() {
             {saveMessage}
           </p>
         )}
+        {isDirty && !saveMessage && (
+          <p style={{
+            fontSize: '11px',
+            color: 'var(--color-accent-gold)',
+            marginBottom: '6px',
+            textAlign: 'center',
+            fontWeight: 600,
+          }}>
+            Unsaved changes
+          </p>
+        )}
         <button
           onClick={handleSave}
-          disabled={saving}
+          disabled={saving || !isDirty}
           className="w-full rounded-xl font-semibold transition-all disabled:opacity-50"
           style={{
             padding: '14px',
@@ -465,12 +585,72 @@ export function MyList() {
             background: 'var(--color-primary)',
             color: '#fff',
             border: 'none',
-            cursor: saving ? 'default' : 'pointer',
+            cursor: (saving || !isDirty) ? 'default' : 'pointer',
           }}
         >
           {saving ? 'Saving...' : items.length > 0 ? 'Save & Publish' : 'Save (Unpublished)'}
         </button>
       </div>
+
+      {/* Unsaved-changes blocker dialog */}
+      {blocker.state === 'blocked' && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center"
+          style={{ background: 'rgba(0,0,0,0.6)' }}
+          onClick={function () { blocker.reset && blocker.reset() }}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            className="rounded-2xl"
+            style={{
+              background: 'var(--color-surface-elevated)',
+              padding: '20px',
+              maxWidth: '320px',
+              width: 'calc(100% - 32px)',
+              border: '1px solid var(--color-divider)',
+            }}
+            onClick={function (e) { e.stopPropagation() }}
+          >
+            <h2 style={{ fontSize: '16px', fontWeight: 700, color: 'var(--color-text-primary)', marginBottom: '6px' }}>
+              Unsaved changes
+            </h2>
+            <p style={{ fontSize: '13px', color: 'var(--color-text-secondary)', marginBottom: '16px', lineHeight: 1.4 }}>
+              You have unsaved edits to your list. Leave anyway?
+            </p>
+            <div className="flex gap-2">
+              <button
+                onClick={function () { blocker.reset && blocker.reset() }}
+                className="flex-1 rounded-lg font-semibold"
+                style={{
+                  padding: '10px',
+                  fontSize: '13px',
+                  background: 'var(--color-surface)',
+                  color: 'var(--color-text-primary)',
+                  border: '1px solid var(--color-divider)',
+                  cursor: 'pointer',
+                }}
+              >
+                Stay
+              </button>
+              <button
+                onClick={function () { blocker.proceed && blocker.proceed() }}
+                className="flex-1 rounded-lg font-semibold"
+                style={{
+                  padding: '10px',
+                  fontSize: '13px',
+                  background: 'var(--color-primary)',
+                  color: '#fff',
+                  border: 'none',
+                  cursor: 'pointer',
+                }}
+              >
+                Leave
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/pages/Playlist.jsx
+++ b/src/pages/Playlist.jsx
@@ -9,6 +9,7 @@ import { getCategoryNeonImage, categoryEmojiFor } from '../constants/categories'
 import { AddDishSearchSheet } from '../components/playlists/AddDishSearchSheet'
 import { capture } from '../lib/analytics'
 import { shareOrCopy } from '../utils/share'
+import { toast } from 'sonner'
 
 export function Playlist() {
   const { id } = useParams()
@@ -84,13 +85,22 @@ export function Playlist() {
     }
   }
 
-  var handleShare = function () {
-    shareOrCopy({
+  var handleShare = async function () {
+    var result = await shareOrCopy({
       url: window.location.href,
       title: playlist.title,
       text: playlist.title + ' — a food playlist on What\'s Good Here',
     })
-    capture('playlist_shared', { playlist_id: id, share_target: 'native_or_clipboard' })
+    capture('playlist_shared', { playlist_id: id, share_target: result.method })
+    if (result.method === 'native_capacitor' || result.method === 'web_share') {
+      // OS share sheet is its own feedback — no toast
+      return
+    }
+    if (result.success) {
+      toast('Link copied')
+    } else {
+      toast('Could not share link')
+    }
   }
 
   return (

--- a/src/utils/share.js
+++ b/src/utils/share.js
@@ -1,18 +1,41 @@
+import { Capacitor } from '@capacitor/core'
+import { Share } from '@capacitor/share'
 import { logger } from './logger'
 
 /**
  * Share or copy a URL with platform-appropriate behavior.
  *
  * Fallback strategy:
- * 1. Web Share API (mobile native share sheets)
- * 2. navigator.clipboard.writeText (modern desktop)
- * 3. Synchronous textarea + execCommand (mobile Safari fallback)
+ * 1. Capacitor Share plugin (native iOS/Android — guaranteed under capacitor:// origin)
+ * 2. Web Share API (mobile browsers)
+ * 3. navigator.clipboard.writeText (modern desktop)
+ * 4. Synchronous textarea + execCommand (last-resort fallback)
+ *
+ * Never throws. Returns { method, success, error? } so callers can toast accordingly.
  *
  * @param {{ url: string, title?: string, text?: string }} options
- * @returns {Promise<{ method: string, success: boolean }>}
+ * @returns {Promise<{ method: string, success: boolean, error?: unknown }>}
  */
 export async function shareOrCopy({ url, title, text }) {
-  // 1. Web Share API (best mobile UX — native share sheet)
+  // 1. Capacitor native share (iOS / Android shell)
+  if (Capacitor?.isNativePlatform?.()) {
+    try {
+      const payload = { url }
+      if (title) payload.title = title
+      if (text) payload.text = text
+      await Share.share(payload)
+      return { method: 'native_capacitor', success: true }
+    } catch (err) {
+      // User cancellation throws too — surface as success:false but don't fall through
+      // to clipboard, otherwise dismissing native sheet would still copy the link.
+      if (err && (err.message || '').toLowerCase().includes('cancel')) {
+        return { method: 'native_capacitor', success: false, error: err }
+      }
+      logger.warn('Capacitor Share failed, falling back:', err)
+    }
+  }
+
+  // 2. Web Share API (mobile browsers)
   if (navigator.share) {
     const shareData = { url }
     if (title) shareData.title = title
@@ -21,17 +44,17 @@ export async function shareOrCopy({ url, title, text }) {
     if (!navigator.canShare || navigator.canShare(shareData)) {
       try {
         await navigator.share(shareData)
-        return { method: 'native', success: true }
+        return { method: 'web_share', success: true }
       } catch (err) {
         if (err.name === 'AbortError') {
-          return { method: 'native', success: false }
+          return { method: 'web_share', success: false }
         }
         // Fall through to clipboard
       }
     }
   }
 
-  // 2. Async clipboard API (desktop browsers)
+  // 3. Async clipboard API (desktop browsers)
   try {
     await navigator.clipboard.writeText(url)
     return { method: 'clipboard', success: true }
@@ -39,8 +62,7 @@ export async function shareOrCopy({ url, title, text }) {
     // Fall through to execCommand
   }
 
-  // 3. Synchronous textarea + execCommand (mobile Safari fallback)
-  // Proven pattern from Admin.jsx invite copy
+  // 4. Synchronous textarea + execCommand (mobile Safari fallback)
   try {
     const textarea = document.createElement('textarea')
     textarea.value = url
@@ -54,7 +76,7 @@ export async function shareOrCopy({ url, title, text }) {
     return { method: 'execCommand', success }
   } catch (err) {
     logger.warn('All share methods failed:', err)
-    return { method: 'execCommand', success: false }
+    return { method: 'execCommand', success: false, error: err }
   }
 }
 


### PR DESCRIPTION
## Summary

Four fixes to make the curator-invite flow + playlist sharing safe to hand to real users:

- **MyList**: hydrates correctly for empty curators (tagline now syncs); shows real error state instead of false "Local Curators Only" lockout; dirty-state guard (`beforeunload` + `useBlocker` confirm dialog); welcome banner for just-accepted curators
- **AcceptCuratorInvite**: passes `justAcceptedCuratorInvite` state so MyList shows the welcome
- **Admin**: new "Local Curator Invites" card — admins can mint + copy invite links without running SQL by hand
- **Share**: `@capacitor/share` first on native iOS (capacitor:// origin can't rely on Web Share API / clipboard), then web share / clipboard / execCommand. Playlist `handleShare` awaits the result and toasts on copy/error

## Why now

Denis wants to start handing playlists + curator invites to real locals. Without these fixes:
- Admin couldn't mint invites (RPC existed, no UI)
- Empty curators saw blank tagline despite server having one
- Any flaky-network curator got "you need an invite" instead of a retry
- Reordering + nav-away silently lost work
- Native iOS share button likely fell through to clipboard at best

## Test plan

- [ ] **Admin → Mint curator invite**: log in as admin, scroll to "Local Curator Invites", click "Mint invite link", confirm link is copied + shown inline
- [ ] **Curator accept flow**: paste invite link → sign in → land on /my-list with welcome banner visible (banner only on first land, dismissable)
- [ ] **Curator empty hydration**: brand-new curator with no dishes — confirm tagline placeholder shows, no stuck loading
- [ ] **Curator dirty-guard (web)**: add a dish → reload tab → browser confirms before discarding
- [ ] **Curator dirty-guard (in-app)**: add a dish → click a nav link → "Unsaved changes" dialog appears with Stay/Leave
- [ ] **Curator save**: hit Save & Publish → "Saved! Your list is live." → unsaved-changes indicator clears
- [ ] **Playlist share (web)**: `/playlist/:id` Share button → Web Share sheet on mobile / clipboard toast on desktop
- [ ] **Playlist share (iOS Capacitor)**: real iPhone — Share button opens iOS native share sheet (this is the unverified one, please run on device)
- [ ] **Curator error state**: kill network mid-load on /my-list → "Couldn't load your list — Retry" instead of "Local Curators Only"

## Notes for reviewers

- `ios/App/CapApp-SPM/Package.swift` not included — needs `npx cap sync` after merge to register CapacitorShare
- `useBlocker` is react-router-dom v7's official API; first usage in this codebase
- No schema changes — `create_curator_invite()` already shipped
- Build/lint/tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)