### PR TITLE
chore(docs): point canonical URLs to wghapp.com

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Mobile-first food discovery app for Martha's Vineyard (expanding to Nantucket + 
 - **Frontend:** React 19, Vite 7, Tailwind CSS 3, React Router v7
 - **Maps:** Leaflet + React Leaflet (dish pins, restaurant discovery)
 - **Backend:** Supabase (PostgreSQL, Auth, Storage, Edge Functions)
-- **Hosting:** Vercel (whats-good-here.vercel.app)
+- **Hosting:** Vercel (wghapp.com)
 - **Analytics:** PostHog, Sentry
 - **Testing:** Vitest (unit), Playwright (E2E)
 - **PWA:** vite-plugin-pwa with service worker

--- a/LEARNING.md
+++ b/LEARNING.md
@@ -362,7 +362,7 @@ const sorted = useMemo(() => dishes.toSorted(...), [dishes])
 
 **DOM (Document Object Model)** — The browser's representation of your page as a tree of elements. React updates the DOM for you.
 
-**URL (Uniform Resource Locator)** — A web address. `https://whats-good-here.vercel.app/browse`
+**URL (Uniform Resource Locator)** — A web address. `https://wghapp.com/browse`
 
 **HTTP** — The protocol browsers use to request web pages and data. GET requests data, POST sends data.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -135,7 +135,7 @@ Follow the prompts and add environment variables when asked.
 
 ### After Deployment
 
-1. Copy your Vercel deployment URL (e.g., `https://whats-good-here.vercel.app`)
+1. Copy your production URL (e.g., `https://wghapp.com`)
 2. Go back to Supabase dashboard > **Authentication > URL Configuration**
 3. Add your Vercel URL to **Site URL** and **Redirect URLs**
 4. Test authentication on your live site

--- a/SPEC.md
+++ b/SPEC.md
@@ -10,7 +10,7 @@
 
 What's Good Here is a mobile-first food discovery app for Martha's Vineyard. Users vote on dishes with a "Would you order this again?" binary plus a 1–10 rating scale, and the app ranks dishes by crowd-sourced consensus. The core loop is: browse/search dishes → vote → see how your taste compares. A gamification layer (badges) and social features (follows, taste compatibility) drive retention.
 
-Tech: React 19, Vite, Tailwind CSS, React Router v7, Supabase (Postgres + Auth + Storage), deployed on Vercel at `whats-good-here.vercel.app`. Analytics via PostHog + Sentry.
+Tech: React 19, Vite, Tailwind CSS, React Router v7, Supabase (Postgres + Auth + Storage), deployed on Vercel at `wghapp.com`. Analytics via PostHog + Sentry.
 
 ---
 

