### PR TITLE
feat(dish): add Call button next to Order/Directions when phone present

### DIFF
--- a/src/pages/Dish.jsx
+++ b/src/pages/Dish.jsx
@@ -553,6 +553,30 @@ export function Dish() {
             </svg>
             Directions
           </a>
+
+          {dish.restaurant_phone && (
+            <a
+              href={'tel:' + dish.restaurant_phone}
+              onClick={() => {
+                capture('call_clicked', {
+                  dish_id: dish.dish_id,
+                  dish_name: dish.dish_name,
+                  restaurant_id: dish.restaurant_id,
+                  restaurant_name: dish.restaurant_name,
+                })
+              }}
+              className="flex-1 flex items-center justify-center gap-2 py-3 rounded-xl font-bold text-sm transition-all active:scale-[0.97]"
+              style={{
+                background: 'var(--color-primary)',
+                color: 'white',
+              }}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 0 0 2.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 0 1-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.733.417-1.173L6.963 3.102a1.125 1.125 0 0 0-1.091-.852H4.5A2.25 2.25 0 0 0 2.25 4.5v2.25Z" />
+              </svg>
+              Call
+            </a>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Adds a Call button to the Dish detail floating action bar, conditional on `dish.restaurant_phone` being present
- Wires `tel:` deeplink, fires `call_clicked` PostHog event with dish + restaurant context
- Mirrors styling of existing Order Now / Directions buttons (var(--color-primary), white text, same icon weight)

## Why
Closes a sub-item of the Memorial Day launch-list line: **Check In + action buttons (Order / Directions / Call) on dishes + restaurants**. Restaurant page already has Call wired; Dish page was the gap.

`dish.restaurant_phone` is already plumbed via `dishesApi.getDishById`'s `restaurants` join — no API or schema change needed.

## Test plan
- [ ] Dish with `restaurant_phone` → Call button visible after Directions
- [ ] Dish without phone → no Call button, no layout shift
- [ ] Tap on iOS → opens dialer
- [ ] PostHog `call_clicked` event captured with dish_id + restaurant_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)