### PR TITLE
fix(prod): site-down on web (AuthLifecycle Router) + cached vercel.app icons (CSP)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import { Layout } from './components/Layout'
 import { BottomNav } from './components/BottomNav'
 import { ProtectedRoute } from './components/ProtectedRoute'
 import { WelcomeModal } from './components/Auth/WelcomeModal'
+import { AuthLifecycle } from './components/Auth/AuthLifecycle'
 import { RouteProgress } from './components/RouteProgress'
 import { preloadSounds } from './lib/sounds'
 import { preloadCategoryImages } from './constants/categories'
@@ -110,6 +111,7 @@ function App() {
       <AuthProvider>
       <LocationProvider>
         <BrowserRouter>
+          <AuthLifecycle />
           <RouteProgress />
           <WelcomeModal />
           <Suspense fallback={<PageLoader />}>

--- a/src/components/Auth/AuthLifecycle.jsx
+++ b/src/components/Auth/AuthLifecycle.jsx
@@ -1,5 +1,8 @@
 // Owns Capacitor App lifecycle listeners that affect auth state.
-// Mounted inside AuthProvider so its effects live adjacent to the auth client.
+// Must be rendered inside <BrowserRouter> — uses useNavigate() for B4
+// deep-link routing. Provider order is AuthProvider > LocationProvider >
+// BrowserRouter, so this is mounted in App.jsx alongside the Routes,
+// not inside AuthProvider.
 //
 // B2: appStateChange → on foreground, reconcile session via authApi.getSession()
 // B4: appUrlOpen    → parse universal-link, exchangeCodeForSession, route by type

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -6,7 +6,6 @@ import { authApi } from '../api/authApi'
 import { capture, identify, reset } from '../lib/analytics'
 import { clearPendingVoteStorage, clearCache, removeStorageItem, removeSessionItem, STORAGE_KEYS } from '../lib/storage'
 import { logger } from '../utils/logger'
-import { AuthLifecycle } from '../components/Auth/AuthLifecycle'
 
 const AuthContext = createContext(null)
 
@@ -111,7 +110,6 @@ export function AuthProvider({ children }) {
 
   return (
     <AuthContext.Provider value={value}>
-      <AuthLifecycle />
       {children}
     </AuthContext.Provider>
   )

--- a/vercel.json
+++ b/vercel.json
@@ -59,7 +59,7 @@
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://*.supabase.co https://images.unsplash.com https://*.tile.openstreetmap.org https://*.basemaps.cartocdn.com https://randomuser.me; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://us.posthog.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://images.unsplash.com https://*.tile.openstreetmap.org https://*.basemaps.cartocdn.com https://nominatim.openstreetmap.org; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://wghapp.com https://*.supabase.co https://images.unsplash.com https://*.tile.openstreetmap.org https://*.basemaps.cartocdn.com https://randomuser.me; connect-src 'self' https://wghapp.com https://*.supabase.co wss://*.supabase.co https://us.posthog.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://images.unsplash.com https://*.tile.openstreetmap.org https://*.basemaps.cartocdn.com https://nominatim.openstreetmap.org; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Two prod-urgent fixes bundled because both surface the same UX symptom (broken site after PR #96 + #106):

1. **`fix(auth)`: hoist `AuthLifecycle` inside `BrowserRouter`** — site-down on every fresh web load.
2. **`fix(csp)`: allow `https://wghapp.com` in `img-src` + `connect-src`** — cached vercel.app PWAs render category icons / dish-pin clusters as broken `?` boxes.

## Why

### Site-down (commit 2)
PR #106 added `useNavigate()` to `AuthLifecycle` for B4 deep-link routing, but `<AuthLifecycle />` is rendered inside `<AuthProvider>`, which sits outside `<BrowserRouter>` per the documented provider order (`AuthProvider > LocationProvider > BrowserRouter`). `useNavigate` throws `"may be used only in the context of a <Router> component"` on every web load → ErrorBoundary catches → blank screen.

Hoisting `<AuthLifecycle />` to App.jsx alongside `<RouteProgress />` (already inside `<BrowserRouter>`) fixes it. AuthLifecycle doesn't read from AuthContext, only calls `authApi` directly, so no functional regression.

This was masked for installed vercel.app PWAs because their service worker served a stale bundle from before #106. Once anyone navigates to wghapp.com (no SW cache), the bug bites immediately.

### Cached icons (commit 1)
After #96's host-redirect, `whats-good-here.vercel.app/categories/icons/*` 308s to `wghapp.com`. CSP only allowed `'self'`, so the redirected image fails CSP — every category icon (top strip + map dish-pin clusters) renders as a broken-image `?`. Whitelisting `wghapp.com` lets cached PWAs keep working until they migrate. Bonus: deploying this also busts the stale `/` edge cache on vercel.app so the page-level redirect to wghapp.com finally fires.

## Test plan
- [ ] Fresh load of wghapp.com (or a hard-reload PWA) does **not** crash with a Router error
- [ ] On vercel.app: category icons + map dish pins render
- [ ] On vercel.app: `/` returns 308 → wghapp.com after deploy
- [ ] On wghapp.com: nothing changes — same-origin everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)