### PR TITLE
chore(launch): codex follow-up — deletion scope + stale embedded claims

### DIFF
--- a/docs/app-store-connect-privacy-details.md
+++ b/docs/app-store-connect-privacy-details.md
@@ -154,7 +154,7 @@ Allowed purposes per Apple: Third-Party Advertising, Developer's Advertising or 
 
 - [x] All Privacy URLs resolve — verified 2026-05-06: `/privacy`, `/terms`, `/` all return 200
 - [x] Test account created and documented in reviewer notes — walshdaniel143+wghdemo@gmail.com / WGH33!
-- [x] Apple Sign-In wired on the login modal — verified 2026-05-06: `LoginModal.jsx:287`, behind `VITE_FEATURES_APPLE_SIGNIN` flag (gated on B3-activate)
+- [~] Apple Sign-In code wired on the login modal — verified 2026-05-06: `LoginModal.jsx:287`, behind `VITE_FEATURES_APPLE_SIGNIN` flag. **NOT yet shippable**: `ios/App/App/App.entitlements` is missing `com.apple.developer.applesignin`; B3-activate (Apple credentials) and B5 (Xcode capability) both gated on Apple Dev clearance. Don't claim "wired" to reviewers until both ship.
 - [x] Places `attributions` field rendering — verified 2026-05-06: `PlaceAttributions` in `RestaurantDetail.jsx:344`; `PoweredByGoogle` in `DishSearch.jsx`, `AddRestaurantModal.jsx`, `SearchAutocomplete.jsx`
 - [ ] Privacy policy physical address — see `project_business_address` memory (virtual address pending)
 - [ ] `wghapp@wghapp.com` mailbox monitored or forwards to monitored address

