### PR TITLE
fix(dish): surface user's own review on public Dish page

### DIFF
--- a/src/api/votesApi.js
+++ b/src/api/votesApi.js
@@ -421,6 +421,7 @@ export const votesApi = {
       const { data, error } = await supabase
         .from('public_votes')
         .select(`
+          id,
           review_text,
           rating_10,
           review_created_at,

--- a/src/components/dish/DishEvidence.jsx
+++ b/src/components/dish/DishEvidence.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { TrustBadge, TrustSummary, JitterExplainer } from '../jitter'
 import { VariantSelector } from '../VariantPicker'
-import { getRatingColor, formatScore10 } from '../../utils/ranking'
+import { getRatingColor, getRatingAccentColor, formatScore10 } from '../../utils/ranking'
 import { formatRelativeTime } from '../../utils/formatters'
 import { ReportModal } from '../ReportModal'
 
@@ -14,6 +14,8 @@ export function DishEvidence({
   dish,
   dishId,
   user,
+  authLoading,
+  priorVote,
   shouldLoadEvidence,
   evidenceSentinelRef,
   friendsVotes,
@@ -35,19 +37,84 @@ export function DishEvidence({
   const displayPhotos = showAllPhotos ? allPhotos : communityPhotos.slice(0, 4)
   const hasMorePhotos = allPhotos.length > 4 && !showAllPhotos
 
+  // Surface the current user's own review here so it isn't lost to the
+  // "Reviews = what others say" filter below. Prefer the loaded review record
+  // (full profile + trust badge) and fall back to priorVote for the brief
+  // window before reviews finish fetching.
+  const ownReviewFromList = user ? reviews.find(r => r.user_id === user.id) : null
+  const ownReview = ownReviewFromList || (
+    user && priorVote && priorVote.review_text
+      ? {
+          rating_10: priorVote.rating_10,
+          review_text: priorVote.review_text,
+          review_created_at: priorVote.review_created_at,
+          user_id: user.id,
+        }
+      : null
+  )
+  const snippetIsOwnReview = !!(user && smartSnippet && smartSnippet.user_id === user.id)
+  const friendIds = new Set(friendsVotes.map(v => v.user_id))
+  const snippetId = !snippetIsOwnReview && smartSnippet && smartSnippet.id ? smartSnippet.id : null
+  const filteredReviews = reviews.filter(r => {
+    if (user && r.user_id === user.id) return false
+    if (friendIds.has(r.user_id)) return false
+    if (snippetId && r.id === snippetId) return false
+    return true
+  })
+
   return (
     <>
       <div ref={evidenceSentinelRef} aria-hidden="true" />
       <div className="px-3 pt-4 pb-4">
 
-        {/* Evidence skeleton while secondary data loads */}
-        {!shouldLoadEvidence && (
+        {/* Evidence skeleton while secondary data loads. authLoading is part of
+            the gate so the user-own-review filter below doesn't briefly leak
+            self-authored reviews into the public list during cold-start auth
+            hydration. */}
+        {(!shouldLoadEvidence || authLoading) && (
           <div className="space-y-3 animate-pulse" role="status" aria-label="Loading details">
             <div className="h-20 rounded-xl" style={{ background: 'var(--color-divider)' }} />
             <div className="grid grid-cols-4 gap-2">
               {[0, 1, 2, 3].map(function (i) { return <div key={i} className="aspect-square rounded-lg" style={{ background: 'var(--color-divider)' }} /> })}
             </div>
             <div className="h-16 rounded-xl" style={{ background: 'var(--color-divider)' }} />
+          </div>
+        )}
+
+        {ownReview && (
+          <div className="mb-4">
+            <h3 className="text-xs font-bold mb-3" style={{ color: 'var(--color-text-tertiary)', letterSpacing: '0.08em', textTransform: 'uppercase' }}>
+              Your Review
+            </h3>
+            <div
+              className="p-4 rounded-xl"
+              style={{
+                background: 'var(--color-card)',
+                border: '1.5px solid var(--color-divider)',
+                borderLeft: '3px solid ' + getRatingAccentColor(ownReview.rating_10),
+              }}
+            >
+              {ownReview.rating_10 ? (
+                <div className="flex items-center gap-2 mb-2.5">
+                  <span
+                    className="rounded-full px-2.5 py-0.5 font-bold text-sm"
+                    style={{ background: getRatingColor(ownReview.rating_10) + '26', color: getRatingColor(ownReview.rating_10) }}
+                  >
+                    {formatScore10(ownReview.rating_10)}
+                  </span>
+                  {ownReview.review_created_at && (
+                    <span className="text-[11px]" style={{ color: 'var(--color-text-secondary)' }}>
+                      {formatRelativeTime(ownReview.review_created_at)}
+                    </span>
+                  )}
+                </div>
+              ) : null}
+              {ownReview.review_text && (
+                <p style={{ color: 'var(--color-text-primary)', fontSize: '15px', lineHeight: 1.7 }}>
+                  {ownReview.review_text}
+                </p>
+              )}
+            </div>
           </div>
         )}
 
@@ -128,8 +195,7 @@ export function DishEvidence({
           )
         })()}
 
-        {/* Smart Snippet */}
-        {smartSnippet && smartSnippet.review_text && (
+        {!snippetIsOwnReview && smartSnippet && smartSnippet.review_text && (
           <div
             className="mb-4 p-4 rounded-xl"
             style={{
@@ -207,17 +273,8 @@ export function DishEvidence({
           </div>
         )}
 
-        {/* Reviews feed */}
-        {(function () {
-          var friendIds = new Set(friendsVotes.map(function (v) { return v.user_id }))
-          var snippetId = smartSnippet && smartSnippet.id ? smartSnippet.id : null
-          var filteredReviews = reviews.filter(function (r) {
-            if (user && r.user_id === user.id) return false
-            if (friendIds.has(r.user_id)) return false
-            if (snippetId && r.id === snippetId) return false
-            return true
-          })
-          return filteredReviews.length > 0 && (
+        {/* Reviews feed (others) */}
+        {filteredReviews.length > 0 && (
           <div className="mb-4">
             <div className="flex items-center justify-between mb-3">
               <h3 className="text-xs font-bold" style={{ color: 'var(--color-text-tertiary)', letterSpacing: '0.08em', textTransform: 'uppercase' }}>
@@ -233,7 +290,7 @@ export function DishEvidence({
               style={{ WebkitOverflowScrolling: 'touch' }}
             >
               {filteredReviews.map(function (review) {
-                var borderColor = review.rating_10 >= 8 ? 'var(--color-success, #22c55e)' : review.rating_10 >= 6 ? 'var(--color-accent-gold)' : 'var(--color-primary)';
+                var borderColor = getRatingAccentColor(review.rating_10);
                 return (
                   <div
                     key={review.id}
@@ -313,11 +370,9 @@ export function DishEvidence({
               })}
             </div>
           </div>
-          )
-        })()}
+        )}
 
-        {/* No reviews message */}
-        {!reviewsLoading && reviews.length === 0 && dish.total_votes > 0 && (
+        {!reviewsLoading && filteredReviews.length === 0 && !ownReview && dish.total_votes > 0 && (
           <div
             className="mb-4 p-4 rounded-xl text-center"
             style={{ background: 'var(--color-surface)', border: '1.5px solid var(--color-divider)' }}

--- a/src/hooks/useDishDetail.js
+++ b/src/hooks/useDishDetail.js
@@ -309,16 +309,27 @@ export function useDishDetail(dishId, user) {
   }
 
   const handleVote = async () => {
-    try {
-      const [data, reviewsData] = await Promise.all([
-        dishesApi.getDishById(dishId),
-        votesApi.getReviewsForDish(dishId, { limit: 20 }),
-      ])
-      const transformedDish = transformDish(data)
-      setDish(transformedDish)
-      setReviews(reviewsData)
-    } catch (err) {
-      logger.error('Failed to refresh dish data after vote:', err)
+    // allSettled (not Promise.all) so a single failed sub-fetch doesn't
+    // discard the others. Matches fetchSecondaryData's pattern above.
+    const [dishResult, reviewsResult, snippetResult] = await Promise.allSettled([
+      dishesApi.getDishById(dishId),
+      votesApi.getReviewsForDish(dishId, { limit: 20 }),
+      votesApi.getSmartSnippetForDish(dishId),
+    ])
+    if (dishResult.status === 'fulfilled') {
+      setDish(transformDish(dishResult.value))
+    } else {
+      logger.error('Failed to refresh dish after vote:', dishResult.reason)
+    }
+    if (reviewsResult.status === 'fulfilled') {
+      setReviews(reviewsResult.value)
+    } else {
+      logger.error('Failed to refresh reviews after vote:', reviewsResult.reason)
+    }
+    if (snippetResult.status === 'fulfilled') {
+      setSmartSnippet(snippetResult.value)
+    } else {
+      logger.error('Failed to refresh smart snippet after vote:', snippetResult.reason)
     }
   }
 

--- a/src/pages/Dish.jsx
+++ b/src/pages/Dish.jsx
@@ -26,7 +26,7 @@ import { ErrorTypes, getUserMessage } from '../utils/errorHandler'
 export function Dish() {
   const { dishId } = useParams()
   const navigate = useNavigate()
-  const { user } = useAuth()
+  const { user, loading: authLoading } = useAuth()
 
   const {
     dish, loading, error,
@@ -438,6 +438,8 @@ export function Dish() {
             dish={dish}
             dishId={dishId}
             user={user}
+            authLoading={authLoading}
+            priorVote={priorVote}
             shouldLoadEvidence={shouldLoadEvidence}
             evidenceSentinelRef={evidenceSentinelRef}
             friendsVotes={friendsVotes}

--- a/src/utils/ranking.js
+++ b/src/utils/ranking.js
@@ -22,6 +22,20 @@ export function getRatingColor(rating) {
 }
 
 /**
+ * Get the left-border accent color used on review cards.
+ * Distinct from getRatingColor — uses theme accent tokens, not badge colors.
+ * @param {number} rating - Rating on 1-10 scale
+ * @returns {string} CSS color value
+ */
+export function getRatingAccentColor(rating) {
+  if (rating === null || rating === undefined) return 'var(--color-divider)'
+  const score = Number(rating)
+  if (score >= 8.0) return 'var(--color-success, #22c55e)'
+  if (score >= 6.0) return 'var(--color-accent-gold)'
+  return 'var(--color-primary)'
+}
+
+/**
  * Get confidence level based on vote count
  * @param {number} totalVotes - Total number of votes
  * @returns {'none' | 'low' | 'medium' | 'high'}


### PR DESCRIPTION
## Summary

The public Dish page silently swallowed the user's just-submitted review. Root cause was not a refetch bug — the data was correctly fetched and stored in state — but a rendering filter (`DishEvidence.jsx:215`) that excludes the user's own review from the "Reviews = what others say" list, with no compensating "Your Review" surface anywhere on the page.

Fixes one broken invariant with four manifestations:

- **Your Review card** — DishEvidence now renders a dedicated card sourced from the loaded reviews list with a `priorVote` fallback for the post-vote refetch window.
- **Cold-start filter leak** — skeleton gate now also catches `authLoading`, killing the brief auth-hydration window where the user-id filter evaluated falsy (because `user` was null) and self-authored reviews flashed into the public list.
- **Stale smart snippet after vote** — `useDishDetail.handleVote` now refetches the snippet alongside dish + reviews.
- **Dead smart-snippet de-dup filter** — `votesApi.getSmartSnippetForDish` now selects `id`, so `snippetId` actually has a value (it was always `null`, killing the dedup filter and the snippet's report button).
- **Silent blank empty state** — empty-state check uses `filteredReviews.length` and accounts for `ownReview`, so the section isn't blank when the current user is the only reviewer.

`handleVote` also switched from `Promise.all` to `Promise.allSettled` so a single failed sub-fetch (e.g. smart snippet) no longer discards the dish + reviews refresh. Matches `fetchSecondaryData`'s pattern in the same hook.

## Review trail

- **Codex CLI (gpt-5.4 / high)** confirmed the primary root cause and surfaced the three adjacent bugs above (dead de-dup filter, stale snippet, broken empty-state).
- **Simplify pass** (3 parallel review agents — reuse / quality / efficiency):
  - Quality flagged 3 over-explanatory comments → deleted.
  - Quality flagged unused fields on the pseudo-review fallback object → slimmed to 4 fields actually read.
  - Reuse flagged duplicated rating→border-color ternary → extracted `getRatingAccentColor()` into `src/utils/ranking.js`.
  - Efficiency flagged `Promise.all` correctness bug → must-fix applied (switched to `allSettled`).

## Deployment status

No DB migrations. No infra changes. UI + hook + small API SELECT only.

## Test plan

- [ ] On public Dish page, rate a dish for the first time → "Your Review" card appears immediately above Friends section, with rating + review text + timestamp.
- [ ] Update an existing rating + change the review text → "Your Review" card reflects the new content without app restart.
- [ ] Sign out, open same Dish page → no "Your Review" card.
- [ ] Cold-start the app on a dish page where you have a review → your review does NOT briefly flash into the public Reviews list during auth hydration.
- [ ] Dish where you are the only reviewer → "Your Review" card shows, no "Be the first to share your thoughts!" message.
- [ ] Dish where you have no review but others do → "Your Review" hidden, public list shows the others.
- [ ] Smart snippet block + reviews list — same review never appears in both (de-dup now works).
- [ ] Smart snippet's "report" button now reachable for other users' snippets (was hidden because `id` was never selected).
- [ ] Regression: voting still updates `total_votes` / `avg_rating` even if the snippet refetch fails (e.g. forced 500 on getSmartSnippetForDish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)