### PR TITLE
fix(waitlist): strip copy to minimum — launching soon + ask

### DIFF
--- a/src/pages/Waitlist.jsx
+++ b/src/pages/Waitlist.jsx
@@ -94,7 +94,7 @@ export default function Waitlist() {
             lineHeight: 1.3,
           }}
         >
-          The lobster roll question, finally answered.
+          Launching soon.
         </p>
 
         <p
@@ -106,8 +106,7 @@ export default function Waitlist() {
             maxWidth: '440px',
           }}
         >
-          Coming soon to Martha's Vineyard. The local guide to what to actually
-          order — a ranked dish list, built from real community ratings.
+          Get on the list — we'll email you the moment the app lands.
         </p>
 
         {status === 'success' ? (


### PR DESCRIPTION
## Summary

Dan's directive: 'Jut about signing up and us launching soon. That's it.'

- Cut 'The lobster roll question, finally answered.' — too specific; cold visitors don't share the context that makes that hook resonate.
- Cut 'Coming soon to Martha's Vineyard. The local guide to what to actually order — a ranked dish list, built from real community ratings.' — over-explains.
- Replaced with: 'Launching soon.' + 'Get on the list — we'll email you the moment the app lands.'

Brand wordmark + Seal + form + consent microcopy + footer all unchanged.

## Test plan
- [x] `npm run build` passes
- [ ] Dan to verify the trimmed copy renders cleanly post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)