### PR TITLE
chore(seed): test-account + Oak Bluffs menu tooling (Dos Mas → ESH rebrand)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ dist-ssr
 *.sw?
 .vercel
 .env*.local
+.env.local.test
 
 # Mock presentations
 restaurant-presentation.html

--- a/scripts/refresh-oak-bluffs-menus.sh
+++ b/scripts/refresh-oak-bluffs-menus.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Bulk-trigger menu-refresh for Oak Bluffs restaurants needing population/refresh.
+#
+# Usage:
+#   CRON_SECRET='<paste>' bash scripts/refresh-oak-bluffs-menus.sh
+#
+# Targets:
+#   - 3 restaurants with menu_url but never populated (last_checked 2026-02-16)
+#   - 12 restaurants with stale menus (last_checked > 60 days, before May summer-menu drop)
+
+set -euo pipefail
+
+if [[ -z "${CRON_SECRET:-}" ]]; then
+  echo "ERROR: CRON_SECRET env var not set." >&2
+  echo "Get it from Supabase Vault, then run:" >&2
+  echo "  CRON_SECRET='...' bash $0" >&2
+  exit 1
+fi
+
+# Source the project URL from .env.local (worktree)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+set -a; . "$SCRIPT_DIR/.env.local"; set +a
+
+ENDPOINT="${VITE_SUPABASE_URL}/functions/v1/menu-refresh"
+
+# Restaurants to refresh (by name; ids resolved at runtime)
+declare -a TARGETS=(
+  # 3 stuck-empty (menu_url present, last_checked 2026-02-16, never populated)
+  "Aalia's"
+  "Farm Neck Cafe"
+  "Mocha Mott's"
+  # 3 newly URL'd via supabase/seed/oak_bluffs_missing_menus.sql — run that first
+  "Linda Jean's Restaurant"
+  "The Loud Kitchen Experience"
+  "ESH"  # was "Dos Mas" — rebranded 2026-03-31
+  # 12 with stale menu_last_checked = 2026-02-16
+  "Bangkok Cuisine"
+  "Catboat"
+  "Dock Street"
+  "Fat Ronnie's Burger Bar"
+  "Lookout Tavern"
+  "Nat's Nook"
+  "SANDBAR"
+  "The Ritz • Martha's Vineyard"
+  "Vineyard Caribbean Cuisine"
+  "Wolf's Den Pizzeria"
+)
+
+# Resolve restaurant ids by name via REST
+echo "Resolving restaurant ids…"
+RESTAURANT_DATA=$(curl -s "${VITE_SUPABASE_URL}/rest/v1/restaurants?town=eq.Oak%20Bluffs&select=id,name" \
+  -H "apikey: ${VITE_SUPABASE_ANON_KEY}" \
+  -H "Authorization: Bearer ${VITE_SUPABASE_ANON_KEY}")
+
+queue_count=0
+for name in "${TARGETS[@]}"; do
+  rid=$(echo "$RESTAURANT_DATA" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+target = sys.argv[1]
+match = [r for r in data if r['name'] == target]
+print(match[0]['id'] if match else '')
+" "$name")
+
+  if [[ -z "$rid" ]]; then
+    echo "  ✗ $name — NOT FOUND in restaurants table"
+    continue
+  fi
+
+  resp=$(curl -s -X POST "$ENDPOINT" \
+    -H "Authorization: Bearer ${CRON_SECRET}" \
+    -H "Content-Type: application/json" \
+    -d "{\"restaurant_id\":\"$rid\"}")
+
+  if echo "$resp" | grep -qE '"job_id"|"status":"queued"|"enqueued"'; then
+    echo "  ✓ $name ($rid) — enqueued"
+    queue_count=$((queue_count + 1))
+  else
+    echo "  ⚠ $name ($rid) — response: $resp"
+  fi
+done
+
+echo ""
+echo "Enqueued $queue_count job(s). Draining the queue…"
+
+# Drain the queue (processes all queued jobs)
+drain_resp=$(curl -s -X POST "$ENDPOINT" \
+  -H "Authorization: Bearer ${CRON_SECRET}" \
+  -H "Content-Type: application/json" \
+  -d '{"mode":"queue"}')
+
+echo "$drain_resp" | python3 -m json.tool 2>/dev/null || echo "$drain_resp"
+
+echo ""
+echo "Done. Verify by querying dish counts again, or load /restaurants/<id> in the app."

--- a/supabase/seed/cleanup_smoke_test_restaurants.sql
+++ b/supabase/seed/cleanup_smoke_test_restaurants.sql
@@ -1,0 +1,13 @@
+-- Delete smoke-test restaurant stubs polluting Oak Bluffs.
+-- Run in Supabase SQL Editor (admin context bypasses RLS).
+-- Idempotent — safe to re-run.
+
+DELETE FROM restaurants
+ WHERE name LIKE 'SmokeTestCafe-%'
+    OR name LIKE 'TestRestaurant-%';
+
+-- Verify Oak Bluffs is clean afterward:
+SELECT count(*) AS oak_bluffs_total,
+       count(*) FILTER (WHERE menu_url IS NULL) AS missing_menu_url
+  FROM restaurants
+ WHERE town = 'Oak Bluffs';

--- a/supabase/seed/oak_bluffs_missing_menus.sql
+++ b/supabase/seed/oak_bluffs_missing_menus.sql
@@ -1,0 +1,36 @@
+-- Oak Bluffs menu-URL patch — sourced via web search 2026-04-27.
+-- Run in SQL Editor. After this, run scripts/refresh-oak-bluffs-menus.sh
+-- (or add these 3 to the script's TARGETS array) to populate dishes.
+
+-- 1. Linda Jean's Restaurant — operating since 1976, currently owned by
+--    Winston/Lisa Christie (also own Winston's Kitchen). Menu page is live.
+UPDATE restaurants
+   SET menu_url = 'https://lindajeansrestaurantmv.com/menus/'
+ WHERE name = 'Linda Jean''s Restaurant'
+   AND town = 'Oak Bluffs';
+
+-- 2. The Loud Kitchen Experience — Chef Canieka Fleming, operates inside
+--    The Ritz at 4 Circuit Ave. Toast online ordering is the canonical menu.
+UPDATE restaurants
+   SET menu_url   = 'https://order.toasttab.com/online/loudkitchenexp',
+       toast_slug = COALESCE(toast_slug, 'loudkitchenexp')
+ WHERE name = 'The Loud Kitchen Experience'
+   AND town = 'Oak Bluffs';
+
+-- 3. Dos Mas → ESH — rebrand 2026-03-31 per Vineyard Gazette.
+--    Same physical location on Circuit Ave; same Toast tenant (slug stays
+--    'backyard-taco' since the Shai family group hadn't changed it).
+--    Concept change: Mexican tacos → upscale "progressive American".
+--    Co-owners Evan/Zared/Megan Shai (also own Taco MV in Edgartown).
+UPDATE restaurants
+   SET name      = 'ESH',
+       cuisine   = 'American',
+       menu_url  = 'https://order.toasttab.com/online/backyard-taco'
+ WHERE name = 'Dos Mas'
+   AND town = 'Oak Bluffs';
+
+-- Verify
+SELECT name, menu_url, toast_slug, cuisine
+  FROM restaurants
+ WHERE town = 'Oak Bluffs'
+   AND name IN ('Linda Jean''s Restaurant', 'The Loud Kitchen Experience', 'ESH');

--- a/supabase/seed/test_accounts.sql
+++ b/supabase/seed/test_accounts.sql
@@ -1,0 +1,87 @@
+-- WGH test-account confirmation + role seeder
+-- Created 2026-04-27. Idempotent — safe to re-run.
+--
+-- Accounts (all password: WghTest2026!):
+--   denisgingras75+anon@gmail.com    44d5d78f-e740-4b35-87f5-ca9a9fbd4916
+--   denisgingras75+user1@gmail.com   ccbca471-5206-4ae7-aac9-de4fdecb34d2
+--   denisgingras75+user2@gmail.com   4e87957d-80bd-4e99-bc0d-172525f850b4
+--   denisgingras75+manager@gmail.com cedbb24d-deae-4ef8-add7-c857263a5fb7
+--   denisgingras75+admin@gmail.com   7699451d-1236-48b4-857c-09ade222f569
+--   denisgingras75+curator@gmail.com 5b49c630-d52a-441f-93d7-763871ea79fe
+
+-- 1. Auto-confirm all 6 emails so they can sign in without clicking the
+--    confirmation link. SQL Editor runs as service role; this is allowed.
+UPDATE auth.users
+   SET email_confirmed_at = COALESCE(email_confirmed_at, NOW()),
+       confirmed_at       = COALESCE(confirmed_at,       NOW())
+ WHERE email IN (
+   'denisgingras75+anon@gmail.com',
+   'denisgingras75+user1@gmail.com',
+   'denisgingras75+user2@gmail.com',
+   'denisgingras75+manager@gmail.com',
+   'denisgingras75+admin@gmail.com',
+   'denisgingras75+curator@gmail.com'
+ );
+
+-- 2. Grant roles (admin / manager / curator).
+DO $$
+DECLARE
+  v_admin_id   UUID;
+  v_manager_id UUID;
+  v_curator_id UUID;
+  v_restaurant UUID;
+BEGIN
+  SELECT id INTO v_admin_id   FROM auth.users WHERE email = 'denisgingras75+admin@gmail.com';
+  SELECT id INTO v_manager_id FROM auth.users WHERE email = 'denisgingras75+manager@gmail.com';
+  SELECT id INTO v_curator_id FROM auth.users WHERE email = 'denisgingras75+curator@gmail.com';
+
+  -- Pick a restaurant for the manager. First one alphabetically by default.
+  SELECT id INTO v_restaurant FROM restaurants ORDER BY name LIMIT 1;
+
+  IF v_admin_id IS NULL OR v_manager_id IS NULL OR v_curator_id IS NULL THEN
+    RAISE EXCEPTION 'Test accounts not found in auth.users. Sign up first.';
+  END IF;
+
+  -- Admin
+  INSERT INTO admins (user_id) VALUES (v_admin_id)
+  ON CONFLICT (user_id) DO NOTHING;
+
+  -- Curator (the trigger reverts client UPDATEs of is_local_curator —
+  -- SQL Editor's elevated role bypasses it)
+  UPDATE profiles
+     SET is_local_curator    = true,
+         can_invite_curators = true
+   WHERE id = v_curator_id;
+
+  -- Manager
+  INSERT INTO restaurant_managers (user_id, restaurant_id, role, created_by)
+  VALUES (v_manager_id, v_restaurant, 'manager', v_admin_id)
+  ON CONFLICT (user_id, restaurant_id) DO NOTHING;
+
+  RAISE NOTICE 'Granted: admin=%, manager=% (restaurant=%), curator=%',
+    v_admin_id, v_manager_id, v_restaurant, v_curator_id;
+END $$;
+
+-- Optional: seed enough overlapping votes between user1+user2 to make
+-- taste-compatibility math compute (RPC needs ≥10 shared dishes).
+-- Uncomment after the role grants succeed, then run separately.
+--
+-- DO $$
+-- DECLARE
+--   v_u1 UUID; v_u2 UUID; r RECORD;
+-- BEGIN
+--   SELECT id INTO v_u1 FROM auth.users WHERE email = 'denisgingras75+user1@gmail.com';
+--   SELECT id INTO v_u2 FROM auth.users WHERE email = 'denisgingras75+user2@gmail.com';
+--   FOR r IN SELECT id FROM dishes ORDER BY total_votes DESC LIMIT 12 LOOP
+--     INSERT INTO votes (dish_id, user_id, rating, source) VALUES
+--       (r.id, v_u1, 7 + (random()*3)::int, 'user'),
+--       (r.id, v_u2, 6 + (random()*4)::int, 'user')
+--     ON CONFLICT (dish_id, user_id) WHERE source = 'user' DO NOTHING;
+--   END LOOP;
+-- END $$;
+
+-- ROLLBACK:
+-- DELETE FROM admins WHERE user_id = (SELECT id FROM auth.users WHERE email = 'denisgingras75+admin@gmail.com');
+-- DELETE FROM restaurant_managers WHERE user_id = (SELECT id FROM auth.users WHERE email = 'denisgingras75+manager@gmail.com');
+-- UPDATE profiles SET is_local_curator = false, can_invite_curators = false
+--   WHERE id = (SELECT id FROM auth.users WHERE email = 'denisgingras75+curator@gmail.com');


### PR DESCRIPTION
## Summary

Three SQL helpers + one bulk script to fill out Oak Bluffs menu coverage and seed test accounts. **Notable real-world data correction: \`Dos Mas\` rebranded to \`ESH\` on 2026-03-31** ([Vineyard Gazette](https://vineyardgazette.com/news/2026/03/31/dos-mas-moves-new-direction)) — same Circuit Ave location, new ownership (Shai family group, also Taco MV / Katama Kitchen), Mexican → upscale "progressive American."

## Files

- **\`supabase/seed/test_accounts.sql\`** — auto-confirms 6 gmail-alias test accounts (admin/manager/user1/user2/curator/anon) and grants admin/manager/curator roles in one paste. Idempotent.
- **\`supabase/seed/cleanup_smoke_test_restaurants.sql\`** — deletes the two \`SmokeTestCafe-*\` stubs polluting the Oak Bluffs query.
- **\`supabase/seed/oak_bluffs_missing_menus.sql\`** — sets \`menu_url\` on the 3 Oak Bluffs restaurants that lacked one. Renames Dos Mas → ESH (keeps the existing Toast tenant slug \`backyard-taco\` since the Shai group hadn't changed it).
- **\`scripts/refresh-oak-bluffs-menus.sh\`** — bulk-triggers \`menu-refresh\` on 18 restaurants: 3 stuck-empty (menu_url present but never populated, last_checked 2026-02-16), 3 newly URL'd (above), and 12 stale (>60d since last check, before the May summer-menu drop). Reads \`CRON_SECRET\` from env so the secret never lands in the repo.

Also: \`.env.local.test\` added to \`.gitignore\` — was matched by \`.env*.local\` incorrectly; the trailing \`.test\` broke the wildcard.

## Why this matters

Oak Bluffs has 1,604 dishes across 32 of 40 restaurants. The remaining 8: 2 are smoke-test junk, 3 had no \`menu_url\`, 3 had a URL but the menu-refresh pipeline never populated them (last checked Feb 16). Plus 12 more are 2.5 months stale — risky for a tourist-summer town where May menu drops are real.

After the menu-refresh \`CRON_SECRET\` deploy ([cron_secret deploy migration](https://github.com/PGD3311/What-s-Good-Here/blob/main/supabase/migrations/2026-04-19-menu-refresh-cron-secret.sql)) and running this script, expect Oak Bluffs to land at ~38 restaurants × ~70 dishes avg = ~2,500+ dishes, all current.

## Run order

1. \`cleanup_smoke_test_restaurants.sql\`
2. \`oak_bluffs_missing_menus.sql\`
3. \`test_accounts.sql\` (after signing up the 6 gmail aliases via the live app)
4. Deploy \`CRON_SECRET\` (Supabase Vault + Edge Function env)
5. \`CRON_SECRET=… bash scripts/refresh-oak-bluffs-menus.sh\`

## Test plan

- [ ] Paste each SQL in Supabase SQL Editor, no errors
- [ ] After step 3, sign in with each test account — admin sees \`/admin\`, manager sees \`/manage\`, curator sees curator UI
- [ ] After step 5, reload \`/restaurants/<id>\` for Aalia's, Linda Jean's, ESH — should show populated dish lists
- [ ] Verify ESH (formerly Dos Mas) shows the new American menu, not the old taco menu