### PR TITLE
fix: Codex hardening Wave 2 — scraper cron + follow rollback + Places IP limits

### DIFF
--- a/src/pages/UserProfile.jsx
+++ b/src/pages/UserProfile.jsx
@@ -304,29 +304,34 @@ export function UserProfile() {
       return
     }
 
+    // Snapshot pre-state for clean rollback. Reading from React state at
+    // catch-time is stale (in the previous version, setIsFollowing happened
+    // *after* the await, so a thrown request never mutated state — yet the
+    // catch tried to invert it, leaving the UI inverted from the truth).
+    const wasFollowing = isFollowing
+    const prevFollowerCount = profile?.follower_count ?? 0
+
+    // Optimistic update.
+    setIsFollowing(!wasFollowing)
+    setProfile(prev => prev ? {
+      ...prev,
+      follower_count: Math.max(0, prevFollowerCount + (wasFollowing ? -1 : 1)),
+    } : prev)
+
     setFollowLoading(true)
     try {
-      if (isFollowing) {
+      if (wasFollowing) {
         await followsApi.unfollow(userId)
-        setIsFollowing(false)
-        setProfile(prev => ({
-          ...prev,
-          follower_count: Math.max(0, (prev.follower_count || 0) - 1)
-        }))
       } else {
         await followsApi.follow(userId)
-        setIsFollowing(true)
-        setProfile(prev => ({
-          ...prev,
-          follower_count: (prev.follower_count || 0) + 1
-        }))
       }
     } catch (error) {
       logger.error('Failed to toggle follow:', error)
-      setIsFollowing(prev => !prev)
+      // Restore exactly to snapshot — no math, no inversion of stale state.
+      setIsFollowing(wasFollowing)
       setProfile(prev => prev ? {
         ...prev,
-        follower_count: (prev.follower_count || 0) + (isFollowing ? 1 : -1)
+        follower_count: prevFollowerCount,
       } : prev)
     } finally {
       setFollowLoading(false)

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -34,3 +34,16 @@ verify_jwt = false
 
 [functions.places-nearby-search]
 verify_jwt = false
+
+# scraper-dispatcher and restaurant-scraper are invoked by pg_cron with
+# `Bearer ${CRON_SECRET}` (a non-JWT shared secret stored in vault and the
+# Edge Functions env). The gateway rejects non-JWT bearers as
+# UNAUTHORIZED_INVALID_JWT_FORMAT, so disable the gateway check. Both
+# functions enforce dual-path auth in code: CRON_SECRET match OR an admin
+# user JWT (auth.getUser + admins row), so manual admin invocation still
+# works.
+[functions.scraper-dispatcher]
+verify_jwt = false
+
+[functions.restaurant-scraper]
+verify_jwt = false

--- a/supabase/functions/_shared/clientIp.ts
+++ b/supabase/functions/_shared/clientIp.ts
@@ -1,0 +1,36 @@
+/**
+ * Extract the originating client IP from request headers.
+ *
+ * Supabase Edge Functions sit behind a proxy that sets `x-forwarded-for`.
+ * If a request originates through Cloudflare (e.g. our Vercel-hosted web
+ * app), `cf-connecting-ip` is most accurate. Fall back through the standard
+ * forwarding headers and return null when nothing usable is present.
+ *
+ * Used by the Places proxy functions to apply per-IP rate limits to
+ * unauthenticated callers, since `auth.uid()`-based limiting only covers
+ * authenticated traffic.
+ */
+export function getClientIp(req: Request): string | null {
+  const cfIp = req.headers.get('cf-connecting-ip')
+  if (cfIp) {
+    const trimmed = cfIp.trim()
+    if (trimmed) return trimmed
+  }
+
+  const xff = req.headers.get('x-forwarded-for')
+  if (xff) {
+    // First entry is the original client; later entries are intermediate
+    // proxies. Trim whitespace and bracket characters that some proxies add
+    // around IPv6 addresses.
+    const first = xff.split(',')[0]?.trim().replace(/^\[|\]$/g, '')
+    if (first) return first
+  }
+
+  const xRealIp = req.headers.get('x-real-ip')
+  if (xRealIp) {
+    const trimmed = xRealIp.trim()
+    if (trimmed) return trimmed
+  }
+
+  return null
+}

--- a/supabase/functions/places-autocomplete/index.ts
+++ b/supabase/functions/places-autocomplete/index.ts
@@ -1,6 +1,7 @@
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { corsHeaders } from '../_shared/cors.ts'
+import { getClientIp } from '../_shared/clientIp.ts'
 
 const GOOGLE_API_KEY = Deno.env.get('GOOGLE_PLACES_API_KEY')
 
@@ -11,23 +12,27 @@ serve(async (req) => {
   }
 
   try {
-    // Auth is fully optional — guests can search without a session.
-    // If an auth header is present, try to identify the user for per-account rate limiting.
+    // Two-tier rate limiting:
+    //   - Authenticated users hit `check_and_record_rate_limit` keyed on
+    //     auth.uid() — 20/min.
+    //   - Anonymous callers (and authenticated users who failed the user
+    //     check) fall through to `check_and_record_ip_rate_limit` keyed on
+    //     cf-connecting-ip / x-forwarded-for — 30/min.
+    // Without the IP tier, guests can drain the Google Places quota.
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!
     const authHeader = req.headers.get('Authorization')
-    let user = null
 
+    let userLimited = false
     if (authHeader) {
       try {
-        const supabaseUrl = Deno.env.get('SUPABASE_URL')!
-        const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!
         const supabase = createClient(supabaseUrl, supabaseAnonKey, {
           global: { headers: { Authorization: authHeader } },
         })
         const { data } = await supabase.auth.getUser()
-        user = data?.user ?? null
+        const user = data?.user ?? null
 
         if (user) {
-          // Rate limit authed users: 20 requests/min
           const { data: rateCheck } = await supabase.rpc('check_and_record_rate_limit', {
             p_action: 'places_autocomplete',
             p_max_attempts: 20,
@@ -39,9 +44,27 @@ serve(async (req) => {
               headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
             })
           }
+          userLimited = true
         }
       } catch (_) {
-        // Auth check failed — continue as guest
+        // Auth check failed — fall through to IP limiter.
+      }
+    }
+
+    if (!userLimited) {
+      const ip = getClientIp(req)
+      const supabase = createClient(supabaseUrl, supabaseAnonKey)
+      const { data: ipCheck } = await supabase.rpc('check_and_record_ip_rate_limit', {
+        p_ip: ip,
+        p_action: 'places_autocomplete',
+        p_max_attempts: 30,
+        p_window_seconds: 60,
+      })
+      if (ipCheck && !ipCheck.allowed) {
+        return new Response(JSON.stringify({ error: 'Rate limit exceeded', retry_after: ipCheck.retry_after_seconds }), {
+          status: 429,
+          headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
+        })
       }
     }
 

--- a/supabase/functions/places-details/index.ts
+++ b/supabase/functions/places-details/index.ts
@@ -1,6 +1,7 @@
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { corsHeaders } from '../_shared/cors.ts'
+import { getClientIp } from '../_shared/clientIp.ts'
 
 const GOOGLE_API_KEY = Deno.env.get('GOOGLE_PLACES_API_KEY')
 
@@ -11,18 +12,54 @@ serve(async (req) => {
   }
 
   try {
-    // Auth is fully optional — guests can fetch place details without a session.
+    // Two-tier rate limiting (see places-autocomplete for full rationale).
+    // Previously this function had no limiter at all.
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!
     const authHeader = req.headers.get('Authorization')
+
+    let userLimited = false
     if (authHeader) {
       try {
-        const supabaseUrl = Deno.env.get('SUPABASE_URL')!
-        const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!
         const supabase = createClient(supabaseUrl, supabaseAnonKey, {
           global: { headers: { Authorization: authHeader } },
         })
-        await supabase.auth.getUser()
+        const { data } = await supabase.auth.getUser()
+        const user = data?.user ?? null
+
+        if (user) {
+          const { data: rateCheck } = await supabase.rpc('check_and_record_rate_limit', {
+            p_action: 'places_details',
+            p_max_attempts: 30,
+            p_window_seconds: 60,
+          })
+          if (rateCheck && !rateCheck.allowed) {
+            return new Response(JSON.stringify({ error: 'Rate limit exceeded', retry_after: rateCheck.retry_after_seconds }), {
+              status: 429,
+              headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
+            })
+          }
+          userLimited = true
+        }
       } catch (_) {
-        // Auth check failed — continue as guest
+        // Auth check failed — fall through to IP limiter.
+      }
+    }
+
+    if (!userLimited) {
+      const ip = getClientIp(req)
+      const supabase = createClient(supabaseUrl, supabaseAnonKey)
+      const { data: ipCheck } = await supabase.rpc('check_and_record_ip_rate_limit', {
+        p_ip: ip,
+        p_action: 'places_details',
+        p_max_attempts: 60,
+        p_window_seconds: 60,
+      })
+      if (ipCheck && !ipCheck.allowed) {
+        return new Response(JSON.stringify({ error: 'Rate limit exceeded', retry_after: ipCheck.retry_after_seconds }), {
+          status: 429,
+          headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
+        })
       }
     }
 

--- a/supabase/functions/places-nearby-search/index.ts
+++ b/supabase/functions/places-nearby-search/index.ts
@@ -1,6 +1,7 @@
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { corsHeaders } from '../_shared/cors.ts'
+import { getClientIp } from '../_shared/clientIp.ts'
 
 const GOOGLE_API_KEY = Deno.env.get('GOOGLE_PLACES_API_KEY')
 
@@ -11,12 +12,15 @@ serve(async (req) => {
   }
 
   try {
-    // Auth is fully optional — guests can search without a session.
+    // Two-tier rate limiting (see places-autocomplete for full rationale):
+    // authed-user limiter first, then IP limiter as fallback for guests.
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!
     const authHeader = req.headers.get('Authorization')
+
+    let userLimited = false
     if (authHeader) {
       try {
-        const supabaseUrl = Deno.env.get('SUPABASE_URL')!
-        const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!
         const supabase = createClient(supabaseUrl, supabaseAnonKey, {
           global: { headers: { Authorization: authHeader } },
         })
@@ -24,7 +28,6 @@ serve(async (req) => {
         const user = data?.user ?? null
 
         if (user) {
-          // Rate limit authed users: 10 requests/min
           const { data: rateCheck } = await supabase.rpc('check_and_record_rate_limit', {
             p_action: 'places_nearby_search',
             p_max_attempts: 10,
@@ -36,9 +39,27 @@ serve(async (req) => {
               headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
             })
           }
+          userLimited = true
         }
       } catch (_) {
-        // Auth check failed — continue as guest
+        // Auth check failed — fall through to IP limiter.
+      }
+    }
+
+    if (!userLimited) {
+      const ip = getClientIp(req)
+      const supabase = createClient(supabaseUrl, supabaseAnonKey)
+      const { data: ipCheck } = await supabase.rpc('check_and_record_ip_rate_limit', {
+        p_ip: ip,
+        p_action: 'places_nearby_search',
+        p_max_attempts: 15,
+        p_window_seconds: 60,
+      })
+      if (ipCheck && !ipCheck.allowed) {
+        return new Response(JSON.stringify({ error: 'Rate limit exceeded', retry_after: ipCheck.retry_after_seconds }), {
+          status: 429,
+          headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
+        })
       }
     }
 

--- a/supabase/functions/restaurant-scraper/index.ts
+++ b/supabase/functions/restaurant-scraper/index.ts
@@ -159,7 +159,8 @@ serve(async (req) => {
   }
 
   try {
-    // Auth gate: require admin user
+    // Dual-path auth gate: CRON_SECRET (cron caller) or admin user JWT.
+    // Mirrors the dispatcher and menu-refresh's CRON_SECRET pattern.
     const authHeader = req.headers.get('Authorization')
     if (!authHeader) {
       return new Response(JSON.stringify({ error: 'Unauthorized' }), {
@@ -168,19 +169,31 @@ serve(async (req) => {
     }
     const supabaseUrl_ = Deno.env.get('SUPABASE_URL')!
     const supabaseAnonKey_ = Deno.env.get('SUPABASE_ANON_KEY')!
-    const authClient = createClient(supabaseUrl_, supabaseAnonKey_, {
-      global: { headers: { Authorization: authHeader } },
-    })
-    const { data: { user: authUser } } = await authClient.auth.getUser()
-    if (!authUser) {
+
+    let isAuthorized = false
+    const cronSecret = Deno.env.get('CRON_SECRET')
+    if (cronSecret && authHeader === `Bearer ${cronSecret}`) {
+      isAuthorized = true
+    }
+
+    if (!isAuthorized) {
+      const authClient = createClient(supabaseUrl_, supabaseAnonKey_, {
+        global: { headers: { Authorization: authHeader } },
+      })
+      const { data: { user: authUser } } = await authClient.auth.getUser()
+      if (authUser) {
+        const { data: adminRow } = await authClient
+          .from('admins')
+          .select('user_id')
+          .eq('user_id', authUser.id)
+          .maybeSingle()
+        if (adminRow) isAuthorized = true
+      }
+    }
+
+    if (!isAuthorized) {
       return new Response(JSON.stringify({ error: 'Unauthorized' }), {
         status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      })
-    }
-    const { data: adminRow } = await authClient.from('admins').select('user_id').eq('user_id', authUser.id).maybeSingle()
-    if (!adminRow) {
-      return new Response(JSON.stringify({ error: 'Admin access required' }), {
-        status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       })
     }
 

--- a/supabase/functions/scraper-dispatcher/index.ts
+++ b/supabase/functions/scraper-dispatcher/index.ts
@@ -19,7 +19,11 @@ serve(async (req) => {
   }
 
   try {
-    // Auth gate: require admin user
+    // Dual-path auth gate. Two valid invocation patterns:
+    //   1. pg_cron sends `Bearer ${CRON_SECRET}` — a non-JWT shared secret
+    //      that pairs with verify_jwt=false in supabase/config.toml.
+    //   2. An admin invokes manually with their user JWT.
+    // Mirrors the CRON_SECRET pattern menu-refresh uses (see PR #58 / #82).
     const authHeader = req.headers.get('Authorization')
     if (!authHeader) {
       return new Response(JSON.stringify({ error: 'Unauthorized' }), {
@@ -28,19 +32,31 @@ serve(async (req) => {
     }
     const supabaseUrl = Deno.env.get('SUPABASE_URL')!
     const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!
-    const authClient = createClient(supabaseUrl, supabaseAnonKey, {
-      global: { headers: { Authorization: authHeader } },
-    })
-    const { data: { user: authUser } } = await authClient.auth.getUser()
-    if (!authUser) {
+
+    let isAuthorized = false
+    const cronSecret = Deno.env.get('CRON_SECRET')
+    if (cronSecret && authHeader === `Bearer ${cronSecret}`) {
+      isAuthorized = true
+    }
+
+    if (!isAuthorized) {
+      const authClient = createClient(supabaseUrl, supabaseAnonKey, {
+        global: { headers: { Authorization: authHeader } },
+      })
+      const { data: { user: authUser } } = await authClient.auth.getUser()
+      if (authUser) {
+        const { data: adminRow } = await authClient
+          .from('admins')
+          .select('user_id')
+          .eq('user_id', authUser.id)
+          .maybeSingle()
+        if (adminRow) isAuthorized = true
+      }
+    }
+
+    if (!isAuthorized) {
       return new Response(JSON.stringify({ error: 'Unauthorized' }), {
         status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      })
-    }
-    const { data: adminRow } = await authClient.from('admins').select('user_id').eq('user_id', authUser.id).maybeSingle()
-    if (!adminRow) {
-      return new Response(JSON.stringify({ error: 'Admin access required' }), {
-        status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       })
     }
 
@@ -76,11 +92,16 @@ serve(async (req) => {
       try {
         const scraperUrl = `${supabaseUrl}/functions/v1/restaurant-scraper`
 
+        // Forward the caller's authHeader so restaurant-scraper can re-run
+        // the same dual-path auth gate. Cron caller → CRON_SECRET stays
+        // valid; admin caller → their JWT stays valid. Service-role keys
+        // are NOT user JWTs and would fail restaurant-scraper's getUser()
+        // path, which is the original Codex-flagged break.
         const response = await fetch(scraperUrl, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${supabaseServiceKey}`,
+            'Authorization': authHeader,
           },
           body: JSON.stringify({
             restaurant_id: restaurant.id,

--- a/supabase/migrations/2026-05-03-ip-rate-limits.sql
+++ b/supabase/migrations/2026-05-03-ip-rate-limits.sql
@@ -1,0 +1,101 @@
+-- 2026-05-03: IP-based rate limiting for unauthenticated Places proxy callers
+--
+-- The Places Edge Functions (places-autocomplete, places-details,
+-- places-nearby-search) run with verify_jwt=false and accept guest traffic
+-- so the Add Restaurant flow works for anonymous users. Until now, only
+-- authenticated callers were rate-limited (via the existing
+-- check_and_record_rate_limit which is keyed on auth.uid()), leaving
+-- guests free to drain the Google Places quota.
+--
+-- This migration introduces an IP-keyed companion limiter so all three
+-- functions can apply a per-IP cap to anonymous traffic.
+--
+-- Codex security HIGH.
+
+-- New table — separate from `rate_limits` so that table's NOT NULL user_id
+-- + FK to auth.users stays intact. RLS is enabled with no public policies;
+-- the SECURITY DEFINER RPC below is the only entry point.
+CREATE TABLE IF NOT EXISTS ip_rate_limits (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  ip_address INET NOT NULL,
+  action TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS ip_rate_limits_lookup_idx
+  ON ip_rate_limits (ip_address, action, created_at DESC);
+
+ALTER TABLE ip_rate_limits ENABLE ROW LEVEL SECURITY;
+
+-- Companion to check_and_record_rate_limit, keyed on caller IP. The Edge
+-- Functions extract the IP from cf-connecting-ip / x-forwarded-for and
+-- pass it as a TEXT that we cast to INET inside the function (cast failure
+-- returns "allowed: true" — fail-open is acceptable for a defense-in-depth
+-- layer that runs alongside the Google Places quota and Cloudflare WAF).
+CREATE OR REPLACE FUNCTION check_and_record_ip_rate_limit(
+  p_ip TEXT, p_action TEXT, p_max_attempts INT DEFAULT 30, p_window_seconds INT DEFAULT 60
+)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_ip INET;
+  v_count INT;
+  v_oldest TIMESTAMPTZ;
+  v_cutoff TIMESTAMPTZ;
+  v_retry_after INT;
+BEGIN
+  IF p_ip IS NULL OR length(trim(p_ip)) = 0 THEN
+    -- No IP available (server-to-server, dashboard tester) — let it through.
+    RETURN jsonb_build_object('allowed', true);
+  END IF;
+
+  BEGIN
+    v_ip := p_ip::INET;
+  EXCEPTION WHEN others THEN
+    -- Malformed IP — fail open. Don't return an obvious error that would
+    -- give a probing client information about parsing rules.
+    RETURN jsonb_build_object('allowed', true);
+  END;
+
+  v_cutoff := NOW() - (p_window_seconds || ' seconds')::INTERVAL;
+
+  SELECT COUNT(*), MIN(created_at) INTO v_count, v_oldest
+  FROM ip_rate_limits
+  WHERE ip_address = v_ip AND action = p_action AND created_at > v_cutoff;
+
+  IF v_count >= p_max_attempts THEN
+    v_retry_after := EXTRACT(EPOCH FROM (v_oldest + (p_window_seconds || ' seconds')::INTERVAL - NOW()))::INT;
+    IF v_retry_after < 0 THEN v_retry_after := 0; END IF;
+    RETURN jsonb_build_object(
+      'allowed', false,
+      'retry_after_seconds', v_retry_after,
+      'message', 'Too many requests. Please wait ' || v_retry_after || ' seconds.'
+    );
+  END IF;
+
+  INSERT INTO ip_rate_limits (ip_address, action) VALUES (v_ip, p_action);
+
+  RETURN jsonb_build_object('allowed', true);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION check_and_record_ip_rate_limit(TEXT, TEXT, INT, INT)
+  TO anon, authenticated, service_role;
+
+-- Schedule cleanup of stale entries (>1 day old) — companion to the existing
+-- cleanup-old-rate-limits cron. Idempotent — re-running is safe.
+DO $$
+BEGIN
+  PERFORM cron.schedule(
+    'cleanup-old-ip-rate-limits',
+    '17 * * * *',
+    $cron$DELETE FROM ip_rate_limits WHERE created_at < NOW() - INTERVAL '1 day'$cron$
+  );
+EXCEPTION WHEN duplicate_object THEN
+  -- Already scheduled, skip.
+  NULL;
+END $$;
+
+-- ROLLBACK:
+-- SELECT cron.unschedule('cleanup-old-ip-rate-limits');
+-- DROP FUNCTION IF EXISTS check_and_record_ip_rate_limit(TEXT, TEXT, INT, INT);
+-- DROP TABLE IF EXISTS ip_rate_limits;

--- a/supabase/migrations/2026-05-03-scraper-cron-secret.sql
+++ b/supabase/migrations/2026-05-03-scraper-cron-secret.sql
@@ -1,0 +1,66 @@
+-- 2026-05-03: Update daily-scraper-dispatch cron to use cron_secret
+--
+-- The original `20260216120000_enable_scraper_cron.sql` migration scheduled
+-- pg_cron to call /functions/v1/scraper-dispatcher with
+-- `Authorization: Bearer ${service_role_key}`. Both scraper-dispatcher and
+-- restaurant-scraper auth via auth.getUser() + admins row. Since a service
+-- role key is NOT a user JWT, getUser() returns no user and the cron call
+-- has been silently rejected with 401 — the events/specials pipeline has
+-- not run via cron since this guard was added.
+--
+-- Fix: switch the cron caller to the same CRON_SECRET shared-secret pattern
+-- used by menu-refresh (PR #58 / #82). Both Edge Functions now accept
+-- `Bearer ${CRON_SECRET}` as a valid auth path in addition to the admin
+-- user JWT.
+--
+-- PRE-DEPLOY MANUAL STEP (Supabase dashboard):
+--   1. Confirm `cron_secret` exists in vault (re-used from menu-refresh
+--      setup; if missing, generate via `openssl rand -hex 32` and add it
+--      under Project Settings → Vault → New secret).
+--   2. Edge Functions env: set CRON_SECRET to the SAME value on BOTH
+--      `scraper-dispatcher` and `restaurant-scraper`
+--      (Settings → Edge Functions → <function> → Manage secrets).
+--   3. Then run this migration in the SQL editor.
+--   4. Verify a cron run: `SELECT jobname, status, return_message FROM
+--      cron.job_run_details ORDER BY end_time DESC LIMIT 5;`
+
+SELECT cron.unschedule('daily-scraper-dispatch');
+
+SELECT cron.schedule(
+  'daily-scraper-dispatch',
+  '0 11 * * *',
+  $$
+  SELECT net.http_post(
+    url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'supabase_url' LIMIT 1) || '/functions/v1/scraper-dispatcher',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'cron_secret' LIMIT 1)
+    ),
+    body := '{}'::jsonb
+  );
+  $$
+);
+
+-- Verify the job is registered with the new headers
+SELECT jobname, schedule, command FROM cron.job WHERE jobname = 'daily-scraper-dispatch';
+
+-- ROLLBACK:
+-- SELECT cron.unschedule('daily-scraper-dispatch');
+-- SELECT cron.schedule(
+--   'daily-scraper-dispatch',
+--   '0 11 * * *',
+--   $$
+--   SELECT net.http_post(
+--     url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'supabase_url' LIMIT 1) || '/functions/v1/scraper-dispatcher',
+--     headers := jsonb_build_object(
+--       'Content-Type', 'application/json',
+--       'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'service_role_key' LIMIT 1)
+--     ),
+--     body := '{}'::jsonb
+--   );
+--   $$
+-- );
+-- Note: rolling back the cron alone leaves both functions still rejecting
+-- service_role bearers. To fully revert, also revert the verify_jwt and
+-- in-function CRON_SECRET changes for scraper-dispatcher and
+-- restaurant-scraper.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -284,6 +284,20 @@ CREATE TABLE IF NOT EXISTS rate_limits (
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+-- IP-keyed companion to rate_limits, used by browser-facing Edge Functions
+-- (places-* proxies) to throttle anonymous traffic that auth.uid()-based
+-- limiting cannot reach. RLS-enabled with no public policies; the
+-- check_and_record_ip_rate_limit RPC is the only entry point.
+CREATE TABLE IF NOT EXISTS ip_rate_limits (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  ip_address INET NOT NULL,
+  action TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS ip_rate_limits_lookup_idx
+  ON ip_rate_limits (ip_address, action, created_at DESC);
+
 
 -- 1s. jitter_profiles (Jitter Protocol: behavioral biometrics for human verification)
 CREATE TABLE IF NOT EXISTS jitter_profiles (
@@ -549,6 +563,7 @@ ALTER TABLE specials ENABLE ROW LEVEL SECURITY;
 ALTER TABLE restaurant_managers ENABLE ROW LEVEL SECURITY;
 ALTER TABLE restaurant_invites ENABLE ROW LEVEL SECURITY;
 ALTER TABLE rate_limits ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ip_rate_limits ENABLE ROW LEVEL SECURITY;
 
 -- restaurants: public read, admin + manager write (column-level protection via trigger)
 CREATE POLICY "Public read access" ON restaurants FOR SELECT USING (true);
@@ -1963,6 +1978,53 @@ $$;
 CREATE OR REPLACE FUNCTION check_vote_rate_limit()
 RETURNS JSONB LANGUAGE sql SECURITY DEFINER SET search_path = public AS $$
   SELECT check_and_record_rate_limit('vote', 10, 60);
+$$;
+
+-- IP-keyed rate limiter for unauthenticated callers (used by Places proxy
+-- functions). The Edge Function passes the caller IP from
+-- cf-connecting-ip / x-forwarded-for. Fail-open on missing/invalid IP
+-- (defense-in-depth alongside the Google quota and Cloudflare WAF).
+CREATE OR REPLACE FUNCTION check_and_record_ip_rate_limit(
+  p_ip TEXT, p_action TEXT, p_max_attempts INT DEFAULT 30, p_window_seconds INT DEFAULT 60
+)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_ip INET;
+  v_count INT;
+  v_oldest TIMESTAMPTZ;
+  v_cutoff TIMESTAMPTZ;
+  v_retry_after INT;
+BEGIN
+  IF p_ip IS NULL OR length(trim(p_ip)) = 0 THEN
+    RETURN jsonb_build_object('allowed', true);
+  END IF;
+
+  BEGIN
+    v_ip := p_ip::INET;
+  EXCEPTION WHEN others THEN
+    RETURN jsonb_build_object('allowed', true);
+  END;
+
+  v_cutoff := NOW() - (p_window_seconds || ' seconds')::INTERVAL;
+
+  SELECT COUNT(*), MIN(created_at) INTO v_count, v_oldest
+  FROM ip_rate_limits
+  WHERE ip_address = v_ip AND action = p_action AND created_at > v_cutoff;
+
+  IF v_count >= p_max_attempts THEN
+    v_retry_after := EXTRACT(EPOCH FROM (v_oldest + (p_window_seconds || ' seconds')::INTERVAL - NOW()))::INT;
+    IF v_retry_after < 0 THEN v_retry_after := 0; END IF;
+    RETURN jsonb_build_object(
+      'allowed', false,
+      'retry_after_seconds', v_retry_after,
+      'message', 'Too many requests. Please wait ' || v_retry_after || ' seconds.'
+    );
+  END IF;
+
+  INSERT INTO ip_rate_limits (ip_address, action) VALUES (v_ip, p_action);
+
+  RETURN jsonb_build_object('allowed', true);
+END;
 $$;
 
 -- Atomic user vote upsert. Targets the partial unique index:
@@ -3401,6 +3463,7 @@ GRANT SELECT ON public_votes TO anon, authenticated;
 GRANT EXECUTE ON FUNCTION get_smart_snippet(UUID) TO authenticated;
 GRANT EXECUTE ON FUNCTION get_smart_snippet(UUID) TO anon;
 GRANT EXECUTE ON FUNCTION check_and_record_rate_limit TO authenticated;
+GRANT EXECUTE ON FUNCTION check_and_record_ip_rate_limit(TEXT, TEXT, INT, INT) TO anon, authenticated, service_role;
 GRANT EXECUTE ON FUNCTION check_vote_rate_limit TO authenticated;
 GRANT EXECUTE ON FUNCTION submit_vote_atomic(UUID, UUID, DECIMAL, TEXT, DECIMAL, DECIMAL, TEXT) TO authenticated;
 GRANT EXECUTE ON FUNCTION check_photo_upload_rate_limit TO authenticated;


### PR DESCRIPTION
## Summary

Wave 2 stacks on PR #126. Three high-impact fixes from the same Codex review pass.

> Review order: merge #126 first; this PR's base auto-rebases to main once #126 lands.

## What's in here (3 commits)

| # | Commit | Source | Severity | Effort |
|---|--------|--------|----------|--------|
| 1 | `8db2ae6` scraper cron-compatible dual-path auth | Codex durability | **CRITICAL** | half-day |
| 2 | `f70da5a` correct follow rollback to snapshot | Codex durability | **HIGH** | 30m |
| 3 | `ea924fc` IP-based rate limiting for Places proxy guests | Codex security | **HIGH** | half-day |

## Highlights

### 1. Scraper cron was silently broken in production
The `daily-scraper-dispatch` cron sent `Bearer ${service_role_key}` to `scraper-dispatcher` and `restaurant-scraper`, but both functions auth via `auth.getUser() + admins`. A service role key isn't a user JWT, so getUser() returned no user — the cron has been silently 401-ing since the admin guard was added. Events/specials pipeline has not run via cron.

Mirror the `CRON_SECRET` pattern menu-refresh adopted in PR #58/#82:
- Both functions accept `Bearer \${CRON_SECRET}` (cron) OR admin user JWT (manual).
- Migration unschedules + reschedules with `cron_secret` from vault.
- `verify_jwt = false` for both in `config.toml` (CRON_SECRET isn't a JWT).
- Dispatcher forwards the same authHeader to restaurant-scraper instead of swapping in service_role.

**Pre-deploy manual:** Set `CRON_SECRET` env var on both `scraper-dispatcher` and `restaurant-scraper` Edge Functions (re-use existing vault `cron_secret`). Then run the migration.

### 2. Follow rollback inverted state on failure
`UserProfile.handleFollowToggle` was structured as confirm-first (state mutated **after** the await), but the catch block tried to roll back by inverting state that was never mutated and adjusting the count using a stale `isFollowing` closure. On any failure, clicking Follow left the UI showing "Following" with a decremented count.

Replaced with true optimistic-update: snapshot pre-state → optimistic flip → restore exact snapshot on error.

### 3. Places proxies were unlimited for guests
The three Places Edge Functions run with `verify_jwt = false` and accept guest traffic. Until now only authed users hit `check_and_record_rate_limit` (keyed on `auth.uid()`); `places-details` had no limiter at all — guests could drain the Google Places quota.

New schema:
- `ip_rate_limits` table (INET key, RLS-enabled, no public policies)
- `check_and_record_ip_rate_limit(p_ip, p_action, max, window)` SECURITY DEFINER RPC, fail-open on missing/invalid IP
- Hourly cleanup cron `cleanup-old-ip-rate-limits`
- New shared helper `_shared/clientIp.ts` extracts IP from cf-connecting-ip / x-forwarded-for / x-real-ip
- Migration with rollback block

All three functions now apply two-tier limiting (user-keyed first, IP fallback for guests):
- autocomplete: 20/min user, 30/min IP
- nearby-search: 10/min user, 15/min IP
- details: 30/min user, 60/min IP (was unlimited)

## Test plan

- [x] `npm run build` passes
- [ ] After #126 merges + this rebases to main: `supabase db push` (dry-run) confirms `ip_rate_limits` migration applies cleanly
- [ ] Set `CRON_SECRET` on both scraper functions in dashboard; deploy functions
- [ ] Run scraper migration in SQL editor
- [ ] Verify `cron.job_run_details` shows `daily-scraper-dispatch` succeeding (not 401-ing)
- [ ] Manual: hammer `/functions/v1/places-details` from curl with no auth — expect 429 after 60 calls
- [ ] Manual: trigger UserProfile follow toggle with network offline → UI restores to original state cleanly

## Wave 3 next

Coming on a fresh branch: `parse-menu` authz, `photo-moderate` ownership verification, Jitter sample server-side ingest, scraper stage-then-swap atomicity, EXIF stripping, migration rollback blocks. Designing the bigger items with Codex CLI before implementing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)