### PR TITLE
fix: Codex hardening pass — Wave 1 (8 surgical fixes)

### DIFF
--- a/src/context/LocationContext.jsx
+++ b/src/context/LocationContext.jsx
@@ -90,8 +90,21 @@ export function LocationProvider({ children }) {
       },
       (err) => {
         logger.warn('Geolocation error:', err.message)
-        setPermissionState('denied')
-        setError('denied')
+        // GeolocationPositionError codes:
+        //   1 PERMISSION_DENIED — real denial, don't auto-reprompt.
+        //   2 POSITION_UNAVAILABLE — GPS/network failed, retryable.
+        //   3 TIMEOUT — too slow, retryable.
+        // Previously every code collapsed to permissionState='denied',
+        // which caused promptForLocation() to refuse to retry on the next
+        // call. Branch the codes so transient failures stay retryable.
+        if (err.code === 1) {
+          setPermissionState('denied')
+          setError('denied')
+        } else {
+          setError(err.code === 3 ? 'timeout' : 'unavailable')
+          // Leave permissionState as-is so a later promptForLocation()
+          // can issue a fresh request.
+        }
         setLocation(DEFAULT_LOCATION)
         setLoading(false)
       },

--- a/src/hooks/useDishDetail.js
+++ b/src/hooks/useDishDetail.js
@@ -5,6 +5,7 @@ import { dishesApi } from '../api/dishesApi'
 import { followsApi } from '../api/followsApi'
 import { dishPhotosApi } from '../api/dishPhotosApi'
 import { votesApi } from '../api/votesApi'
