### PR TITLE
fix(my-list): remove useBlocker — crashes accept flow on every recipient

### DIFF
--- a/src/pages/MyList.jsx
+++ b/src/pages/MyList.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
-import { useNavigate, useLocation, useBlocker } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import { useMyLocalList } from '../hooks/useMyLocalList'
 import { useDishSearch } from '../hooks/useDishSearch'
 import { getCategoryEmoji } from '../constants/categories'
@@ -70,11 +70,6 @@ export function MyList() {
     window.addEventListener('beforeunload', handler)
     return function () { window.removeEventListener('beforeunload', handler) }
   }, [isDirty])
-
-  // In-app navigation block while dirty.
-  var blocker = useBlocker(function (args) {
-    return isDirty && args.currentLocation.pathname !== args.nextLocation.pathname
-  })
 
   // Loading and error states (must come before the !listMeta gate so a
   // failed fetch doesn't masquerade as "you're not a curator").
@@ -592,65 +587,6 @@ export function MyList() {
         </button>
       </div>
 
-      {/* Unsaved-changes blocker dialog */}
-      {blocker.state === 'blocked' && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center"
-          style={{ background: 'rgba(0,0,0,0.6)' }}
-          onClick={function () { blocker.reset && blocker.reset() }}
-        >
-          <div
-            role="dialog"
-            aria-modal="true"
-            className="rounded-2xl"
-            style={{
-              background: 'var(--color-surface-elevated)',
-              padding: '20px',
-              maxWidth: '320px',
-              width: 'calc(100% - 32px)',
-              border: '1px solid var(--color-divider)',
-            }}
-            onClick={function (e) { e.stopPropagation() }}
-          >
-            <h2 style={{ fontSize: '16px', fontWeight: 700, color: 'var(--color-text-primary)', marginBottom: '6px' }}>
-              Unsaved changes
-            </h2>
-            <p style={{ fontSize: '13px', color: 'var(--color-text-secondary)', marginBottom: '16px', lineHeight: 1.4 }}>
-              You have unsaved edits to your list. Leave anyway?
-            </p>
-            <div className="flex gap-2">
-              <button
-                onClick={function () { blocker.reset && blocker.reset() }}
-                className="flex-1 rounded-lg font-semibold"
-                style={{
-                  padding: '10px',
-                  fontSize: '13px',
-                  background: 'var(--color-surface)',
-                  color: 'var(--color-text-primary)',
-                  border: '1px solid var(--color-divider)',
-                  cursor: 'pointer',
-                }}
-              >
-                Stay
-              </button>
-              <button
-                onClick={function () { blocker.proceed && blocker.proceed() }}
-                className="flex-1 rounded-lg font-semibold"
-                style={{
-                  padding: '10px',
-                  fontSize: '13px',
-                  background: 'var(--color-primary)',
-                  color: '#fff',
-                  border: 'none',
-                  cursor: 'pointer',
-                }}
-              >
-                Leave
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## What's actually broken

When a brand-new curator accepts an invite, the app navigates them to `/my-list` (`AcceptCuratorInvite.jsx:50`). MyList mounts, calls `useBlocker`, and throws on render:

```
Error: useBlocker must be used within a data router
  at MyList-T4hNlj3K.js
```

`useBlocker` (added 2026-04-24, PR #91) requires react-router-dom's data router (`createBrowserRouter` + `RouterProvider`). `App.jsx:109` uses the legacy `<BrowserRouter><Routes>` pattern, so this hook can't work — it has thrown 100% of the time since it shipped.

The recipient never sees the empty Top 10 page — they see the global ErrorBoundary's "Refresh / Try Again" UI. Token is already consumed server-side at this point, so refreshing or returning to the invite link gives "already claimed" with no recovery.

This is the actual root cause behind the friend report yesterday and the cause Dennis hit just now after PR #100. PR #100 fixed real-but-secondary issues (creator self-click burn, friendly copy); this fixes the actual crash.

## Fix

Remove the `useBlocker` import, the hook call, and the "Unsaved changes" modal block from `MyList.jsx`. 64 lines deleted, no other changes.

## Trade-off

- **Lost:** The in-app "Unsaved changes" modal that intercepted navigation to other SPA routes while the curator had dirty edits.
- **Preserved:** The `beforeunload` handler (browser tab close / page reload warning), which still fires for the most common data-loss scenario.

## Follow-up (separate PR)

Migrate `App.jsx` from `<BrowserRouter><Routes>` to `createBrowserRouter` + `RouterProvider`. That brings `useBlocker` back as a real option AND unlocks loaders, actions, and the rest of the data router API. Larger refactor — touches every route and the provider stack — so explicitly not bundled here.

## Test plan

- [ ] Build / lint pass (verified locally)
- [ ] Mint a fresh curator invite at `/admin`
- [ ] Send to a non-admin test account; accept → should land on `/my-list` with empty state, no error
- [ ] Add a dish, hit Save & Publish → should save normally
- [ ] Add a dish, then close the browser tab → `beforeunload` warning should still fire
- [ ] Confirm Dennis can now successfully accept

🤖 Generated with [Claude Code](https://claude.com/claude-code)