### PR TITLE
fix(native): wrap external links via @capacitor/browser on iOS

### DIFF
--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.3.1"),
         .package(name: "CapacitorApp", path: "../../../node_modules/@capacitor/app"),
+        .package(name: "CapacitorBrowser", path: "../../../node_modules/@capacitor/browser"),
         .package(name: "CapgoCapacitorSocialLogin", path: "../../../node_modules/@capgo/capacitor-social-login")
     ],
     targets: [
@@ -22,6 +23,7 @@ let package = Package(
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
                 .product(name: "CapacitorApp", package: "CapacitorApp"),
+                .product(name: "CapacitorBrowser", package: "CapacitorBrowser"),
                 .product(name: "CapgoCapacitorSocialLogin", package: "CapgoCapacitorSocialLogin")
             ]
         )

--- a/src/components/DishListItem.jsx
+++ b/src/components/DishListItem.jsx
@@ -6,6 +6,7 @@ import { getCategoryNeonImage, getCategoryEmoji, getDishNameIcon } from '../cons
 import { RestaurantAvatar } from './RestaurantAvatar'
 import { HearingIcon } from './HearingIcon'
 import { sanitizeUrl } from '../utils/sanitize'
+import { openExternalLink } from '../utils/openExternalLink'
 /**
  * DishListItem — the ONE component for showing a dish in any list.
  *
@@ -207,7 +208,7 @@ export const DishListItem = memo(function DishListItem({
                 href={toastSlug ? 'https://order.toasttab.com/online/' + toastSlug : sanitizeUrl(orderUrl)}
                 target="_blank"
                 rel="noopener noreferrer"
-                onClick={function (e) { e.stopPropagation() }}
+                onClick={(e) => { e.stopPropagation(); openExternalLink(e, e.currentTarget.href) }}
                 className="flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold"
                 style={{
                   background: 'var(--color-primary)',
@@ -223,7 +224,7 @@ export const DishListItem = memo(function DishListItem({
                 href={'https://www.google.com/maps/dir/?api=1&destination=' + restaurantLat + ',' + restaurantLng}
                 target="_blank"
                 rel="noopener noreferrer"
-                onClick={function (e) { e.stopPropagation() }}
+                onClick={(e) => { e.stopPropagation(); openExternalLink(e, e.currentTarget.href) }}
                 className="flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
                 style={{
                   border: '1px solid var(--color-divider)',

--- a/src/components/PlaceAttributions.jsx
+++ b/src/components/PlaceAttributions.jsx
@@ -9,6 +9,8 @@
  *
  * Reference: https://developers.google.com/maps/documentation/places/web-service/policies
  */
