### PR TITLE
fix(brand): home wordmark to Fraunces italic for full congruency

### DIFF
--- a/src/components/home/HomeListMode.jsx
+++ b/src/components/home/HomeListMode.jsx
@@ -56,18 +56,19 @@ export const HomeListMode = memo(function HomeListMode({
     >
       {/* Fixed header: brand + search + chips */}
       <div style={{ flexShrink: 0, background: 'var(--color-bg)', zIndex: 10, paddingTop: 'env(safe-area-inset-top, 0px)' }}>
-        {/* Brand header */}
+        {/* Brand header — Fraunces italic, matches splash + login + welcome modal */}
         <div className="text-center pt-4 pb-1">
           <h2 style={{
-            fontFamily: "'Amatic SC', cursive",
-            fontSize: '42px',
-            fontWeight: 700,
+            fontFamily: "'Fraunces', serif",
+            fontStyle: 'italic',
+            fontWeight: 900,
+            fontSize: '44px',
             color: 'var(--color-text-primary)',
-            letterSpacing: '0.04em',
-            lineHeight: 1,
+            letterSpacing: '-0.02em',
+            lineHeight: 0.95,
             margin: 0,
           }}>
-            What's <span style={{ color: 'var(--color-primary)' }}>Good</span> Here
+            what&rsquo;s <span style={{ color: 'var(--color-primary)' }}>good</span> here<span style={{ color: 'var(--color-primary)' }}>.</span>
           </h2>
           <p style={{
             fontSize: '10px',


### PR DESCRIPTION
## Summary

Closes the last gap in the brand-rebrand thread: the homepage list-mode \`What's Good Here\` brand header was still on Amatic SC. Now Fraunces italic 900 — matching splash, login welcome, and WelcomeModal celebration. All visible \`what's good here.\` wordmarks use the same font.

## Review trail

Codex confirmed: no other hero-style wordmark still on Amatic SC; remaining \`What's Good Here\` strings are seal aria-labels, legal copy, or UI labels — not wordmark rendering.

## Test plan

- [ ] Hard-refresh wghapp.com → home list mode header reads \`what's good here.\` in Fraunces italic, same look as splash
- [ ] Cross-check splash + login + WelcomeModal — all use same italic Fraunces

🤖 Generated with [Claude Code](https://claude.com/claude-code)