### PR TITLE
feat(brand): coral TopBar + corner-positioned splash layout

### DIFF
--- a/src/components/NotificationBell.jsx
+++ b/src/components/NotificationBell.jsx
@@ -123,7 +123,7 @@ export function NotificationBell() {
       <button
         onClick={handleBellClick}
         className="relative p-2 rounded-full transition-all duration-150 active:scale-95 active:opacity-80"
-        style={{ color: 'var(--color-text-secondary)' }}
+        style={{ color: 'var(--color-surface)' }}
         aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ''}`}
         aria-expanded={showDropdown}
         aria-haspopup="true"

--- a/src/components/SettingsDropdown.jsx
+++ b/src/components/SettingsDropdown.jsx
@@ -73,7 +73,7 @@ export function SettingsDropdown() {
         ref={gearButtonRef}
         onClick={() => setShowDropdown(!showDropdown)}
         className="relative p-2 rounded-full transition-all duration-150 active:scale-95 active:opacity-80"
-        style={{ color: 'var(--color-text-secondary)' }}
+        style={{ color: 'var(--color-surface)' }}
         aria-label="Settings"
         aria-expanded={showDropdown}
         aria-haspopup="true"

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -12,7 +12,13 @@ export function TopBar() {
         {/* Spacer for symmetry — keeps Seal optically centered */}
         <div style={{ width: '60px' }} />
 
-        <Seal size={36} showRing={false} ariaLabel="What's Good Here" />
+        <Seal
+          size={36}
+          showRing={false}
+          plateColor="var(--color-surface)"
+          monoColor="var(--color-primary)"
+          ariaLabel="What's Good Here"
+        />
 
         {/* Settings + Notifications grouped right */}
         <div className="flex items-center">

--- a/src/index.css
+++ b/src/index.css
@@ -195,13 +195,13 @@
     transform: scale(1.05);
   }
 
-  /* TopBar - Subtle brand anchor in safe-area region */
+  /* TopBar - Coral brand band — inverted Seal sits on coral, controls in cream */
   .top-bar {
     position: relative;
     width: 100%;
-    background: #FFFFFF;
+    background: var(--color-primary);
     padding-top: env(safe-area-inset-top, 0px);
-    border-bottom: 1px solid var(--color-divider);
+    border-bottom: none;
     box-shadow: none;
   }
 
@@ -235,7 +235,7 @@
     z-index: 99999;
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: stretch;
     justify-content: space-between;
     padding: max(env(safe-area-inset-top, 0px), 20px) 28px max(env(safe-area-inset-bottom, 0px), 36px);
     box-sizing: border-box;
@@ -245,14 +245,14 @@
   }
 
   .wgh-splash__seal {
-    margin-top: 18vh;
+    margin-top: 8vh;
+    align-self: flex-end;
     animation: sealStampIn 0.9s cubic-bezier(.2, .7, .3, 1.2) both;
   }
 
   .wgh-splash__wordmark {
-    margin-bottom: 10vh;
-    width: 100%;
-    text-align: center;
+    margin-bottom: 6vh;
+    text-align: left;
     font-family: 'Fraunces', serif;
     font-style: italic;
     font-weight: 900;


### PR DESCRIPTION
## Summary

Two related brand moves:

**1. TopBar now coral.** Background `--color-primary` (was white), border-bottom removed for a seamless brand band. The Seal flips to its inverted variant (cream plate, coral `wgh` monogram) so it reads on coral. Settings gear + Notification bell trigger buttons go cream so they stay visible.

**2. Splash corner layout.** Seal anchored top-right (`align-self: flex-end`, `margin-top: 8vh`). Wordmark anchored bottom-left (`text-align: left`, `margin-bottom: 6vh`). Replaces the previously-centered stack with the asymmetric magazine-cover layout from Dan's reference screenshot.

## Review trail

Codex confirmed:
- Cream-on-coral contrast (#F7F4F1 on #E4440A ≈ 3.74:1) clears WCAG AA for 24px UI icons.
- SettingsDropdown / NotificationBell are TopBar-only — cream button color doesn't leak elsewhere.
- Splash wordmark on 375px iPhone resolves clamp() to ~67px, fits comfortably.
- Seal stamp animation unaffected by `align-self`.

## Test plan

- [ ] Hard-refresh wghapp.com → top bar is now coral with cream Seal mark + cream gear + cream bell
- [ ] Open settings dropdown → gear contrast clear, dropdown items still readable
- [ ] Open notifications dropdown → bell contrast clear
- [ ] Splash on next session-start → seal pops in top-right, wordmark fades up bottom-left
- [ ] Regression: bottom nav, page content, modals all unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)