+import { openExternalLink } from '../utils/openExternalLink'
+
 export function PlaceAttributions({ attributions, className = '' }) {
   if (!Array.isArray(attributions) || attributions.length === 0) return null
 
@@ -25,6 +27,7 @@ export function PlaceAttributions({ attributions, className = '' }) {
               href={a.url}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={(e) => openExternalLink(e, e.currentTarget.href)}
               style={{ color: 'var(--color-accent-gold)' }}
             >
               {a.provider}

--- a/src/pages/Dish.jsx
+++ b/src/pages/Dish.jsx
@@ -18,6 +18,7 @@ import { ReportModal } from '../components/ReportModal'
 import { getStorageItem, setStorageItem, STORAGE_KEYS } from '../lib/storage'
 import { MIN_VOTES_FOR_RANKING } from '../constants/app'
 import { sanitizeUrl } from '../utils/sanitize'
+import { openExternalLink } from '../utils/openExternalLink'
 import { authApi } from '../api/authApi'
 import { dishPhotosApi } from '../api/dishPhotosApi'
 
@@ -400,12 +401,15 @@ export function Dish() {
                 href={sanitizeUrl(dish.website_url)}
                 target="_blank"
                 rel="noopener noreferrer"
-                onClick={() => capture('order_link_clicked', {
-                  dish_id: dish.dish_id,
-                  dish_name: dish.dish_name,
-                  restaurant_id: dish.restaurant_id,
-                  restaurant_name: dish.restaurant_name,
-                })}
+                onClick={(e) => {
+                  capture('order_link_clicked', {
+                    dish_id: dish.dish_id,
+                    dish_name: dish.dish_name,
+                    restaurant_id: dish.restaurant_id,
+                    restaurant_name: dish.restaurant_name,
+                  })
+                  openExternalLink(e, e.currentTarget.href)
+                }}
                 className="w-full flex items-center justify-center gap-2 py-3 px-4 rounded-xl font-bold text-sm transition-all active:scale-95"
                 style={{
                   background: 'var(--color-primary)',
@@ -443,13 +447,16 @@ export function Dish() {
               href={dish.toast_slug ? 'https://order.toasttab.com/online/' + dish.toast_slug : sanitizeUrl(dish.order_url)}
               target="_blank"
               rel="noopener noreferrer"
-              onClick={function () { capture('order_clicked', {
-                dish_id: dish.dish_id,
-                dish_name: dish.dish_name,
-                restaurant_id: dish.restaurant_id,
-                restaurant_name: dish.restaurant_name,
-                source: dish.toast_slug ? 'toast' : 'order_url',
-              }) }}
+              onClick={(e) => {
+                capture('order_clicked', {
+                  dish_id: dish.dish_id,
+                  dish_name: dish.dish_name,
+                  restaurant_id: dish.restaurant_id,
+                  restaurant_name: dish.restaurant_name,
+                  source: dish.toast_slug ? 'toast' : 'order_url',
+                })
+                openExternalLink(e, e.currentTarget.href)
+              }}
               className="flex-1 flex items-center justify-center gap-2 py-3 rounded-xl font-bold text-sm transition-all active:scale-[0.97]"
               style={{
                 background: 'var(--color-accent-orange)',
@@ -466,6 +473,7 @@ export function Dish() {
               href={sanitizeUrl(dish.website_url)}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={(e) => openExternalLink(e, e.currentTarget.href)}
               className="flex-1 flex items-center justify-center gap-2 py-3 rounded-xl font-bold text-sm transition-all active:scale-[0.97]"
               style={{
                 background: 'var(--color-primary)',
@@ -486,6 +494,7 @@ export function Dish() {
             }
             target="_blank"
             rel="noopener noreferrer"
+            onClick={(e) => openExternalLink(e, e.currentTarget.href)}
             className="flex-1 flex items-center justify-center gap-2 py-3 rounded-xl font-bold text-sm transition-all active:scale-[0.97]"
             style={{
               background: 'var(--color-accent-gold)',

--- a/src/pages/RestaurantDetail.jsx
+++ b/src/pages/RestaurantDetail.jsx
@@ -8,6 +8,7 @@ import { logger } from '../utils/logger'
 import { getUserMessage } from '../utils/errorHandler'
 import { shareOrCopy } from '../utils/share'
 import { sanitizeUrl } from '../utils/sanitize'
+import { openExternalLink } from '../utils/openExternalLink'
 import { restaurantsApi } from '../api/restaurantsApi'
 import { placesApi } from '../api/placesApi'
 import { votesApi } from '../api/votesApi'
@@ -474,6 +475,7 @@ export function RestaurantDetail() {
                   }
                   target="_blank"
                   rel="noopener noreferrer"
+                  onClick={(e) => openExternalLink(e, e.currentTarget.href)}
                   className="flex items-center gap-1.5 text-sm transition-opacity hover:opacity-80"
                   style={{ color: 'var(--color-accent-gold)' }}
                 >
@@ -500,6 +502,7 @@ export function RestaurantDetail() {
                   href={sanitizeUrl(restaurant.website_url)}
                   target="_blank"
                   rel="noopener noreferrer"
+                  onClick={(e) => openExternalLink(e, e.currentTarget.href)}
                   className="flex items-center gap-1.5 text-sm transition-opacity hover:opacity-80"
                   style={{ color: 'var(--color-accent-gold)' }}
                 >
@@ -514,6 +517,7 @@ export function RestaurantDetail() {
                   href={sanitizeUrl(restaurant.facebook_url)}
                   target="_blank"
                   rel="noopener noreferrer"
+                  onClick={(e) => openExternalLink(e, e.currentTarget.href)}
                   className="flex items-center gap-1.5 text-sm transition-opacity hover:opacity-80"
                   style={{ color: 'var(--color-accent-gold)' }}
                 >
@@ -528,6 +532,7 @@ export function RestaurantDetail() {
                   href={sanitizeUrl(restaurant.instagram_url)}
                   target="_blank"
                   rel="noopener noreferrer"
+                  onClick={(e) => openExternalLink(e, e.currentTarget.href)}
                   className="flex items-center gap-1.5 text-sm transition-opacity hover:opacity-80"
                   style={{ color: 'var(--color-accent-gold)' }}
                 >
@@ -689,6 +694,7 @@ export function RestaurantDetail() {
               href={restaurant.toast_slug ? 'https://order.toasttab.com/online/' + restaurant.toast_slug : sanitizeUrl(restaurant.order_url)}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={(e) => openExternalLink(e, e.currentTarget.href)}
               className="flex-1 flex items-center justify-center gap-2 py-3 rounded-xl font-bold text-sm transition-all active:scale-[0.98]"
               style={{
                 background: 'var(--color-accent-orange)',

--- a/src/utils/openExternalLink.js
+++ b/src/utils/openExternalLink.js
@@ -1,0 +1,19 @@
+import { Capacitor } from '@capacitor/core'
+import { logger } from './logger'
+
+// Open external links via @capacitor/browser on native iOS (SFSafariViewController)
+// instead of the in-app WebView, where target="_blank" has no usable back gesture.
+// On web, lets the default <a target="_blank"> behavior run unchanged.
+//
+// Usage: <a href={url} target="_blank" rel="noopener noreferrer"
+//          onClick={(e) => openExternalLink(e, url)}>...</a>
+export async function openExternalLink(event, url) {
+  if (!Capacitor.isNativePlatform()) return
+  event?.preventDefault?.()
+  try {
+    const { Browser } = await import('@capacitor/browser')
+    await Browser.open({ url })
+  } catch (err) {
+    logger.warn('openExternalLink failed; falling back to default link behavior', err)
+  }
+}

--- a/src/utils/openExternalLink.test.js
+++ b/src/utils/openExternalLink.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const isNativeMock = vi.fn()
+const browserOpenMock = vi.fn()
+const loggerWarnMock = vi.fn()
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: { isNativePlatform: () => isNativeMock() },
+}))
+
+vi.mock('@capacitor/browser', () => ({
+  Browser: { open: (...args) => browserOpenMock(...args) },
+}))
+
+vi.mock('./logger', () => ({
+  logger: { warn: (...args) => loggerWarnMock(...args) },
+}))
+
+import { openExternalLink } from './openExternalLink'
+
+beforeEach(() => {
+  isNativeMock.mockReset()
+  browserOpenMock.mockReset().mockResolvedValue(undefined)
+  loggerWarnMock.mockReset()
+})
+
+describe('openExternalLink', () => {
+  it('on web, does not preventDefault and does not call Browser.open', async () => {
+    isNativeMock.mockReturnValue(false)
+    const event = { preventDefault: vi.fn() }
+    await openExternalLink(event, 'https://example.com')
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(browserOpenMock).not.toHaveBeenCalled()
+  })
+
+  it('on native, preventDefault and Browser.open with the url', async () => {
+    isNativeMock.mockReturnValue(true)
+    const event = { preventDefault: vi.fn() }
+    await openExternalLink(event, 'https://example.com')
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(browserOpenMock).toHaveBeenCalledWith({ url: 'https://example.com' })
+  })
+
+  it('on native, swallows Browser.open errors and logs a warning', async () => {
+    isNativeMock.mockReturnValue(true)
+    browserOpenMock.mockRejectedValueOnce(new Error('boom'))
+    const event = { preventDefault: vi.fn() }
+    await expect(openExternalLink(event, 'https://example.com')).resolves.toBeUndefined()
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(loggerWarnMock).toHaveBeenCalled()
+  })
+
+  it('handles missing event gracefully', async () => {
+    isNativeMock.mockReturnValue(true)
+    await expect(openExternalLink(undefined, 'https://example.com')).resolves.toBeUndefined()
+    expect(browserOpenMock).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
L2 from App Store readiness audit. target="_blank" inside Capacitor WebView has no back gesture — links open in the same WebView with no way home. Wrap 12 external links to use SFSafariViewController via @capacitor/browser on native (DishListItem, PlaceAttributions, Dish, RestaurantDetail). Web behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)