### PR TITLE
feat(curator-invite): decouple minting from admin role

### DIFF
--- a/supabase/migrations/curator-inviter-flag.sql
+++ b/supabase/migrations/curator-inviter-flag.sql
@@ -1,0 +1,64 @@
+-- Decouple curator-invite minting from full admin role.
+-- Adds profiles.can_invite_curators flag, lets non-admin holders mint links.
+-- Run in Supabase SQL editor against project vpioftosgdkyiwvhxewy.
+
+BEGIN;
+
+-- 1. New column on profiles. Default false; admins remain authorized via the
+--    RPC's existing is_admin() branch, so existing flow is unchanged.
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS can_invite_curators BOOLEAN DEFAULT false;
+
+-- 2. Replace the RPC. Now allows EITHER is_admin() OR profile flag.
+CREATE OR REPLACE FUNCTION create_curator_invite()
+RETURNS JSON AS $$
+DECLARE
+  v_invite RECORD;
+BEGIN
+  IF NOT (
+    is_admin()
+    OR EXISTS (SELECT 1 FROM profiles WHERE id = auth.uid() AND can_invite_curators = true)
+  ) THEN
+    RETURN json_build_object('success', false, 'error', 'Not authorized');
+  END IF;
+
+  INSERT INTO curator_invites (created_by)
+  VALUES (auth.uid())
+  RETURNING * INTO v_invite;
+
+  RETURN json_build_object(
+    'success', true,
+    'token', v_invite.token,
+    'expires_at', v_invite.expires_at
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+COMMIT;
+
+-- Verify with:
+--   SELECT pg_get_functiondef('create_curator_invite()'::regprocedure);
+--   \d profiles  -- should now list can_invite_curators
+--
+-- Grant the flag to a specific user (non-admin):
+--   UPDATE profiles SET can_invite_curators = true
+--   WHERE id = (SELECT id FROM auth.users WHERE email = 'community-manager@example.com');
+--
+-- ROLLBACK:
+-- BEGIN;
+--   CREATE OR REPLACE FUNCTION create_curator_invite()
+--   RETURNS JSON AS $$
+--   DECLARE
+--     v_invite RECORD;
+--   BEGIN
+--     IF NOT is_admin() THEN
+--       RETURN json_build_object('success', false, 'error', 'Admin only');
+--     END IF;
+--     INSERT INTO curator_invites (created_by)
+--     VALUES (auth.uid())
+--     RETURNING * INTO v_invite;
+--     RETURN json_build_object('success', true, 'token', v_invite.token, 'expires_at', v_invite.expires_at);
+--   END;
+--   $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+--   ALTER TABLE profiles DROP COLUMN IF EXISTS can_invite_curators;
+-- COMMIT;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -107,6 +107,7 @@ CREATE TABLE IF NOT EXISTS profiles (
   follower_count INTEGER DEFAULT 0,
   following_count INTEGER DEFAULT 0,
   is_local_curator BOOLEAN DEFAULT false,
+  can_invite_curators BOOLEAN DEFAULT false,
   avatar_url TEXT,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
@@ -562,8 +563,10 @@ CREATE POLICY "profiles_insert_own" ON profiles FOR INSERT WITH CHECK ((select a
 CREATE POLICY "profiles_update_own" ON profiles FOR UPDATE
   USING ((select auth.uid()) = id)
   WITH CHECK ((select auth.uid()) = id);
--- Protected fields (is_local_curator, follower_count, following_count) are guarded by
--- protect_profile_fields_trigger (BEFORE UPDATE) — not RLS — to avoid infinite recursion.
+-- Protected fields (is_local_curator, can_invite_curators, follower_count, following_count) are
+-- meant to be guarded by protect_profile_fields_trigger (BEFORE UPDATE) — not RLS — to avoid
+-- infinite recursion. NOTE: trigger function is referenced here but is not in schema.sql; verify
+-- it exists in the live DB and includes all protected columns.
 -- No DELETE policy on profiles — users must not delete their own profile row (orphans FKs)
 
 -- favorites: users manage own only
@@ -3000,14 +3003,17 @@ AS $$
   ORDER BY li."position";
 $$;
 
--- RPC: Admin creates a curator invite link
+-- RPC: Admin (or user with profiles.can_invite_curators = true) creates a curator invite link
 CREATE OR REPLACE FUNCTION create_curator_invite()
 RETURNS JSON AS $$
 DECLARE
   v_invite RECORD;
 BEGIN
-  IF NOT is_admin() THEN
-    RETURN json_build_object('success', false, 'error', 'Admin only');
+  IF NOT (
+    is_admin()
+    OR EXISTS (SELECT 1 FROM profiles WHERE id = auth.uid() AND can_invite_curators = true)
+  ) THEN
+    RETURN json_build_object('success', false, 'error', 'Not authorized');
   END IF;
 
   INSERT INTO curator_invites (created_by)


### PR DESCRIPTION
## Summary

Adds \`profiles.can_invite_curators\` flag. \`create_curator_invite()\` now authorizes either \`is_admin()\` OR the new flag — so a non-admin community manager can mint invite links without full admin powers.

Follow-up to #91. Path A (admins inserted) unblocked tonight; this is path B (decouple).

## Why

Per discussion: admin and curator-inviter are two different concepts. Admin in this app is operations-scoped (restaurant CRUD, manager invites, specials/events) — not god-mode. But coupling curator-invite minting to admin still meant any future community manager would need full admin to hand out curator links. This decouples them.

## What changed

- \`profiles.can_invite_curators BOOLEAN DEFAULT false\` — new column
- \`create_curator_invite()\` RPC — checks \`is_admin() OR profile flag\` instead of admin-only
- \`supabase/migrations/curator-inviter-flag.sql\` — paste-ready migration with rollback
- Stale comment about \`protect_profile_fields_trigger\` updated to flag that the trigger function is referenced but not actually defined in \`schema.sql\` — see "known caveat" below

## Apply

After merge, run \`supabase/migrations/curator-inviter-flag.sql\` in the Supabase SQL editor against the production project. Verify with:

\`\`\`sql
\\d profiles  -- can_invite_curators column present
SELECT pg_get_functiondef('create_curator_invite()'::regprocedure);
\`\`\`

Grant to a specific user later:

\`\`\`sql
UPDATE profiles SET can_invite_curators = true
WHERE id = (SELECT id FROM auth.users WHERE email = 'community-manager@example.com');
\`\`\`

## Known caveat (not introduced by this PR, but worth flagging)

\`schema.sql\` line ~565 says \`is_local_curator\`, \`follower_count\`, \`following_count\` are guarded by \`protect_profile_fields_trigger\`. The trigger function is **not defined anywhere in \`schema.sql\`** — only the comment exists. If the trigger isn't deployed in the live DB either, those columns (and now \`can_invite_curators\`) are self-grantable via direct UPDATE under the \`profiles_update_own\` policy.

Recommended follow-up: verify the trigger is live, and if not, write one that protects all four columns. Out of scope for this PR.

## Test plan

- [ ] Merge + run migration in Supabase SQL editor
- [ ] As admin: \`/admin\` → "Mint invite link" still works (admin path)
- [ ] As non-admin user with flag set: \`/admin\` is gated, but the RPC works if called directly (no UI for non-admins yet — that's another PR)
- [ ] As regular user: RPC returns \`{success: false, error: "Not authorized"}\`
- [ ] Verify rollback block in the migration file actually reverts (read-through, no need to execute)

🤖 Generated with [Claude Code](https://claude.com/claude-code)