### PR TITLE
feat(waitlist): pre-launch landing page at /waitlist

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -54,6 +54,7 @@ const MapPage = lazyWithRetry(() => import('./pages/Map'), 'Map')
 const HowReviewsWork = lazyWithRetry(() => import('./pages/HowReviewsWork'), 'HowReviewsWork')
 const ForRestaurants = lazyWithRetry(() => import('./pages/ForRestaurants'), 'ForRestaurants')
 const JitterLanding = lazyWithRetry(() => import('./pages/JitterLanding'))
+const Waitlist = lazyWithRetry(() => import('./pages/Waitlist'))
 const RestaurantReviews = lazyWithRetry(() => import('./pages/RestaurantReviews'), 'RestaurantReviews')
 const PlaylistPage = lazyWithRetry(() => import('./pages/Playlist'), 'Playlist')
 const Locals = lazyWithRetry(() => import('./pages/Locals'), 'Locals')
@@ -141,6 +142,7 @@ function App() {
               <Route path="/for-restaurants" element={<ForRestaurants />} />
               <Route path="/playlist/:id" element={<Layout><PlaylistPage /></Layout>} />
               <Route path="/jitter" element={<Layout><JitterLanding /></Layout>} />
+              <Route path="/waitlist" element={<Waitlist />} />
               <Route path="/locals" element={<Layout><Locals /></Layout>} />
               <Route path="/locals/:userId" element={<Layout><LocalsCurator /></Layout>} />
               <Route path="*" element={<NotFound />} />

--- a/src/api/waitlistApi.js
+++ b/src/api/waitlistApi.js
@@ -1,0 +1,68 @@
+import { supabase } from '../lib/supabase'
+import { logger } from '../utils/logger'
+import { createClassifiedError } from '../utils/errorHandler'
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const WAITLIST_EMAIL_UNIQUE = 'waitlist_email_unique'
+
+/**
+ * Validation errors thrown from join() that the UI should surface verbatim
+ * (vs. routing through generic getUserMessage()). Detect by `error.kind`.
+ */
+class WaitlistValidationError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'WaitlistValidationError'
+    this.kind = 'validation'
+  }
+}
+
+export const waitlistApi = {
+  WaitlistValidationError,
+
+  /**
+   * Join the pre-launch waitlist.
+   * @param {Object} params
+   * @param {string} params.email - Subscriber email address
+   * @param {string} [params.source] - Optional campaign / referral source ('web', 'instagram', etc.)
+   * @returns {Promise<{ success: true, email: string }>}
+   */
+  async join({ email, source = 'web' }) {
+    if (!email?.trim()) {
+      throw new WaitlistValidationError('Please enter your email address')
+    }
+    const normalized = email.trim().toLowerCase()
+
+    if (!EMAIL_REGEX.test(normalized)) {
+      throw new WaitlistValidationError('Please enter a valid email address')
+    }
+
+    try {
+      const { error } = await supabase
+        .from('waitlist')
+        .insert([{ email: normalized, source }])
+
+      // Treat "already on the list" as success without leaking enumeration.
+      // Narrow the swallow to the EMAIL unique constraint specifically — a
+      // future unique constraint on another column shouldn't be silently
+      // hidden.
+      if (error && !isAlreadyOnWaitlist(error)) {
+        throw createClassifiedError(error)
+      }
+
+      return { success: true, email: normalized }
+    } catch (error) {
+      if (error?.kind === 'validation') throw error
+      logger.error('waitlistApi.join:', error)
+      throw error.type ? error : createClassifiedError(error)
+    }
+  },
+}
+
+function isAlreadyOnWaitlist(error) {
+  if (error?.code !== '23505') return false
+  // Postgres error includes constraint info in either `details` or
+  // `message`; check both because PostgREST surfaces them inconsistently.
+  const haystack = `${error.details || ''} ${error.message || ''}`
+  return haystack.includes(WAITLIST_EMAIL_UNIQUE)
+}

