### PR TITLE
fix(brand): all wordmarks to Amatic SC (home is canonical)

### DIFF
--- a/src/components/Auth/WelcomeModal.jsx
+++ b/src/components/Auth/WelcomeModal.jsx
@@ -141,21 +141,20 @@ export function WelcomeModal() {
             <Seal size={88} />
           </div>
 
-          {/* Brand name — Fraunces italic, matches splash for congruency */}
+          {/* Brand name — Amatic SC, matches home + login + splash */}
           <h1
             style={{
-              fontFamily: "'Fraunces', serif",
-              fontStyle: 'italic',
-              fontWeight: 900,
-              fontSize: '44px',
+              fontFamily: "'Amatic SC', cursive",
+              fontSize: '42px',
+              fontWeight: 700,
               color: 'var(--color-text-primary)',
-              lineHeight: 0.95,
-              letterSpacing: '-0.02em',
+              lineHeight: 1,
+              letterSpacing: '0.04em',
               position: 'relative',
               zIndex: 1,
             }}
           >
-            what&rsquo;s <span style={{ color: 'var(--color-primary)' }}>good</span> here<span style={{ color: 'var(--color-primary)' }}>.</span>
+            What&rsquo;s <span style={{ color: 'var(--color-primary)' }}>Good</span> Here
           </h1>
 
           {/* Welcome line */}

--- a/src/components/WelcomeSplash.jsx
+++ b/src/components/WelcomeSplash.jsx
@@ -59,11 +59,9 @@ export function WelcomeSplash() {
         borderColor="var(--color-surface)"
       />
       <div className="wgh-splash__wordmark">
-        <span className="wgh-splash__line">what&rsquo;s</span>
-        <span className="wgh-splash__line">good</span>
-        <span className="wgh-splash__line">
-          here<span className="wgh-splash__period">.</span>
-        </span>
+        <span className="wgh-splash__line">What&rsquo;s</span>
+        <span className="wgh-splash__line wgh-splash__line--accent">Good</span>
+        <span className="wgh-splash__line">Here</span>
       </div>
     </div>
   )

--- a/src/components/home/HomeListMode.jsx
+++ b/src/components/home/HomeListMode.jsx
@@ -56,19 +56,18 @@ export const HomeListMode = memo(function HomeListMode({
     >
       {/* Fixed header: brand + search + chips */}
       <div style={{ flexShrink: 0, background: 'var(--color-bg)', zIndex: 10, paddingTop: 'env(safe-area-inset-top, 0px)' }}>
-        {/* Brand header — Fraunces italic, matches splash + login + welcome modal */}
+        {/* Brand header */}
         <div className="text-center pt-4 pb-1">
           <h2 style={{
-            fontFamily: "'Fraunces', serif",
-            fontStyle: 'italic',
-            fontWeight: 900,
-            fontSize: '44px',
+            fontFamily: "'Amatic SC', cursive",
+            fontSize: '42px',
+            fontWeight: 700,
             color: 'var(--color-text-primary)',
-            letterSpacing: '-0.02em',
-            lineHeight: 0.95,
+            letterSpacing: '0.04em',
+            lineHeight: 1,
             margin: 0,
           }}>
-            what&rsquo;s <span style={{ color: 'var(--color-primary)' }}>good</span> here<span style={{ color: 'var(--color-primary)' }}>.</span>
+            What's <span style={{ color: 'var(--color-primary)' }}>Good</span> Here
           </h2>
           <p style={{
             fontSize: '10px',

--- a/src/index.css
+++ b/src/index.css
@@ -253,12 +253,11 @@
   .wgh-splash__wordmark {
     margin-bottom: 6vh;
     text-align: left;
-    font-family: 'Fraunces', serif;
-    font-style: italic;
-    font-weight: 900;
-    font-size: clamp(56px, 18vw, 88px);
-    line-height: 0.82;
-    letter-spacing: -0.04em;
+    font-family: 'Amatic SC', cursive;
+    font-weight: 700;
+    font-size: clamp(80px, 24vw, 132px);
+    line-height: 0.92;
+    letter-spacing: 0.04em;
     color: var(--color-surface);
     animation: sealFadeUp 0.5s 0.55s both;
   }
@@ -267,7 +266,7 @@
     display: block;
   }
 
-  .wgh-splash__period {
+  .wgh-splash__line--accent {
     color: var(--color-text-primary);
   }
 

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -229,18 +229,17 @@ export function Login() {
               </div>
               <h1
                 style={{
-                  fontFamily: "'Fraunces', serif",
-                  fontStyle: 'italic',
-                  fontWeight: 900,
-                  fontSize: '44px',
+                  fontFamily: "'Amatic SC', cursive",
+                  fontSize: '42px',
+                  fontWeight: 700,
                   color: 'var(--color-text-primary)',
-                  lineHeight: 0.95,
-                  letterSpacing: '-0.02em',
+                  lineHeight: 1,
+                  letterSpacing: '0.04em',
                   position: 'relative',
                   zIndex: 1,
                 }}
               >
-                what&rsquo;s <span style={{ color: 'var(--color-primary)' }}>good</span> here<span style={{ color: 'var(--color-primary)' }}>.</span>
+                What&rsquo;s <span style={{ color: 'var(--color-primary)' }}>Good</span> Here
               </h1>
               <p
                 style={{


### PR DESCRIPTION
## Summary

Tonight's font direction was wrong — **home wordmark Amatic SC is canonical**, everywhere else should match it (not the other way around). Reverses #123 + flips the in-app wordmarks Fraunces → Amatic SC.

- **Home list-mode header** — restored to Amatic SC (revert of #123)
- **Splash wordmark** — Fraunces italic → Amatic SC 700. "What's Good Here" stacked, capitalized, with "Good" in INK (instead of coral; coral-on-coral wouldn't read on the splash bg)
- **Login welcome h1** — matches home exactly (Amatic SC 42px, "Good" in coral on cream bg)
- **WelcomeModal celebration h1** — same as Login

Seal monogram stays Fraunces italic 900 — that's the brand mark, separate from wordmark text.

## Test plan

- [ ] Hard-refresh wghapp.com → home, splash, login welcome all use Amatic SC for "What's Good Here"
- [ ] Splash: "Good" reads as ink on the coral bg
- [ ] Home + Login welcome: "Good" reads as coral on the cream bg
- [ ] Seal mark on TopBar / Privacy / Terms / Support unchanged (still Fraunces italic monogram)

🤖 Generated with [Claude Code](https://claude.com/claude-code)