### PR TITLE
feat(restaurant): surface "You're here" badge when geolocated at restaurant

### DIFF
--- a/src/pages/RestaurantDetail.jsx
+++ b/src/pages/RestaurantDetail.jsx
@@ -303,6 +303,24 @@ export function RestaurantDetail() {
                 <span> · {restaurant.distance_miles} mi away</span>
               )}
             </p>
+            {isHere && (
+              <span
+                className="inline-flex items-center gap-1 rounded-full"
+                style={{
+                  marginTop: '6px',
+                  padding: '2px 8px',
+                  fontSize: '12px',
+                  fontWeight: 600,
+                  background: 'rgba(217, 167, 101, 0.15)',
+                  color: 'var(--color-accent-gold)',
+                  border: '1px solid var(--color-accent-gold)',
+                }}
+                aria-label="You are at this restaurant"
+              >
+                <span aria-hidden="true">📍</span>
+                You&rsquo;re here
+              </span>
+            )}
             {/* Scores row */}
             {(wghFoodScore || googleRating) && (
               <div className="flex items-center gap-4" style={{ marginTop: '6px' }}>


### PR DESCRIPTION
## Summary
- Surfaces a small gold pill below the dish-count line on RestaurantDetail when `isHere` is true
- `isHere = nearbyRestaurant?.id === restaurantId` was already computed via `useNearbyRestaurant`, just unused
- Passive contextual feedback — no flow, no schema, no DB write

## Why
Closes a sub-item of the Memorial Day launch-list line: **Check In + action buttons (Order / Directions / Call) on dishes + restaurants**. Foundation was built; just needed surfacing.

A future PR can layer an actual check-in record / social post on top.

## Test plan
- [ ] Visit a restaurant detail page from within geofence (~50m) → "You're here" pill shows
- [ ] Visit from outside geofence → no pill, no layout shift
- [ ] Pill renders with gold accent + map-pin emoji, accessible label

🤖 Generated with [Claude Code](https://claude.com/claude-code)