### PR TITLE
feat(db): auto-scrape trigger on restaurant insert

### DIFF
--- a/supabase/migrations/20260427_auto_scrape_on_restaurant_insert.sql
+++ b/supabase/migrations/20260427_auto_scrape_on_restaurant_insert.sql
@@ -1,0 +1,73 @@
+-- =============================================
+-- Auto-scrape trigger: fire restaurant-scraper on new restaurant insert
+-- =============================================
+-- When a new restaurant is inserted with a scrapeable URL (website, menu, or facebook),
+-- immediately fire the restaurant-scraper edge function via pg_net to extract
+-- events and specials. Uses the same vault secrets pattern as the daily cron.
+--
+-- Prerequisites:
+--   1. pg_net extension enabled
+--   2. vault secrets: 'supabase_url' and 'service_role_key'
+--   3. Edge function deployed: restaurant-scraper
+--
+-- Run this in Supabase SQL Editor.
+--
+-- ROLLBACK:
+--   DROP TRIGGER IF EXISTS trg_auto_scrape_on_restaurant_insert ON restaurants;
+--   DROP FUNCTION IF EXISTS fn_auto_scrape_on_restaurant_insert();
+-- =============================================
+
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+CREATE OR REPLACE FUNCTION fn_auto_scrape_on_restaurant_insert()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, net, vault
+AS $$
+DECLARE
+  _supabase_url TEXT;
+  _service_role_key TEXT;
+BEGIN
+  -- Only fire if the restaurant has at least one scrapeable URL
+  IF NEW.website_url IS NULL AND NEW.menu_url IS NULL AND NEW.facebook_url IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- Read secrets from vault (same pattern as daily cron)
+  SELECT decrypted_secret INTO _supabase_url
+    FROM vault.decrypted_secrets WHERE name = 'supabase_url' LIMIT 1;
+  SELECT decrypted_secret INTO _service_role_key
+    FROM vault.decrypted_secrets WHERE name = 'service_role_key' LIMIT 1;
+
+  -- Guard: skip if vault secrets not configured
+  IF _supabase_url IS NULL OR _service_role_key IS NULL THEN
+    RAISE WARNING 'auto_scrape trigger: vault secrets not configured, skipping';
+    RETURN NEW;
+  END IF;
+
+  -- Fire async HTTP POST to restaurant-scraper edge function
+  PERFORM net.http_post(
+    url := _supabase_url || '/functions/v1/restaurant-scraper',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || _service_role_key
+    ),
+    body := jsonb_build_object(
+      'restaurant_id', NEW.id,
+      'restaurant_name', NEW.name,
+      'website_url', NEW.website_url,
+      'facebook_url', NEW.facebook_url
+    )
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+-- Attach trigger (AFTER INSERT so the row is committed and visible to the edge function)
+DROP TRIGGER IF EXISTS trg_auto_scrape_on_restaurant_insert ON restaurants;
+CREATE TRIGGER trg_auto_scrape_on_restaurant_insert
+  AFTER INSERT ON restaurants
+  FOR EACH ROW
+  EXECUTE FUNCTION fn_auto_scrape_on_restaurant_insert();


### PR DESCRIPTION
## Summary

Adds an `AFTER INSERT` trigger on `restaurants` that fires the existing `restaurant-scraper` edge function via `pg_net` for the new row. Pairs with the unified search + instant-insert flow (PR #113): tap a Google Places result → restaurant created → menu/events/specials populate within ~30s instead of waiting for the daily cron.

## Why

Previously the AI scraper only ran on the daily cron (`scraper-dispatcher` at 11:00 UTC) and the biweekly menu refresh. New restaurants added through the in-app "Add to WGH" flow had no menu / events / specials until the next cron tick — so a user who added a place couldn't immediately see anything for it.

## Changes

`supabase/migrations/20260427_auto_scrape_on_restaurant_insert.sql`:
- `CREATE EXTENSION IF NOT EXISTS pg_net`
- `fn_auto_scrape_on_restaurant_insert()` trigger function (SECURITY DEFINER, reads `vault.decrypted_secrets` for `supabase_url` + `service_role_key` — same pattern as the daily cron migration)
- Skips fire when `website_url`, `menu_url`, and `facebook_url` are all NULL (scraper has nothing to chew on)
- `trg_auto_scrape_on_restaurant_insert` AFTER INSERT trigger
- Rollback block included at top of file

## Test plan

- [ ] `INSERT INTO restaurants (name, lat, lng, website_url) VALUES (...)` — check `pg_net._http_response` for a 200 from `restaurant-scraper`
- [ ] Insert a restaurant with all scrapeable URLs NULL — trigger should skip (no row in `pg_net._http_response`)
- [ ] Verify `restaurant-scraper` ran for that restaurant (events / specials tables populated)
- [ ] Daily cron unaffected (still backfills existing restaurants)

## Notes

- Migration is already deployed in production Supabase (run via SQL Editor today). This PR commits the file for repo record-keeping and so other envs can apply it.
- Vault prereq: `supabase_url` and `service_role_key` secrets must exist (they already do — used by the daily cron in `20260216120000_enable_scraper_cron.sql`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)