### PR TITLE
fix(siwa): rotate exposed .p8 key (Track B of root-fix pass)

### DIFF
--- a/scripts/generate-apple-client-secret.mjs
+++ b/scripts/generate-apple-client-secret.mjs
@@ -19,7 +19,10 @@ import { readFileSync } from 'node:fs'
 import { createSign } from 'node:crypto'
 
 const TEAM_ID = 'K447QTHBR9'
-const KEY_ID = 'JXT4ZZQW67'
+// Key ID rotated 2026-05-08 from JXT4ZZQW67 (revoked due to chat exposure)
+// to 9LL6V25287. The old key is dead in Apple's system; old JWTs signed
+// with it return invalid_client.
+const KEY_ID = '9LL6V25287'
 const SERVICES_ID = 'com.whatsgoodhere.service'
 const TTL_SECONDS = 180 * 24 * 3600 // 180 days — Apple's max JWT lifetime
 


### PR DESCRIPTION
## Summary

Rotates the Apple Sign-In .p8 key after the original (`JXT4ZZQW67`) was inadvertently pasted into a Claude Code chat earlier today. New key: `9LL6V25287`. Old key revoked on Apple — any JWT signed with it now returns `invalid_client`.

## Done outside this diff (operational on Apple Dev Portal + Supabase)
- Old key revoked at https://developer.apple.com/account/resources/authkeys/
- New key created + new .p8 downloaded
- New JWT pasted in Supabase Apple provider Secret Key
- Vault `apple_signing_key_v1` overwritten with new .p8 (clean, 257 chars)
- Vault `apple_key_id_v1` overwritten with new Key ID
- Old .p8 deleted from ~/Downloads/

## In this diff
- `scripts/generate-apple-client-secret.mjs`: `KEY_ID` constant updated, comment block added documenting the rotation

## Verification
- `vault.decrypted_secrets WHERE name = 'apple_key_id_v1'` → `9LL6V25287`, len 10
- `vault.decrypted_secrets WHERE name = 'apple_signing_key_v1'` → starts `-----BEGIN PRIVATE KEY-----`, len 257
- Supabase dashboard Apple provider Secret Key field updated with fresh JWT
- Web Apple Sign-In still works (verified in earlier smoke; no functional change since the new JWT was signed with the new .p8 keyed by the new Key ID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)