### PR TITLE
feat(dish): "+ Add to your Top 10" button on Dish detail for curators

### DIFF
--- a/src/api/localListsApi.js
+++ b/src/api/localListsApi.js
@@ -100,6 +100,17 @@ export const localListsApi = {
     }
   },
 
+  async addDishToMyList(dishId) {
+    try {
+      const { data, error } = await supabase.rpc('add_dish_to_my_local_list', { p_dish_id: dishId })
+      if (error) throw createClassifiedError(error)
+      return data
+    } catch (error) {
+      logger.error('Failed to add dish to my local list:', error)
+      throw error.type ? error : createClassifiedError(error)
+    }
+  },
+
   async saveMyList({ tagline, items }) {
     try {
       validateContentField(tagline, 'Curator tagline')

--- a/src/hooks/useMyLocalList.js
+++ b/src/hooks/useMyLocalList.js
@@ -22,6 +22,17 @@ export function useMyLocalList() {
     },
   })
 
+  var addDishMutation = useMutation({
+    mutationFn: function (dishId) {
+      return localListsApi.addDishToMyList(dishId)
+    },
+    onSuccess: function () {
+      queryClient.invalidateQueries({ queryKey: ['myLocalList'] })
+      queryClient.invalidateQueries({ queryKey: ['localLists'] })
+      queryClient.invalidateQueries({ queryKey: ['localList'] })
+    },
+  })
+
   // Parse the raw RPC rows into structured data
   var items = data || []
   var listMeta = items.length > 0 ? {
@@ -45,5 +56,7 @@ export function useMyLocalList() {
     saveError: saveMutation.error
       ? { message: getUserMessage(saveMutation.error, 'saving your list') }
       : null,
+    addDish: addDishMutation.mutateAsync,
+    adding: addDishMutation.isPending,
   }
 }

--- a/src/pages/Dish.jsx
+++ b/src/pages/Dish.jsx
@@ -7,6 +7,8 @@ import { shareOrCopy, buildDishShareData } from '../utils/share'
 import { toast } from 'sonner'
 import { useFavorites } from '../hooks/useFavorites'
 import { useDishDetail } from '../hooks/useDishDetail'
+import { useProfile } from '../hooks/useProfile'
+import { useMyLocalList } from '../hooks/useMyLocalList'
 import { ReviewFlow } from '../components/ReviewFlow'
 import { PhotoUploadConfirmation } from '../components/PhotoUploadConfirmation'
 import { LoginModal } from '../components/Auth/LoginModal'
@@ -45,6 +47,31 @@ export function Dish() {
   const [priorVote, setPriorVote] = useState(null)
   const [existingPhoto, setExistingPhoto] = useState(null)
   const { isFavorite, toggleFavorite } = useFavorites(user?.id)
+  const { profile } = useProfile(user?.id)
+  const { dishes: myListDishes, addDish, adding: addingToMyList, loading: myListLoading } = useMyLocalList()
+  const isCurator = !!profile?.is_local_curator
+  const isOnMyList = isCurator && myListDishes.some((d) => d.dish_id === dishId)
+  const myListIsFull = isCurator && myListDishes.length >= 10
+  const myListReady = isCurator && !myListLoading
+
+  const handleAddToTop10 = async () => {
+    if (!isCurator || isOnMyList || myListIsFull || addingToMyList) return
+    try {
+      const result = await addDish(dishId)
+      if (result?.success) {
+        if (result.already_present) {
+          toast.success("Already on your Top 10", { duration: 2000 })
+        } else {
+          toast.success(`Added to your Top 10 (${result.item_count}/10)`, { duration: 2500 })
+        }
+      } else {
+        toast.error(result?.error || "Couldn't add to your Top 10")
+      }
+    } catch (err) {
+      logger.error('Add to Top 10 failed:', err)
+      toast.error(err?.message || "Couldn't add to your Top 10")
+    }
+  }
 
   // Ear icon tooltip — show once per device
   const [showEarTooltip, setShowEarTooltip] = useState(false)
@@ -374,6 +401,50 @@ export function Dish() {
                   onPhotoUploaded={handlePhotoUploaded}
                 />
               </div>
+            )}
+            {myListReady && (
+              isOnMyList ? (
+                <button
+                  type="button"
+                  onClick={() => navigate('/my-list')}
+                  className="w-full py-3 px-4 rounded-xl font-semibold transition-all active:scale-98"
+                  style={{
+                    background: 'var(--color-surface-elevated)',
+                    color: 'var(--color-text-primary)',
+                    border: '1px solid var(--color-divider)',
+                  }}
+                >
+                  ✓ On your Top 10 — manage in My List
+                </button>
+              ) : myListIsFull ? (
+                <button
+                  type="button"
+                  onClick={() => navigate('/my-list')}
+                  className="w-full py-3 px-4 rounded-xl font-semibold transition-all active:scale-98"
+                  style={{
+                    background: 'var(--color-surface-elevated)',
+                    color: 'var(--color-text-secondary)',
+                    border: '1px solid var(--color-divider)',
+                  }}
+                >
+                  Top 10 is full — remove a dish in My List first
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={handleAddToTop10}
+                  disabled={addingToMyList}
+                  className="w-full py-3 px-4 rounded-xl font-semibold transition-all active:scale-98 disabled:opacity-60"
+                  style={{
+                    background: 'var(--color-surface-elevated)',
+                    color: 'var(--color-primary)',
+                    border: '1.5px dashed var(--color-primary)',
+                    cursor: addingToMyList ? 'default' : 'pointer',
+                  }}
+                >
+                  {addingToMyList ? 'Adding…' : `+ Add to your Top 10 (${myListDishes.length}/10)`}
+                </button>
+              )
             )}
           </div>
 

