### PR TITLE
Unify search bars + bold/authoritative design pass

### DIFF
--- a/src/components/DishSearch.jsx
+++ b/src/components/DishSearch.jsx
@@ -153,10 +153,11 @@ export function DishSearch({ loading = false, placeholder = "Find What's Good ne
     <div className="relative w-full">
       {/* Search Input */}
       <div
-        className="relative flex items-center gap-3 px-4 py-3 rounded-xl transition-all duration-200"
+        className="relative flex items-center gap-3 px-4 py-3 rounded-md transition-colors duration-200"
         style={{
           background: 'var(--color-surface-elevated)',
-          border: isFocused ? '2px solid var(--color-primary)' : '1.5px solid var(--color-divider)',
+          border: '2px solid',
+          borderColor: isFocused ? 'var(--color-primary)' : 'var(--color-text-primary)',
           minHeight: '48px',
         }}
       >
@@ -232,16 +233,16 @@ export function DishSearch({ loading = false, placeholder = "Find What's Good ne
           id="dish-search-suggestions"
           role="listbox"
           aria-label="Suggestions"
-          className="absolute top-full left-0 right-0 mt-2 rounded-xl overflow-hidden z-50"
+          className="absolute top-full left-0 right-0 mt-2 rounded-md overflow-hidden z-50"
           style={{
             background: 'var(--color-surface)',
-            border: '1.5px solid var(--color-divider)',
+            border: '2px solid var(--color-text-primary)',
           }}
         >
-          <div className="px-4 py-2 border-b" style={{ borderColor: 'var(--color-divider)' }}>
+          <div className="px-4 py-2.5 border-b-2" style={{ borderColor: 'var(--color-text-primary)' }}>
             <span
-              className="text-[10px] font-semibold uppercase tracking-wider"
-              style={{ color: 'var(--color-text-tertiary)' }}
+              className="text-[11px] font-bold uppercase"
+              style={{ color: 'var(--color-text-primary)', letterSpacing: '0.18em' }}
             >
               Try a category
             </span>
@@ -254,13 +255,13 @@ export function DishSearch({ loading = false, placeholder = "Find What's Good ne
                 key={category.id}
                 type="button"
                 onClick={() => handleSuggestionTap(category)}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm transition-colors active:scale-[0.97]"
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-sm transition-colors active:scale-[0.97]"
                 style={{
                   background: 'var(--color-surface-elevated)',
-                  border: '1px solid var(--color-divider)',
+                  border: '1.5px solid var(--color-text-primary)',
                   color: 'var(--color-text-primary)',
                   fontSize: '13px',
-                  fontWeight: 500,
+                  fontWeight: 600,
                   cursor: 'pointer',
                 }}
                 onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--color-primary-muted)' }}
@@ -272,15 +273,15 @@ export function DishSearch({ loading = false, placeholder = "Find What's Good ne
             ))}
           </div>
           <div
-            className="px-4 py-2 border-t"
+            className="px-4 py-2 border-t-2"
             style={{
-              borderColor: 'var(--color-divider)',
+              borderColor: 'var(--color-text-primary)',
               background: 'var(--color-surface-elevated)',
             }}
           >
             <span
-              className="text-[10px] uppercase tracking-wider"
-              style={{ color: 'var(--color-text-tertiary)' }}
+              className="text-[10px] font-semibold uppercase"
+              style={{ color: 'var(--color-text-secondary)', letterSpacing: '0.16em' }}
             >
               or type a dish, restaurant, or place
             </span>
@@ -295,10 +296,10 @@ export function DishSearch({ loading = false, placeholder = "Find What's Good ne
           id="dish-search-dropdown"
           role="listbox"
           aria-label="Search results"
-          className="absolute top-full left-0 right-0 mt-2 rounded-xl overflow-hidden z-50"
+          className="absolute top-full left-0 right-0 mt-2 rounded-md overflow-hidden z-50"
           style={{
             background: 'var(--color-surface)',
-            border: '1.5px solid var(--color-divider)',
+            border: '2px solid var(--color-text-primary)',
           }}
         >
           {isLoading ? (
@@ -322,8 +323,8 @@ export function DishSearch({ loading = false, placeholder = "Find What's Good ne
               {/* Dish Results */}
               {results.dishes.length > 0 && (
                 <div>
-                  <div className="px-4 py-2 border-b" style={{ borderColor: 'var(--color-divider)' }}>
-                    <span className="text-[10px] font-semibold uppercase tracking-wider" style={{ color: 'var(--color-text-tertiary)' }}>
+                  <div className="px-4 py-2.5 border-b-2" style={{ borderColor: 'var(--color-text-primary)' }}>
+                    <span className="text-[11px] font-bold uppercase" style={{ color: 'var(--color-text-primary)', letterSpacing: '0.18em' }}>
                       {town ? `Best in ${town}` : 'Best Matches'}
                     </span>
                   </div>
@@ -342,13 +343,13 @@ export function DishSearch({ loading = false, placeholder = "Find What's Good ne
               {results.categories.length > 0 && (
                 <div>
                   <div
-                    className="px-4 py-2 border-b"
+                    className="px-4 py-2.5 border-b-2 border-t-2"
                     style={{
-                      borderColor: 'var(--color-divider)',
+                      borderColor: 'var(--color-text-primary)',
                       background: results.dishes.length > 0 ? 'var(--color-surface)' : 'transparent',
                     }}
                   >
-                    <span className="text-[10px] font-semibold uppercase tracking-wider" style={{ color: 'var(--color-text-tertiary)' }}>
+                    <span className="text-[11px] font-bold uppercase" style={{ color: 'var(--color-text-primary)', letterSpacing: '0.18em' }}>
                       Categories
                     </span>
                   </div>
@@ -365,8 +366,8 @@ export function DishSearch({ loading = false, placeholder = "Find What's Good ne
               {/* Restaurant fallback — local DB + Google Places */}
               {hasRestaurantResults && (
                 <div>
-                  <div className="px-4 py-2 border-b" style={{ borderColor: 'var(--color-divider)' }}>
-                    <span className="text-[10px] font-semibold uppercase tracking-wider" style={{ color: 'var(--color-text-tertiary)' }}>
+                  <div className="px-4 py-2.5 border-b-2 border-t-2" style={{ borderColor: 'var(--color-text-primary)' }}>
+                    <span className="text-[11px] font-bold uppercase" style={{ color: 'var(--color-text-primary)', letterSpacing: '0.18em' }}>
                       Restaurants
                     </span>
                   </div>
@@ -444,8 +445,8 @@ function DishResult({ dish, rank, onClick }) {
       onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
     >
       <span
-        className="w-6 text-center text-sm font-bold flex-shrink-0"
-        style={{ color: 'var(--color-text-tertiary)' }}
+        className="w-6 text-center text-sm font-extrabold flex-shrink-0 tabular-nums"
+        style={{ color: 'var(--color-text-primary)' }}
       >
         {rank}
       </span>
@@ -484,8 +485,8 @@ function CategoryResult({ category, onClick }) {
     >
       {/* Category icon */}
       <div
-        className="w-10 h-10 rounded-lg overflow-hidden flex-shrink-0 flex items-center justify-center"
-        style={{ background: 'var(--color-surface)' }}
+        className="w-10 h-10 rounded-md overflow-hidden flex-shrink-0 flex items-center justify-center"
+        style={{ background: 'var(--color-surface)', border: '1.5px solid var(--color-text-primary)' }}
       >
         {getCategoryNeonImage(category.id) ? (
           <img

--- a/src/components/DishSearch.jsx
+++ b/src/components/DishSearch.jsx
@@ -35,9 +35,10 @@ export function DishSearch({ loading = false, placeholder = "Find What's Good ne
     town
   )
 
-  // Restaurant search fallback — shows when dish results are thin (dropdown mode only)
+  // Restaurant search runs in both inline (home/map) and dropdown (browse) modes so users
+  // can find local + Google Places restaurants from any DishSearch surface.
   const isDropdownMode = !onSearchChange
-  const showRestaurantFallback = isDropdownMode && query.length >= MIN_SEARCH_LENGTH && !hookLoading
+  const showRestaurantFallback = query.length >= MIN_SEARCH_LENGTH && !hookLoading
   const placesLat = isUsingDefault ? null : (location ? location.lat : null)
   const placesLng = isUsingDefault ? null : (location ? location.lng : null)
   const restaurantData = useRestaurantSearch(query, placesLat, placesLng, showRestaurantFallback)
@@ -83,8 +84,10 @@ export function DishSearch({ loading = false, placeholder = "Find What's Good ne
   }
 
   const hasResults = results.dishes.length > 0 || results.categories.length > 0 || hasRestaurantResults
-  const showDropdown = !onSearchChange && isFocused && query.length >= MIN_SEARCH_LENGTH
-  const isLoading = loading || (hookLoading && !onSearchChange)
+  // In inline mode, the parent renders dishes inline; the dropdown still appears so users can
+  // see local + Google Places restaurants and tap "+ Add to WGH".
+  const showDropdown = isFocused && query.length >= MIN_SEARCH_LENGTH && (isDropdownMode || hasRestaurantResults || restaurantData.loading)
+  const isLoading = loading || (hookLoading && !onSearchChange) || (!isDropdownMode && restaurantData.loading && !hasRestaurantResults)
 
   // Handle dish selection
   const handleDishSelect = (dish) => {
@@ -203,14 +206,12 @@ export function DishSearch({ loading = false, placeholder = "Find What's Good ne
         {rightSlot}
       </div>
 
-      {/* Add Restaurant Modal (dropdown mode only) */}
-      {isDropdownMode && (
-        <AddRestaurantModal
-          isOpen={addModalOpen}
-          onClose={() => setAddModalOpen(false)}
-          initialQuery={addModalQuery}
-        />
-      )}
+      {/* Add Restaurant Modal — available in both modes so home/map users can add via Places tap */}
+      <AddRestaurantModal
+        isOpen={addModalOpen}
+        onClose={() => setAddModalOpen(false)}
+        initialQuery={addModalQuery}
+      />
 
       {/* Autocomplete Dropdown */}
       {showDropdown && (
@@ -235,7 +236,7 @@ export function DishSearch({ loading = false, placeholder = "Find What's Good ne
           ) : !hasResults ? (
             <div className="px-4 py-6 text-center">
               <p className="text-sm" style={{ color: 'var(--color-text-secondary)' }}>
-                No dishes found for "{query}"
+                {isDropdownMode ? `No dishes found for "${query}"` : `No restaurants found for "${query}"`}
               </p>
               <p className="text-xs mt-1" style={{ color: 'var(--color-text-tertiary)' }}>
                 Try a different search term

--- a/src/components/DishSearch.jsx
+++ b/src/components/DishSearch.jsx
@@ -6,7 +6,7 @@ import { useLocationContext } from '../context/LocationContext'
 import { useRestaurantSearch } from '../hooks/useRestaurantSearch'
 import { AddRestaurantModal } from './AddRestaurantModal'
 import { PoweredByGoogle } from './PoweredByGoogle'
-import { getCategoryNeonImage, matchCategories } from '../constants/categories'
+import { getCategoryNeonImage, matchCategories, BROWSE_CATEGORIES } from '../constants/categories'
 import { MIN_VOTES_FOR_RANKING } from '../constants/app'
 import { getRatingColor } from '../utils/ranking'
 const MIN_SEARCH_LENGTH = 2
@@ -87,6 +87,7 @@ export function DishSearch({ loading = false, placeholder = "Find What's Good ne
   // In inline mode, the parent renders dishes inline; the dropdown still appears so users can
   // see local + Google Places restaurants and tap "+ Add to WGH".
   const showDropdown = isFocused && query.length >= MIN_SEARCH_LENGTH && (isDropdownMode || hasRestaurantResults || restaurantData.loading)
+  const showEmptyState = isFocused && query.length < MIN_SEARCH_LENGTH && isDropdownMode
   const isLoading = loading || (hookLoading && !onSearchChange) || (!isDropdownMode && restaurantData.loading && !hasRestaurantResults)
 
   // Handle dish selection
@@ -114,6 +115,17 @@ export function DishSearch({ loading = false, placeholder = "Find What's Good ne
       result_type: 'category',
       selected_category: category.id,
       results_count: results.categories.length,
+    })
+    setQuery('')
+    setIsFocused(false)
+    navigate(`/browse?category=${encodeURIComponent(category.id)}`)
+  }
+
+  // Empty-state suggestion tap (focused, no query yet — dropdown mode only)
+  const handleSuggestionTap = (category) => {
+    capture('search_suggestion_tapped', {
+      suggestion: category.id,
+      source: 'empty_state',
     })
     setQuery('')
     setIsFocused(false)
@@ -212,6 +224,69 @@ export function DishSearch({ loading = false, placeholder = "Find What's Good ne
         onClose={() => setAddModalOpen(false)}
         initialQuery={addModalQuery}
       />
+
+      {/* Empty-state suggestions — focused but hasn't typed enough yet */}
+      {showEmptyState && (
+        <div
+          ref={dropdownRef}
+          id="dish-search-suggestions"
+          role="listbox"
+          aria-label="Suggestions"
+          className="absolute top-full left-0 right-0 mt-2 rounded-xl overflow-hidden z-50"
+          style={{
+            background: 'var(--color-surface)',
+            border: '1.5px solid var(--color-divider)',
+          }}
+        >
+          <div className="px-4 py-2 border-b" style={{ borderColor: 'var(--color-divider)' }}>
+            <span
+              className="text-[10px] font-semibold uppercase tracking-wider"
+              style={{ color: 'var(--color-text-tertiary)' }}
+            >
+              Try a category
+            </span>
+          </div>
+          <div
+            className="flex flex-wrap gap-2 p-3"
+          >
+            {BROWSE_CATEGORIES.slice(0, 8).map((category) => (
+              <button
+                key={category.id}
+                type="button"
+                onClick={() => handleSuggestionTap(category)}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm transition-colors active:scale-[0.97]"
+                style={{
+                  background: 'var(--color-surface-elevated)',
+                  border: '1px solid var(--color-divider)',
+                  color: 'var(--color-text-primary)',
+                  fontSize: '13px',
+                  fontWeight: 500,
+                  cursor: 'pointer',
+                }}
+                onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--color-primary-muted)' }}
+                onMouseLeave={(e) => { e.currentTarget.style.background = 'var(--color-surface-elevated)' }}
+              >
+                <span aria-hidden="true">{category.emoji}</span>
+                <span>{category.label}</span>
+              </button>
+            ))}
+          </div>
+          <div
+            className="px-4 py-2 border-t"
+            style={{
+              borderColor: 'var(--color-divider)',
+              background: 'var(--color-surface-elevated)',
+            }}
+          >
+            <span
+              className="text-[10px] uppercase tracking-wider"
+              style={{ color: 'var(--color-text-tertiary)' }}
+            >
+              or type a dish, restaurant, or place
+            </span>
+          </div>
+        </div>
+      )}
 
       {/* Autocomplete Dropdown */}
       {showDropdown && (


### PR DESCRIPTION
## Summary

Three commits, smallest-to-largest blast radius:

1. **`65b6344` fix(search): home/map search shows local + Google Places restaurants** — drops the \`isDropdownMode\` gate on \`useRestaurantSearch\` so users on \`/\` (home, Map.jsx) and other inline-mode surfaces actually see local + Google Places results when they type. Inline-mode home keeps rendering dishes via the parent — the floating dropdown only appears when there are restaurant matches or a Places lookup is in flight. Also un-gates \`AddRestaurantModal\` so any DishSearch consumer can offer the Add-to-WGH flow. (This commit was originally authored on a sibling branch \`fix/home-search-shows-places\`; it lives here as the cleanest base for the rest.)

2. **\`f424e21\` feat(search): empty-state suggestions when search bar is focused** — when the dropdown-mode search bar (Browse) is focused but query is below 2 chars, surface 8 popular categories ("Try a category" eyebrow + tappable chips) instead of an empty void. Gated to dropdown mode; inline-mode home already shows category chips elsewhere on the page.

3. **\`4b35b4f\` style(search): authoritative design pass** — visual-only changes to lean editorial:
   - \`rounded-xl\` → \`rounded-md\` on input + dropdown; \`rounded-full\` → \`rounded\` on chips
   - Constant 2px \`text-primary\` border, focus = color swap to \`primary\` (not thickness change)
   - Section eyebrows ("Best Matches" / "Categories" / "Restaurants" / "Try a category"): 10px tertiary → 11px primary 700 + 0.18em tracking
   - Chip text weight 500 → 600
   - Dish rank: tertiary font-bold → primary font-extrabold + tabular-nums
   - Category icon: \`rounded-lg\` → \`rounded-md\` + 1.5px text-primary border
   - Section dividers: hairline → 2px text-primary

No font-family changes — stays inside Outfit/Amatic. No behavior changes. Realtime cache invalidation (#107) unaffected. Tokens unchanged.

## Test plan

- [ ] \`npm run build\` passes (verified locally — 7s, no warnings)
- [ ] On \`/\`: focus search, type "cl" — dropdown shows local restaurants + "Add to WGH" rows for Google Places matches
- [ ] On \`/browse\`: focus empty search — see "TRY A CATEGORY" with 8 chips; tap one navigates to \`/browse?category=\`
- [ ] On \`/browse\`: type "lobster" — see BEST IN \[town\] / CATEGORIES / RESTAURANTS section eyebrows in 11px primary bold
- [ ] On \`/restaurants\` and \`/locals\`: search bar surfaces dish + restaurant + Places results (was bespoke \`<input>\` filtering local list only)
- [ ] Visual: every search input has 2px black border, sharp corners (rounded-md), no bordertypeswap on focus

## Notes

- Supersedes the local \`fix/home-search-shows-places\` branch — its single commit is preserved here as \`65b6344\`.
- Built in an isolated git-worktree to avoid agent collisions on the shared working dir.