--- a/src/pages/Waitlist.jsx
+++ b/src/pages/Waitlist.jsx
@@ -1,0 +1,278 @@
+import { useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { Seal } from '../components/Seal'
+import { waitlistApi } from '../api/waitlistApi'
+import { getUserMessage } from '../utils/errorHandler'
+import { logger } from '../utils/logger'
+
+/**
+ * Waitlist — pre-launch landing page.
+ *
+ * Captures email signups during the App Store review wait. Linked from
+ * social posts and any external marketing during the run-up to launch.
+ *
+ * Optional `?source=X` query param tracks which campaign drove the signup.
+ *
+ * Route: /waitlist
+ */
+export default function Waitlist() {
+  const [searchParams] = useSearchParams()
+  const source = searchParams.get('source') || 'web'
+
+  const [email, setEmail] = useState('')
+  // Honeypot — bots fill all visible inputs; real users won't see this one.
+  // If it's non-empty on submit we silently "succeed" without writing.
+  const [honeypot, setHoneypot] = useState('')
+  const [status, setStatus] = useState('idle') // 'idle' | 'submitting' | 'success' | 'error'
+  const [errorMessage, setErrorMessage] = useState(null)
+  const [normalizedEmail, setNormalizedEmail] = useState('')
+
+  async function handleSubmit(event) {
+    event.preventDefault()
+    if (status === 'submitting') return
+
+    setStatus('submitting')
+    setErrorMessage(null)
+
+    if (honeypot.trim() !== '') {
+      // Naive bot — pretend we accepted but don't actually write.
+      setNormalizedEmail(email.trim().toLowerCase())
+      setStatus('success')
+      return
+    }
+
+    try {
+      const result = await waitlistApi.join({ email, source })
+      setNormalizedEmail(result.email)
+      setStatus('success')
+    } catch (error) {
+      logger.error('Waitlist submit failed:', error)
+      // Validation errors carry their own user-readable messages — surface
+      // verbatim. Other errors go through the generic classifier.
+      const message =
+        error?.kind === 'validation'
+          ? error.message
+          : getUserMessage(error, 'joining the waitlist')
+      setErrorMessage(message)
+      setStatus('error')
+    }
+  }
+
+  return (
+    <div
+      className="min-h-screen flex flex-col"
+      style={{ background: 'var(--color-bg)' }}
+    >
+      <main
+        className="flex-1 flex flex-col items-center justify-center px-6 py-16 text-center"
+        style={{ maxWidth: '560px', margin: '0 auto', width: '100%' }}
+      >
+        <div className="mb-8">
+          <Seal size={88} ariaLabel="What's Good Here" />
+        </div>
+
+        <h1
+          className="mb-4"
+          style={{
+            fontFamily: "'Amatic SC', cursive",
+            fontWeight: 700,
+            fontSize: '52px',
+            lineHeight: 1.05,
+            letterSpacing: '0.01em',
+            color: 'var(--color-text-primary)',
+          }}
+        >
+          What's <span style={{ color: 'var(--color-accent-gold)' }}>Good</span> Here
+        </h1>
+
+        <p
+          className="mb-3"
+          style={{
+            color: 'var(--color-text-primary)',
+            fontSize: '20px',
+            fontWeight: 600,
+            lineHeight: 1.3,
+          }}
+        >
+          The lobster roll question, finally answered.
+        </p>
+
+        <p
+          className="mb-10"
+          style={{
+            color: 'var(--color-text-secondary)',
+            fontSize: '16px',
+            lineHeight: 1.6,
+            maxWidth: '440px',
+          }}
+        >
+          Coming soon to Martha's Vineyard. The local guide to what to actually
+          order — a ranked dish list, built from real community ratings.
+        </p>
+
+        {status === 'success' ? (
+          <SuccessState email={normalizedEmail} />
+        ) : (
+          <form
+            onSubmit={handleSubmit}
+            className="w-full"
+            style={{ maxWidth: '420px' }}
+            noValidate
+          >
+            {/* Honeypot — visually hidden, accessibility hidden, but in the
+                DOM so naive bots fill it. Do NOT use display:none (some bots
+                skip those); use absolute off-screen positioning. */}
+            <div
+              aria-hidden="true"
+              style={{
+                position: 'absolute',
+                left: '-9999px',
+                width: '1px',
+                height: '1px',
+                overflow: 'hidden',
+              }}
+            >
+              <label htmlFor="waitlist-website">
+                Leave this field empty
+                <input
+                  id="waitlist-website"
+                  type="text"
+                  tabIndex={-1}
+                  autoComplete="off"
+                  value={honeypot}
+                  onChange={(event) => setHoneypot(event.target.value)}
+                />
+              </label>
+            </div>
+
+            <label htmlFor="waitlist-email" className="sr-only">
+              Email address
+            </label>
+            <input
+              id="waitlist-email"
+              type="email"
+              inputMode="email"
+              autoComplete="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="you@example.com"
+              required
+              maxLength={320}
+              disabled={status === 'submitting'}
+              className="w-full px-4 py-3 rounded-xl mb-3"
+              style={{
+                background: 'var(--color-surface-elevated)',
+                border: '2px solid var(--color-divider)',
+                color: 'var(--color-text-primary)',
+                fontSize: '16px',
+                outline: 'none',
+              }}
+            />
+            <button
+              type="submit"
+              disabled={status === 'submitting' || !email.trim()}
+              className="w-full px-6 py-3 rounded-xl font-semibold active:scale-[0.98] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+              style={{
+                background: 'var(--color-primary)',
+                color: 'var(--color-text-on-primary, #FFFFFF)',
+                fontSize: '16px',
+                minHeight: 48,
+              }}
+            >
+              {status === 'submitting' ? 'Adding you…' : 'Get on the list'}
+            </button>
+
+            {status === 'error' && errorMessage && (
+              <p
+                role="alert"
+                className="mt-3 text-sm"
+                style={{ color: 'var(--color-danger)' }}
+              >
+                {errorMessage}
+              </p>
+            )}
+
+            <p
+              className="mt-3 text-xs"
+              style={{ color: 'var(--color-text-tertiary)', lineHeight: 1.5 }}
+            >
+              By joining, you agree to our{' '}
+              <a
+                href="/privacy"
+                style={{ color: 'var(--color-text-tertiary)' }}
+                className="underline"
+              >
+                Privacy Policy
+              </a>{' '}
+              and{' '}
+              <a
+                href="/terms"
+                style={{ color: 'var(--color-text-tertiary)' }}
+                className="underline"
+              >
+                Terms
+              </a>
+              . We'll email you once when the app lands. No spam, unsubscribe anytime.
+            </p>
+          </form>
+        )}
+      </main>
+
+      <footer
+        className="px-6 py-6 text-center text-sm"
+        style={{
+          color: 'var(--color-text-tertiary)',
+          borderTop: '1px solid var(--color-divider)',
+        }}
+      >
+        <a
+          href="/privacy"
+          style={{ color: 'var(--color-text-tertiary)' }}
+          className="underline mr-4"
+        >
+          Privacy
+        </a>
+        <a
+          href="/terms"
+          style={{ color: 'var(--color-text-tertiary)' }}
+          className="underline"
+        >
+          Terms
+        </a>
+      </footer>
+    </div>
+  )
+}
+
+function SuccessState({ email }) {
+  return (
+    <div
+      className="w-full rounded-2xl p-6 text-center"
+      style={{
+        maxWidth: '420px',
+        background: 'var(--color-surface-elevated)',
+        border: '1px solid var(--color-divider)',
+      }}
+    >
+      <div
+        style={{
+          fontFamily: "'Amatic SC', cursive",
+          fontWeight: 700,
+          fontSize: '32px',
+          color: 'var(--color-accent-gold)',
+          lineHeight: 1.1,
+          marginBottom: '8px',
+        }}
+      >
+        You're in.
+      </div>
+      <p
+        className="text-sm"
+        style={{ color: 'var(--color-text-secondary)', lineHeight: 1.6 }}
+      >
+        We'll email <strong style={{ color: 'var(--color-text-primary)' }}>{email}</strong> the
+        moment the app lands.
+      </p>
+    </div>
+  )
+}