--- a/supabase/migrations/add-dish-to-my-local-list.sql
+++ b/supabase/migrations/add-dish-to-my-local-list.sql
@@ -1,0 +1,102 @@
+-- Granular RPC: append a single dish to the caller's Top 10.
+--
+-- Why a dedicated RPC instead of reusing save_my_local_list?
+-- save_my_local_list is full-list-replace (DELETE + INSERT) with no
+-- revision check. Calling it from Dish.jsx with a stale React Query
+-- cache would silently clobber concurrent edits in another tab. This
+-- RPC reads list state inside the transaction and only INSERTs, so
+-- there's no lost-update class of bug.
+--
+-- Run in Supabase SQL editor against project vpioftosgdkyiwvhxewy.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION add_dish_to_my_local_list(p_dish_id UUID)
+RETURNS JSON AS $$
+DECLARE
+  v_user_id UUID;
+  v_list_id UUID;
+  v_item_count INT;
+  v_next_position INT;
+  v_dish_exists BOOLEAN;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Not authenticated');
+  END IF;
+
+  IF NOT is_local_curator() THEN
+    RETURN json_build_object('success', false, 'error', 'Not a local curator');
+  END IF;
+
+  IF p_dish_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'dish_id required');
+  END IF;
+
+  SELECT EXISTS (SELECT 1 FROM dishes WHERE id = p_dish_id) INTO v_dish_exists;
+  IF NOT v_dish_exists THEN
+    RETURN json_build_object('success', false, 'error', 'Dish not found');
+  END IF;
+
+  -- Lock the list row so concurrent appends serialize cleanly.
+  SELECT id INTO v_list_id
+    FROM local_lists
+   WHERE user_id = v_user_id
+   FOR UPDATE;
+
+  IF v_list_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'No list found — accept an invite first');
+  END IF;
+
+  SELECT COUNT(*) INTO v_item_count FROM local_list_items WHERE list_id = v_list_id;
+
+  IF EXISTS (SELECT 1 FROM local_list_items WHERE list_id = v_list_id AND dish_id = p_dish_id) THEN
+    RETURN json_build_object(
+      'success', true,
+      'already_present', true,
+      'item_count', v_item_count
+    );
+  END IF;
+
+  IF v_item_count >= 10 THEN
+    RETURN json_build_object(
+      'success', false,
+      'list_full', true,
+      'item_count', v_item_count,
+      'error', 'Top 10 is full — remove a dish in My List first'
+    );
+  END IF;
+
+  -- Append at the next position.
+  v_next_position := v_item_count + 1;
+
+  INSERT INTO local_list_items (list_id, dish_id, "position", note)
+  VALUES (v_list_id, p_dish_id, v_next_position, NULL);
+
+  -- Promote the list to active now that it has at least one item, matching
+  -- save_my_local_list's behaviour (is_active = item_count > 0).
+  UPDATE local_lists SET is_active = true WHERE id = v_list_id AND is_active = false;
+
+  RETURN json_build_object(
+    'success', true,
+    'already_present', false,
+    'item_count', v_next_position
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+COMMIT;
+
+-- Verify with:
+--   -- as a curator (must have an existing local_list row):
+--   SELECT add_dish_to_my_local_list('<some-dish-uuid>');     -- expect success
+--   SELECT add_dish_to_my_local_list('<same-dish-uuid>');     -- expect already_present=true
+--   -- after 10 items:
+--   SELECT add_dish_to_my_local_list('<eleventh-dish-uuid>'); -- expect list_full=true
+--   -- as a non-curator:
+--   SELECT add_dish_to_my_local_list('<some-dish-uuid>');     -- expect 'Not a local curator'
+--
+-- ROLLBACK:
+-- BEGIN;
+--   DROP FUNCTION IF EXISTS add_dish_to_my_local_list(UUID);
+-- COMMIT;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -3206,6 +3206,63 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
 
+-- RPC: Append a single dish to the caller's Top 10 (race-safe granular add).
+-- Used by the Dish detail page's "+ Add to Top 10" button. Locks the list
+-- row inside the transaction so concurrent appends from multiple tabs
+-- serialize without losing items. Idempotent on duplicate dish_id.
+CREATE OR REPLACE FUNCTION add_dish_to_my_local_list(p_dish_id UUID)
+RETURNS JSON AS $$
+DECLARE
+  v_user_id UUID;
+  v_list_id UUID;
+  v_item_count INT;
+  v_next_position INT;
+  v_dish_exists BOOLEAN;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Not authenticated');
+  END IF;
+
+  IF NOT is_local_curator() THEN
+    RETURN json_build_object('success', false, 'error', 'Not a local curator');
+  END IF;
+
+  IF p_dish_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'dish_id required');
+  END IF;
+
+  SELECT EXISTS (SELECT 1 FROM dishes WHERE id = p_dish_id) INTO v_dish_exists;
+  IF NOT v_dish_exists THEN
+    RETURN json_build_object('success', false, 'error', 'Dish not found');
+  END IF;
+
+  SELECT id INTO v_list_id FROM local_lists WHERE user_id = v_user_id FOR UPDATE;
+
+  IF v_list_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'No list found — accept an invite first');
+  END IF;
+
+  SELECT COUNT(*) INTO v_item_count FROM local_list_items WHERE list_id = v_list_id;
+
+  IF EXISTS (SELECT 1 FROM local_list_items WHERE list_id = v_list_id AND dish_id = p_dish_id) THEN
+    RETURN json_build_object('success', true, 'already_present', true, 'item_count', v_item_count);
+  END IF;
+
+  IF v_item_count >= 10 THEN
+    RETURN json_build_object('success', false, 'list_full', true, 'item_count', v_item_count, 'error', 'Top 10 is full — remove a dish in My List first');
+  END IF;
+
+  v_next_position := v_item_count + 1;
+  INSERT INTO local_list_items (list_id, dish_id, "position", note)
+  VALUES (v_list_id, p_dish_id, v_next_position, NULL);
+
+  UPDATE local_lists SET is_active = true WHERE id = v_list_id AND is_active = false;
+
+  RETURN json_build_object('success', true, 'already_present', false, 'item_count', v_next_position);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
 -- ============================================================
 -- Locals' Picks — TOC route data layer
 -- ============================================================


