### PR TITLE
fix(splash): tighten to standard 1.6s total length

### DIFF
--- a/src/components/WelcomeSplash.jsx
+++ b/src/components/WelcomeSplash.jsx
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react'
 import { Seal } from './Seal'
 
-// Total visible time before fade-out starts. Stamp lands ~0.9s,
-// wordmark settles ~1.25s, hold a beat, then fade out.
-const SPLASH_DURATION_MS = 1500
+// 1.6s total = standard splash length (industry-typical 1.5-2s).
+// Stamp lands at 0.9s; wordmark fadeUp (0.5s w/ 0.55s delay) lands at 1.05s.
+// Hold ~0.25s, then fade out 0.3s. Both keyframes complete before fade starts.
+const SPLASH_DURATION_MS = 1300
 const FADE_OUT_MS = 300
 
 // Module-level flag — persists across re-renders within a session so

--- a/src/index.css
+++ b/src/index.css
@@ -260,7 +260,7 @@
     line-height: 0.82;
     letter-spacing: -0.04em;
     color: var(--color-surface);
-    animation: sealFadeUp 0.6s 0.85s both;
+    animation: sealFadeUp 0.5s 0.55s both;
   }
 
   .wgh-splash__line {


### PR DESCRIPTION
## Summary

Splash duration was 1.8s (1500ms visible + 300ms fade). Tightening to 1.6s total (1300ms + 300ms fade) — standard branded-splash range is 1.5-2s; 1.6s feels snappier without truncating the stamp+wordmark choreography.

## Test plan

- [ ] Hard-refresh wghapp.com after deploy → splash appears for 1.6s then fades
- [ ] Stamp animation (0.9s) + wordmark settle (~1.25s) both still complete before fade kicks in

🤖 Generated with [Claude Code](https://claude.com/claude-code)