### PR TITLE
feat(auth): B4 — universal links + deep-link auth returns

### DIFF
--- a/.github/workflows/aasa-check.yml
+++ b/.github/workflows/aasa-check.yml
@@ -1,0 +1,27 @@
+name: AASA validation
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  aasa:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch AASA from production
+        run: |
+          URL="https://wghapp.com/.well-known/apple-app-site-association"
+          HTTP_CODE=$(curl -o aasa.json -w "%{http_code}" -sL --max-redirs 0 "$URL")
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::AASA returned $HTTP_CODE (expected 200, no redirects)"
+            exit 1
+          fi
+          CONTENT_TYPE=$(curl -sI "$URL" | awk -F': ' '/^Content-Type/{print tolower($2)}' | tr -d '\r\n')
+          if [[ "$CONTENT_TYPE" != "application/json"* ]]; then
+            echo "::error::AASA Content-Type is '$CONTENT_TYPE', expected application/json"
+            exit 1
+          fi
+          # Schema check
+          jq -e '.applinks.details[0].appIDs | length >= 1' aasa.json > /dev/null
+          jq -e '.applinks.details[0].paths | length >= 1' aasa.json > /dev/null
+          echo "AASA OK"

--- a/e2e/pioneer/cross-device-pkce.spec.js
+++ b/e2e/pioneer/cross-device-pkce.spec.js
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test'
+
+// Cross-device PKCE recovery — when a user opens a magic link / password
+// reset on a device that didn't initiate the auth flow, supabase rejects
+// exchangeCodeForSession with a "code verifier" error. The frontend should
+// land them on /auth/cross-device with a friendly resend form.
+//
+// This test exercises the recovery PAGE directly. The full universal-link
+// flow (Capacitor App.appUrlOpen → exchange → navigate) only fires inside
+// the iOS native build, which Playwright doesn't drive. Here we just verify
+// the recovery page renders correctly when navigated to manually — that's
+// the only piece in this PR that's reachable from a browser.
+
+test.use({ storageState: { cookies: [], origins: [] } })
+
+test.describe('Pioneer — Cross-device PKCE recovery', () => {
+  test('cross-device recovery page renders and accepts an email', async ({ page }) => {
+    await page.goto('/auth/cross-device')
+
+    // Dismiss splash if present
+    try {
+      const splash = page.getByRole('button', { name: /Welcome splash/ })
+      await splash.waitFor({ state: 'visible', timeout: 3000 })
+      await splash.click()
+      await splash.waitFor({ state: 'hidden', timeout: 3000 })
+    } catch {
+      // No splash
+    }
+
+    // Headline + body
+    await expect(page.getByRole('heading', { name: /Open the link on this device/i })).toBeVisible()
+    await expect(page.getByText(/different device/i)).toBeVisible()
+
+    // Email input + submit button visible
+    const emailInput = page.getByPlaceholder('you@example.com')
+    await expect(emailInput).toBeVisible()
+    await expect(page.getByRole('button', { name: /Send new link/i })).toBeVisible()
+
+    // Submitting an email transitions to the "Check your email" confirmation.
+    // Default type (no location.state) is 'magiclink' so this hits authApi.signInWithMagicLink.
+    // The actual send happens against Supabase — non-deterministic in CI. We just
+    // verify the form accepts the input and the page doesn't crash.
+    await emailInput.fill('e2e-cross-device@example.com')
+    // Don't submit — no Supabase available in CI without test env. The interaction
+    // surface (typing) is enough to prove the page is reachable + interactive.
+  })
+
+  test('cross-device recovery page is accessible without auth', async ({ page }) => {
+    // Confirm /auth/cross-device is in the public route allow-list (not gated by
+    // login). A logged-out user receiving a stale link must reach the recovery
+    // page — that's the whole point.
+    const response = await page.goto('/auth/cross-device')
+    expect(response?.status()).toBeLessThan(400)
+    await expect(page.getByRole('heading', { name: /Open the link on this device/i })).toBeVisible()
+  })
+})

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -299,6 +299,7 @@
 			baseConfigurationReference = 958DCC722DB07C7200EA8C5F /* debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = App/Info.plist;
@@ -321,6 +322,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = App/Info.plist;

--- a/ios/App/App/App.entitlements
+++ b/ios/App/App/App.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:wghapp.com</string>
+	</array>
+</dict>
+</plist>

--- a/public/.well-known/README.md
+++ b/public/.well-known/README.md
@@ -1,0 +1,60 @@
+# `.well-known/` — Apple App Site Association (AASA)
+
+This directory hosts the AASA file that iOS fetches to learn which web URLs the
+What's Good Here native app should claim as universal links.
+
+## File
+
+- `apple-app-site-association` — JSON, **no extension** (iOS spec requirement).
+- Served at `https://wghapp.com/.well-known/apple-app-site-association`.
+- `Content-Type: application/json` is forced via a header rule in `vercel.json`
+  (Vercel doesn't infer the type from an extensionless filename).
+
+## ⚠️ `<TEAMID>` placeholder — must be replaced before app install
+
+The `appIDs` field currently reads `"<TEAMID>.com.whatsgoodhere.app"`. The
+literal string `<TEAMID>` is a deliberate marker, not a real Team ID.
+
+**Why a placeholder?** As of the OAuth Plan B B4.1 ship, Apple Developer
+verification has not cleared, so we don't know our 10-character Team ID yet.
+Apple will reject the AASA structurally until this is replaced with the real
+ID, but iOS only re-verifies AASA on app install — meaning we can replace it
+in the same window we register the App ID.
+
+**When to replace:**
+
+- During **B3-activate**, once Apple Developer credentials land and the App ID
+  `com.whatsgoodhere.app` is registered, copy the 10-character Team ID from
+  the Apple Developer portal (Membership page) and replace `<TEAMID>` with it.
+- The replacement is a single-string substitution in this file — no other
+  changes needed.
+- Re-deploy to Vercel; the next iOS app install will pick up the corrected
+  AASA.
+
+**How to verify after replacement:**
+
+```bash
+curl -sI https://wghapp.com/.well-known/apple-app-site-association \
+  | grep -i content-type
+# expect: content-type: application/json
+
+curl -s https://wghapp.com/.well-known/apple-app-site-association \
+  | jq '.applinks.details[0].appIDs'
+# expect: ["ABCD123456.com.whatsgoodhere.app"] (no angle brackets)
+```
+
+Apple's CDN-cached AASA endpoint (`app-site-association.cdn-apple.com`) refreshes
+within ~24h after the file changes; for development you can install via Xcode
+which forces a direct fetch.
+
+## CI guard
+
+`.github/workflows/aasa-check.yml` runs on every push to `main` and validates:
+
+- HTTP 200, no redirects
+- `Content-Type: application/json`
+- Schema: `applinks.details[0].appIDs` non-empty, `paths` non-empty
+
+The CI does **not** validate that `<TEAMID>` has been replaced — it can't,
+because we don't know the real ID at CI time. That's a manual checklist item
+during B3-activate.

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,20 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appIDs": ["<TEAMID>.com.whatsgoodhere.app"],
+        "paths": [
+          "/auth/*",
+          "/reset-password",
+          "/reset-password/*"
+        ],
+        "components": [
+          { "/": "/auth/*", "comment": "Auth callbacks — open app" },
+          { "/": "/reset-password", "comment": "Password reset — open app" },
+          { "/": "/reset-password/*", "comment": "Password reset with query — open app" }
+        ]
+      }
+    ]
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,6 +44,7 @@ const Terms = lazyWithRetry(() => import('./pages/Terms'), 'Terms')
 const Support = lazyWithRetry(() => import('./pages/Support'), 'Support')
 const UserProfile = lazyWithRetry(() => import('./pages/UserProfile'), 'UserProfile')
 const ResetPassword = lazyWithRetry(() => import('./pages/ResetPassword'), 'ResetPassword')
+const CrossDevicePkce = lazyWithRetry(() => import('./pages/CrossDevicePkce'))
 const AcceptInvite = lazyWithRetry(() => import('./pages/AcceptInvite'), 'AcceptInvite')
 const AcceptCuratorInvite = lazyWithRetry(() => import('./pages/AcceptCuratorInvite'), 'AcceptCuratorInvite')
 const MyList = lazyWithRetry(() => import('./pages/MyList'), 'MyList')
@@ -125,6 +126,7 @@ function App() {
               <Route path="/user/:userId" element={<Layout><UserProfile /></Layout>} />
               <Route path="/login" element={<Login />} />
               <Route path="/reset-password" element={<ResetPassword />} />
+              <Route path="/auth/cross-device" element={<CrossDevicePkce />} />
               <Route path="/admin" element={<ProtectedRoute><Admin /></ProtectedRoute>} />
               <Route path="/invite/:token" element={<AcceptInvite />} />
               <Route path="/curator-invite/:token" element={<AcceptCuratorInvite />} />

--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -113,6 +113,18 @@ export const authApi = {
   },
 
   /**
+   * Exchange an auth code (from a universal-link / deep-link return) for a
+   * Supabase session. Used by AuthLifecycle on appUrlOpen (B4).
+   *
+   * Returns Supabase's raw `{ data, error }` shape so callers can branch on
+   * cross-device PKCE failures (`error.message` containing "code verifier")
+   * without us collapsing the error into an opaque classified throw.
+   */
+  async exchangeCodeForSession(code) {
+    return supabase.auth.exchangeCodeForSession(code)
+  },
+
+  /**
    * Sign in with Google OAuth
    * @param {string|null} redirectUrl - Optional custom redirect URL (must be same-origin)
    * @returns {Promise<Object>} Auth response

--- a/src/components/Auth/AuthLifecycle.jsx
+++ b/src/components/Auth/AuthLifecycle.jsx
@@ -22,6 +22,11 @@ export function AuthLifecycle() {
     let stateHandle
     let urlHandle
     let mounted = true
+    // Idempotency guard: dedupe concurrent appUrlOpen events for the same code.
+    // Capacitor can fire the URL more than once (cold-launch + foreground), and
+    // exchangeCodeForSession is one-time-use — a duplicate exchange returns
+    // an error and would overwrite navigation with /login.
+    const inFlightCodes = new Set()
 
     ;(async () => {
       const { App } = await import('@capacitor/app')
@@ -40,12 +45,20 @@ export function AuthLifecycle() {
         const parsed = parseAuthUrl(url)
         if (!parsed) return // not an auth URL — leave it to the router / other handlers
         const { code, type } = parsed
+        if (inFlightCodes.has(code)) return // duplicate event for the same code
+        inFlightCodes.add(code)
         try {
           const { error } = await authApi.exchangeCodeForSession(code)
           if (error) {
+            // Cross-device PKCE detection: when a user opens a link on a
+            // device different from the one that initiated the auth flow,
+            // the local code_verifier is missing. Supabase surfaces this
+            // through error.message wording — brittle against SDK changes,
+            // but error.code isn't yet exposed for this case. Re-check on
+            // SDK upgrades. Falling through to /login if the heuristic
+            // misses is the safe degrade (user retries from there).
             const msg = String(error.message || '').toLowerCase()
             if (msg.includes('code verifier') || msg.includes('verifier not found')) {
-              // Cross-device PKCE — user clicked link on a different device than they signed up from.
               navigate('/auth/cross-device', { state: { type } })
               return
             }

--- a/src/components/Auth/AuthLifecycle.jsx
+++ b/src/components/Auth/AuthLifecycle.jsx
@@ -2,20 +2,25 @@
 // Mounted inside AuthProvider so its effects live adjacent to the auth client.
 //
 // B2: appStateChange → on foreground, reconcile session via authApi.getSession()
-// B4: appUrlOpen    → hand off to authUrl.parse → exchangeCodeForSession
+// B4: appUrlOpen    → parse universal-link, exchangeCodeForSession, route by type
 //
 // Web (non-Capacitor): effect early-returns — nothing to mount.
 
 import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Capacitor } from '@capacitor/core'
 import { authApi } from '../../api/authApi'
+import { parse as parseAuthUrl } from '../../lib/authUrl'
 import { logger } from '../../utils/logger'
 
 export function AuthLifecycle() {
+  const navigate = useNavigate()
+
   useEffect(() => {
     if (!Capacitor.isNativePlatform()) return undefined
 
     let stateHandle
+    let urlHandle
     let mounted = true
 
     ;(async () => {
@@ -30,13 +35,46 @@ export function AuthLifecycle() {
           logger.warn('AuthLifecycle getSession on foreground failed', err)
         }
       })
+
+      urlHandle = await App.addListener('appUrlOpen', async ({ url }) => {
+        const parsed = parseAuthUrl(url)
+        if (!parsed) return // not an auth URL — leave it to the router / other handlers
+        const { code, type } = parsed
+        try {
+          const { error } = await authApi.exchangeCodeForSession(code)
+          if (error) {
+            const msg = String(error.message || '').toLowerCase()
+            if (msg.includes('code verifier') || msg.includes('verifier not found')) {
+              // Cross-device PKCE — user clicked link on a different device than they signed up from.
+              navigate('/auth/cross-device', { state: { type } })
+              return
+            }
+            logger.warn('AuthLifecycle exchangeCodeForSession failed', error)
+            navigate('/login', { state: { authError: 'link_expired' } })
+            return
+          }
+          // Route by type per spec Flow D:
+          //   recovery  → password reset page
+          //   confirm   → home (WelcomeModal auto-opens for new users)
+          //   magiclink → home
+          if (type === 'recovery') {
+            navigate('/reset-password')
+          } else {
+            navigate('/')
+          }
+        } catch (err) {
+          logger.warn('AuthLifecycle appUrlOpen handler threw', err)
+          navigate('/login', { state: { authError: 'link_failed' } })
+        }
+      })
     })()
 
     return () => {
       mounted = false
       stateHandle?.remove?.()
+      urlHandle?.remove?.()
     }
-  }, [])
+  }, [navigate])
 
   return null
 }

--- a/src/pages/CrossDevicePkce.jsx
+++ b/src/pages/CrossDevicePkce.jsx
@@ -1,0 +1,104 @@
+import { useState } from 'react'
+import { useLocation } from 'react-router-dom'
+import { authApi } from '../api/authApi'
+import { logger } from '../utils/logger'
+
+export default function CrossDevicePkce() {
+  const { state } = useLocation()
+  const type = state?.type ?? 'magiclink'
+  const [email, setEmail] = useState('')
+  const [sent, setSent] = useState(false)
+  const [error, setError] = useState(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  const submit = async (e) => {
+    e.preventDefault()
+    setError(null)
+    setSubmitting(true)
+    try {
+      if (type === 'recovery') {
+        await authApi.resetPassword(email)
+      } else {
+        await authApi.signInWithMagicLink(email)
+      }
+      setSent(true)
+    } catch (err) {
+      logger.warn('CrossDevicePkce submit failed', err)
+      setError(err?.message || 'Could not send. Try again.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div style={{ padding: 24, maxWidth: 480, margin: '0 auto', minHeight: '100vh' }}>
+      <h1
+        style={{
+          fontFamily: "'Amatic SC', cursive",
+          fontSize: 36,
+          color: 'var(--color-text-primary)',
+          marginBottom: 12,
+        }}
+      >
+        Open the link on this device
+      </h1>
+      <p
+        style={{
+          color: 'var(--color-text-secondary)',
+          marginBottom: 16,
+          lineHeight: 1.5,
+        }}
+      >
+        For security, the link you used started on a different device. Enter your email and we'll send a fresh one here.
+      </p>
+      {sent ? (
+        <p style={{ color: 'var(--color-text-primary)' }}>Check your email — a new link is on the way.</p>
+      ) : (
+        <form onSubmit={submit}>
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@example.com"
+            disabled={submitting}
+            style={{
+              width: '100%',
+              padding: 12,
+              marginBottom: 12,
+              borderRadius: 8,
+              border: '2px solid var(--color-divider, #ddd)',
+              fontFamily: 'inherit',
+              fontSize: 16,
+            }}
+          />
+          <button
+            type="submit"
+            disabled={submitting}
+            style={{
+              width: '100%',
+              padding: 14,
+              borderRadius: 8,
+              background: 'var(--color-primary)',
+              color: '#fff',
+              fontWeight: 600,
+              border: 'none',
+              cursor: submitting ? 'wait' : 'pointer',
+              fontSize: 16,
+            }}
+          >
+            {submitting ? 'Sending…' : 'Send new link'}
+          </button>
+          {error && (
+            <p
+              role="alert"
+              style={{ color: 'var(--color-danger)', marginTop: 8 }}
+            >
+              {error}
+            </p>
+          )}
+        </form>
+      )}
+    </div>
+  )
+}

--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -227,6 +227,12 @@ export function Privacy() {
               included your votes will be recalculated without them. Deletion happens in-app —
               you do not need to email us to close your account.
             </p>
+            <p className="leading-relaxed mt-3" style={{ color: 'var(--color-text-secondary)' }}>
+              If you signed in with Apple, deleting your account also revokes the
+              authorization Apple granted us to share your information. After deletion,
+              Apple will treat any future sign-in with the same Apple ID as a fresh first-time
+              connection.
+            </p>
           </section>
 
           <section>

--- a/vercel.json
+++ b/vercel.json
@@ -25,6 +25,12 @@
   ],
   "headers": [
     {
+      "source": "/.well-known/apple-app-site-association",
+      "headers": [
+        { "key": "Content-Type", "value": "application/json" }
+      ]
+    },
+    {
       "source": "/assets/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }


### PR DESCRIPTION
## Summary

Universal-link routing for iOS — auth callbacks (OAuth, magic link, password reset) now open the native app instead of Safari. Plus the Privacy update for Apple consent revocation.

Implements PR B4 from `docs/superpowers/plans/2026-04-21-oauth-native-plan-b.md` (lines 3602–3967).

**Surfaces:**
- `public/.well-known/apple-app-site-association` (no extension, JSON, with `<TEAMID>` placeholder)
- `public/.well-known/README.md` documenting the placeholder + replacement procedure
- Vercel `Content-Type: application/json` header rule
- GitHub Actions AASA validation workflow (push-only on main, 200 + JSON + schema check)
- iOS Associated Domains entitlement: `applinks:wghapp.com`
- `AuthLifecycle.jsx` extended with `appUrlOpen` listener — parses, exchanges code for session, routes by type, falls through to cross-device recovery on PKCE-verifier-missing
- `CrossDevicePkce.jsx` — friendly recovery page that resends a fresh link to the current device
- `authApi.exchangeCodeForSession` thin passthrough (required because the CLAUDE.md hard-rule hook blocks direct Supabase calls in components)
- `Privacy.jsx` — discloses Apple consent revocation on account deletion (Guideline 5.1.1(v) tie-in)
- E2E test verifying the recovery page is reachable + interactive

## Per-task review history

| Task | Codex |
|---|---|
| B4.1 AASA + CI | Manual review (Codex hung — trivial infra) |
| B4.2 Xcode entitlement | Manual review |
| B4.3 appUrlOpen + recovery page | Codex caught 2 Important — concurrency race + brittle PKCE detection. Fixed: idempotency Set + documented limitation. Commit b4c29a5 |
| B4.4 Privacy disclosure | Manual review |
| B4.5 E2E test | Manual review |
| B4.6 Final Codex pass | Hung at 0 bytes after 15 min — skipped; per-task gates already cleared substantive issues |

## Known follow-ups (not blocking)

1. **`<TEAMID>` placeholder in AASA** — replace with real Apple Team ID before iOS app install. Lands in B3-activate.
2. **Xcode project navigator** — `App.entitlements` reachable from build settings but not added to `PBXGroup`. Dan: `Right-click App → Add Files to "App"...` once.
3. **Cross-device PKCE detection via `error.message`** — brittle vs Supabase SDK changes. Documented in `AuthLifecycle.jsx`.
4. **`inFlightCodes` Set** never pruned — unbounded growth in theory, irrelevant in practice.
5. **AASA CI push-only on main** — no PR-time validation. Trade-off: avoids first-deploy false-positives.

## Activation gates

- This PR ships dormant — no behavior change until Apple Dev verification + real Team ID + TestFlight install.
- B3-activate replaces `<TEAMID>` and uploads Apple credentials.
- B5 ships SIWA capability + Info.plist + TestFlight.

## Test plan

- [x] `npm run build` passes
- [x] AASA JSON validates (jq schema check)
- [x] CrossDevicePkce route registered + page renders
- [ ] Real-device smoke after B3-activate

🤖 Generated with [Claude Code](https://claude.com/claude-code)