### PR TITLE
chore(vercel): 308 redirect vercel.app subdomain → wghapp.com

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,12 @@
 {
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "whats-good-here.vercel.app" }],
+      "destination": "https://wghapp.com/:path*",
+      "permanent": true
+    }
+  ],
   "rewrites": [
     {
       "source": "/dish/:id",


### PR DESCRIPTION
## Summary

Consolidate the canonical domain. Anyone landing on \`whats-good-here.vercel.app/<path>\` gets a permanent (308) redirect to \`wghapp.com/<path>\`.

**Why it matters:**
- SEO/analytics no longer split across two hostnames
- Old shared links (texts, social posts pre-2026-04-21) start funneling to the canonical domain
- Single source of truth for share previews + bookmarks going forward

## Safety check

- **Host-match is exact:** Vercel preview URLs (\`whats-good-here-<hash>-<team>.vercel.app\`) do NOT match — devs keep their previews.
- **Capacitor iOS WebView** loads from \`capacitor://localhost\`, never from the vercel URL — completely unaffected.
- **Query strings + paths** are preserved through 308.
- **Auth callbacks:** Supabase OAuth uses fragment-based delivery; fragments survive 308.

## Test plan

- [ ] After deploy: \`curl -I https://whats-good-here.vercel.app\` returns 308 with \`location: https://wghapp.com/\`
- [ ] \`curl -IL https://whats-good-here.vercel.app/dish/<some-id>\` follows to \`https://wghapp.com/dish/<some-id>\`
- [ ] Visit a preview URL (\`whats-good-here-<hash>-<team>.vercel.app\`) — does NOT redirect
- [ ] iOS app cold-launch still works (loads from capacitor://localhost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)