### PR DESCRIPTION
## Summary

Curators had no way to add a dish unless they remembered its name and went back to `/my-list` to search for it. This adds an "+ Add to your Top 10" CTA on the Dish detail page, gated on `profile.is_local_curator`.

Three states:
- **Default** — `+ Add to your Top 10 (N/10)` (dashed primary border, click → adds)
- **Already on list** — `✓ On your Top 10 — manage in My List` (links to `/my-list`)
- **Full** — `Top 10 is full — remove a dish in My List first` (links to `/my-list`)

Hidden completely for non-curators and during the initial profile/list load (no flicker).

## Why a new RPC instead of reusing `save_my_local_list`

Codex caught this at the planning stage: `save_my_local_list` is full-list-replace (`DELETE` then re-`INSERT`) with no revision check. Calling it from Dish.jsx with a stale React Query cache would silently clobber concurrent edits in another tab — e.g., curator with `/my-list` open in tab A typing a tagline, clicks Add on a dish in tab B, tab B's save resets tagline to whatever was last fetched.

The new `add_dish_to_my_local_list(p_dish_id)` RPC:
- Locks `local_lists` row with `FOR UPDATE` so concurrent appends serialize
- Reads list state inside the transaction (server-authoritative)
- Idempotent on duplicate dish_id (`already_present: true`)
- Refuses at 10 items (`list_full: true`)
- Promotes `is_active = true` once the first item lands
- `SECURITY DEFINER` + checks `is_local_curator()` for authorization

## Deployment

Migration `supabase/migrations/add-dish-to-my-local-list.sql` already applied to live DB (`vpioftosgdkyiwvhxewy`) via Management API ahead of this PR. Frontend ships safely after.

## Review trail

Codex `gpt-5.3-codex` at high reasoning — planning pass before any code:
- Flagged the `save_my_local_list` concurrency hole → switched to granular RPC
- Caught toast lib mismatch (`sonner` not `react-hot-toast`) → fixed before writing
- Recommended skipping optimistic update in favor of cheap refetch → adopted
- Recommended gating CTA on both queries resolved (no flicker) → done via `myListReady`

Verify pass after implementation came back clean (false positive about missing migration; it exists as untracked then staged).

## Test plan

- [ ] Build / lint pass (verified locally)
- [ ] As Dennis (a curator with empty list): visit any dish → see `+ Add to your Top 10 (0/10)` button
- [ ] Click → toast `Added to your Top 10 (1/10)`, button flips to `✓ On your Top 10`
- [ ] Visit `/my-list` → dish is there at position 1, list is `is_active=true`
- [ ] Repeat for 10 dishes → 11th dish shows `Top 10 is full — remove a dish in My List first`
- [ ] Visit a dish already on list → see the on-list state immediately (no flicker through default)
- [ ] As a non-curator: visit any dish → no Top 10 CTA visible at all
- [ ] As a logged-out user: no Top 10 CTA visible

## Out of scope (filed as backlog)

- Same affordance on `DishListItem` cards (browse, restaurants, map). More aggressive — defer until we see whether the Dish detail button is enough.
- Reorder / remove from Dish detail. Manage in My List handles this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)