### PR TITLE
fix(search): override PostgREST 1000-row cap (Leo Burger bug)

### DIFF
--- a/src/api/dishesApi.js
+++ b/src/api/dishesApi.js
@@ -257,7 +257,14 @@ export const dishesApi = {
   /**
    * Get all dishes with search-relevant fields for client-side caching.
    * Returns a flat array (restaurant data denormalized into each dish).
-   * ~300 rows, ~50KB. Cached by React Query in useAllDishes hook.
+   *
+   * Range explicit to override PostgREST's default 1000-row cap. As of
+   * 2026-05-03 the dishes table has ~6k rows; without this, dishes with
+   * low/null avg_rating fall past the silent cutoff and disappear from
+   * homepage search (every menu-imported dish starts at 0 votes / 0.0
+   * rating, so this affects most of the catalog). Post-launch this should
+   * move to a server-side FTS RPC — fetching the whole table won't scale.
+   *
    * @returns {Promise<Array>} All dishes with restaurant metadata
    */
   async getAllSearchable() {
@@ -273,6 +280,7 @@ export const dishesApi = {
           )
         `)
         .order('avg_rating', { ascending: false, nullsFirst: false })
+        .range(0, 19999)
 
       if (error) throw createClassifiedError(error)
 


### PR DESCRIPTION
## Summary

Fixes silent search-result truncation: ~5000 of 5983 dishes were unfindable on homepage because PostgREST capped the query at 1000 rows.

## How it surfaced

\"Leo Burger\" from Mo's Lunch reproducibly didn't appear in homepage search even though:
- Dish row exists with that exact name
- Mo's restaurant is_open = true
- Mo's lat/lng are valid (Oak Bluffs, MV)
- Radius set to \"All\"
- Search algorithm scores \"Leo Burger\" with token \"leo\" at 80 (well above match threshold)
- Other burgers (with non-zero avg_rating) appear normally

## Root cause

\`getAllSearchable\` selects from \`dishes\` ordered by \`avg_rating DESC NULLS LAST\` with no explicit \`.range\` or \`.limit\`. PostgREST silently caps unbounded queries at **1000 rows** by default. With **5983 dishes in DB** (verified 2026-05-03), dishes ranked past row 1000 — every menu-imported dish that hasn't received any votes yet — fall off the search cache.

\"Leo Burger\" has \`avg_rating = 0.0, total_votes = 0\`, so it sorts at the bottom and was below the cutoff.

**Affects ~83% of the catalog.** Every menu-imported dish starts at 0/0, so every newly-added restaurant's menu was effectively invisible until someone voted on each dish.

## Fix

One line — add \`.range(0, 19999)\` to \`getAllSearchable\`. ~3x headroom over current count.

## Caveat (not in this PR)

Fetching 6k rows on every cache build is ~1MB+ payload. This client-side-cache approach won't scale — added a docstring note that this should move to a server-side FTS RPC (\`tsvector\` + \`pg_trgm\`) post-launch.

## Test plan

- [ ] After merge + Vercel deploy: open app on phone (PWA), search \"leo\" → \"Leo Burger\" appears
- [ ] Verify cache loads in <2s (1MB+ payload concern)
- [ ] No regression on previously-findable dishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)