--- a/supabase/migrations/20260507_waitlist.sql
+++ b/supabase/migrations/20260507_waitlist.sql
@@ -1,0 +1,57 @@
+-- Pre-launch waitlist
+--
+-- Captures email addresses from /waitlist landing page during the App Store
+-- review wait. Used to send launch announcement when v1.0 ships. Anonymous
+-- inserts allowed; reads are admin-only (service role) to prevent enumeration
+-- of subscribers.
+--
+-- ROLLBACK:
+-- DROP TRIGGER IF EXISTS waitlist_normalize_email ON waitlist;
+-- DROP FUNCTION IF EXISTS waitlist_normalize_email();
+-- DROP POLICY IF EXISTS "waitlist anon insert" ON waitlist;
+-- DROP TABLE IF EXISTS waitlist;
+
+CREATE TABLE IF NOT EXISTS waitlist (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email TEXT NOT NULL CHECK (LENGTH(email) <= 320 AND email LIKE '%_@_%.__%'),
+  source TEXT CHECK (source IS NULL OR LENGTH(source) <= 64),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Normalize email at the DB layer so direct SQL callers can't bypass the API
+-- and store junk like ' Dan@Example.COM '. Trigger lowercases + trims; the
+-- unique index then dedupes correctly without a generated column.
+CREATE OR REPLACE FUNCTION waitlist_normalize_email()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.email = LOWER(BTRIM(NEW.email));
+  IF NEW.source IS NOT NULL THEN
+    NEW.source = BTRIM(NEW.source);
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS waitlist_normalize_email ON waitlist;
+CREATE TRIGGER waitlist_normalize_email
+  BEFORE INSERT OR UPDATE ON waitlist
+  FOR EACH ROW EXECUTE FUNCTION waitlist_normalize_email();
+
+CREATE UNIQUE INDEX IF NOT EXISTS waitlist_email_unique
+  ON waitlist (email);
+
+CREATE INDEX IF NOT EXISTS waitlist_created_at_idx
+  ON waitlist (created_at DESC);
+
+ALTER TABLE waitlist ENABLE ROW LEVEL SECURITY;
+
+-- Anon-only insert. Logged-in users who somehow hit /waitlist are unusual;
+-- the actual signup flow for them is the regular auth modal. Keeping this
+-- anon-only matches the design intent and prevents authenticated callers
+-- from spoofing source / abusing the table.
+CREATE POLICY "waitlist anon insert" ON waitlist
+  FOR INSERT
+  TO anon
+  WITH CHECK (TRUE);
+
+-- No SELECT policy. Reads are limited to service_role (admin export).


### PR DESCRIPTION
## Summary

Pre-launch waitlist landing page at `/waitlist`. Captures email signups during the App Store review wait so we have an audience to ping when v1.0 lands. Linked from social posts and external marketing during the run-up.

## Pieces

- **DB**: `supabase/migrations/20260507_waitlist.sql` — table + normalization trigger + CHECK constraints + anon-only INSERT policy. Reads admin-only via service role.
- **API**: `src/api/waitlistApi.js` — `waitlistApi.join({ email, source })`. Custom validation error class so UI surfaces specific messages. Already-on-list = success (no enumeration leak).
- **Page**: `src/pages/Waitlist.jsx` — brand wordmark, lobster-roll hook, softened body copy. Honeypot field for bot defense. Consent microcopy.
- **Route**: `src/App.jsx` — lazy `<Route path="/waitlist" />` (no Layout wrapper).

## Codex review applied before commit

11 findings, 9 fixed:
- DB-level normalization trigger (LOWER + BTRIM) so direct SQL callers can't store junk
- CHECK constraints on email shape + length + source length
- Narrowed `23505` swallow to the specific `waitlist_email_unique` constraint
- **Softened page copy** — removed "every dish at every restaurant" and "people who've eaten it" (same falsifiable claims Codex flagged on the description; the waitlist page is in the iOS bundle so reviewer-reachable)
- Aria `role="alert" aria-live="polite"` was contradictory; dropped the redundant aria-live
- Honeypot field — absolute-positioned off-screen so bots fill it but real users don't see it
- Anon-only INSERT policy (was anon + authenticated)
- Custom `WaitlistValidationError` so `getUserMessage()` doesn't collapse "Please enter a valid email" → "Please check your input"
- Success state echoes the normalized email from the API response, not the raw input

Codex accepted: regex simplicity (fine for waitlist), no FK CASCADE concern (standalone table).

## Deployment notes

⚠️ **Migration must be run in Supabase SQL Editor before `/waitlist` works in prod.** Adding to migrations folder does NOT auto-deploy. Run `supabase/migrations/20260507_waitlist.sql` against the `vpioftosgdkyiwvhxewy` project before testing.

## Test plan

- [x] `npm run build` passes
- [x] `npx eslint` clean on touched files
- [ ] Dan to run migration in Supabase SQL Editor
- [ ] Dan to test `/waitlist` end-to-end after migration: submit valid email → success → submit same email again → still success (dedupe silent)
- [ ] Dan to verify Vercel deploy renders /waitlist correctly post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)