### PR TITLE
refactor(auth): pass returnPath intent, not OAuth callback URLs

### DIFF
--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -16,26 +16,28 @@ const APPLE_PERSIST_TRANSIENT_STATUSES = new Set([500, 502, 503, 504])
 const APPLE_PERSIST_RETRY_DELAY_MS = 1000
 
 /**
- * Validate redirect URL against allowlist to prevent open redirect attacks
- * Only allows same-origin URLs
- * @param {string|null} redirectUrl - URL to validate
- * @returns {string} Safe redirect URL (defaults to origin if invalid)
+ * Resolve a caller-supplied return path (relative path or absolute URL) into a
+ * same-origin absolute URL safe to hand Supabase as `redirectTo`. Strips any
+ * cross-origin override to prevent open-redirect attacks. Web-only — native
+ * (Capacitor) flows skip this entirely.
+ *
+ * @param {string|null} returnPath - Path like `/dish/123?q=foo#bar`, an absolute
+ *   same-origin URL, or null. Cross-origin URLs are rejected and fall back to origin.
+ * @returns {string} Same-origin absolute URL.
  */
-function getSafeRedirectUrl(redirectUrl) {
-  if (!redirectUrl) {
+function buildWebRedirectUrl(returnPath) {
+  if (!returnPath) {
     return window.location.origin
   }
 
   try {
-    const url = new URL(redirectUrl, window.location.origin)
-    // Only allow same-origin redirects
+    const url = new URL(returnPath, window.location.origin)
     if (url.origin === window.location.origin) {
       return url.toString()
     }
     logger.warn('Blocked redirect to external origin:', url.origin)
     return window.location.origin
   } catch {
-    // Invalid URL, fall back to origin
     return window.location.origin
   }
 }
@@ -125,11 +127,18 @@ export const authApi = {
   },
 
   /**
-   * Sign in with Google OAuth
-   * @param {string|null} redirectUrl - Optional custom redirect URL (must be same-origin)
+   * Sign in with Google. On web, performs an OAuth redirect dance and returns
+   * the user to `returnPath` after auth. On native (Capacitor), uses the Capgo
+   * plugin's ID-token flow — no browser redirect, no `returnPath` needed
+   * (React Router state survives the in-WKWebView sign-in).
+   *
+   * @param {{ returnPath?: string|null }} [options]
+   * @param {string|null} [options.returnPath] - Web only: path to return to
+   *   post-auth (e.g. `/dish/123?votingDish=abc`). Cross-origin values are rejected.
+   *   Ignored on native.
    * @returns {Promise<Object>} Auth response
    */
-  async signInWithGoogle(redirectUrl = null) {
+  async signInWithGoogle({ returnPath = null } = {}) {
     try {
       const rateLimit = checkRateLimit('auth', RATE_LIMITS.auth)
       if (!rateLimit.allowed) {
@@ -142,6 +151,9 @@ export const authApi = {
       })
 
       if (Capacitor.isNativePlatform()) {
+        // Native: Capgo plugin → Google ID token → Supabase. No redirect dance,
+        // no `returnPath` needed — the WKWebView keeps the same JS context, so
+        // React Router state set by the caller survives sign-in.
         const { signInWithGoogleNative } = await import('../lib/nativeAuth')
         let tokens
         try {
@@ -166,7 +178,7 @@ export const authApi = {
 
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
-        options: { redirectTo: getSafeRedirectUrl(redirectUrl) },
+        options: { redirectTo: buildWebRedirectUrl(returnPath) },
       })
       if (error) {
         capture('login_failed', { method: 'google', error: error.message })
@@ -188,17 +200,19 @@ export const authApi = {
    * Supabase Apple provider is configured.
    *
    * Web flow uses signInWithOAuth → full-page redirect to Apple → Supabase
-   * validates the ID token on the callback. Native (Capacitor) flow using
-   * signInWithIdToken is deferred — see the H2 plan.
+   * validates the ID token on the callback. Native (Capacitor) flow uses the
+   * Capgo plugin's ID-token flow — no redirect dance.
    *
    * Note: Apple's identity token does NOT include the user's name (unlike
    * Google), so display_name will be null on first sign-in via web. The
    * WelcomeModal handles that case by opening when display_name is missing.
    *
-   * @param {string|null} redirectUrl - Optional custom redirect URL (must be same-origin)
+   * @param {{ returnPath?: string|null }} [options]
+   * @param {string|null} [options.returnPath] - Web only: path to return to
+   *   post-auth. Cross-origin values are rejected. Ignored on native.
    * @returns {Promise<Object>} Auth response
    */
-  async signInWithApple(redirectUrl = null) {
+  async signInWithApple({ returnPath = null } = {}) {
     try {
       const rateLimit = checkRateLimit('auth', RATE_LIMITS.auth)
       if (!rateLimit.allowed) {
@@ -211,6 +225,8 @@ export const authApi = {
       })
 
       if (Capacitor.isNativePlatform()) {
+        // Native: Capgo plugin → Apple identity token → Supabase. No redirect
+        // dance, no `returnPath` needed — same WKWebView JS context survives.
         const { signInWithAppleNative } = await import('../lib/nativeAuth')
         let appleRes
         try {
@@ -266,7 +282,7 @@ export const authApi = {
 
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'apple',
-        options: { redirectTo: getSafeRedirectUrl(redirectUrl) },
+        options: { redirectTo: buildWebRedirectUrl(returnPath) },
       })
       if (error) {
         capture('login_failed', { method: 'apple', error: error.message })
@@ -297,7 +313,7 @@ export const authApi = {
       const { error } = await supabase.auth.signInWithOtp({
         email,
         options: {
-          emailRedirectTo: getSafeRedirectUrl(redirectUrl),
+          emailRedirectTo: buildWebRedirectUrl(redirectUrl),
         },
       })
       if (error) {

--- a/src/api/authApi.test.js
+++ b/src/api/authApi.test.js
@@ -84,10 +84,10 @@ describe('Auth API', () => {
       })
     })
 
-    it('should use same-origin redirect URL if provided', async () => {
+    it('should use same-origin redirect URL if returnPath is absolute same-origin', async () => {
       supabase.auth.signInWithOAuth.mockResolvedValueOnce({ error: null })
 
-      await authApi.signInWithGoogle(`${window.location.origin}/callback`)
+      await authApi.signInWithGoogle({ returnPath: `${window.location.origin}/callback` })
 
       expect(supabase.auth.signInWithOAuth).toHaveBeenCalledWith({
         provider: 'google',
@@ -97,10 +97,23 @@ describe('Auth API', () => {
       })
     })
 
+    it('should resolve relative returnPath against current origin', async () => {
+      supabase.auth.signInWithOAuth.mockResolvedValueOnce({ error: null })
+
+      await authApi.signInWithGoogle({ returnPath: '/browse?q=ramen#top' })
+
+      expect(supabase.auth.signInWithOAuth).toHaveBeenCalledWith({
+        provider: 'google',
+        options: {
+          redirectTo: `${window.location.origin}/browse?q=ramen#top`,
+        },
+      })
+    })
+
     it('should block external redirect URLs', async () => {
       supabase.auth.signInWithOAuth.mockResolvedValueOnce({ error: null })
 
-      await authApi.signInWithGoogle('https://evil-site.com')
+      await authApi.signInWithGoogle({ returnPath: 'https://evil-site.com' })
 
       expect(supabase.auth.signInWithOAuth).toHaveBeenCalledWith({
         provider: 'google',
@@ -115,6 +128,67 @@ describe('Auth API', () => {
       supabase.auth.signInWithOAuth.mockResolvedValueOnce({ error })
 
       await expect(authApi.signInWithGoogle()).rejects.toThrow('OAuth error')
+    })
+  })
+
+  describe('signInWithApple (web)', () => {
+    it('should call signInWithOAuth with correct params and no returnPath', async () => {
+      supabase.auth.signInWithOAuth.mockResolvedValueOnce({ error: null })
+
+      await authApi.signInWithApple()
+
+      expect(supabase.auth.signInWithOAuth).toHaveBeenCalledWith({
+        provider: 'apple',
+        options: {
+          redirectTo: window.location.origin,
+        },
+      })
+    })
+
+    it('should use same-origin redirect URL if returnPath is absolute same-origin', async () => {
+      supabase.auth.signInWithOAuth.mockResolvedValueOnce({ error: null })
+
+      await authApi.signInWithApple({ returnPath: `${window.location.origin}/callback` })
+
+      expect(supabase.auth.signInWithOAuth).toHaveBeenCalledWith({
+        provider: 'apple',
+        options: {
+          redirectTo: `${window.location.origin}/callback`,
+        },
+      })
+    })
+
+    it('should resolve relative returnPath against current origin', async () => {
+      supabase.auth.signInWithOAuth.mockResolvedValueOnce({ error: null })
+
+      await authApi.signInWithApple({ returnPath: '/dish/abc?votingDish=xyz' })
+
+      expect(supabase.auth.signInWithOAuth).toHaveBeenCalledWith({
+        provider: 'apple',
+        options: {
+          redirectTo: `${window.location.origin}/dish/abc?votingDish=xyz`,
+        },
+      })
+    })
+
+    it('should block external redirect URLs', async () => {
+      supabase.auth.signInWithOAuth.mockResolvedValueOnce({ error: null })
+
+      await authApi.signInWithApple({ returnPath: 'https://evil-site.com' })
+
+      expect(supabase.auth.signInWithOAuth).toHaveBeenCalledWith({
+        provider: 'apple',
+        options: {
+          redirectTo: window.location.origin,
+        },
+      })
+    })
+
+    it('should throw error if OAuth fails', async () => {
+      const error = new Error('Apple OAuth error')
+      supabase.auth.signInWithOAuth.mockResolvedValueOnce({ error })
+
+      await expect(authApi.signInWithApple()).rejects.toThrow('Apple OAuth error')
     })
   })
 

--- a/src/components/Auth/LoginModal.jsx
+++ b/src/components/Auth/LoginModal.jsx
@@ -55,13 +55,17 @@ export function LoginModal({ isOpen, onClose, pendingAction = null }) {
 
   if (!isOpen) return null
 
-  const buildOAuthRedirect = () => {
-    const redirectUrl = new URL(window.location.href)
+  // Stay on current page after web OAuth, plus carry the pending vote target
+  // so Browse.jsx can auto-open the dish detail (reads ?votingDish on mount).
+  // Path-only — authApi resolves it to a same-origin absolute URL on web and
+  // ignores it on native (modal unmounts on success either way).
+  const getReturnPath = () => {
+    const url = new URL(window.location.href)
     const pending = getPendingVoteFromStorage()
     if (pending?.dishId) {
-      redirectUrl.searchParams.set('votingDish', pending.dishId)
+      url.searchParams.set('votingDish', pending.dishId)
     }
-    return redirectUrl.toString()
+    return url.pathname + url.search + url.hash
   }
 
   // Native flow resolves in-place (no browser redirect). Close modal on
@@ -70,7 +74,7 @@ export function LoginModal({ isOpen, onClose, pendingAction = null }) {
   const handleGoogleSignIn = async () => {
     try {
       setLoading(true)
-      const result = await authApi.signInWithGoogle(buildOAuthRedirect())
+      const result = await authApi.signInWithGoogle({ returnPath: getReturnPath() })
       if (result?.cancelled) {
         setLoading(false)
         return
@@ -88,7 +92,7 @@ export function LoginModal({ isOpen, onClose, pendingAction = null }) {
   const handleAppleSignIn = async () => {
     try {
       setLoading(true)
-      const result = await authApi.signInWithApple(buildOAuthRedirect())
+      const result = await authApi.signInWithApple({ returnPath: getReturnPath() })
       if (result?.cancelled) {
         setLoading(false)
         return

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -71,13 +71,10 @@ export function Login() {
     return () => clearTimeout(timer)
   }, [username, mode])
 
-  const buildOAuthRedirect = () => {
+  const getReturnPath = () => {
     const fromLocation = location.state?.from
     return fromLocation
-      ? new URL(
-          fromLocation.pathname + (fromLocation.search || '') + (fromLocation.hash || ''),
-          window.location.origin
-        ).toString()
+      ? fromLocation.pathname + (fromLocation.search || '') + (fromLocation.hash || '')
       : null
   }
 
@@ -87,7 +84,7 @@ export function Login() {
   const handleGoogleSignIn = async () => {
     try {
       setLoading(true)
-      const result = await authApi.signInWithGoogle(buildOAuthRedirect())
+      const result = await authApi.signInWithGoogle({ returnPath: getReturnPath() })
       if (result?.cancelled) {
         setLoading(false)
       }
@@ -100,7 +97,7 @@ export function Login() {
   const handleAppleSignIn = async () => {
     try {
       setLoading(true)
-      const result = await authApi.signInWithApple(buildOAuthRedirect())
+      const result = await authApi.signInWithApple({ returnPath: getReturnPath() })
       if (result?.cancelled) {
         setLoading(false)
       }


### PR DESCRIPTION
## Summary

- Call sites (`Login.jsx`, `LoginModal.jsx`) no longer construct OAuth callback URLs — they pass platform-agnostic intent (`returnPath` — a path string) and `authApi` decides whether/how that becomes a same-origin redirect URL.
- Helper renamed `getSafeRedirectUrl` → `buildWebRedirectUrl` (web-only, resolves a path to a same-origin absolute URL with open-redirect protection).
- Native branches in `authApi` now document why `returnPath` is unused (Capgo ID-token flow keeps the same WKWebView JS context, so React Router state survives sign-in — no redirect dance).
- New tests: Apple web open-redirect sanitization (was untested) + relative-path resolution tests for both providers.

## Why

`Login.jsx` and `LoginModal.jsx` were building fully-qualified OAuth callback URLs from `window.location.href` / `window.location.origin`. On Capacitor iOS, `window.location.origin` is `capacitor://localhost` — a meaningless OAuth redirect target. The value was silently ignored on native (platform branches in `authApi` use the Capgo ID-token flow, not a redirect dance), but the call sites lied to readers about what they were doing. Wrong abstraction at the wrong layer.

This is a root fix, not a band-aid (no rename / no comment). Callers express intent; `authApi` owns the platform-aware mechanism.

## What changed

| File | Change |
|---|---|
| `src/api/authApi.js` | `signInWithGoogle({ returnPath })` + `signInWithApple({ returnPath })`. Helper renamed `getSafeRedirectUrl` → `buildWebRedirectUrl`. Native branches gain comments explaining intentional non-use of `returnPath`. |
| `src/pages/Login.jsx` | `buildOAuthRedirect()` (built `capacitor://...` on native) → `getReturnPath()` (returns path string from `location.state?.from`). |
| `src/components/Auth/LoginModal.jsx` | Same rename + path return. **Preserves** the `votingDish` query-param flow that `Browse.jsx:158-173` consumes for auto-navigate post-login. |
| `src/api/authApi.test.js` | 4 existing Google web tests updated to new shape. Adds 5 new tests: Apple web no-arg / same-origin / relative-path / evil-origin / error, plus a Google relative-path test. |

## Codex review

Routed through Codex CLI (`gpt-5.4` / `high`) before implementation. Codex caught two real gaps in my initial plan that landed in the final code:

1. `LoginModal` has different intent from `Login` — it preserves the current URL **plus** `votingDish` (consumed by `Browse.jsx`). A naive copy-paste of `Login.jsx`'s `getReturnPath` into the modal would have silently broken the post-login auto-navigate to a pending vote.
2. Apple web sanitization had no test coverage (only Google had the `https://evil-site.com` open-redirect test). PR adds parity.

## Test plan

- [x] `npm run test` — 445/445 unit tests pass (was 440, +5 new Apple web + relative-path tests)
- [x] `npm run build` — clean, 8.63s
- [x] `eslint` on touched files — zero issues
- [x] `grep buildOAuthRedirect|getSafeRedirectUrl src/` — zero results (refactor is complete)
- [ ] **Real-device sanity** on iPhone via Xcode: tap "Continue with Google" + "Continue with Apple" from `/login` (after Apple Dev verification + `VITE_GOOGLE_IOS_CLIENT_ID` provisioned). Native branches don't depend on `returnPath` so behavior is unchanged, but worth a smoke.
- [ ] **Web sanity**: tap Google sign-in from a deep link like `/dish/abc` and confirm post-auth lands back on `/dish/abc` (web `redirectTo` flow).

## Notes

- Branched from `origin/main` (`e60502e`). No conflict with the in-flight brand refresh on a parallel session — this PR's `Login.jsx` keeps the existing `SmileyPin` import; brand work is shipped separately.
- `signInWithMagicLink` keeps its `(email, redirectUrl)` signature — magic links are web-only by definition (sends an email link), so the lying-on-native concern doesn't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)