### PR TITLE
feat(brand): splash wordmark to Fraunces 900 Roman, no period

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
     <link rel="preconnect" href="https://images.unsplash.com" crossorigin />
     <link rel="dns-prefetch" href="https://us.posthog.com" />
 
-    <!-- Fonts: Amatic SC (display/headers), Outfit (body), Fraunces italic 900 (splash wordmark + Seal monogram), JetBrains Mono 600 (Seal ring text) -->
-    <link href="https://fonts.googleapis.com/css2?family=Amatic+SC:wght@400;700&family=Outfit:wght@300;400;500;600;700;800&family=Fraunces:ital,wght@1,900&family=JetBrains+Mono:wght@600&display=swap" rel="stylesheet" />
+    <!-- Fonts: Amatic SC (display/headers), Outfit (body), Fraunces 900 (splash wordmark roman + Seal monogram italic), JetBrains Mono 600 (Seal ring text) -->
+    <link href="https://fonts.googleapis.com/css2?family=Amatic+SC:wght@400;700&family=Outfit:wght@300;400;500;600;700;800&family=Fraunces:ital,wght@0,900;1,900&family=JetBrains+Mono:wght@600&display=swap" rel="stylesheet" />
 
     <!-- Mobile-first viewport with safe area support -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />

--- a/src/components/WelcomeSplash.jsx
+++ b/src/components/WelcomeSplash.jsx
@@ -60,7 +60,7 @@ export function WelcomeSplash() {
       />
       <div className="wgh-splash__wordmark">
         <span className="wgh-splash__line">What&rsquo;s</span>
-        <span className="wgh-splash__line wgh-splash__line--accent">Good</span>
+        <span className="wgh-splash__line">Good</span>
         <span className="wgh-splash__line">Here</span>
       </div>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -253,21 +253,17 @@
   .wgh-splash__wordmark {
     margin-bottom: 6vh;
     text-align: left;
-    font-family: 'Amatic SC', cursive;
-    font-weight: 700;
-    font-size: clamp(80px, 24vw, 132px);
-    line-height: 0.92;
-    letter-spacing: 0.04em;
+    font-family: 'Fraunces', serif;
+    font-weight: 900;
+    font-size: clamp(64px, 20vw, 100px);
+    line-height: 0.88;
+    letter-spacing: -0.04em;
     color: var(--color-surface);
     animation: sealFadeUp 0.5s 0.55s both;
   }
 
   .wgh-splash__line {
     display: block;
-  }
-
-  .wgh-splash__line--accent {
-    color: var(--color-text-primary);
   }
 
   @keyframes sealStampIn {


### PR DESCRIPTION
## Summary

Per Dan's mockup pick — Option 1 (Fraunces 900 Roman). Splash wordmark goes from Amatic SC to Fraunces 900 Roman:
- Pairs with Amatic SC on home as a classic display-serif + handdrawn combo
- Shares a font family with the Seal monogram (italic 900) so the brand has type-system coherence
- All three lines render in cream (no ink "Good" accent, no trailing period)
- Sizing dropped to clamp(64,20vw,100)px since Fraunces is heavier per character

Home wordmark + Login welcome + WelcomeModal celebration h1 stay Amatic SC (canonical).

## Review trail

Codex confirmed: clamp(64-100)px fits 375px iPhone, no orphan accent-class references remain, cream-on-coral passes WCAG AA at large size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)