### PR TITLE
feat(brand): seal in TopBar + Fraunces-italic wordmark for congruency

### DIFF
--- a/src/components/Auth/WelcomeModal.jsx
+++ b/src/components/Auth/WelcomeModal.jsx
@@ -141,20 +141,21 @@ export function WelcomeModal() {
             <Seal size={88} />
           </div>
 
-          {/* Brand name */}
+          {/* Brand name — Fraunces italic, matches splash for congruency */}
           <h1
             style={{
-              fontFamily: "'Amatic SC', cursive",
-              fontSize: '42px',
-              fontWeight: 700,
+              fontFamily: "'Fraunces', serif",
+              fontStyle: 'italic',
+              fontWeight: 900,
+              fontSize: '44px',
               color: 'var(--color-text-primary)',
-              lineHeight: 1,
-              letterSpacing: '0.04em',
+              lineHeight: 0.95,
+              letterSpacing: '-0.02em',
               position: 'relative',
               zIndex: 1,
             }}
           >
-            What's <span style={{ color: 'var(--color-primary)' }}>Good</span> Here
+            what&rsquo;s <span style={{ color: 'var(--color-primary)' }}>good</span> here<span style={{ color: 'var(--color-primary)' }}>.</span>
           </h1>
 
           {/* Welcome line */}

--- a/src/components/Seal.jsx
+++ b/src/components/Seal.jsx
@@ -29,9 +29,13 @@ export function Seal({
     ? { role: 'img', 'aria-label': ariaLabel }
     : { 'aria-hidden': true }
 
+  // When the ring is hidden, crop the viewBox to the inner plate so the
+  // mark fills the icon area instead of leaving the ring padding empty.
+  const viewBox = showRing ? '0 0 200 200' : '40 40 120 120'
+
   return (
     <svg
-      viewBox="0 0 200 200"
+      viewBox={viewBox}
       width={size}
       height={size}
       className={className}

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -1,30 +1,18 @@
 import { NotificationBell } from './NotificationBell'
 import { SettingsDropdown } from './SettingsDropdown'
+import { Seal } from './Seal'
 
 /**
- * TopBar - Brand anchor with WGH wordmark, settings gear, and notification bell
+ * TopBar - Brand anchor with Seal mark, settings gear, and notification bell
  */
 export function TopBar() {
   return (
     <div className="top-bar">
       <div className="top-bar-content" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%', padding: '0 12px' }}>
-        {/* Spacer for symmetry */}
+        {/* Spacer for symmetry — keeps Seal optically centered */}
         <div style={{ width: '60px' }} />
 
-        {/* WGH wordmark — centered, Amatic SC */}
-        <span
-          style={{
-            fontFamily: "'Amatic SC', cursive",
-            fontSize: '24px',
-            fontWeight: 700,
-            color: 'var(--color-text-primary)',
-            letterSpacing: '0.04em',
-            lineHeight: 1,
-            whiteSpace: 'nowrap',
-          }}
-        >
-          What's <span style={{ color: 'var(--color-primary)' }}>Good</span> Here
-        </span>
+        <Seal size={36} showRing={false} ariaLabel="What's Good Here" />
 
         {/* Settings + Notifications grouped right */}
         <div className="flex items-center">

--- a/src/components/WelcomeSplash.jsx
+++ b/src/components/WelcomeSplash.jsx
@@ -1,10 +1,9 @@
 import { useState, useEffect } from 'react'
 import { Seal } from './Seal'
 
-// 1.6s total = standard splash length (industry-typical 1.5-2s).
-// Stamp lands at 0.9s; wordmark fadeUp (0.5s w/ 0.55s delay) lands at 1.05s.
-// Hold ~0.25s, then fade out 0.3s. Both keyframes complete before fade starts.
-const SPLASH_DURATION_MS = 1300
+// 1.8s total. Stamp lands at 0.9s; wordmark fadeUp (0.5s w/ 0.55s delay)
+// lands at 1.05s. Hold ~0.45s, then fade out 0.3s.
+const SPLASH_DURATION_MS = 1500
 const FADE_OUT_MS = 300
 
 // Module-level flag — persists across re-renders within a session so

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -229,17 +229,18 @@ export function Login() {
               </div>
               <h1
                 style={{
-                  fontFamily: "'Amatic SC', cursive",
-                  fontSize: '42px',
-                  fontWeight: 700,
+                  fontFamily: "'Fraunces', serif",
+                  fontStyle: 'italic',
+                  fontWeight: 900,
+                  fontSize: '44px',
                   color: 'var(--color-text-primary)',
-                  lineHeight: 1,
-                  letterSpacing: '0.04em',
+                  lineHeight: 0.95,
+                  letterSpacing: '-0.02em',
                   position: 'relative',
                   zIndex: 1,
                 }}
               >
-                What's <span style={{ color: 'var(--color-primary)' }}>Good</span> Here
+                what&rsquo;s <span style={{ color: 'var(--color-primary)' }}>good</span> here<span style={{ color: 'var(--color-primary)' }}>.</span>
               </h1>
               <p
                 style={{


### PR DESCRIPTION
## Summary

Three brand-congruency moves following the seal rebrand (#116) + duration tweak (#118):

1. **TopBar:** `<span>What's <Good> Here</span>` (Amatic SC) → `<Seal size={36} showRing={false} />`. Seal viewBox now crops to the inner plate when `showRing=false` so the mark fills the icon area instead of leaving 50% empty padding.
2. **WelcomeModal celebration h1 + Login welcome h1:** Amatic SC → Fraunces italic 900, lowercase `what's good here.` Same font/style as the splash wordmark — congruency across splash, post-onboarding, and pre-auth.
3. **Splash duration:** 1.6s → 1.8s. Wordmark animation timing unchanged (lands at 1.05s, 450ms before fade).

## Review trail

Codex flagged the original Seal-at-32 sizing as too small (cream plate rendering at 16px). Fixed via cropped viewBox + size 36 (plate now ~30px). Re-reviewed: no findings.

## Test plan

- [ ] Hard-refresh wghapp.com → splash shows for 1.8s
- [ ] Home/Browse/Restaurants pages → top bar shows the small seal centered (no Amatic SC wordmark)
- [ ] Login `/login` welcome view → italic Fraunces wordmark (lowercase, period in coral) + Seal above
- [ ] Sign up new user → celebration screen shows italic Fraunces wordmark + Seal
- [ ] Regression: Privacy/Terms/Support still show the full Seal at top (size 96, with ring)

## Out of scope (still in flight)

OAuth API refactor preserved unstaged on this branch — needs its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)