### PR TITLE
docs(launch): soften demo-account claim in reviewer notes to match reality

### DIFF
--- a/docs/superpowers/specs/2026-05-03-app-store-reviewer-notes.md
+++ b/docs/superpowers/specs/2026-05-03-app-store-reviewer-notes.md
@@ -42,8 +42,8 @@ DEMO ACCOUNT (email + password)
 Email:    walshdaniel143+wghdemo@gmail.com
 Password: WGH33!
 
-This account is pre-populated with rated dishes, photos, and favorites
-to show representative content (not an empty state).
+This account is pre-populated with rated dishes to show representative
+content (not an empty state).
 
 PLEASE DO NOT DELETE THIS ACCOUNT — it is shared across all reviewers.
 If you wish to test the account-deletion flow (Guideline 5.1.1(v)),
@@ -98,7 +98,7 @@ Email: wghapp@wghapp.com
 Before pasting into ASC, verify each placeholder is real:
 
 - [x] Demo account credentials filled in (created 2026-05-04)
-- [x] Demo account is populated (5 rated dishes, profile name set — sufficient for "not empty" reviewer bar). Note: §1 above describes the account as pre-populated with "rated dishes, photos, and favorites" — Dan to enrich with at least 1 photo + 1 favorite before submission to match that description, OR edit §1 to omit "photos and favorites" if leaving as-is. **Do not let §1 and the actual account contradict each other.**
+- [x] Demo account is populated (5 rated dishes, profile name set — sufficient for "not empty" reviewer bar). §1 wording softened 2026-05-06 to match actual account state (no photo claim, no favorites claim).
 - [ ] `https://wghapp.com/privacy` resolves to a live Privacy page (not 404)
 - [ ] `https://wghapp.com/terms` resolves to a live Terms page (not 404)
 - [ ] `wghapp@wghapp.com` is monitored OR forwards to a monitored address

--- a/docs/superpowers/specs/2026-05-06-app-store-submission-day.md
+++ b/docs/superpowers/specs/2026-05-06-app-store-submission-day.md
@@ -22,7 +22,7 @@ If the source docs and this doc disagree, **trust this doc** — it's the latest
 - [ ] B5 complete (if path A): Sign in with Apple capability added in Xcode (`App.entitlements` currently has NO `com.apple.developer.applesignin` key — verified 2026-05-06), real-device smoke passed
 - [ ] TestFlight build uploaded and at least one internal tester has signed in successfully
 - [ ] Demo account verified working in TestFlight build: `walshdaniel143+wghdemo@gmail.com` / `WGH33!`
-- [ ] **Demo account enriched** to match reviewer-notes claim of "rated dishes, photos, and favorites" — currently has 5 rated dishes + name set; needs at least 1 photo + 1 favorite OR reviewer-notes wording softened to match. Don't let the doc and the account contradict each other.
+- [x] **Demo account matches reviewer-notes wording** — reviewer-notes softened 2026-05-06 to claim only "rated dishes" (no photos, no favorites). Account has 5 ratings + name set, which matches. No enrichment needed.
 - [ ] `https://wghapp.com/privacy` returns 200 (verified 2026-05-06 ✅) — and includes Anthropic + Jitter in third-party list (added 2026-05-06)
 - [ ] `https://wghapp.com/terms` returns 200 (verified 2026-05-06 ✅)
 - [ ] `https://wghapp.com/support` returns 200 (verified 2026-05-06 ✅)
@@ -334,8 +334,8 @@ DEMO ACCOUNT (email + password)
 Email:    walshdaniel143+wghdemo@gmail.com
 Password: WGH33!
 
-This account is pre-populated with rated dishes, photos, and favorites
-to show representative content (not an empty state).
+This account is pre-populated with rated dishes to show representative
+content (not an empty state).
 
 PLEASE DO NOT DELETE THIS ACCOUNT — it is shared across all reviewers.
 If you wish to test the account-deletion flow (Guideline 5.1.1(v)),


### PR DESCRIPTION
## Summary

- Reviewer notes claimed the shared demo account is "pre-populated with rated dishes, photos, and favorites" — but it only has 5 rated dishes + name set. Dan doesn't have dish photos to upload.
- Softened to "pre-populated with rated dishes" — truthful, still well above the "not empty" reviewer bar. Reviewers test the upload flow itself, not how many photos a demo account already has.
- Cleared the matching pre-submission-checklist warning in both `2026-05-03-app-store-reviewer-notes.md` and `2026-05-06-app-store-submission-day.md`.

## Test plan

- [x] `grep "rated dishes, photos, and favorites" docs/ -r` returns no matches
- [x] Both files still grep-clean for the canonical wording
- [ ] Dan to verify the softened claim still reads acceptable as part of final reviewer-notes paste

🤖 Generated with [Claude Code](https://claude.com/claude-code)