### PR TITLE
chore(launch): app store submission prep — codex fixes + email correction

### DIFF
--- a/docs/app-store-connect-privacy-details.md
+++ b/docs/app-store-connect-privacy-details.md
@@ -49,7 +49,7 @@ Check these in the form:
 
 ### Identifiers
 - [x] **User ID** — collected (Supabase auth.users.id; core to the app)
-- [x] **Device ID** — collected (PostHog and Sentry each assign one for session stitching)
+- [x] **Device ID** — collected (verified 2026-05-06: PostHog assigns anonymous distinct_id on first load, links to user_id on `identify()` post-login; Sentry assigns one for session stitching)
 
 ### Purchases
 - [ ] — app is free; no IAP
@@ -100,9 +100,9 @@ PostHog and Sentry are service providers processing data on our behalf — they'
 | User ID | ✅ Yes | Inherently |
 | Device ID | ✅ Yes | PostHog identifies devices to users on login |
 | Product Interaction | ✅ Yes | PostHog events linked to user |
-| Crash Data | ✅ Yes | Sentry user scope is set when logged in |
-| Performance Data | ✅ Yes | Linked via session recording + replay |
-| Other Diagnostic Data | ✅ Yes | Sentry breadcrumbs linked to session |
+| Crash Data | ❌ No | Sentry is initialized globally; no `Sentry.setUser()` call in src/ — verified 2026-05-06 |
+| Performance Data | ❌ No | Same as Crash Data — Sentry session not user-scoped |
+| Other Diagnostic Data | ❌ No | Same as Crash Data |
 | Other Data (Jitter cadence) | ✅ Yes | Stored under user account |
 
 ### Q3: What are the purposes of using this data?
@@ -136,41 +136,28 @@ Allowed purposes per Apple: Third-Party Advertising, Developer's Advertising or 
 
 ## App Privacy "Data Used to Contact You" section
 
-**Primary contact:** `hello@whatsgoodhere.app`
+**Primary contact:** `wghapp@wghapp.com`
 **Developer:** Daniel Walsh (individual enrollment)
-**Support URL:** `https://wghapp.com/support`
+**Support URL:** `https://wghapp.com/support` (or `https://wghapp.com` if /support not yet shipped)
 **Privacy Policy URL:** `https://wghapp.com/privacy`
 **Marketing URL (optional):** `https://wghapp.com` (homepage works as marketing)
 
 ---
 
-## Reviewer-notes draft (for the "Notes for Reviewer" field)
+## Reviewer-notes draft
 
-Paste this into the App Store Connect "App Review Information → Notes" field. It preempts the most likely reviewer questions:
-
-> What's Good Here is a community food-rating app for Martha's Vineyard. Users rate dishes, write reviews, upload photos, and build food playlists.
->
-> **Moderation:** Every review, photo, dish, and user profile has a Report affordance (three-dot menu). Reports go to an admin queue with 48h SLA. Users can also Block other users (tap kebab on their profile → Block); the Blocked users list is managed in Settings → gear icon → Blocked users.
->
-> **Account deletion:** Settings → gear icon → Delete Account. Requires typing "DELETE" to confirm. Immediately removes votes, reviews, photos, favorites, playlists, and profile.
->
-> **Sign-in methods:** Google OAuth and Apple Sign-In (both wired; Apple is the default offered alongside Google on the login modal).
->
-> **Jitter Protocol (keystroke cadence):** We measure typing cadence on reviews to detect bot-generated content. This is disclosed in our Privacy Policy and is not used to identify individual users.
->
-> **Google Places data:** Used to help users discover and add unclaimed restaurants. Attribution ("Google Maps" or "Powered by Google") is shown wherever Places data appears. Places data is only rendered in list views, never on our Leaflet map, per Google's TOS.
->
-> **Test account for Apple reviewer:** [fill in: email + password of a pre-populated test account so reviewer can see the full app without signing up]
+⚠️ **STALE — superseded.** The canonical reviewer-notes copy lives in `docs/superpowers/specs/2026-05-03-app-store-reviewer-notes.md`. That doc has the final paste-ready text with real demo credentials, codex-reviewed phrasing, and corrected sign-in method disclosure. Do NOT paste from this section.
 
 ---
 
 ## Things to double-check before submitting
 
-- [ ] All Privacy URLs resolve (test `/privacy`, `/terms`, `/support`)
-- [ ] Test account created and documented in reviewer notes
-- [ ] Apple Sign-In actually wired on the login modal (H2 must ship before submission — see `docs/superpowers/plans/2026-04-13-h2-sign-in-with-apple.md`)
-- [ ] Privacy policy physical address reflects whatever mailing address Dan sets up (currently email-only — may need a UPS Store PMB address before submission depending on reviewer strictness)
-- [ ] `attributions` field display confirmed rendering on RestaurantDetail + NearbyPlaceCard in prod
+- [x] All Privacy URLs resolve — verified 2026-05-06: `/privacy`, `/terms`, `/` all return 200
+- [x] Test account created and documented in reviewer notes — walshdaniel143+wghdemo@gmail.com / WGH33!
+- [x] Apple Sign-In wired on the login modal — verified 2026-05-06: `LoginModal.jsx:287`, behind `VITE_FEATURES_APPLE_SIGNIN` flag (gated on B3-activate)
+- [x] Places `attributions` field rendering — verified 2026-05-06: `PlaceAttributions` in `RestaurantDetail.jsx:344`; `PoweredByGoogle` in `DishSearch.jsx`, `AddRestaurantModal.jsx`, `SearchAutocomplete.jsx`
+- [ ] Privacy policy physical address — see `project_business_address` memory (virtual address pending)
+- [ ] `wghapp@wghapp.com` mailbox monitored or forwards to monitored address
 
 ---
 

--- a/docs/superpowers/specs/2026-05-03-app-store-reviewer-notes.md
+++ b/docs/superpowers/specs/2026-05-03-app-store-reviewer-notes.md
@@ -64,12 +64,14 @@ confirm step.
 USER-GENERATED CONTENT (Guideline 1.2)
 ────────────────────────────
 
-- All user reviews and photos pass a content-safety filter before
-  display.
-- Reviewers can report inappropriate content via the report button on
-  any review or photo.
-- Reviewers can block other users; blocked users' content is hidden.
-- Reports are reviewed by our admin moderation queue.
+- Dish photos pass an automated content-safety check (Anthropic Claude
+  vision) before display.
+- Review text is filtered against a profanity/slur/spam blocklist on
+  submission.
+- Users can report inappropriate content via the report button on any
+  review, photo, dish, or profile.
+- Users can block other users; blocked users' content is hidden.
+- Reports are reviewed by our admin moderation queue (48h SLA).
 
 ────────────────────────────
 PRIVACY
@@ -86,7 +88,7 @@ PRIVACY
 SUPPORT
 ────────────────────────────
 
-Email: hello@wghapp.com
+Email: wghapp@wghapp.com
 ```
 
 ---
@@ -96,10 +98,10 @@ Email: hello@wghapp.com
 Before pasting into ASC, verify each placeholder is real:
 
 - [x] Demo account credentials filled in (created 2026-05-04)
-- [x] Demo account is populated (5 rated dishes, profile name set, no photo uploads — sufficient for "not empty" reviewer bar)
+- [x] Demo account is populated (5 rated dishes, profile name set — sufficient for "not empty" reviewer bar). Note: §1 above describes the account as pre-populated with "rated dishes, photos, and favorites" — Dan to enrich with at least 1 photo + 1 favorite before submission to match that description, OR edit §1 to omit "photos and favorites" if leaving as-is. **Do not let §1 and the actual account contradict each other.**
 - [ ] `https://wghapp.com/privacy` resolves to a live Privacy page (not 404)
 - [ ] `https://wghapp.com/terms` resolves to a live Terms page (not 404)