--- a/docs/superpowers/specs/2026-04-27-app-store-listing-assets.md
+++ b/docs/superpowers/specs/2026-04-27-app-store-listing-assets.md
@@ -36,7 +36,7 @@ Apple requires **6.7"/6.9" iPhone** screenshots (e.g. iPhone 16 Pro Max — 1290
 
 ### Shot 4 — Profile / journal (the identity)
 **Story:** "this is your food life" — your ratings, your shelves, your taste fingerprint.
-**Setup:** sign in as a test user with 10+ rated dishes + at least one favorite. Shelf filter visible. Journal feed showing recent activity.
+**Setup:** sign in as a test user with 5+ rated dishes (the demo account walshdaniel143+wghdemo@gmail.com works). Journal feed showing recent activity. Favorites/photos optional — populated screens look richer but the empty-state for those tabs is acceptable.
 **Caption (≤30 chars):** `Your food life, organized`
 **Why this shot:** the "social" without saying social. Hooks foodies who care about tracking.
 
@@ -83,7 +83,7 @@ expansion is planned post-launch — geofencing is intentional (data
 quality over breadth).
 ```
 
-**Action:** create the demo account before submission. Use a real-but-disposable email Dan controls. Make sure the account has rated dishes, photos uploaded, and at least one favorite — reviewers test "empty state" if you give them an empty profile.
+**Action:** demo account already created (`walshdaniel143+wghdemo@gmail.com` / `WGH33!`) with 5 rated dishes + name set. Reviewer notes (canonical: `2026-05-03-app-store-reviewer-notes.md`) describe it as "pre-populated with rated dishes" — no photo or favorite claim, matches actual state. Don't recreate the contradiction.
 
 ---
 

--- a/docs/superpowers/specs/2026-05-03-app-store-reviewer-notes.md
+++ b/docs/superpowers/specs/2026-05-03-app-store-reviewer-notes.md
@@ -1,7 +1,7 @@
 # App Store Connect — Reviewer Notes (final form)
 
-**Date:** 2026-05-03
-**Status:** Final-form copy ready to paste into App Store Connect → "App Review Information" → "Notes". Only blank: demo account credentials (created at submission time).
+**Date:** 2026-05-03 (last touched 2026-05-06)
+**Status:** Final-form copy ready to paste into App Store Connect → "App Review Information" → "Notes". Demo credentials filled in; no remaining blanks.
 
 This replaces the §2 stub in `docs/superpowers/specs/2026-04-27-app-store-listing-assets.md`. Codex (gpt-5.4 / high) reviewed the prior draft 2026-05-03 — this version applies its findings.
 
@@ -57,8 +57,8 @@ ACCOUNT DELETION (Guideline 5.1.1(v))
 Path: Profile tab → tap the gear icon (top-right) → Delete Account.
 
 Deletion is permanent and irreversible: votes, reviews, photos,
-profile, and follows are removed. The action requires an explicit
-confirm step.
+favorites, playlists, follows, and profile are removed. The action
+requires an explicit confirm step.
 
 ────────────────────────────
 USER-GENERATED CONTENT (Guideline 1.2)

--- a/docs/superpowers/specs/2026-05-06-app-store-submission-day.md
+++ b/docs/superpowers/specs/2026-05-06-app-store-submission-day.md
@@ -349,19 +349,21 @@ ACCOUNT DELETION (Guideline 5.1.1(v))
 Path: Profile tab → tap the gear icon (top-right) → Delete Account.
 
 Deletion is permanent and irreversible: votes, reviews, photos,
-profile, and follows are removed. The action requires an explicit
-confirm step.
+favorites, playlists, follows, and profile are removed. The action
+requires an explicit confirm step.
 
 ────────────────────────────
 USER-GENERATED CONTENT (Guideline 1.2)
 ────────────────────────────
 
-- All user reviews and photos pass a content-safety filter before
-  display.
-- Reviewers can report inappropriate content via the report button on
-  any review or photo.
-- Reviewers can block other users; blocked users' content is hidden.
-- Reports are reviewed by our admin moderation queue.
+- Dish photos pass an automated content-safety check (Anthropic Claude
+  vision) before display.
+- Review text is filtered against a profanity/slur/spam blocklist on
+  submission.
+- Users can report inappropriate content via the report button on any
+  review, photo, dish, or profile.
+- Users can block other users; blocked users' content is hidden.
+- Reports are reviewed by our admin moderation queue (48h SLA).
 
 ────────────────────────────
 PRIVACY

--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -228,9 +228,9 @@ export function Privacy() {
             <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
               You can delete your account from the in-app settings menu (tap the gear icon,
               then <strong>Delete Account</strong>). Deletion is permanent and removes your
-              votes, reviews, photos, favorites, playlists, and profile. Dish rankings that
-              included your votes will be recalculated without them. Deletion happens in-app —
-              you do not need to email us to close your account.
+              votes, reviews, photos, favorites, playlists, follows, and profile. Dish
+              rankings that included your votes will be recalculated without them. Deletion
+              happens in-app — you do not need to email us to close your account.
             </p>
             <p className="leading-relaxed mt-3" style={{ color: 'var(--color-text-secondary)' }}>
               If you signed in with Apple, deleting your account also revokes the


### PR DESCRIPTION
## Summary

Codex re-review (post PR #141) caught five drift bugs my prior batches missed and two doc-hygiene issues. All addressed.

### Drift fixes
1. **Privacy.jsx deletion section** missing 'follows' — now lists votes/reviews/photos/favorites/playlists/follows/profile (matches DeleteAccountSection.jsx + schema cascade)
2. **Reviewer-notes deletion line** missing 'favorites' and 'playlists' — same canonical list now
3. **Submission-day doc UGC block was stale** — claimed 'paste verbatim' from canonical reviewer-notes but had the OLD content-safety wording (overstates text moderation, narrows reported surfaces). Now matches canonical split (Anthropic vision for photos, blocklist for review text)
4. **Submission-day deletion block** had same favorites/playlists gap
5. **`app-store-connect-privacy-details.md`** said Apple Sign-In is 'wired on the login modal' without acknowledging the missing entitlement. Softened to 'code wired, NOT yet shippable until B3-activate + B5'

### Doc hygiene
- Reviewer-notes header said 'Only blank: demo account credentials' but credentials are filled. Updated to 'no remaining blanks.'
- Listing-assets Shot 4 setup + demo-account guidance still assumed photos + favorite. Updated to match the actual demo account state and reference the canonical reviewer-notes spec.

### Codex was wrong on 1 finding
Codex claimed Jitter Protocol is missing from `src/pages/Privacy.jsx` third-party services list. Verified: it IS at line 188. Codex's resumed-session read was stale — pushed back separately.

## Test plan
- [x] `npm run build` passes
- [x] All 4 deletion-scope mentions now consistent (DeleteAccountSection.jsx + Privacy.jsx + reviewer-notes spec + submission-day embedded copy)
- [x] Submission-day doc UGC block now matches canonical reviewer-notes spec verbatim
- [ ] Dan to re-skim privacy/terms in browser after deploy (no behavioral change, but visible copy edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)