--- a/api/share.ts
+++ b/api/share.ts
@@ -23,7 +23,7 @@ const BOT_PATTERNS = [
 
 const SUPABASE_URL = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || ''
 const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_ANON_KEY || ''
-const BASE_URL = 'https://whats-good-here.vercel.app'
+const BASE_URL = 'https://wghapp.com'
 
 function escHtml(s: string): string {
   return s

--- a/docs/PARTNER-UPDATE-FEB-22.md
+++ b/docs/PARTNER-UPDATE-FEB-22.md
@@ -1,7 +1,7 @@
 # What Changed Since the Unified Merge
 
 **Date:** Feb 22, 2026
-**Branch:** `main` (live on Vercel: whats-good-here.vercel.app)
+**Branch:** `main` (live on Vercel: wghapp.com)
 **Since:** commit `42e3275` — "unified merge — partner's polished UI + Denis's infrastructure"
 **Commits:** 22 | **Files changed:** 67 | **Lines added:** ~22,000
 

--- a/docs/app-store-connect-privacy-details.md
+++ b/docs/app-store-connect-privacy-details.md
@@ -138,9 +138,9 @@ Allowed purposes per Apple: Third-Party Advertising, Developer's Advertising or 
 
 **Primary contact:** `hello@whatsgoodhere.app`
 **Developer:** Daniel Walsh (individual enrollment)
-**Support URL:** `https://whats-good-here.vercel.app/support` (or the final custom domain once set)
-**Privacy Policy URL:** `https://whats-good-here.vercel.app/privacy`
-**Marketing URL (optional):** `https://whats-good-here.vercel.app` (homepage works as marketing)
+**Support URL:** `https://wghapp.com/support`
+**Privacy Policy URL:** `https://wghapp.com/privacy`
+**Marketing URL (optional):** `https://wghapp.com` (homepage works as marketing)
 
 ---
 

--- a/docs/google-oauth-setup.md
+++ b/docs/google-oauth-setup.md
@@ -17,13 +17,13 @@ The frontend code for Google OAuth is fully implemented. This guide covers the S
    - User Type: **External**
    - App name: **What's Good Here**
    - Support email: your email
-   - Authorized domains: add `whats-good-here.vercel.app` and your Supabase project domain (e.g., `supabase.co`)
+   - Authorized domains: add `wghapp.com` and your Supabase project domain (e.g., `supabase.co`)
    - Scopes: `email`, `profile`, `openid` (defaults)
 6. Back in Credentials, create OAuth client ID:
    - Application type: **Web application**
    - Name: **WGH Production**
    - Authorized JavaScript origins:
-     - `https://whats-good-here.vercel.app`
+     - `https://wghapp.com`
      - `http://localhost:5173` (for local dev)
    - Authorized redirect URIs:
      - `https://<YOUR_SUPABASE_PROJECT_REF>.supabase.co/auth/v1/callback`
@@ -41,9 +41,9 @@ The frontend code for Google OAuth is fully implemented. This guide covers the S
 ## Step 3: Verify Redirect URLs
 
 In **Authentication > URL Configuration**:
-- **Site URL**: `https://whats-good-here.vercel.app`
+- **Site URL**: `https://wghapp.com`
 - **Redirect URLs** (add all):
-  - `https://whats-good-here.vercel.app/**`
+  - `https://wghapp.com/**`
   - `http://localhost:5173/**` (for local dev)
 
 ## Step 4: Run the `handle_new_user` Trigger

--- a/docs/plans/2026-02-15-logo-creative-brief.md
+++ b/docs/plans/2026-02-15-logo-creative-brief.md
@@ -6,7 +6,7 @@ What's Good Here is a mobile-first food discovery app. Users rate individual dis
 
 Currently live on Martha's Vineyard, but the concept is location-agnostic and designed to expand.
 
-**Website:** whats-good-here.vercel.app
+**Website:** wghapp.com
 
 ## What We Need
 

--- a/docs/plans/2026-02-22-launch-checklist.md
+++ b/docs/plans/2026-02-22-launch-checklist.md
@@ -10,7 +10,7 @@
 These are blocking. Nothing else matters until these are confirmed.
 
 ### 1. Smoke Test the Live URL
-- [ ] Open https://whats-good-here.vercel.app on your phone
+- [ ] Open https://wghapp.com on your phone
 - [ ] Home page loads — map renders with CARTO tiles (CSP fix just shipped)
 - [ ] Browse page shows ranked dishes with real data
 - [ ] Tap a dish — Dish page loads with score, reviews, restaurant info

--- a/docs/superpowers/plans/2026-03-10-self-service-local-lists.md
+++ b/docs/superpowers/plans/2026-03-10-self-service-local-lists.md
@@ -1674,7 +1674,7 @@ SELECT create_curator_invite();
 
 This returns `{"success": true, "token": "abc123...", "expires_at": "..."}`.
 
-The invite URL is: `https://whats-good-here.vercel.app/curator-invite/<token>`
+The invite URL is: `https://wghapp.com/curator-invite/<token>`
 
 Share this URL with the local via text/email. They click it, sign in (or create account), accept, and build their list.
 

--- a/docs/superpowers/plans/2026-03-31-ask-wgh.md
+++ b/docs/superpowers/plans/2026-03-31-ask-wgh.md
@@ -931,7 +931,7 @@ import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 
 const corsHeaders = {
-  'Access-Control-Allow-Origin': 'https://whats-good-here.vercel.app',
+  'Access-Control-Allow-Origin': 'https://wghapp.com',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 }
 

--- a/docs/superpowers/plans/2026-04-13-h2-sign-in-with-apple.md
+++ b/docs/superpowers/plans/2026-04-13-h2-sign-in-with-apple.md
@@ -45,7 +45,7 @@ Once Apple Dev account is active:
 
 - [ ] **Create a Services ID** (web-flow client ID)
   - Example: `com.whatsgoodhere.service`
-  - **Associated Domains** (domains where the SIWA button appears): `whats-good-here.vercel.app` (and any future custom domain)
+  - **Associated Domains** (domains where the SIWA button appears): `wghapp.com` (and any future custom domain)
   - **Return URL** (OAuth callback — must be Supabase): `https://vpioftosgdkyiwvhxewy.supabase.co/auth/v1/callback`
   - These are two separate fields in the Apple Services ID config.
 

--- a/supabase/seed/generate-pitch-invites.sql
+++ b/supabase/seed/generate-pitch-invites.sql
@@ -35,7 +35,7 @@ BEGIN
     INSERT INTO restaurant_invites (restaurant_id, created_by)
     VALUES (v_badmarthas_id, v_admin_id)
     RETURNING token INTO v_token_badmarthas;
-    RAISE NOTICE 'Bad Martha''s: https://whats-good-here.vercel.app/invite/%', v_token_badmarthas;
+    RAISE NOTICE 'Bad Martha''s: https://wghapp.com/invite/%', v_token_badmarthas;
   ELSE
     RAISE NOTICE 'Bad Martha''s Brewery not found in restaurants table';
   END IF;
@@ -44,7 +44,7 @@ BEGIN
     INSERT INTO restaurant_invites (restaurant_id, created_by)
     VALUES (v_nomans_id, v_admin_id)
     RETURNING token INTO v_token_nomans;
-    RAISE NOTICE 'Noman''s: https://whats-good-here.vercel.app/invite/%', v_token_nomans;
+    RAISE NOTICE 'Noman''s: https://wghapp.com/invite/%', v_token_nomans;
   ELSE
     RAISE NOTICE 'Noman''s not found in restaurants table';
   END IF;
@@ -53,7 +53,7 @@ BEGIN
     INSERT INTO restaurant_invites (restaurant_id, created_by)
     VALUES (v_nancys_id, v_admin_id)
     RETURNING token INTO v_token_nancys;
-    RAISE NOTICE 'Nancy''s: https://whats-good-here.vercel.app/invite/%', v_token_nancys;
+    RAISE NOTICE 'Nancy''s: https://wghapp.com/invite/%', v_token_nancys;
   ELSE
     RAISE NOTICE 'Nancy''s not found in restaurants table';
   END IF;


### PR DESCRIPTION
## Summary

\`wghapp.com\` has been the canonical production domain since 2026-04-21. The Vercel-internal URL (\`whats-good-here.vercel.app\`) still resolves to the same deployment, but it's no longer the address users see or share.

This PR updates docs and human-facing link generators to point at the canonical domain.

## Scope

**Updated:**
- All \`.md\` docs (CLAUDE, SPEC, SETUP, LEARNING, plans, specs)
- \`api/share.ts\` \`BASE_URL\` — drives OG share preview URLs (\`og:url\`, fallback links)
- \`supabase/seed/generate-pitch-invites.sql\` — \`RAISE NOTICE\` strings printing invite URLs

**Intentionally NOT touched:**
- \`middleware.js\` and \`supabase/functions/_shared/cors.ts\` — both already allowlist \`wghapp.com\` AND \`whats-good-here.vercel.app\` (the Vercel URL is kept as labeled legacy fallback for the transition).
- 7 individual Edge Functions (\`menu-refresh\`, \`discover-restaurants\`, \`seed-reviews\`, \`restaurant-scraper\`, \`scraper-dispatcher\`, \`backfill-restaurants\`) hard-code \`Access-Control-Allow-Origin: 'https://whats-good-here.vercel.app'\`. **This is a real bug** — calls from \`wghapp.com\` to those functions are currently failing CORS. The fix is to refactor them onto \`_shared/cors.ts\`, not just swap the URL string. Tracking separately.

## Review trail

- **Codex GPT-5.4 / high** static review: approved. Caught one false-positive concern about \`docs/google-oauth-setup.md\` (which is a setup guide where leading users to wghapp.com is intentional) and 2 NITs: SETUP.md "Vercel deployment URL" was misleading after the swap (changed to "production URL"); app-store-connect-privacy "or the final custom domain once set" parenthetical was stale (removed). Both fixes applied.

## Test plan

- [ ] Open a shared dish link in an iMessage/Slack preview — OG card now points at \`wghapp.com\`
- [ ] Run \`generate-pitch-invites.sql\` in SQL Editor — printed invite URLs use \`wghapp.com\`
- [ ] Skim updated docs (CLAUDE.md Tech Stack section, SETUP.md deploy section) — wording reads correctly with the new domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)