-- [ ] `hello@wghapp.com` is monitored OR forwards to a monitored address
+- [ ] `wghapp@wghapp.com` is monitored OR forwards to a monitored address
 - [ ] Account deletion path actually works on a fresh test account (smoke test)
 - [ ] The submitted build can sign in with the demo email + password (do this on TestFlight before promoting to App Store review)
 
@@ -114,7 +116,7 @@ Before pasting into ASC, verify each placeholder is real:
 - **Replaced "people who actually ate them"** (unverifiable) with "community-submitted 1–10 ratings."
 - **Added UGC-safety block** citing Guideline 1.2: report/block flows + photo moderation. H3 reporting/blocking is shipped per memory.
 - **Removed internal file-path references** (PrivacyInfo.xcprivacy, Info.plist) — reviewers can't verify those, only binary behavior.
-- **Email unified to `hello@wghapp.com`** (matches Privacy.jsx and Terms.jsx).
+- **Email unified to `wghapp@wghapp.com`** (matches Privacy.jsx and Terms.jsx).
 - **Cut 30–40% length** per Codex — reviewer notes should read like test instructions, not internal rationale.
 
 ## 4. What NOT to add

--- a/docs/superpowers/specs/2026-05-06-app-store-age-rating.md
+++ b/docs/superpowers/specs/2026-05-06-app-store-age-rating.md
@@ -1,0 +1,130 @@
+# App Store Age Rating Questionnaire — Answers
+
+**Date:** 2026-05-06
+**Status:** Paste-ready answers for App Store Connect → "Age Rating" questionnaire.
+**Expected result:** **12+** (driven by user-generated content + infrequent alcohol references via restaurant data).
+
+App Store Connect computes the final age rating from these answers. There is no "I want 4+" override — Apple derives it. The bar to clear for our wedge: **avoid 17+** (which would happen with frequent/intense content, unrestricted web access, or graphic UGC).
+
+---
+
+## Apple Apps Age Rating Questionnaire (IARC-aligned)
+
+### Violence & Gore
+
+| Question | Answer | Rationale |
+|---|---|---|
+| Cartoon or Fantasy Violence | **None** | Food app — no characters, no combat. |
+| Realistic Violence | **None** | Food app — no violence depicted. |
+| Prolonged Graphic or Sadistic Realistic Violence | **No** | N/A. |
+| Violence — Realistic, Prolonged Graphic | **No** | N/A. |
+
+### Sexual Content
+
+| Question | Answer | Rationale |
+|---|---|---|
+| Sexual Content or Nudity | **None** | None depicted. UGC reviews are filtered via `validateUserContent` (blocklist) and reportable. |
+| Graphic Sexual Content and Nudity | **No** | N/A. Photos are user-uploaded dish images; review queue catches violations. |
+
+### Profanity & Crude Humor
+
+| Question | Answer | Rationale |
+|---|---|---|
+| Profanity or Crude Humor | **None** | UGC reviews pass `validateUserContent` profanity blocklist before display. Reportable post-display. |
+
+### Suggestive / Mature Themes
+
+| Question | Answer | Rationale |
+|---|---|---|
+| Mature/Suggestive Themes | **None** | Food and dining content only. |
+| Horror/Fear Themes | **None** | N/A. |
+
+### Medical / Treatment
+
+| Question | Answer | Rationale |
+|---|---|---|
+| Medical/Treatment Information | **None** | App does not provide medical advice. |
+
+### Alcohol, Tobacco, Drugs
+
+| Question | Answer | Rationale |
+|---|---|---|
+| Alcohol, Tobacco, or Drug Use or References | **Infrequent or Mild** | ⚠️ Judgment call. Restaurant menus include cocktails, beer, wine; dish names and descriptions occasionally reference alcohol (e.g. "Aperol Spritz", "rum cake"). The app does not promote consumption. **"None" is defensible** if Apple reviewers parse "the app itself doesn't reference alcohol" — but **"Infrequent or Mild" is safer** because reviewers may search restaurant menus and find alcohol items. Recommend "Infrequent or Mild" to avoid a rejection-and-resubmit cycle. |
+
+### Gambling
+
+| Question | Answer | Rationale |
+|---|---|---|
+| Simulated Gambling | **None** | No gambling mechanics. |
+| Real Gambling | **No** | N/A. |
+| Contests | **No** | No contests, sweepstakes, or prize draws. |
+
+### Web / External
+
+| Question | Answer | Rationale |
+|---|---|---|
+| Unrestricted Web Access | **No** | App opens specific external URLs (restaurant sites, Order Now via Toast, Privacy/Terms pages). It is not a general-purpose browser. On native iOS, outbound links open via `@capacitor/browser` (SFSafariViewController) — a sandboxed Safari view, not a free-form WKWebView under our control. The user has no address bar, cannot navigate to arbitrary URLs from inside the app. |
+
+### User-Generated Content
+
+| Question | Answer | Rationale |
+|---|---|---|
+| User-Generated Content | **Yes** | Users submit dish ratings (1–10), text reviews (200 char max), and photos. |
+| Does your app have UGC moderation controls? | **Yes** | (1) `validateUserContent` blocklist filters submissions before display. (2) Three-dot Report button on every review/photo/dish/profile. (3) Block button on user profiles. (4) Admin moderation queue with 48h SLA. (5) Photo moderation tier classification. |
+
+### Medical / Healthcare
+
+| Question | Answer | Rationale |
+|---|---|---|
+| Medical/Treatment Information | **None** | N/A — repeats the earlier question; same answer. |
+
+### Other
+
+| Question | Answer | Rationale |
+|---|---|---|
+| In-app purchases | **No** | App is free with no IAP. |
+| Made for Kids | **No** | App is general audience, not specifically for children under 13. |
+
+---
+
+## Expected Final Rating
+
+Based on the above, App Store Connect should derive: **12+**
+
+The drivers for 12+:
+- "Infrequent or Mild" alcohol references → 12+ minimum
+- UGC with moderation controls → does not bump to 17+ when filtered/reported
+
+If Dan answers "None" for alcohol, the rating will likely be **9+** or **4+** depending on Apple's UGC weighting. **Recommend 12+ for defensibility** — comparable category apps (Yelp, Beli, OpenTable, Resy) are rated 12+ to 17+. Going lower invites a "you have alcohol references" rejection.
+
+---
+
+## How to enter in App Store Connect
+
+1. Go to **App Store Connect → My Apps → What's Good Here → App Information → Age Rating**
+2. Click **Edit**
+3. Answer each row above. The system auto-derives the final rating in real time as you click — verify it lands at **12+** when complete.
+4. Save.
+
+If Apple's questionnaire UI has questions not covered above, default to the most conservative "None" / "No" answer and document it inline in this file for the next session.
+
+---
+
+## Why not 4+
+
+A "4+" rating is achievable only if alcohol = "None" AND UGC moderation is sufficient. Two risks:
+1. **Reviewer can find alcohol in the restaurant data** — restaurants serve alcohol; their menus list cocktails; Apple's reviewer will see this when testing the demo account.
+2. **UGC apps without explicit "Infrequent or Mild" mature content typically get pushed to 12+ on appeal.** Better to set 12+ at submission than fight an "incorrect age rating" rejection.
+
+The App Store doesn't penalize a higher rating for installs — both 4+ and 12+ apps are downloadable by the same audience (subject to Screen Time controls).
+
+---
+
+## Why not 17+
+
+17+ is for apps with frequent intense content. WGH would only reach 17+ if:
+- We added unrestricted web access (in-app browser to arbitrary URLs)
+- Reviews/photos showed graphic content unfiltered
+- App promoted alcohol consumption (e.g. "best spots to get drunk")
+
+None of these apply. 12+ is the correct band.

