### PR TITLE
fix(search): root-fix stale dish-search cache via Supabase Realtime

### DIFF
--- a/src/api/dishesApi.js
+++ b/src/api/dishesApi.js
@@ -309,6 +309,31 @@ export const dishesApi = {
   },
 
   /**
+   * Subscribe to all changes on the dishes table via Supabase Realtime.
+   * Fires `onChange()` for every INSERT/UPDATE/DELETE row event.
+   * Returns an unsubscribe function — call it on unmount to remove the channel.
+   *
+   * Used by useAllDishes to invalidate its cache automatically — every dish
+   * write (manual creation, menu-refresh cron, admin, restaurant cascade
+   * delete) refreshes the search cache without per-call invalidation.
+   *
+   * @param {() => void} onChange - Called for every dish row change
+   * @returns {() => void} Unsubscribe — call to remove the channel
+   */
+  subscribeToChanges(onChange) {
+    const channelName = 'dishes-changes-' + Math.random().toString(36).slice(2, 10)
+    const channel = supabase
+      .channel(channelName)
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'dishes' },
+        onChange
+      )
+      .subscribe()
+    return () => { supabase.removeChannel(channel) }
+  },
+
+  /**
    * Get variants for a parent dish
    * @param {string} parentDishId - Parent dish ID
    * @returns {Promise<Array>} Array of variant dishes with vote stats

--- a/src/hooks/useAllDishes.js
+++ b/src/hooks/useAllDishes.js
@@ -1,16 +1,23 @@
 import { useEffect } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { dishesApi } from '../api/dishesApi'
 import { logger } from '../utils/logger'
 
 /**
  * Cache all dishes for client-side search.
- * ~300 rows, ~50KB. Fetched once, refreshed on window focus and every 5 minutes.
+ * ~300 rows, ~50KB. Fetched once. A Supabase Realtime subscription on the
+ * `dishes` table invalidates the cache on any INSERT/UPDATE/DELETE — so
+ * newly-created dishes (manual add, menu-refresh cron, admin tools, cascade
+ * delete on restaurant removal) become searchable within ~1s without
+ * per-mutation invalidation plumbing at every write site.
+ *
  * @param {Object} [options]
  * @param {boolean} [options.enabled=true] - Pass false to defer fetching until needed (e.g. until user starts searching)
  * @returns {Object} { dishes, loading, error }
  */
 export function useAllDishes({ enabled = true } = {}) {
+  const queryClient = useQueryClient()
+
   const { data, isLoading, error } = useQuery({
     queryKey: ['allDishes'],
     queryFn: () => dishesApi.getAllSearchable(),
@@ -22,6 +29,21 @@ export function useAllDishes({ enabled = true } = {}) {
   useEffect(() => {
     if (error) logger.error('Error loading dish cache:', error)
   }, [error])
+
+  useEffect(() => {
+    if (!enabled) return undefined
+
+    // Invalidate immediately on (re)open: between teardown and reopen the
+    // subscription was off, so any dish writes during that gap were missed.
+    // Without this, React Query reuses the still-fresh cache on the next
+    // search and never sees those changes (Codex review caught this).
+    queryClient.invalidateQueries({ queryKey: ['allDishes'] })
+
+    const unsubscribe = dishesApi.subscribeToChanges(() => {
+      queryClient.invalidateQueries({ queryKey: ['allDishes'] })
+    })
+    return unsubscribe
+  }, [enabled, queryClient])
 
   return {
     dishes: data || [],

--- a/supabase/migrations/2026-04-27-realtime-dishes.sql
+++ b/supabase/migrations/2026-04-27-realtime-dishes.sql
@@ -1,0 +1,23 @@
+-- Enable Supabase Realtime broadcasts on the dishes table.
+--
+-- Why: client-side search reads from a React Query cache (useAllDishes,
+-- queryKey ['allDishes']) populated by dishesApi.getAllSearchable. Pre-fix,
+-- nothing invalidated that cache after dish writes — newly-inserted dishes
+-- (manual add, menu-refresh cron, admin tools, restaurant cascade delete)
+-- were invisible to homepage search until the 5-min staleTime expired or
+-- the component remounted. Subscribing to dishes-table row events lets the
+-- hook auto-invalidate on any change without per-write-site plumbing.
+--
+-- Idempotent: if `dishes` is already in the publication (re-running this),
+-- ALTER PUBLICATION will error. Wrap in a DO block so reruns are safe.
+
+DO $$
+BEGIN
+  ALTER PUBLICATION supabase_realtime ADD TABLE dishes;
+EXCEPTION
+  WHEN duplicate_object THEN
+    RAISE NOTICE 'dishes is already in supabase_realtime publication — no-op';
+END $$;
+
+-- ROLLBACK:
+-- ALTER PUBLICATION supabase_realtime DROP TABLE dishes;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -5214,3 +5214,15 @@ $$;
 -- function is too large to duplicate here. The migration runs the updated
 -- CREATE OR REPLACE that adds `AND NOT is_blocked_pair((select auth.uid()),
 -- dp.user_id)` to the best_photos CTE WHERE clause.
+
+
+-- =============================================
+-- 15. REALTIME PUBLICATIONS
+-- =============================================
+-- Tables added here broadcast row changes to subscribed Supabase Realtime
+-- clients. Subscribe in app code via dishesApi.subscribeToChanges (see
+-- src/hooks/useAllDishes.js for the search-cache invalidation use case).
+-- Migration: supabase/migrations/2026-04-27-realtime-dishes.sql
+
+ALTER PUBLICATION supabase_realtime ADD TABLE dishes;
+


### PR DESCRIPTION
## The bug Dan hit
Re-added Mo's Lunch → menu-refresh inserted 25 dishes including Leo Burger → restaurant page showed it → homepage search did NOT. Same root issue regressed every dish-create path: AddRestaurantModal + menu-import-completion, RateYourMeal, ManageRestaurant, admin tools, restaurant cascade delete.

## Why it kept happening
T36 refactored search from server-side (`dishesApi.search()`) to a client-side cache (`useAllDishes` + `useDishSearch` + `dishSearch.js`) for instant local filtering. Every dish-creation path forgot to invalidate the new `['allDishes']` cache. **No code in the entire repo invalidated that key.** Bandaid would be to patch each write site forever; that's exactly what we said no to.

## The root fix
Subscribe `useAllDishes` to Supabase Realtime `postgres_changes` on the `dishes` table. Any INSERT/UPDATE/DELETE in the DB invalidates the cache automatically — covers manual creation, server-side menu-refresh cron, admin, cascade deletes, future write paths. One wire-up, all paths covered.

## Codex review caught one issue (now fixed)
Subscription is gated on `enabled` (search-active). Changes happening while user *isn't* searching would be missed because the channel is torn down. Fix: invalidate cache on every subscription (re)open, so the next search-activation always grabs fresh data and ongoing changes during the search are also caught.

## Files
- `supabase/schema.sql`: `ALTER PUBLICATION supabase_realtime ADD TABLE dishes`
- `supabase/migrations/2026-04-27-realtime-dishes.sql`: idempotent migration (rerun-safe via `EXCEPTION WHEN duplicate_object`)
- `src/api/dishesApi.js`: `dishesApi.subscribeToChanges(onChange)` — wraps the raw `supabase.channel` call so hooks comply with CLAUDE.md §1.4 (no direct supabase calls in hooks)
- `src/hooks/useAllDishes.js`: subscribes via the API method, invalidates cache on each event + on every (re)open, cleans up the channel on unmount

## Test plan
- [x] `npm run lint` — 16 errors / 46 warnings (matches main baseline, no regression)
- [x] `npm run test` — 439/439 pass
- [x] `npm run build` — clean
- [x] Codex peer review (gpt-5.4, high effort): found gap-window bug, fixed, re-verified
- [ ] After merge + deploy: paste `supabase/migrations/2026-04-27-realtime-dishes.sql` in SQL Editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)