+import { ErrorTypes, createClassifiedError } from '../utils/errorHandler'
 
 /**
  * Transform raw dish data from API to component format
@@ -41,7 +42,12 @@ function transformDish(data) {
 export function useDishDetail(dishId, user) {
   const [dish, setDish] = useState(null)
   const [loading, setLoading] = useState(true)
+  // error is null | classified Error (with .type from ErrorTypes). The page
+  // distinguishes NOT_FOUND from transient failures so users see "Try again"
+  // instead of a fake "Dish not found" when Supabase is just slow or down.
   const [error, setError] = useState(null)
+  const [refetchKey, setRefetchKey] = useState(0)
+  const refetchDish = useCallback(() => setRefetchKey(k => k + 1), [])
 
   // Variant state
   const [variants, setVariants] = useState([])
@@ -125,7 +131,15 @@ export function useDishDetail(dishId, user) {
       } catch (err) {
         if (cancelled) return
         logger.error('Error fetching dish:', err)
-        setError('Dish not found')
+        // dishesApi.getDishById throws `new Error('Dish not found')` only
+        // when the row genuinely doesn't exist. Everything else (network,
+        // RLS, server) goes through createClassifiedError. Preserve that
+        // distinction so the page can offer retry vs hard 404.
+        const classified = err.type ? err : createClassifiedError(err)
+        if (err.message === 'Dish not found') {
+          classified.type = ErrorTypes.NOT_FOUND
+        }
+        setError(classified)
       } finally {
         if (!cancelled) setLoading(false)
       }
@@ -133,7 +147,7 @@ export function useDishDetail(dishId, user) {
 
     fetchDish()
     return () => { cancelled = true }
-  }, [dishId])
+  }, [dishId, refetchKey])
 
   // Fetch variant data
   useEffect(() => {
@@ -344,5 +358,6 @@ export function useDishDetail(dishId, user) {
     handlePhotoUploaded,
     handleVote,
     clearPhotoUploaded,
+    refetchDish,
   }
 }

--- a/src/hooks/useRestaurantSearch.js
+++ b/src/hooks/useRestaurantSearch.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { restaurantsApi } from '../api/restaurantsApi'
 import { placesApi } from '../api/placesApi'
 import { logger } from '../utils/logger'
@@ -18,21 +18,23 @@ export function useRestaurantSearch(query, lat, lng, enabled = true, radiusMiles
   const [localResults, setLocalResults] = useState([])
   const [externalResults, setExternalResults] = useState([])
   const [loading, setLoading] = useState(false)
-  const mountedRef = useRef(true)
-
-  useEffect(() => {
-    mountedRef.current = true
-    return () => { mountedRef.current = false }
-  }, [])
 
   useEffect(() => {
     if (!enabled || !query || query.trim().length < 2) {
       setLocalResults([])
       setExternalResults([])
+      // Clear loading: prevents stuck spinner if user clears the query while
+      // a previous fetch is still in flight (the in-flight fetch is cancelled
+      // below, so its `finally` won't run).
+      setLoading(false)
       return
     }
 
     const trimmed = query.trim()
+    // Effect-scoped cancellation flag. Each effect run owns its own flag, so
+    // a slow response from a previous query can't clobber state for a newer
+    // query even though both `fetchResults` closures are alive briefly.
+    let cancelled = false
     setLoading(true)
 
     // Only bias toward user location if we actually have one
@@ -56,7 +58,7 @@ export function useRestaurantSearch(query, lat, lng, enabled = true, radiusMiles
           }),
         ])
 
-        if (!mountedRef.current) return
+        if (cancelled) return
 
         // Collect google_place_ids from local results for dedup
         const localPlaceIds = new Set()
@@ -71,12 +73,12 @@ export function useRestaurantSearch(query, lat, lng, enabled = true, radiusMiles
         setExternalResults(dedupedExternal)
       } catch (err) {
         logger.error('Restaurant search error:', err)
-        if (mountedRef.current) {
+        if (!cancelled) {
           setLocalResults([])
           setExternalResults([])
         }
       } finally {
-        if (mountedRef.current) {
+        if (!cancelled) {
           setLoading(false)
         }
       }
@@ -84,7 +86,10 @@ export function useRestaurantSearch(query, lat, lng, enabled = true, radiusMiles
 
     // Debounce
     const timer = setTimeout(fetchResults, 400)
-    return () => clearTimeout(timer)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
   }, [query, lat, lng, enabled, radiusMiles])
 
   return { localResults, externalResults, loading }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { initBackButtonInterceptor } from './utils/backButtonInterceptor'
+import { isRetryable } from './utils/errorHandler'
 import './index.css'
 import App from './App.jsx'
 
@@ -15,7 +16,10 @@ const queryClient = new QueryClient({
     queries: {
       staleTime: 1000 * 60 * 2, // Data stays fresh for 2 minutes
       gcTime: 1000 * 60 * 10, // Cache garbage collected after 10 minutes
-      retry: 2, // Retry failed requests twice
+      // Only retry transient failures (network/timeout/5xx/rate-limit). 401,
+      // 403, 404, and validation errors fail fast so the user sees the error
+      // UI immediately instead of waiting through two pointless retries.
+      retry: (failureCount, error) => isRetryable(error) && failureCount < 2,
       refetchOnWindowFocus: false, // Don't refetch on tab focus
     },
   },

--- a/src/pages/Dish.jsx
+++ b/src/pages/Dish.jsx
@@ -21,6 +21,7 @@ import { sanitizeUrl } from '../utils/sanitize'
 import { openExternalLink } from '../utils/openExternalLink'
 import { authApi } from '../api/authApi'
 import { dishPhotosApi } from '../api/dishPhotosApi'
+import { ErrorTypes, getUserMessage } from '../utils/errorHandler'
 
 export function Dish() {
   const { dishId } = useParams()
@@ -35,6 +36,7 @@ export function Dish() {
     reviews, reviewsLoading,
     shouldLoadEvidence, evidenceSentinelRef,
     handlePhotoUploaded, handleVote, clearPhotoUploaded,
+    refetchDish,
   } = useDishDetail(dishId, user)
 
   const [loginModalOpen, setLoginModalOpen] = useState(false)
@@ -216,6 +218,9 @@ export function Dish() {
   }
 
   if (error || !dish) {
+    // Treat null-error-null-dish defensively as not-found; only render a
+    // retryable failure when we have a non-NOT_FOUND classified error.
+    const isLoadFailure = error && error.type && error.type !== ErrorTypes.NOT_FOUND
     return (
       <div className="min-h-screen flex items-center justify-center" style={{ background: 'var(--color-surface-elevated)' }}>
         <div className="text-center p-4">
@@ -225,17 +230,22 @@ export function Dish() {
             className="w-16 h-16 mx-auto mb-4 rounded-full object-cover"
           />
           <p className="font-bold mb-2" style={{ color: 'var(--color-text-primary)' }}>
-            Dish not found
+            {isLoadFailure ? 'Couldn’t load this dish' : 'Dish not found'}
           </p>
+          {isLoadFailure && (
+            <p className="text-sm" style={{ color: 'var(--color-text-secondary)' }}>
+              {getUserMessage(error, 'loading dish')}
+            </p>
+          )}
           <button
-            onClick={handleBack}
+            onClick={isLoadFailure ? refetchDish : handleBack}
             className="mt-4 px-5 py-2.5 text-sm font-bold rounded-lg card-press"
             style={{
               background: 'var(--color-primary)',
               color: '#FFFFFF',
             }}
           >
-            Go Back
+            {isLoadFailure ? 'Try Again' : 'Go Back'}
           </button>
         </div>
       </div>

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -71,7 +71,7 @@ serve(async (req) => {
     }
 
     const userId = user.id
-    console.log(`delete-account: starting deletion for user ${userId}`)
+    console.log(`delete-account: starting deletion for user ${await hashUserId(userId)}`)
 
     // Service-role client bypasses RLS for destructive operations
     const admin = createClient(supabaseUrl, supabaseServiceKey)
@@ -369,7 +369,7 @@ serve(async (req) => {
     // If pendingRowId === null: non-Apple user or unrevokable sentinel (Case B).
     // Case B sentinel is intentionally left in place for audit.
 
-    console.log(`delete-account: user ${userId} successfully deleted`)
+    console.log(`delete-account: user ${await hashUserId(userId)} successfully deleted`)
     return json({ success: true })
   } catch (error) {
     console.error('delete-account: unexpected error:', error)

--- a/supabase/functions/discover-restaurants/index.ts
+++ b/supabase/functions/discover-restaurants/index.ts
@@ -247,6 +247,35 @@ serve(async (req) => {
   }
 
   try {
+    // Auth gate: require admin user. Mirrors restaurant-scraper.
+    const authHeader = req.headers.get('Authorization')
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      })
+    }
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!
+    const authClient = createClient(supabaseUrl, supabaseAnonKey, {
+      global: { headers: { Authorization: authHeader } },
+    })
+    const { data: { user: authUser } } = await authClient.auth.getUser()
+    if (!authUser) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      })
+    }
+    const { data: adminRow } = await authClient
+      .from('admins')
+      .select('user_id')
+      .eq('user_id', authUser.id)
+      .maybeSingle()
+    if (!adminRow) {
+      return new Response(JSON.stringify({ error: 'Admin access required' }), {
+        status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      })
+    }
+
     if (!GOOGLE_API_KEY) {
       return new Response(JSON.stringify({ error: 'GOOGLE_PLACES_API_KEY not configured' }), {
         status: 500,
@@ -254,7 +283,6 @@ serve(async (req) => {
       })
     }
 
-    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
     const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
     const supabase = createClient(supabaseUrl, supabaseServiceKey)
 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1533,7 +1533,7 @@ DECLARE
   calculated_category_biases JSONB;
 BEGIN
   -- Calculate MAD (mean absolute deviation) dynamically
-  SELECT ROUND(AVG(ABS(v.rating_10 - d.avg_rating)), 1), COUNT(*)::INT
+  SELECT ROUND(AVG(ABS(v.rating_10 - d.avg_rating))::NUMERIC, 1), COUNT(*)::INT
   INTO calculated_bias, calculated_votes_with_consensus
   FROM votes v JOIN dishes d ON v.dish_id = d.id
   WHERE v.user_id = target_user_id AND v.rating_10 IS NOT NULL
@@ -1556,7 +1556,7 @@ BEGIN
   INTO calculated_category_biases
   FROM (
     SELECT COALESCE(v.category_snapshot, d.category) AS category,
-      ROUND(AVG(v.rating_10 - d.avg_rating), 1) AS bias
+      ROUND(AVG(v.rating_10 - d.avg_rating)::NUMERIC, 1) AS bias
     FROM votes v JOIN dishes d ON v.dish_id = d.id
     WHERE v.user_id = target_user_id AND v.rating_10 IS NOT NULL
       AND d.avg_rating IS NOT NULL AND d.total_votes >= 5
@@ -1648,7 +1648,7 @@ BEGIN
   FROM (
     SELECT v.category_snapshot AS category, COUNT(*) AS total_ratings,
       COUNT(*) FILTER (WHERE d.consensus_ready = TRUE) AS consensus_ratings,
-      ROUND(AVG(v.rating_10 - d.avg_rating) FILTER (WHERE d.consensus_ready = TRUE AND v.rating_10 IS NOT NULL), 1) AS bias
+      ROUND((AVG(v.rating_10 - d.avg_rating) FILTER (WHERE d.consensus_ready = TRUE AND v.rating_10 IS NOT NULL))::NUMERIC, 1) AS bias
     FROM votes v JOIN dishes d ON v.dish_id = d.id
     WHERE v.user_id = p_user_id AND v.category_snapshot IS NOT NULL
     GROUP BY v.category_snapshot
@@ -2176,7 +2176,7 @@ DECLARE
 BEGIN
   IF NEW.rating_10 IS NULL THEN RETURN NEW; END IF;
 
-  SELECT COUNT(*), ROUND(AVG(rating_10), 1) INTO total_votes_count, consensus_avg
+  SELECT COUNT(*), ROUND(AVG(rating_10)::NUMERIC, 1) INTO total_votes_count, consensus_avg
   FROM votes WHERE dish_id = NEW.dish_id AND rating_10 IS NOT NULL;
 
   IF total_votes_count >= consensus_threshold THEN
@@ -2189,7 +2189,7 @@ BEGIN
 
       FOR v IN SELECT * FROM votes WHERE dish_id = NEW.dish_id AND scored_at IS NULL AND rating_10 IS NOT NULL
       LOOP
-        user_deviation := ROUND(v.rating_10 - consensus_avg, 1);
+        user_deviation := ROUND((v.rating_10 - consensus_avg)::NUMERIC, 1);
         is_early := v.vote_position <= 3;
 
         SELECT rating_bias INTO user_bias_before FROM user_rating_stats WHERE user_id = v.user_id;
@@ -2198,7 +2198,7 @@ BEGIN
         UPDATE votes SET scored_at = NOW() WHERE id = v.id;
 
         -- Use ABS for overall bias (MAD)
-        SELECT ROUND(AVG(ABS(votes.rating_10 - d.consensus_rating)), 1) INTO user_bias_after
+        SELECT ROUND(AVG(ABS(votes.rating_10 - d.consensus_rating))::NUMERIC, 1) INTO user_bias_after
         FROM votes JOIN dishes d ON votes.dish_id = d.id
         WHERE votes.user_id = v.user_id AND d.consensus_ready = TRUE
           AND votes.rating_10 IS NOT NULL AND votes.scored_at IS NOT NULL;
@@ -2221,7 +2221,7 @@ BEGIN
         -- Category biases stay SIGNED
         UPDATE user_rating_stats SET category_biases = jsonb_set(
           COALESCE(category_biases, '{}'::jsonb), ARRAY[v.category_snapshot],
-          (SELECT to_jsonb(ROUND(AVG(votes.rating_10 - d.consensus_rating), 1))
+          (SELECT to_jsonb(ROUND(AVG(votes.rating_10 - d.consensus_rating)::NUMERIC, 1))
            FROM votes JOIN dishes d ON votes.dish_id = d.id
            WHERE votes.user_id = v.user_id AND d.consensus_ready = TRUE
              AND votes.rating_10 IS NOT NULL AND votes.scored_at IS NOT NULL
@@ -2237,7 +2237,7 @@ BEGIN
         consensus_votes = total_votes_count, consensus_calculated_at = NOW()
       WHERE id = NEW.dish_id;
 
-      user_deviation := ROUND(NEW.rating_10 - consensus_avg, 1);
+      user_deviation := ROUND((NEW.rating_10 - consensus_avg)::NUMERIC, 1);
       is_early := FALSE;
 
       SELECT rating_bias INTO user_bias_before FROM user_rating_stats WHERE user_id = NEW.user_id;
@@ -2245,7 +2245,7 @@ BEGIN
 
       UPDATE votes SET scored_at = NOW() WHERE id = NEW.id;
 
-      SELECT ROUND(AVG(ABS(votes.rating_10 - d.consensus_rating)), 1) INTO user_bias_after
+      SELECT ROUND(AVG(ABS(votes.rating_10 - d.consensus_rating))::NUMERIC, 1) INTO user_bias_after
       FROM votes JOIN dishes d ON votes.dish_id = d.id
       WHERE votes.user_id = NEW.user_id AND d.consensus_ready = TRUE
         AND votes.rating_10 IS NOT NULL AND votes.scored_at IS NOT NULL;
@@ -2267,7 +2267,7 @@ BEGIN
       -- Category biases stay SIGNED
       UPDATE user_rating_stats SET category_biases = jsonb_set(
         COALESCE(category_biases, '{}'::jsonb), ARRAY[NEW.category_snapshot],
-        (SELECT to_jsonb(ROUND(AVG(votes.rating_10 - d.consensus_rating), 1))
+        (SELECT to_jsonb(ROUND(AVG(votes.rating_10 - d.consensus_rating)::NUMERIC, 1))
          FROM votes JOIN dishes d ON votes.dish_id = d.id
          WHERE votes.user_id = NEW.user_id AND d.consensus_ready = TRUE
            AND votes.rating_10 IS NOT NULL AND votes.scored_at IS NOT NULL

--- a/vite.config.js
+++ b/vite.config.js
@@ -70,6 +70,11 @@ export default defineConfig({
     }),
   ],
   build: {
+    // Floor: Safari 15 / Chrome 109 / Firefox 109 / Edge 109. CLAUDE.md §1.1
+    // requires Safari <16 and Chrome <110 to run; Vite 7's default
+    // `baseline-widely-available` target is Safari 16+ and would lock those
+    // users out before React mounts.
+    target: ['safari15', 'chrome109', 'firefox109', 'edge109'],
     chunkSizeWarningLimit: 1000,
     rollupOptions: {
       output: {


### PR DESCRIPTION
## Summary

First batch of remediation from a deep two-track Codex review (security + durability) run with `gpt-5.4` / `xhigh`. Every commit is one finding, one file (or one tightly scoped pair), independently verifiable. No auth-flow surface touched — that bucket waits for the other in-flight session to land.

## What's in here (8 commits)

| # | Commit | Source | Severity | Effort |
|---|--------|--------|----------|--------|
| 1 | `ac6e17d` lock vite `build.target` to safari15+/chrome109+/ff109+/edge109+ | Codex durability | **CRITICAL** | 30m |
| 2 | `5979a33` admin gate on `discover-restaurants` Edge Function | Codex security | **HIGH** | 30m |
| 3 | `3d36205` `useRestaurantSearch` request-safe + unstickable loading | Codex durability | **HIGH** | 30m |
| 4 | `80335f5` Dish page: distinguish NOT_FOUND from transient load failures (with retry) | Codex durability | **HIGH** | 30m |
| 5 | `2b876c5` Hash user UUIDs in `delete-account` log messages | Codex security | **LOW** | 5m |
| 6 | `32a3fd4` `ROUND(...)::NUMERIC` casts in `schema.sql` (rule alignment, no migration needed) | Codex durability | **MEDIUM** | 30m |
| 7 | `413f422` React Query: skip retries on non-retryable errors | Codex durability | **MEDIUM** | 30m |
| 8 | `f69d275` Geolocation: distinguish TIMEOUT/UNAVAILABLE from real denial | Codex durability | **MEDIUM** | 30m |

## Wave 1 highlights

- **Vite default target was Safari 16+** under Vite 7's `baseline-widely-available`, locking out Safari 15.x users before React mounts. CLAUDE.md §1.1 mandates Safari <16 must run.
- **`discover-restaurants` had zero auth gate** in front of a service-role client + `restaurants` insert path. Any authenticated user could trigger website probing + DB writes. Now requires an `admins` row, mirroring `restaurant-scraper`.
- **`useRestaurantSearch`** had two real races: stale-response clobber (newer query overwritten by older completion) and stuck-loading (cleared query left spinner spinning). Replaced `mountedRef` with effect-scoped `cancelled` flag.
- **Dish page** collapsed every fetch error to "Dish not found" with no retry. Now classifies and offers Try Again on transient.

## Pushed back on

- **Codex flagged `delete-account/index.ts:423` as a UUID log leak** — that line logs a table name, not a UUID. Two real offenders fixed (lines 74, 372); 423 left alone with reasoning in the commit body.
- **Codex framed `ROUND()` casts as a "violation"** — strictly the project rule applies "on float expressions" and the columns are all `DECIMAL(3,1)`, so the live deploy works correctly today. Fixed schema.sql for source-of-truth alignment + future-drift defense, but **no migration needed** (it would be a no-op rewrite of two ~200-line function bodies).

## Bonus finding (NOT in this PR — needs separate work)

Production bundle scan after the vite target change surfaced **`@sentry-internal/browser-utils` ships `.at(-1)` to our main bundle** in `InteractionManager.js`. Sentry fixed this in `LayoutShiftManager.js` but missed `InteractionManager.js`. CLAUDE.md §1.1 forbids `Array.at` because it crashes Safari 15.0–15.3 (15.4+ supports it, but our floor is `safari15`). Three options to weigh in Wave 2: bump Sentry, polyfill `Array.prototype.at` for old browsers, or raise floor to `safari15.4`.

## Deferred (queued for Wave 2 / Wave 3)

Auth-touching items waiting on the other in-flight terminal session:
- Server-side rate limiting for password reset / magic link in `authApi.js` (Codex security MEDIUM).

Other Wave 2 work coming next:
- Places anon/IP throttling + `places-details` limiter (security HIGH)
- `parse-menu` + `photo-moderate` authz + rate limits (security HIGH)
- Jitter sample server-side-only ingest (security HIGH)
- Scraper cron auth contract + stage-then-swap atomicity (durability CRITICAL/HIGH)
- Follow rollback bug in `UserProfile` (durability HIGH)
- EXIF stripping on photo upload (security MEDIUM)
- Migration rollback blocks (durability MEDIUM)

Wave 3 (day+ each):
- Photo pipeline lockdown — RLS + Storage policy + server-authoritative finalization (security **CRITICAL**)
- Kill restaurant-create → menu-import SSRF path (security HIGH)
- Blocking anon-bypass RLS rewrite (security MEDIUM)
- Re-green browser E2E suite (durability HIGH)

## Test plan

- [x] `npm run build` — passes; bundle scan reports 1 remaining `.at(-1)` (third-party Sentry, see bonus finding)
- [x] `npx eslint` — clean on every modified file
- [x] `npx vitest run src/utils/errorHandler.test.js` — 29/29 pass
- [ ] Manual smoke test on iPhone Safari 15.x (verifies build target works in the field)
- [ ] Verify `discover-restaurants` rejects non-admin users (curl with anon JWT → 403)
- [ ] Manual: type rapidly in Add Restaurant search, then clear → spinner stops
- [ ] Manual: pull network during dish detail load → see "Try Again" instead of "Dish not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)