--- a/docs/superpowers/specs/2026-05-06-app-store-submission-day.md
+++ b/docs/superpowers/specs/2026-05-06-app-store-submission-day.md
@@ -1,0 +1,456 @@
+# App Store Submission Day — Single Source of Truth
+
+**Date:** 2026-05-06
+**Status:** Open this doc the moment Apple Dev verification clears. Walk top-to-bottom. Every field has paste-ready content. Estimated time start-to-submit: **30–60 minutes** (assuming build is already on TestFlight).
+
+This consolidates: `2026-05-04-app-store-description-final.md` · `2026-05-03-app-store-reviewer-notes.md` · `app-store-connect-privacy-details.md` · `2026-04-27-app-store-listing-assets.md` · `2026-05-06-app-store-age-rating.md` · `2026-05-06-app-store-whats-new.md`.
+
+If the source docs and this doc disagree, **trust this doc** — it's the latest reconciliation. Then update the source.
+
+---
+
+## §0 — Preflight (do BEFORE opening App Store Connect)
+
+**All must be ✅ before pasting anything:**
+
+- [ ] Apple Developer enrollment cleared (Account screen shows "Apple Developer Program" active, not pending)
+- [ ] **SIWA path decided** (Codex 4.8 finding): either (A) ship SIWA end-to-end via B3-activate + B5 + Xcode capability, OR (B) hide Google sign-in button in the review build to avoid 4.8 violation. Cannot ship Google-without-Apple.
+- [ ] **iPad path decided** (Codex finding): either drop `TARGETED_DEVICE_FAMILY` in `ios/App/App.xcodeproj/project.pbxproj` from `"1,2"` to `"1"` (iPhone only — recommended), OR shoot + upload iPad screenshots at 13" / 12.9" tiers.
+- [ ] **PrivacyInfo.xcprivacy rebuilt into TestFlight build** — updated 2026-05-06 to add SearchHistory/UserID/DeviceID/OtherDataTypes (Jitter)/OtherDiagnosticData and remove PreciseLocation. Must be in the binary Apple scans, not just on disk.
+- [ ] **Phone field has a real number** (not the placeholder in §8 below).
+- [ ] B3-activate complete (if path A): Apple credentials in Supabase Vault, Auth provider configured, AASA Team ID replaced, `VITE_FEATURES_APPLE_SIGNIN=true` in prod
+- [ ] B5 complete (if path A): Sign in with Apple capability added in Xcode (`App.entitlements` currently has NO `com.apple.developer.applesignin` key — verified 2026-05-06), real-device smoke passed
+- [ ] TestFlight build uploaded and at least one internal tester has signed in successfully
+- [ ] Demo account verified working in TestFlight build: `walshdaniel143+wghdemo@gmail.com` / `WGH33!`
+- [ ] **Demo account enriched** to match reviewer-notes claim of "rated dishes, photos, and favorites" — currently has 5 rated dishes + name set; needs at least 1 photo + 1 favorite OR reviewer-notes wording softened to match. Don't let the doc and the account contradict each other.
+- [ ] `https://wghapp.com/privacy` returns 200 (verified 2026-05-06 ✅) — and includes Anthropic + Jitter in third-party list (added 2026-05-06)
+- [ ] `https://wghapp.com/terms` returns 200 (verified 2026-05-06 ✅)
+- [ ] `https://wghapp.com/support` returns 200 (verified 2026-05-06 ✅)
+- [ ] `wghapp@wghapp.com` is monitored or forwards to a monitored inbox
+- [ ] 5 screenshots at 1320×2868 (or 1290×2796) saved + visually QAed (verified 2026-05-06 ✅)
+- [ ] Account-deletion flow tested end-to-end on a fresh test account in TestFlight build (text now says "votes, reviews, photos, favorites, playlists, follows, and profile" — updated 2026-05-06 to match schema cascade)
+
+If any of the above is ❌, stop and resolve before submitting.
+
+---
+
+## §1 — App Information (App Store Connect → My Apps → Create)
+
+### Name
+```
+What's Good Here
+```
+*(15 chars / 30 max)*
+
+### Subtitle
+```
+Locally rated dishes, mapped
+```
+*(28 chars / 30 max — Dan to confirm or pick alternate from `2026-04-27-app-store-listing-assets.md` §3)*
+
+Alternates Dan can substitute:
+- `Find the best dish nearby` (25 chars)
+- `Map-first food discovery` (24 chars)
+- `The best dish on the island` (28 chars)
+
+### Bundle ID
+```
+com.whatsgoodhere.app
+```
+*(Locked — never change. Per `project_bundle_id` memory.)*
+
+### SKU
+```
+wgh-ios-001
+```
+*(Internal Apple identifier; never exposed to users.)*
+
+### Primary Language
+```
+English (U.S.)
+```
+
+### Category
+- **Primary:** `Food & Drink`
+- **Secondary:** `Travel`
+
+### Content Rights
+- **Does your app contain, show, or access third-party content?** **Yes**
+- Specifically: Google Places data (restaurant discovery), OpenStreetMap tiles (map base layer)
+- All sources have appropriate licensing (Google Places API agreement; OpenStreetMap ODbL)
+
+---
+
+## §2 — Pricing and Availability
+
+| Field | Value |
+|---|---|
+| Price | **Free** (Tier 0) |
+| Availability | **United States** at launch |
+| Pre-order | **No** |
+| Educational Discount | **No** |
+
+*Geo-restricting to US at launch reduces surprise. Expand to Canada/UK post-launch when we have data quality confidence.*
+
+---
+
+## §3 — Age Rating
+
+Paste-ready answers in `docs/superpowers/specs/2026-05-06-app-store-age-rating.md`. **Expected derived rating: 12+.**
+
+Critical answers:
+- Alcohol, Tobacco, or Drug Use or References → **Infrequent or Mild** (defensible — restaurant menus contain alcohol)
+- User-Generated Content → **Yes** (with moderation controls)
+- Unrestricted Web Access → **No**
+- All violence/sexual/profanity questions → **None**
+- Made for Kids → **No**
+
+ASC computes the rating live as you click. Verify it lands at **12+** before saving. If it derives **17+**, double-check you didn't accidentally answer "Frequent or Intense" anywhere.
+
+---
+
+## §4 — App Privacy
+
+Paste-ready in `docs/app-store-connect-privacy-details.md`. ASC asks two layers:
+
+### Layer 1: Data types collected (check these boxes)
+- Contact Info → ✅ Email Address, ✅ Name
+- Location → ✅ Coarse Location *(NOT Precise — we don't use `enableHighAccuracy`)*
+- User Content → ✅ Photos or Videos, ✅ Other User Content (ratings/reviews/favorites/playlists/reports/blocks)
+- Search History → ✅ Search History (PostHog events)
+- Identifiers → ✅ User ID, ✅ Device ID
+- Usage Data → ✅ Product Interaction
+- Diagnostics → ✅ Crash Data, ✅ Performance Data, ✅ Other Diagnostic Data
+- Other Data → ✅ Other Data (Jitter Protocol keystroke cadence — flag in reviewer notes)
+
+### Layer 2: For each data type
+- **Tracking:** **No** for all (we do not share with data brokers, do not match against third-party data for ads)
+- **Linked to identity:** YES for Email/Name/Photos/User Content/Search History/User ID/Device ID/Product Interaction/Jitter; **NO** for Coarse Location (in-session only, not persisted with user ID); **NO** for Crash Data / Performance Data / Other Diagnostic Data (Sentry initialized globally; no `Sentry.setUser()` call in src/ — verified 2026-05-06)
+- **Purpose:** App Functionality for content/identity; Analytics for diagnostics + product interaction; App Functionality for Jitter (fraud prevention)
+
+Full grid in `docs/app-store-connect-privacy-details.md`.
+
+### ⚠️ Disclosures reviewers will probe (per Codex review 2026-05-06)
+- **Anthropic Claude vision** processes user-uploaded dish photos for content-safety check before display. Disclosed in `Privacy.jsx` "Dish Photos" + third-party services list. Mention in reviewer notes if asked about photo moderation.
+- **Jitter Protocol** receives keystroke metadata + `user_id` for review trust scoring. Disclosed in `Privacy.jsx` "Typing Cadence" + third-party services list.
+- Both are required disclosures under Guideline 5.1.2(i) (third-party data sharing, including third-party AI).
+
+---
+
+## §5 — Version Information (1.0)
+
+### Version Number
+```
+1.0
+```
+
+### Copyright
+```
+© 2026 Daniel Walsh
+```
+*(Update when LLC formed per `project_apple_dev_account` memory.)*
+
+### Promotional Text (≤170 chars, editable post-launch without re-review)
+
+**At launch:**
+```
+The best dishes on Martha's Vineyard, ranked by people who actually ate them. Map-first discovery. Memorial Day weekend, ready when you are.
+```
+*(146 chars)*
+
+### Description (≤4000 chars) — paste-ready
+
+```
+Trying to find the best lobster roll near you? We got you.
+
+What's Good Here is the local guide to what to actually order — every dish at every restaurant, rated 1 through 10 by people who've eaten it.
+
+Pick a restaurant the old way. Then pick what to order the new way. We add the layer underneath: every dish on the menu, ranked by the people who've tried it. Whether you're new to a place or you've eaten there for years, the answer is in the app.
+
+How it works:
+- Browse dishes ranked by people who tried them
+- Switch to map mode to see what's good near you
+- Rate dishes 1–10 — your votes shape what's actually good
+- Save the ones worth coming back for
+
+What's good here? Now you know.
+```
+*(~810 chars / 4000 max — final per `2026-05-04-app-store-description-final.md`)*
+
+#### ⚠️ Codex flagged 2 falsifiable claims (low risk, holding original)
+- **"every dish at every restaurant"** — we don't actually have every dish; aspirational marketing
+- **"by people who've eaten it"** — no purchase/checkin verification; community-submitted
+
+**Decision: keep original copy.** Industry-standard claims (Yelp/OpenTable use equivalent language). Apple rarely rejects for aspirational marketing prose in descriptions. **Backup wording if Apple kicks back under 2.3:**
+
+```
+Trying to find the best lobster roll near you? We got you.
+
+What's Good Here is the local guide to what to actually order — many of the dishes at the restaurants we cover, rated 1 through 10 by the community.
+
+Pick a restaurant the old way. Then pick what to order the new way. We add the layer underneath: a ranked dish list for the restaurants we cover, built from real community ratings. Whether you're new to a place or you've eaten there for years, the answer is in the app.
+
+How it works:
+- Browse dishes ranked by community ratings
+- Switch to map mode to see what's good near you
+- Rate dishes 1–10 — your votes shape what's actually good
+- Save the ones worth coming back for
+
+What's good here? Now you know.
+```
+
+### Keywords (≤100 chars total, comma-separated, no spaces around commas)
+
+```
+food,dish,restaurant,menu,vineyard,nantucket,cape cod,review,rating,local,where,top,map
+```
+*(75 chars — leaves headroom)*
+
+Notes:
+- Don't repeat "good" or "here" — already indexed via app name
+- Geo-keywords ("vineyard", "nantucket", "cape cod") match local-search behavior
+- "where" and "top" capture intent queries ("where to eat", "top dishes")
+
+### Support URL
+```
+https://wghapp.com/support
+```
+*(`/support` page is shipped and live — verified 2026-05-06.)*
+
+### Marketing URL
+```
+https://wghapp.com
+```
+
+### Privacy Policy URL
+```
+https://wghapp.com/privacy
+```
+
+### Version Release
+- **Manually release this version** (recommended) — gives Dan control over launch timing relative to Memorial Day push
+- (Alternate: Automatically release after approval — risky for marketing coordination)
+
+### What's New in This Version (≤4000 chars)
+
+```
+First release. The local guide to what to actually order — every dish at every restaurant, ranked 1 through 10 by people who've eaten it.
+
+- Browse top-rated dishes near you
+- Switch to map mode to see what's good around you
+- Rate dishes 1–10 to shape what's actually good
+- Save the ones worth coming back for
+
+What's good here? Now you know.
+```
+*(287 chars — per `2026-05-06-app-store-whats-new.md`)*
+
+---
+
+## §6 — Screenshots (5 required, 6.9" tier)
+
+**Location:** `~/Desktop/Simulator Screenshot - iPhone 17 Pro Max - 2026-05-06 at 14.{44.03,44.43,45.09,45.49,46.12}.png`
+**Dimensions:** 1320×2868 (Apple-compliant, verified 2026-05-06)
+
+Upload order in App Store Connect (drag in this sequence — first screenshot is the App Store hero):
+
+1. **Map mode** — `14.44.03.png` (the wedge — what makes WGH different)
+2. **Top 10 list** — `14.44.43.png` (social proof — crowd-rated dishes)
+3. **Dish detail** — `14.45.09.png` (depth — ratings, reviews, Jitter trust badge)
+4. **Profile** — `14.45.49.png` (identity — your food story)
+5. **Restaurant detail** — `14.46.12.png` (loop close — order with confidence)
+
+**Captions (App Store Connect lets you add overlay text — optional but recommended):** see `2026-04-27-app-store-listing-assets.md` §1 for caption per shot.
+
+### App Preview Video
+**Skip for v1.0.** Optional. Adds production overhead with no marginal install lift for first launch.
+
+---
+
+## §7 — Build (uploaded from Xcode → TestFlight → promoted here)
+
+ASC pulls the build from your TestFlight uploads. Steps:
+1. In App Store Connect → My Apps → What's Good Here → 1.0 → "Build" section
+2. Click **"+"** → select the latest TestFlight build
+3. Verify build number matches what passed real-device smoke
+4. Apple will scan the build for entitlements + privacy manifest compliance — check no warnings before proceeding
+
+---
+
+## §8 — App Review Information
+
+### Sign-In Information (required because the app has authenticated features)
+
+| Field | Value |
+|---|---|
+| Sign-in required | **Yes** |
+| Username | `walshdaniel143+wghdemo@gmail.com` |
+| Password | `WGH33!` |
+| Sign-in steps | (paste from §9 reviewer notes — covers location prompt + sign-in flow) |
+
+### Contact Information
+
+| Field | Value |
+|---|---|
+| First Name | `Daniel` |
+| Last Name | `Walsh` |
+| Phone | **⚠️ Dan to fill in real phone number — required field, can't ship placeholder** |
+| Email | `walshdaniel143@gmail.com` *(personal — Apple uses this for review correspondence; NOT the public support address)* |
+
+### Notes for Review
+
+Paste verbatim from `docs/superpowers/specs/2026-05-03-app-store-reviewer-notes.md` §1 — the block between the triple-backticks. Reproduced here for paste convenience:
+
+```
+What's Good Here is a map-first food discovery app for Martha's Vineyard.
+Users find the best DISHES (not restaurants), ranked by community-
+submitted 1–10 ratings.
+
+────────────────────────────
+HOW TO TEST
+────────────────────────────
+
+1. Location is optional. If you deny the location prompt, the app
+   defaults to Martha's Vineyard and core browsing still works.
+
+2. The home screen shows a ranked list of nearby dishes by default.
+   Tap the floating round button in the bottom-right corner to switch
+   to map mode. Pins use category emoji (pizza slice, lobster, etc.)
+   to indicate dish type.
+
+3. Tap any dish to see its detail page: ratings, reviews, photo,
+   restaurant info.
+
+4. Tap any restaurant name to see the restaurant's ranked dish list.
+
+5. To test authenticated features (voting, favorites, photo upload,
+   profile), sign in with the demo account below using EMAIL +
+   PASSWORD. Other features (browse, search, map) are guest-accessible.
+
+────────────────────────────
+DEMO ACCOUNT (email + password)
+────────────────────────────
+
+Email:    walshdaniel143+wghdemo@gmail.com
+Password: WGH33!
+
+This account is pre-populated with rated dishes, photos, and favorites
+to show representative content (not an empty state).
+
+PLEASE DO NOT DELETE THIS ACCOUNT — it is shared across all reviewers.
+If you wish to test the account-deletion flow (Guideline 5.1.1(v)),
+please create a new account via the email signup flow on the login
+screen, then delete that account.
+
+────────────────────────────
+ACCOUNT DELETION (Guideline 5.1.1(v))
+────────────────────────────
+
+Path: Profile tab → tap the gear icon (top-right) → Delete Account.
+
+Deletion is permanent and irreversible: votes, reviews, photos,
+profile, and follows are removed. The action requires an explicit
+confirm step.
+
+────────────────────────────
+USER-GENERATED CONTENT (Guideline 1.2)
+────────────────────────────
+
+- All user reviews and photos pass a content-safety filter before
+  display.
+- Reviewers can report inappropriate content via the report button on
+  any review or photo.
+- Reviewers can block other users; blocked users' content is hidden.
+- Reports are reviewed by our admin moderation queue.
+
+────────────────────────────
+PRIVACY
+────────────────────────────
+
+- Privacy policy: https://wghapp.com/privacy
+- Terms of service: https://wghapp.com/terms
+- Camera and photo library permissions are requested only when a user
+  uploads a dish photo.
+- We do not use third-party advertising SDKs.
+- We do not track users across other companies' apps or websites.
+
+────────────────────────────
+SUPPORT
+────────────────────────────
+
+Email: wghapp@wghapp.com
+```
+
+### Attachment(s)
+None required. If reviewers raise questions, attach screenshots showing the report/block/delete flows on follow-up.
+
+---
+
+## §9 — Submit for Review
+
+After every section above is filled and saved:
+
+1. Click **"Add for Review"** at the top right
+2. ASC runs final validation — fix any red errors before submitting
+3. Click **"Submit for Review"**
+4. Status changes to **"Waiting for Review"** → **"In Review"** (typically 12–48h) → **"Pending Developer Release"** (because we set Manual release)
+5. Once "Pending Developer Release", Dan clicks **"Release This Version"** at his chosen launch moment
+
+**Apple review SLA:** typically 24–72h for apps without complex entitlements. SIWA + UGC may add a day. Build a 3–5 day buffer before Memorial Day for the rejection-and-resubmit cycle.
+
+---
+
+## §10 — Rejection Playbook (in case of)
+
+Most likely rejections, ordered by historical frequency, with pre-staged responses:
+
+### "Demo account doesn't work"
+**Cause:** TestFlight build promoted to App Store had a regression OR demo account password was changed
+**Response:** Verify locally on TestFlight build → fix → resubmit. Don't argue with reviewer.
+
+### "Account deletion not found / unclear"
+**Cause:** Reviewer can't find the path
+**Response:** Reply with screenshot of: Profile → gear icon → Delete Account. Pin to first paragraph of follow-up.
+
+### "Sign in with Apple required"
+**Cause:** Apple requires SIWA whenever the app offers third-party social sign-in (Google). We have this — verify B3-activate is fully live in submitted build.
+**Response:** Confirm SIWA is offered in the submitted build (not just behind a flag). If `VITE_FEATURES_APPLE_SIGNIN` was false in build, fix and resubmit.
+
+### "Privacy nutrition label inaccurate"
+**Cause:** Apple found data collection not declared (or vice versa)
+**Response:** Most common miss: not declaring Device ID. We declared it ✅. If they cite something else, audit `docs/app-store-connect-privacy-details.md` against actual code.
+
+### "Inappropriate content / UGC moderation insufficient"
+**Cause:** Reviewer found content via search that they consider violating
+**Response:** Cite UGC moderation block in reviewer notes. Show report flow. May need to flush specific content if cited explicitly.
+
+### "Guideline 4.0 — Design"
+**Cause:** Reviewer thinks the app is incomplete or low-utility
+**Response:** This is rare for v1.0 of a well-positioned product. If raised, lean on the wedge: "ranked dish-level recommendations are not provided by Yelp or Google." Don't capitulate to "make it look more like Yelp" feedback.
+
+---
+
+## §11 — After Submission
+
+- [ ] Set a calendar reminder to check status every 12 hours
+- [ ] Monitor `walshdaniel143@gmail.com` for ASC notifications (review status, rejections)
+- [ ] Monitor `wghapp@wghapp.com` in case Apple emails the public support address
+- [ ] Keep a quick-fix branch ready for the 1–2 most likely rejections (demo account regression, missing screenshot, etc.)
+- [ ] Do NOT push new builds to TestFlight while in review (it can confuse the reviewer about which build is canonical)
+
+---
+
+## §12 — Source Docs Index
+
+| Topic | Source doc |
+|---|---|
+| Description copy | `docs/superpowers/specs/2026-05-04-app-store-description-final.md` |
+| Reviewer notes | `docs/superpowers/specs/2026-05-03-app-store-reviewer-notes.md` |
+| Privacy nutrition labels | `docs/app-store-connect-privacy-details.md` |
+| Subtitle / keywords / promo / screenshots shotlist | `docs/superpowers/specs/2026-04-27-app-store-listing-assets.md` |
+| Age rating | `docs/superpowers/specs/2026-05-06-app-store-age-rating.md` |
+| What's New text | `docs/superpowers/specs/2026-05-06-app-store-whats-new.md` |
+| Final push plan (engineering blocks) | `docs/superpowers/plans/2026-04-27-app-store-final-push.md` |
+| Apple Dev wait + contingency | `docs/superpowers/plans/2026-05-06-apple-dev-wait-plan.md` |
+
+If you find a discrepancy between this doc and a source, **this doc wins** — then update the source.

--- a/docs/superpowers/specs/2026-05-06-app-store-whats-new.md
+++ b/docs/superpowers/specs/2026-05-06-app-store-whats-new.md
@@ -1,0 +1,66 @@
+# App Store "What's New in This Version" — v1.0
+
+**Date:** 2026-05-06
+**Status:** Paste-ready for App Store Connect → "Version Information" → "What's New in This Version"
+**Char limit:** 4000 (same as Description). Ours is short on purpose.
+
+---
+
+## Recommended (paste this)
+
+```
+First release. The local guide to what to actually order — every dish at every restaurant, ranked 1 through 10 by people who've eaten it.
+
+- Browse top-rated dishes near you
+- Switch to map mode to see what's good around you
+- Rate dishes 1–10 to shape what's actually good
+- Save the ones worth coming back for
+
+What's good here? Now you know.
+```
+
+(287 chars. Mirrors the Description voice without re-pasting it.)
+
+---
+
+## Why this short
+
+For v1.0, "What's New" is essentially a second hook — the user is reading it because they tapped into the listing or the update screen. Reviewers also read it. Two principles:
+
+1. **Don't repeat the Description.** Apple's UI shows them on the same screen. Repetition burns trust.
+2. **Don't promise features for next versions.** Reviewers reject apps that advertise unreleased functionality.
+
+For v1.0 specifically, "First release" is the most honest framing. Subsequent versions get changelog-style entries.
+
+---
+
+## Future versions — template
+
+When shipping v1.1+, follow this pattern:
+
+```
+What's new:
+- [Most user-visible improvement, one line]
+- [Second improvement]
+- Bug fixes and performance improvements
+
+[Optional one-line voice closer if there's something earned to say]
+```
+
+Example v1.1 (hypothetical):
+```
+What's new:
+- Top 10 by category — Pizza, Seafood, Cocktails, more
+- Faster map loading on slower connections
+- Bug fixes and performance improvements
+```
+
+---
+
+## What NOT to put in "What's New"
+
+- "Thanks for using our app!" — empty calories, reviewers ignore
+- Roadmap or "coming soon"
+- Marketing dates (Memorial Day, etc.)
+- Explanations of features that already shipped in earlier versions
+- Apologies for delays

--- a/docs/superpowers/specs/2026-05-06-google-killswitch-contingency.md
+++ b/docs/superpowers/specs/2026-05-06-google-killswitch-contingency.md
@@ -1,0 +1,173 @@
+# Google Sign-In Kill Switch — Contingency
+
+**Date:** 2026-05-06
+**Status:** Pre-staged. Apply ONLY if Apple Dev verification fails to clear in time AND we still need to submit before Memorial Day.
+
+**Why this exists:** Apple Guideline 4.8 requires Sign in with Apple if the app offers any third-party social sign-in. Google is currently in the build. SIWA is gated on Apple Dev clearance (B3-activate + B5). If Apple Dev doesn't clear, we can't ship SIWA. The only way to submit without 4.8 violation is to remove Google for the review build.
+
+This doc is the 5-minute apply path. Restore in v1.1 once SIWA is configured.
+
+---
+
+## Trigger conditions (apply this when ALL are true)
+
+1. Apple Dev verification has NOT cleared
+2. Memorial Day deadline is < 7 days away
+3. Dan has decided to ship email-only for v1.0
+
+If any of those is false, do NOT apply.
+
+---
+
+## Step 1 — Add feature flag (1 file, 1 line)
+
+`src/constants/features.js` — add a new flag mirroring the Apple pattern:
+
+```diff
+ export const FEATURES = {
+   // Sign in with Apple — code is wired up; button only renders when this flag
+   // is true AND the iOS Capacitor build has the SIWA capability.
+   APPLE_SIGNIN_ENABLED: import.meta.env.VITE_FEATURES_APPLE_SIGNIN === 'true',
++
++  // Google Sign-In — defaults to ON; flip to false via env var to hide the
++  // Google button (used for Apple-Guideline-4.8 compliance when SIWA isn't
++  // yet shipped). Default-on means existing deploys keep working unchanged.
++  GOOGLE_SIGNIN_ENABLED: import.meta.env.VITE_FEATURES_GOOGLE_SIGNIN !== 'false',
+ }
+```
+
+---
+
+## Step 2 — Gate the LoginModal Google button
+
+`src/components/Auth/LoginModal.jsx` — wrap the existing Google button block (~lines 305–319):
+
+```diff
+-              {/* Google Sign In */}
+-              <button
+-                onClick={handleGoogleSignIn}
++              {/* Google Sign In — gated on FEATURES.GOOGLE_SIGNIN_ENABLED for
++                  Apple-4.8 compliance when SIWA isn't shipped */}
++              {FEATURES.GOOGLE_SIGNIN_ENABLED && (
++              <button
++                onClick={handleGoogleSignIn}
+                 disabled={loading}
+                 ... existing className + style + svg + label ...
+               </button>
++              )}
+```
+
+(Keep the divider + email button as-is — they're outside the Google block.)
+
+---
+
+## Step 3 — Gate the Login.jsx Google button
+
+`src/pages/Login.jsx` — wrap the existing Google button block (~lines 416–430):
+
+```diff
+-                {/* Google Sign In */}
+-                <button
+-                  onClick={handleGoogleSignIn}
++                {/* Google Sign In — gated on FEATURES.GOOGLE_SIGNIN_ENABLED for
++                    Apple-4.8 compliance when SIWA isn't shipped */}
++                {FEATURES.GOOGLE_SIGNIN_ENABLED && (
++                <button
++                  onClick={handleGoogleSignIn}
+                   disabled={loading}
+                   ... existing className + style + svg + label ...
+                 </button>
++                )}
+```
+
+Verify `FEATURES` is already imported at top of `Login.jsx`. If not, add:
+
+```js
+import { FEATURES } from '../constants/features'
+```
+
+---
+
+## Step 4 — Flip the env var
+
+In Vercel project settings → Environment Variables → set for Production (and Preview if you want previews to mirror):
+
+```
+VITE_FEATURES_GOOGLE_SIGNIN=false
+```
+
+Trigger a rebuild — Vercel auto-rebuilds on env var change.
+
+For the iOS native build (Capacitor), the same env var needs to be in the local `.env` (or `.env.production`) at the time you run `npm run build && npx cap sync ios`. The Vite build embeds env vars at build time.
+
+---
+
+## Step 5 — Verify before TestFlight upload
+
+Local smoke check:
+
+```bash
+VITE_FEATURES_GOOGLE_SIGNIN=false npm run build
+# Open a built page and confirm the Google button is GONE from the login modal
+```
+
+Then:
+
+```bash
+VITE_FEATURES_GOOGLE_SIGNIN=false npm run build && npx cap sync ios
+# Open Xcode, archive, upload to TestFlight
+# Smoke test: install via TestFlight, open login modal — verify only "Sign in with Email" is present
+```
+
+---
+
+## Step 6 — Update reviewer notes
+
+Edit `docs/superpowers/specs/2026-05-03-app-store-reviewer-notes.md` — change the auth-method line:
+
+```diff
+- 5. To test authenticated features (voting, favorites, photo upload,
+-    profile), sign in with the demo account below using EMAIL +
+-    PASSWORD. Other features (browse, search, map) are guest-accessible.
++ 5. To test authenticated features (voting, favorites, photo upload,
++    profile), sign in with the demo account below using EMAIL +
++    PASSWORD. (Email is the only sign-in method offered in this version;
++    additional sign-in methods will be added in a follow-up release.)
++    Other features (browse, search, map) are guest-accessible.
+```
+
+This pre-empts the obvious reviewer question "why no Google?".
+
+---
+
+## Step 7 — Restore in v1.1
+
+After Apple Dev clears + B3-activate + B5 ship:
+
+1. Remove `VITE_FEATURES_GOOGLE_SIGNIN=false` from Vercel env (or set to `true`)
+2. Add `VITE_FEATURES_APPLE_SIGNIN=true`
+3. Add SIWA capability in Xcode (`com.apple.developer.applesignin` in `App.entitlements`)
+4. Submit v1.1 — both Google + Apple visible, equal prominence
+
+---
+
+## Why a feature flag instead of deleting the button
+
+- **Reversible in 1 env-var flip** — no code re-PR for v1.1
+- **Default-on means non-iOS builds keep working** — web users still see Google
+- **Won't lose the JSX** — comments, styles, click handler all intact
+- **Mirrors the existing `APPLE_SIGNIN_ENABLED` pattern** — consistent codebase
+
+---
+
+## Estimated apply time: 5 minutes
+
+1. Add 4 lines to `features.js` — 30s
+2. Wrap LoginModal Google block — 30s
+3. Wrap Login.jsx Google block — 30s
+4. Flip Vercel env var — 30s
+5. Local build verify — 60s
+6. Update reviewer notes — 60s
+7. iOS Capacitor build + TestFlight upload — 5–10 min separately
+
+If we're at this point, the gate is Apple Dev clearance + a clean TestFlight build. The code is the trivial part.

--- a/ios/App/App/PrivacyInfo.xcprivacy
+++ b/ios/App/App/PrivacyInfo.xcprivacy
@@ -34,6 +34,31 @@
         </dict>
         <dict>
             <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeUserID</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+                <string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeDeviceID</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
             <string>NSPrivacyCollectedDataTypePhotosorVideos</string>
             <key>NSPrivacyCollectedDataTypeLinked</key>
             <true/>
@@ -58,6 +83,18 @@
         </dict>
         <dict>
             <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeSearchHistory</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
             <string>NSPrivacyCollectedDataTypeCoarseLocation</string>
             <key>NSPrivacyCollectedDataTypeLinked</key>
             <false/>
@@ -70,14 +107,15 @@
         </dict>
         <dict>
             <key>NSPrivacyCollectedDataType</key>
-            <string>NSPrivacyCollectedDataTypePreciseLocation</string>
+            <string>NSPrivacyCollectedDataTypeProductInteraction</string>
             <key>NSPrivacyCollectedDataTypeLinked</key>
-            <false/>
+            <true/>
             <key>NSPrivacyCollectedDataTypeTracking</key>
             <false/>
             <key>NSPrivacyCollectedDataTypePurposes</key>
             <array>
-                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+                <string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+                <string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
             </array>
         </dict>
         <dict>
@@ -107,14 +145,26 @@
         </dict>
         <dict>
             <key>NSPrivacyCollectedDataType</key>
-            <string>NSPrivacyCollectedDataTypeProductInteraction</string>
+            <string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
             <key>NSPrivacyCollectedDataTypeLinked</key>
             <true/>
             <key>NSPrivacyCollectedDataTypeTracking</key>
             <false/>
             <key>NSPrivacyCollectedDataTypePurposes</key>
             <array>
-                <string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
             </array>
         </dict>
     </array>

--- a/src/components/profile/DeleteAccountSection.jsx
+++ b/src/components/profile/DeleteAccountSection.jsx
@@ -34,8 +34,8 @@ export function DeleteAccountSection() {
           className="leading-relaxed"
           style={{ color: 'var(--color-text-secondary)', fontSize: '14px', marginBottom: '16px' }}
         >
-          This permanently removes your votes, reviews, photos, favorites, and profile.
-          This can't be undone.
+          This permanently removes your votes, reviews, photos, favorites, playlists, follows,
+          and profile. This can't be undone.
         </p>
         <button
           type="button"
@@ -127,9 +127,9 @@ export function DeleteAccountModal({ onClose }) {
             className="text-sm leading-relaxed mb-5"
             style={{ color: 'var(--color-text-secondary)' }}
           >
-            This is permanent. We'll remove your votes, reviews, photos, favorites, and profile
-            from What's Good Here. Dish rankings that included your votes will be recalculated
-            without them.
+            This is permanent. We'll remove your votes, reviews, photos, favorites, playlists,
+            follows, and profile from What's Good Here. Dish rankings that included your votes
+            will be recalculated without them.
           </p>
 
           <label

--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -41,18 +41,19 @@ export function Privacy() {
               What's Good Here is operated by Daniel Walsh (Martha's Vineyard, Massachusetts).
               Contact:{' '}
               <a
-                href="mailto:hello@wghapp.com"
+                href="mailto:wghapp@wghapp.com"
                 className="font-medium"
                 style={{ color: 'var(--color-primary)' }}
               >
-                hello@wghapp.com
+                wghapp@wghapp.com
               </a>
               . Mailing address: Daniel Walsh, 134 Franklin Ter, Vineyard Haven, MA 02568.
             </p>
             <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
               What's Good Here ("we", "our", or "the app") is a community-driven food discovery
-              platform for Martha's Vineyard. This Privacy Policy explains what we collect, what
-              we do with it, and what choices you have.
+              platform, currently focused on Martha's Vineyard with coverage extending to nearby
+              coastal Massachusetts as the data quality is earned. This Privacy Policy explains
+              what we collect, what we do with it, and what choices you have.
             </p>
           </section>
 
@@ -86,9 +87,11 @@ export function Privacy() {
                 <h3 className="font-medium mb-1" style={{ color: 'var(--color-text-primary)' }}>Dish Photos</h3>
                 <p>
                   When you upload a photo of a dish, we store the image, the dish it's attached
-                  to, and a timestamp. We don't use your photos for anything other than displaying
-                  them on the dish page and in your profile. You can delete a photo you uploaded
-                  at any time.
+                  to, and a timestamp. Before a photo is shown on the dish page, we send it to
+                  Anthropic's Claude vision model for an automated content-safety check (to
+                  catch inappropriate images). We don't use your photos for anything other than
+                  this safety check and displaying them on the dish page and in your profile.
+                  You can delete a photo you uploaded at any time.
                 </p>
               </div>
               <div>
@@ -182,8 +185,10 @@ export function Privacy() {
               <li><strong>Vercel</strong> — our hosting provider</li>
               <li><strong>Google</strong> — Sign in with Google, and the Google Places API for restaurant discovery (we send location queries to Google to find nearby places)</li>
               <li><strong>Apple</strong> — Sign in with Apple on iOS and web (subject to Apple's privacy policy)</li>
+              <li><strong>Anthropic</strong> — Claude vision model for automated dish-photo content-safety checks before display</li>
               <li><strong>PostHog</strong> — product analytics</li>
               <li><strong>Sentry</strong> — error tracking</li>
+              <li><strong>Jitter Protocol</strong> — third-party trust-scoring service for review-cadence attestation (see "Typing Cadence" above)</li>
             </ul>
           </section>
 
@@ -295,11 +300,11 @@ export function Privacy() {
               If you believe a dish photo or review on the app infringes your copyright, send
               a written notice to{' '}
               <a
-                href="mailto:hello@wghapp.com"
+                href="mailto:wghapp@wghapp.com"
                 className="font-medium"
                 style={{ color: 'var(--color-primary)' }}
               >
-                hello@wghapp.com
+                wghapp@wghapp.com
               </a>
               {' '}that includes: (1) an identification of the copyrighted work you claim has
               been infringed; (2) the URL or description of the infringing content; (3) your
@@ -329,11 +334,11 @@ export function Privacy() {
             <p className="leading-relaxed mb-2" style={{ color: 'var(--color-text-secondary)' }}>
               If you have questions about this Privacy Policy, please contact us at:{' '}
               <a
-                href="mailto:hello@wghapp.com"
+                href="mailto:wghapp@wghapp.com"
                 className="font-medium"
                 style={{ color: 'var(--color-primary)' }}
               >
-                hello@wghapp.com
+                wghapp@wghapp.com
               </a>
             </p>
             <address className="not-italic leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>

--- a/src/pages/Support.jsx
+++ b/src/pages/Support.jsx
@@ -60,11 +60,11 @@ export function Support() {
               The fastest way to reach us:
             </p>
             <a
-              href="mailto:hello@wghapp.com"
+              href="mailto:wghapp@wghapp.com"
               className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl font-semibold"
               style={{ background: 'var(--color-primary)', color: 'var(--color-text-on-primary)', fontSize: '14px' }}
             >
-              hello@wghapp.com
+              wghapp@wghapp.com
             </a>
             <p className="leading-relaxed mt-3" style={{ color: 'var(--color-text-secondary)', fontSize: '13px' }}>
               We read every email. Typical response time: 1-2 business days.

--- a/src/pages/Terms.jsx
+++ b/src/pages/Terms.jsx
@@ -50,8 +50,9 @@ export function Terms() {
             </h2>
             <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
               What's Good Here is a community-driven platform that helps people discover great
-              dishes on Martha's Vineyard. Users rate dishes, write reviews, upload photos, and
-              we aggregate those signals to create rankings that help others find the best food.
+              dishes, currently focused on Martha's Vineyard with coverage extending to nearby
+              coastal Massachusetts. Users rate dishes, write reviews, upload photos, and we
+              aggregate those signals to create rankings that help others find the best food.
             </p>
           </section>
 
@@ -213,11 +214,11 @@ export function Terms() {
                 <li>You represent that you are not located in a country subject to U.S. government embargo or designated as a "terrorist supporting" country, and you are not on any U.S. government list of prohibited or restricted parties.</li>
                 <li>Any questions or complaints about the app should be directed to{' '}
                   <a
-                    href="mailto:hello@wghapp.com"
+                    href="mailto:wghapp@wghapp.com"
                     className="font-medium"
                     style={{ color: 'var(--color-primary)' }}
                   >
-                    hello@wghapp.com
+                    wghapp@wghapp.com
                   </a>
                   .
                 </li>
@@ -266,11 +267,11 @@ export function Terms() {
             <p className="leading-relaxed mb-2" style={{ color: 'var(--color-text-secondary)' }}>
               Questions about these Terms? Contact us at:{' '}
               <a
-                href="mailto:hello@wghapp.com"
+                href="mailto:wghapp@wghapp.com"
                 className="font-medium"
                 style={{ color: 'var(--color-primary)' }}
               >
-                hello@wghapp.com
+                wghapp@wghapp.com
               </a>
             </p>
             <address className="not-italic leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>


### PR DESCRIPTION
## Summary

Codex review of the v1.0 App Store submission packet caught launch-blockers across **native (PrivacyInfo.xcprivacy), web (Privacy/Terms/Support pages), and the submission docs themselves**. This PR batches the fixes plus a consolidated submission-day playbook so the moment Apple Dev verification clears, paste-and-submit is a single doc workflow.

### What's in here

- **Native privacy manifest:** `ios/App/App/PrivacyInfo.xcprivacy` — added `SearchHistory`, `UserID`, `DeviceID`, `OtherDataTypes` (Jitter), `OtherDiagnosticData`; removed `PreciseLocation` (LocationContext uses default-accuracy geolocation). Apple's manifest scanner blocks submission on this kind of mismatch.
- **Privacy disclosures (5.1.2(i)):** `Privacy.jsx` now lists Anthropic Claude vision (photo moderation) and Jitter Protocol (review trust scoring) in third-party services, plus inline disclosure on the Dish Photos section.
- **Falsifiable framing softened:** "platform for Martha's Vineyard" → "currently focused on Martha's Vineyard with coverage extending to nearby coastal Massachusetts" in `Privacy.jsx` and `Terms.jsx` (towns.js already covers Nantucket/Cape Cod/Boston).
- **Support email corrected everywhere:** `wghapp@wghapp.com` (Dan's actual monitored inbox). All 6 source files updated; the prior `hello@wghapp.com` was wrong.
- **Account-deletion text:** now lists votes/reviews/photos/favorites/playlists/follows/profile to match what `auth.users` cascade actually deletes.
- **Doc reconciliation:** privacy-details and reviewer-notes docs updated for Sentry-not-linked (no `Sentry.setUser` call), demo-account contradiction flagged, content-safety phrasing split (Anthropic vision for photos, blocklist for review text), web-access rationale corrected to SFSafariViewController.
- **NEW: `2026-05-06-app-store-submission-day.md`** — single-source-of-truth ASC field-by-field paste guide with preflight checklist, alternate description copy as backup if Apple kicks back original under 2.3, rejection playbook.
- **NEW: `2026-05-06-app-store-age-rating.md`** — question-by-question answers, recommended 12+, alcohol "Infrequent or Mild" defended.
- **NEW: `2026-05-06-app-store-whats-new.md`** — v1.0 release notes.
- **NEW: `2026-05-06-google-killswitch-contingency.md`** — 5-min apply path if Apple Dev verification fails to clear in time and we have to ship email-only for v1.0 to dodge Guideline 4.8 (Sign-In with Apple required when Google is offered). Default-on feature flag, mirrors `APPLE_SIGNIN_ENABLED` pattern. Not applied — pre-staged only.

### Outstanding decisions (not in this PR)

These stay on the launch checklist for Dan to call:

1. **SIWA path** — ship Apple sign-in end-to-end (B3-activate + B5, gated on Apple Dev clearance) OR apply the kill-switch and ship email-only v1.0
2. **iPad** — drop `TARGETED_DEVICE_FAMILY` from `"1,2"` to `"1"` (recommended) OR shoot iPad screenshots at 13" / 12.9" tiers
3. **Phone field** — submission-day doc still has placeholder; needs real number before ASC submit

## Test plan

- [x] `npm run build` passes (verified twice — once after Privacy/Terms edits, once after email correction)
- [x] `plutil -lint ios/App/App/PrivacyInfo.xcprivacy` returns OK
- [x] No remaining `hello@wghapp.com` in active source files (3 stale references remain in older April plan docs but those aren't consulted at submission)
- [ ] Dan to rebuild iOS in Xcode + verify next TestFlight build embeds the new PrivacyInfo manifest
- [ ] Dan to confirm `wghapp@wghapp.com` continues to receive mail end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)