### PR TITLE
fix(curator-invite): don't burn token on creator self-click + friendlier error copy

### DIFF
--- a/src/pages/AcceptCuratorInvite.jsx
+++ b/src/pages/AcceptCuratorInvite.jsx
@@ -15,8 +15,13 @@ export function AcceptCuratorInvite() {
   var [accepting, setAccepting] = useState(false)
   var [error, setError] = useState(null)
 
+  // Wait for auth to settle before fetching — get_curator_invite_details
+  // reads auth.uid() to compute is_creator, so an early call would return
+  // is_creator=false and miss the "this is your own link" UI.
   useEffect(function () {
+    if (authLoading) return undefined
     var cancelled = false
+    setLoading(true)
 
     async function fetchInvite() {
       try {
@@ -38,7 +43,7 @@ export function AcceptCuratorInvite() {
 
     fetchInvite()
     return function () { cancelled = true }
-  }, [token])
+  }, [token, authLoading, user?.id])
 
   async function handleAccept() {
     setAccepting(true)
@@ -80,7 +85,7 @@ export function AcceptCuratorInvite() {
         <div className="text-center max-w-md px-6">
           <div style={{ fontSize: '40px', marginBottom: '16px' }}>😕</div>
           <h1 className="text-xl font-bold mb-2" style={{ color: 'var(--color-text-primary)' }}>
-            Invalid Invite
+            Can't open this invite
           </h1>
           <p className="text-sm mb-6" style={{ color: 'var(--color-text-secondary)' }}>
             {error?.message || error}
@@ -91,6 +96,30 @@ export function AcceptCuratorInvite() {
             style={{ background: 'var(--color-primary)', color: '#fff', border: 'none', cursor: 'pointer' }}
           >
             Go Home
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (user && invite.is_creator) {
+    return (
+      <div className="min-h-screen flex items-center justify-center" style={{ background: 'var(--color-bg)' }}>
+        <div className="text-center max-w-md px-6">
+          <div style={{ fontSize: '40px', marginBottom: '16px' }}>🔗</div>
+          <h1 className="text-xl font-bold mb-2" style={{ color: 'var(--color-text-primary)' }}>
+            This is your invite link
+          </h1>
+          <p className="text-sm mb-6" style={{ color: 'var(--color-text-secondary)' }}>
+            Share it with the person you want to make a local curator. Clicking it yourself
+            won't burn the token — they'll still be able to accept.
+          </p>
+          <button
+            onClick={function () { navigate('/admin') }}
+            className="w-full px-6 py-3 rounded-xl font-semibold"
+            style={{ background: 'var(--color-primary)', color: '#fff', border: 'none', cursor: 'pointer' }}
+          >
+            Back to Admin
           </button>
         </div>
       </div>

--- a/supabase/migrations/curator-invite-self-test.sql
+++ b/supabase/migrations/curator-invite-self-test.sql
@@ -1,0 +1,131 @@
+-- Curator-invite UX fixes:
+-- 1. accept_curator_invite no longer consumes the token when the creator
+--    clicks their own link — testing/previewing is safe again.
+-- 2. get_curator_invite_details exposes is_creator so the page can show
+--    "this is your own link" instead of an Accept button.
+-- 3. Friendlier user-facing copy for already-used and expired states.
+--
+-- Run in Supabase SQL editor against project vpioftosgdkyiwvhxewy.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION get_curator_invite_details(p_token TEXT)
+RETURNS JSON AS $$
+DECLARE
+  v_invite RECORD;
+BEGIN
+  SELECT * INTO v_invite FROM curator_invites WHERE token = p_token;
+
+  IF NOT FOUND THEN
+    RETURN json_build_object('valid', false, 'error', 'Invite not found');
+  END IF;
+  IF v_invite.used_by IS NOT NULL THEN
+    RETURN json_build_object('valid', false, 'error', 'This invite was already claimed. Ask the person who sent it to mint a new one.');
+  END IF;
+  IF v_invite.expires_at < NOW() THEN
+    RETURN json_build_object('valid', false, 'error', 'This invite has expired. Ask the person who sent it to mint a new one.');
+  END IF;
+
+  RETURN json_build_object(
+    'valid', true,
+    'expires_at', v_invite.expires_at,
+    'is_creator', (auth.uid() IS NOT NULL AND v_invite.created_by = auth.uid())
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+CREATE OR REPLACE FUNCTION accept_curator_invite(p_token TEXT)
+RETURNS JSON AS $$
+DECLARE
+  v_invite RECORD;
+  v_user_id UUID;
+  v_display_name TEXT;
+  v_list_id UUID;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Not authenticated');
+  END IF;
+
+  SELECT * INTO v_invite FROM curator_invites WHERE token = p_token FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN json_build_object('success', false, 'error', 'Invite not found');
+  END IF;
+  IF v_invite.used_by IS NOT NULL THEN
+    RETURN json_build_object('success', false, 'error', 'This invite was already claimed. Ask the person who sent it to mint a new one.');
+  END IF;
+  IF v_invite.expires_at < NOW() THEN
+    RETURN json_build_object('success', false, 'error', 'This invite has expired. Ask the person who sent it to mint a new one.');
+  END IF;
+  -- Self-click guard runs AFTER used/expired checks so the creator gets the
+  -- accurate state for a dead token instead of "this is your own link".
+  IF v_invite.created_by = v_user_id THEN
+    RETURN json_build_object(
+      'success', false,
+      'is_creator', true,
+      'error', 'This is your own invite link. Share it with the person you want to invite.'
+    );
+  END IF;
+
+  UPDATE profiles SET is_local_curator = true WHERE id = v_user_id;
+
+  SELECT display_name INTO v_display_name FROM profiles WHERE id = v_user_id;
+
+  INSERT INTO local_lists (user_id, title, is_active)
+  VALUES (v_user_id, COALESCE(v_display_name, 'My') || '''s Top 10', false)
+  ON CONFLICT (user_id) DO NOTHING
+  RETURNING id INTO v_list_id;
+
+  IF v_list_id IS NULL THEN
+    SELECT id INTO v_list_id FROM local_lists WHERE user_id = v_user_id;
+  END IF;
+
+  UPDATE curator_invites SET used_by = v_user_id, used_at = NOW() WHERE id = v_invite.id;
+
+  RETURN json_build_object('success', true, 'list_id', v_list_id);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+COMMIT;
+
+-- Verify with:
+--   -- creator clicks their own link → success=false, is_creator=true, no consumption
+--   SELECT accept_curator_invite('<token-you-just-minted>');
+--   SELECT used_by FROM curator_invites WHERE token = '<token>';  -- should still be NULL
+--
+-- ROLLBACK:
+-- BEGIN;
+--   CREATE OR REPLACE FUNCTION get_curator_invite_details(p_token TEXT)
+--   RETURNS JSON AS $$
+--   DECLARE v_invite RECORD;
+--   BEGIN
+--     SELECT * INTO v_invite FROM curator_invites WHERE token = p_token;
+--     IF NOT FOUND THEN RETURN json_build_object('valid', false, 'error', 'Invite not found'); END IF;
+--     IF v_invite.used_by IS NOT NULL THEN RETURN json_build_object('valid', false, 'error', 'Invite already used'); END IF;
+--     IF v_invite.expires_at < NOW() THEN RETURN json_build_object('valid', false, 'error', 'Invite has expired'); END IF;
+--     RETURN json_build_object('valid', true, 'expires_at', v_invite.expires_at);
+--   END;
+--   $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+--
+--   CREATE OR REPLACE FUNCTION accept_curator_invite(p_token TEXT)
+--   RETURNS JSON AS $$
+--   DECLARE v_invite RECORD; v_user_id UUID; v_display_name TEXT; v_list_id UUID;
+--   BEGIN
+--     v_user_id := auth.uid();
+--     IF v_user_id IS NULL THEN RETURN json_build_object('success', false, 'error', 'Not authenticated'); END IF;
+--     SELECT * INTO v_invite FROM curator_invites WHERE token = p_token FOR UPDATE;
+--     IF NOT FOUND THEN RETURN json_build_object('success', false, 'error', 'Invite not found'); END IF;
+--     IF v_invite.used_by IS NOT NULL THEN RETURN json_build_object('success', false, 'error', 'Invite already used'); END IF;
+--     IF v_invite.expires_at < NOW() THEN RETURN json_build_object('success', false, 'error', 'Invite has expired'); END IF;
+--     UPDATE profiles SET is_local_curator = true WHERE id = v_user_id;
+--     SELECT display_name INTO v_display_name FROM profiles WHERE id = v_user_id;
+--     INSERT INTO local_lists (user_id, title, is_active)
+--     VALUES (v_user_id, COALESCE(v_display_name, 'My') || '''s Top 10', false)
+--     ON CONFLICT (user_id) DO NOTHING RETURNING id INTO v_list_id;
+--     IF v_list_id IS NULL THEN SELECT id INTO v_list_id FROM local_lists WHERE user_id = v_user_id; END IF;
+--     UPDATE curator_invites SET used_by = v_user_id, used_at = NOW() WHERE id = v_invite.id;
+--     RETURN json_build_object('success', true, 'list_id', v_list_id);
+--   END;
+--   $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+-- COMMIT;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2973,17 +2973,23 @@ BEGIN
     RETURN json_build_object('valid', false, 'error', 'Invite not found');
   END IF;
   IF v_invite.used_by IS NOT NULL THEN
-    RETURN json_build_object('valid', false, 'error', 'Invite already used');
+    RETURN json_build_object('valid', false, 'error', 'This invite was already claimed. Ask the person who sent it to mint a new one.');
   END IF;
   IF v_invite.expires_at < NOW() THEN
-    RETURN json_build_object('valid', false, 'error', 'Invite has expired');
+    RETURN json_build_object('valid', false, 'error', 'This invite has expired. Ask the person who sent it to mint a new one.');
   END IF;
 
-  RETURN json_build_object('valid', true, 'expires_at', v_invite.expires_at);
+  RETURN json_build_object(
+    'valid', true,
+    'expires_at', v_invite.expires_at,
+    'is_creator', (auth.uid() IS NOT NULL AND v_invite.created_by = auth.uid())
+  );
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
 
--- RPC: Accept curator invite — sets flag, creates empty list
+-- RPC: Accept curator invite — sets flag, creates empty list.
+-- The creator's own click is a no-op so they can safely test/preview the link
+-- without burning the single-use token.
 CREATE OR REPLACE FUNCTION accept_curator_invite(p_token TEXT)
 RETURNS JSON AS $$
 DECLARE
@@ -3003,10 +3009,19 @@ BEGIN
     RETURN json_build_object('success', false, 'error', 'Invite not found');
   END IF;
   IF v_invite.used_by IS NOT NULL THEN
-    RETURN json_build_object('success', false, 'error', 'Invite already used');
+    RETURN json_build_object('success', false, 'error', 'This invite was already claimed. Ask the person who sent it to mint a new one.');
   END IF;
   IF v_invite.expires_at < NOW() THEN
-    RETURN json_build_object('success', false, 'error', 'Invite has expired');
+    RETURN json_build_object('success', false, 'error', 'This invite has expired. Ask the person who sent it to mint a new one.');
+  END IF;
+  -- Self-click guard runs AFTER used/expired checks so the creator gets the
+  -- accurate state for a dead token instead of "this is your own link".
+  IF v_invite.created_by = v_user_id THEN
+    RETURN json_build_object(
+      'success', false,
+      'is_creator', true,
+      'error', 'This is your own invite link. Share it with the person you want to invite.'
+    );
   END IF;
 
   -- Set curator flag


### PR DESCRIPTION
## Summary

Fixes the "Invalid Invite — Invite already used" experience a friend got after I tested my own curator invite link before sending it. Single-use tokens were getting consumed by the creator's own click, leaving the real recipient with a dead link.

- `accept_curator_invite()` short-circuits with `{success:false, is_creator:true}` when `auth.uid() = curator_invites.created_by`, leaving the token unspent. Self-click guard runs **after** used/expired so a creator clicking a dead token still gets the accurate state, not a misleading "this is your own link" message.
- `get_curator_invite_details()` exposes `is_creator` so the page can render a "this is your invite link — share it" panel instead of an Accept button.
- Frontend gates the RPC fetch on `!authLoading` and re-runs on `user?.id` change, since `is_creator` depends on `auth.uid()` being available when the RPC runs.
- Friendlier copy on already-used / expired states ("Ask the person who sent it to mint a new one") and softened error heading ("Can't open this invite" instead of "Invalid Invite").

## Review trail

- Codex `gpt-5.3-codex` at high reasoning, two passes:
  - Initial pass caught **(a)** an auth-loading race in the `useEffect` deps and **(b)** the `created_by` check ordering relative to `used_by`/`expires_at` — both addressed before commit.
  - Re-review confirmed both fixes hold; remaining nit (timestamped migration filename) doesn't apply since none of the existing migrations are timestamped.
- Local simplify pass (reuse / quality / efficiency agents): flagged schema↔migration drift in a comment (synced) and three out-of-scope follow-ups (see below). No blockers.

## Deployment

Run `supabase/migrations/curator-invite-self-test.sql` in the Supabase SQL editor against project `vpioftosgdkyiwvhxewy` **before** merging the frontend, or alongside it. The frontend is backward compatible: if the schema change isn't live yet, `invite.is_creator` is `undefined` and the page falls through to the existing Accept flow normally.

Verification queries are inlined in the migration file's footer.

## Out-of-scope follow-ups (not in this PR)

- `accept_restaurant_invite` (restaurant manager invites) has the **same** single-use-burn-on-self-click bug. Same fix shape would apply.
- `AcceptInvite.jsx` (restaurant manager invite page) still uses the old "Invalid Invite" copy.
- Five+ pages hand-roll the same `min-h-screen flex centered` + emoji + heading + body + CTA pattern; a `<CenteredMessage>` component would collapse them.

## Test plan

- [ ] Run the migration in Supabase SQL editor; verify both functions deploy without error.
- [ ] As an admin: mint a curator invite at `/admin`, click the link yourself → should see "This is your invite link" panel, no consumption.
- [ ] Verify in DB: `SELECT used_by FROM curator_invites WHERE token = '<token>'` is still NULL after self-click.
- [ ] Send the same link to a non-admin test account → recipient should be able to accept normally (`is_local_curator = true`, list created, token marked used).
- [ ] After acceptance, recipient revisits the link → sees the friendlier "This invite was already claimed. Ask the person who sent it to mint a new one." copy.
- [ ] Mint a token, manually expire it via `UPDATE curator_invites SET expires_at = NOW() - INTERVAL '1 day' WHERE token = '<token>'`, click as admin → should see expired message, NOT "this is your own link".

🤖 Generated with [Claude Code](https://claude.com/claude-code)