### PR TITLE
fix(seal): force display opsz=144 at every size

### DIFF
--- a/src/components/Seal.jsx
+++ b/src/components/Seal.jsx
@@ -119,7 +119,7 @@ export function Seal({
           fontSize={wghFontSize}
           fill={mono}
           letterSpacing={wghLetterSpacing}
-          style={{ fontVariationSettings: '"opsz" 144' }}
+          style={{ fontOpticalSizing: 'none', fontVariationSettings: '"opsz" 144' }}
         >
           wgh
         </text>

--- a/src/components/home/LocalsPicksStamp.jsx
+++ b/src/components/home/LocalsPicksStamp.jsx
@@ -29,7 +29,7 @@ export function LocalsPicksStamp({ seed = 4, includeRibbon = true, size = 72 }) 
             </text>
           </>
         )}
-        <text x="50" y="62" textAnchor="middle" fontFamily="'Fraunces', serif" fontStyle="italic" fontSize="28" fontWeight="900" letterSpacing="-1.5" fill={ink} stroke="none" style={{ fontVariationSettings: '"opsz" 144' }}>wgh</text>
+        <text x="50" y="62" textAnchor="middle" fontFamily="'Fraunces', serif" fontStyle="italic" fontSize="28" fontWeight="900" letterSpacing="-1.5" fill={ink} stroke="none" style={{ fontOpticalSizing: 'none', fontVariationSettings: '"opsz" 144' }}>wgh</text>
       </g>
     </svg>
   )


### PR DESCRIPTION
## Summary
The in-app Seal was rendering with sharper (text-cut) Fraunces letterforms instead of the chunky retro (display-cut) letterforms the launcher icon shows. Cause: Chrome lets \`font-optical-sizing: auto\` (the default) win over an explicit \`font-variation-settings: 'opsz' 144\` at small render sizes.

Fix: add \`font-optical-sizing: none\` so the explicit opsz=144 is honored at TopBar/login/legal/modal sizes too. Same one-line addition to \`LocalsPicksStamp\` for consistency.

The baked launcher PNG was unaffected — it rendered large enough that auto opsz coincidentally picked 144 anyway.

## Test plan
- [ ] Hit \`wghapp.com/login\` — Seal wgh now matches the chunky display letterforms in \`ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-1024.png\`
- [ ] Hit \`/privacy\` — same chunky letterforms
- [ ] Hard refresh to defeat browser cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)