### PR TITLE
fix(migration): make scraper-cron-secret idempotent on fresh projects

### DIFF
--- a/supabase/migrations/2026-05-03-scraper-cron-secret.sql
+++ b/supabase/migrations/2026-05-03-scraper-cron-secret.sql
@@ -24,7 +24,21 @@
 --   4. Verify a cron run: `SELECT jobname, status, return_message FROM
 --      cron.job_run_details ORDER BY end_time DESC LIMIT 5;`
 
-SELECT cron.unschedule('daily-scraper-dispatch');
+-- Make sure pg_cron + pg_net are available. The earlier
+-- 20260216120000_enable_scraper_cron.sql migration was never run on
+-- some projects (Denis's wghapp project), so this file can't assume
+-- the daily-scraper-dispatch job already exists. Wrap unschedule in a
+-- safe block, then schedule fresh.
+CREATE EXTENSION IF NOT EXISTS pg_net;
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+DO $$
+BEGIN
+  PERFORM cron.unschedule('daily-scraper-dispatch');
+EXCEPTION WHEN others THEN
+  -- Job didn't exist (fresh project, or never created). Nothing to do.
+  NULL;
+END $$;
 
 SELECT cron.schedule(
   'daily-scraper-dispatch',


### PR DESCRIPTION
## Summary

Backport of an inline fix made during the 2026-05-06 deploy of the Codex hardening pass. The migration as originally written assumed the `daily-scraper-dispatch` cron job already existed (from `20260216120000_enable_scraper_cron.sql`) and called `cron.unschedule(...)` directly. That earlier migration was never run on the production wghapp project, so when this one ran it failed with:

```
ERROR: XX000: could not find valid entry for job 'daily-scraper-dispatch'
```

The fix wraps `cron.unschedule` in a `DO ... EXCEPTION WHEN others THEN NULL` block so the migration is safe to run whether or not the prior job exists. Also adds explicit `CREATE EXTENSION IF NOT EXISTS pg_net / pg_cron` for self-contained replay.

The corrected version was already run by hand on production. This PR backports the fix into the file so:
- Future operators / fresh-project bootstraps don't hit the same error
- The migration history matches what's actually live in `cron.job`

## Verification (already done in production)

```
SELECT jobname, schedule, command FROM cron.job WHERE jobname = 'daily-scraper-dispatch';
```

Returns one row with the `Bearer ${cron_secret}` header, confirmed 2026-05-06.

## Test plan

- [x] Manual: ran corrected version against production project `vpioftosgdkyiwvhxewy` — succeeded
- [ ] Optional: run against a fresh local Supabase instance to confirm idempotency end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)