### PR TITLE
feat(ios): add whatsgoodhere URL scheme fallback

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -80,6 +80,14 @@
 				<string>com.googleusercontent.apps.959822716440-vrio6ig6sj0dkg63v2d8k0a3o0h05vip</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>app.whatsgoodhere</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>whatsgoodhere</string>
+			</array>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Adds `whatsgoodhere://` custom URL scheme to `ios/App/App/Info.plist` as a fallback for when iOS universal-link dispatch fails (stale AASA state, Mail stripping https://, etc.)
- Universal links remain primary — the scheme is a last-resort backup so password-reset and magic-link emails always have a path back to the app
- Canonical spec: Plan B B5.1 (`docs/superpowers/plans/2026-04-21-oauth-native-plan-b.md` lines 3993-4011)
- Codex flagged this on the Phase C pre-flight audit

## Test plan
- [ ] Pull on workstation, `plutil -lint ios/App/App/Info.plist` (verified locally — OK)
- [ ] After merge: open Xcode, archive, install on device
- [ ] Send a password-reset email, force-quit app, tap link in iOS Mail → app opens via universal link (primary path still works)
- [ ] Manually craft `whatsgoodhere://reset?token=...` (or similar deep link) and confirm app opens to expected route (fallback path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)