### PR TITLE
feat(siwa): AASA Team ID + JWT generator script

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -3,7 +3,7 @@
     "apps": [],
     "details": [
       {
-        "appIDs": ["<TEAMID>.com.whatsgoodhere.app"],
+        "appIDs": ["K447QTHBR9.com.whatsgoodhere.app"],
         "paths": [
           "/auth/*",
           "/reset-password",

--- a/scripts/generate-apple-client-secret.mjs
+++ b/scripts/generate-apple-client-secret.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * Generate the Apple Sign-In client-secret JWT for the Supabase Auth
+ * dashboard's "Secret Key (for OAuth)" field.
+ *
+ * Apple won't accept the raw .p8 here — they want a JWT signed with it,
+ * with specific claims. Apple's spec caps the JWT lifetime at 6 months;
+ * regenerate before it expires (calendar reminder ~5 months out).
+ *
+ * No npm dependencies — uses Node's built-in crypto.
+ *
+ * Usage:
+ *   node scripts/generate-apple-client-secret.mjs ~/Downloads/AuthKey_<KEYID>.p8
+ *
+ * Output: the JWT on stdout. Copy the entire single-line string into
+ * Supabase Auth → Providers → Apple → Secret Key (for OAuth).
+ */
+import { readFileSync } from 'node:fs'
+import { createSign } from 'node:crypto'
+
+const TEAM_ID = 'K447QTHBR9'
+const KEY_ID = 'JXT4ZZQW67'
+const SERVICES_ID = 'com.whatsgoodhere.service'
+const TTL_SECONDS = 180 * 24 * 3600 // 180 days — Apple's max JWT lifetime
+
+const p8Path = process.argv[2]
+if (!p8Path) {
+  console.error(
+    'Usage: node scripts/generate-apple-client-secret.mjs <path-to-.p8>',
+  )
+  process.exit(1)
+}
+
+const privateKey = readFileSync(p8Path, 'utf8')
+
+const header = { alg: 'ES256', kid: KEY_ID }
+const now = Math.floor(Date.now() / 1000)
+const payload = {
+  iss: TEAM_ID,
+  iat: now,
+  exp: now + TTL_SECONDS,
+  aud: 'https://appleid.apple.com',
+  sub: SERVICES_ID,
+}
+
+const b64url = (obj) =>
+  Buffer.from(JSON.stringify(obj)).toString('base64url')
+
+const signingInput = `${b64url(header)}.${b64url(payload)}`
+
+const signature = createSign('SHA256')
+  .update(signingInput)
+  .sign({ key: privateKey, dsaEncoding: 'ieee-p1363' })
+  .toString('base64url')
+
+console.log(`${signingInput}.${signature}`)


### PR DESCRIPTION
## Summary

**B.3 of B3-activate.** Apple Dev verification cleared today (2026-05-08), Phase A credentials captured.

- `public/.well-known/apple-app-site-association`: replaced `<TEAMID>` placeholder with the real Team ID `K447QTHBR9`. Without this, universal-link verification fails — password-reset / magic-link emails open in Safari instead of the app.
- `scripts/generate-apple-client-secret.mjs`: pure-Node (no deps) JWT generator for the Supabase Apple provider Secret Key field. Used today to fill in the Secret Key (for OAuth) field; Apple caps JWTs at 180 days, must regenerate before 2026-11-04 (memory pinned).

## Test plan
- [x] AASA JSON validates (`python3 -m json.tool`)
- [x] JWT script runs successfully on Dan's machine, output is 298 chars (typical JWT length)
- [x] JWT pasted into Supabase Apple provider Secret Key field, saved successfully
- [ ] After deploy, verify https://wghapp.com/.well-known/apple-app-site-association serves the file with correct Team ID
- [ ] B.4 (pg_cron) and B.5 (prod flag flip) still to come; full smoke (B.6) after those

🤖 Generated with [Claude Code](https://claude.com/claude-code)