### PR TITLE
docs: 2026-05-14 progress refresh — Apple Dev cleared, smoke green

### DIFF
--- a/CURRENT_FOCUS.md
+++ b/CURRENT_FOCUS.md
@@ -20,9 +20,11 @@ Confirmed 2026-05-14 via clean cherry-pick attempt: **everything that needed to 
 
 ## Where we are
 
-**SIWA infrastructure: production-live (as of 2026-05-08).** Web Apple Sign-In tested end-to-end (sign-in, lands signed in, brand wordmark with name, journal feed loads). Cron worker (`apple-revocation-retry`) verified under synthetic failure — drains, increments attempts, schedules backoff, releases lease, does not dead-letter prematurely.
+**SIWA infrastructure: production-live (as of 2026-05-08).** Web Apple Sign-In tested end-to-end. Cron worker (`apple-revocation-retry`) verified under synthetic failure. Apple Dev verification **CLEARED 2026-05-13**.
 
-**Why nothing has shipped since 5/8:** Phase C requires Xcode + a physical iPhone, which is a different cognitive mode than the previous infra work. Whatever the friction is — break it today.
+**Heavy shipping 2026-05-12 → 2026-05-14:** PR #157 (SIWA capability + new app icon + iOS safe-area double-padding fix + Capgo Apple plugin field-name fix + Apple endpoint 15s timeouts + homepage polish), PRs #158/#159/#160/#161 (brand iteration including the PR #161 PNG-bake-wgh fix for iOS WebKit ignoring `font-optical-sizing`), PR #162 (surface user's own review on public dish page), PR #163 (ASC paperwork: description in Dan's voice + 4 of 5 screenshots at 1290×2796 + Codex-reviewed on-device smoke runbook), plus account-deletion fixes (`e328a8e` Apple identity lookup via Auth Admin API, `f037382` silent-500 logging, `99945ec` dish-modal prompt suppression, `e6e8e82` reset-password URL parsing).
+
+**Real-device smoke (2026-05-14):** Dan walking `2026-05-13-onDevice-smoke-runbook.md`. Sections A (cold launch + anon browse) and B (auth — email, Apple first-time, Apple returning, Google) are GREEN. Sections C (authenticated actions on demo account), D (account deletion on Apple-relay user — Apple 5.1.1(v) gate), and E (regression checks) still to run.
 
 **What's left to launch:**
 
@@ -83,6 +85,33 @@ Confirmed 2026-05-14 via clean cherry-pick attempt: **everything that needed to 
 - **C.2 Cron worker end-to-end ✅** — seeded synthetic pending row, manually invoked cron, verified: function reaches decryption, handles failure gracefully, increments attempts (0→1), schedules backoff (~16 min for attempts=1), releases lease, doesn't dead-letter prematurely
 - C.3 Inline revocation flow — DEFERRED to Phase C real-device (needs Apple-signed-in user with token)
 
+### PR #157 (2026-05-12) — feat(ios): SIWA + new app icon + iOS layout polish ✅
+- `com.apple.developer.applesignin` entitlement; `DEVELOPMENT_TEAM = K447QTHBR9`; `PrivacyInfo.xcprivacy` re-registered with fresh fileRef UUIDs
+- New WGH app icon (coral plate, italic wgh, star at 10 o'clock) across iOS launcher 1024, apple-touch-icon 180, favicon 64+SVG, iOS splash 2732×2732, og-image 1200×630
+- `Seal.jsx` `variant` prop (`monogram` | `seal` | `icon`) — defaults backward-compat
+- **iOS safe-area double-padding fix:** Capacitor `contentInset: 'always' → 'never'` + body-level CSS `env(safe-area-inset-top)` + Layout negative-margin (Codex-confirmed). Killed the huge empty coral band over the Seal + giant grey void over the homepage wordmark.
+- Homepage rhythm tightened (search → chalkboards → Locals' Picks)
+- Locals' Picks banner mark swapped from red ink-stamp to new coral app-icon mark
+- Capgo Apple plugin field-name fix: `result.idToken` + `result.profile?.user` (was failing real-device with "Missing identityToken")
+- Apple endpoint fetches get 15s AbortController timeout — fixes account-deletion silent 500
+- Stale test fix: `signInWithGoogle` test aligned with PR #127's `access_token` drop
+
+### Brand iteration + native fixes (2026-05-13) ✅
+- **PR #158** — new wgh app icon — wide-rim plate
+- **PR #159** — roll out new wgh plate icon across the app
+- **PR #160** — force Fraunces display opsz at every size
+- **PR #161** — bake wgh as PNG to defeat iOS WebKit ignoring `font-optical-sizing` (real-device finding; the mark was rendering distorted on iOS only)
+- **PR #162** — surface user's own review on public Dish page
+- `99945ec` — suppress 'rate now?' prompt when already rated this session
+- `e6e8e82` — `parseAuthUrl` now recognizes `/reset-password` redirect paths
+- `e328a8e` — delete-account uses Auth Admin API for Apple identity lookup
+- `f037382` — log silent 500 paths in delete-account for diagnostics
+
+### PR #163 (2026-05-13) — docs: App Store submission prep ✅
+- `2026-05-13-app-store-description.md` — ~1,720 char description in Dan's voice for ASC's Description field
+- `2026-05-13-screenshots/` — 4 of 5 ASC screenshots at exact 6.7" iPhone Pro Max spec (1290×2796), captured via Playwright with mobile emulation. Missing `04-profile-journal.png` — requires auth, Dan to AirDrop from device
+- `2026-05-13-onDevice-smoke-runbook.md` — tap-by-tap smoke test for real-device pre-TestFlight, with explicit pass criteria tied to specific commits. Codex-reviewed (gpt-5.3-codex high effort): 5 additions, 2 corrections applied, 1 push-back on re-introducing custom URL scheme
+
 ---
 
 ## Daily ritual
@@ -98,10 +127,13 @@ Until App Store launch:
 
 | Topic | File |
 |---|---|
-| Phase C execution playbook | `docs/superpowers/specs/2026-05-07-b3-activate-execution-prep.md` |
+| **Smoke runbook (use for real-device work — STARTS HERE)** | `docs/superpowers/specs/2026-05-13-onDevice-smoke-runbook.md` |
+| **ASC description draft (Dan's voice)** | `docs/superpowers/specs/2026-05-13-app-store-description.md` |
+| **ASC screenshots (4 of 5)** | `docs/superpowers/specs/2026-05-13-screenshots/` |
+| Phase C execution playbook (Archive → TestFlight) | `docs/superpowers/specs/2026-05-07-b3-activate-execution-prep.md` §C.5–C.6 |
 | ASC submission paste guide | `docs/superpowers/specs/2026-05-06-app-store-submission-day.md` |
 | Reviewer notes copy | `docs/superpowers/specs/2026-05-03-app-store-reviewer-notes.md` |
-| Description copy | `docs/superpowers/specs/2026-05-04-app-store-description-final.md` |
+| Description copy (earlier draft, superseded by `2026-05-13-app-store-description.md`) | `docs/superpowers/specs/2026-05-04-app-store-description-final.md` |
 | Privacy nutrition labels | `docs/app-store-connect-privacy-details.md` |
 | Age rating answers | `docs/superpowers/specs/2026-05-06-app-store-age-rating.md` |
 | What's New v1.0 copy | `docs/superpowers/specs/2026-05-06-app-store-whats-new.md` |

--- a/LAUNCH-READINESS.md
+++ b/LAUNCH-READINESS.md
@@ -1,6 +1,6 @@
 # Launch Readiness — Memorial Day 2026-05-25
 
-**~22 days remaining as of 2026-05-03. Apple Dev verification is the critical-path blocker — see `docs/superpowers/plans/2026-04-27-app-store-final-push.md`. Dan has a call with Apple tomorrow (2026-05-04).**
+**11 days remaining as of 2026-05-14. Apple Dev verification CLEARED 2026-05-13. The bottleneck has moved from Apple's clock to ours: real-device smoke (green so far) → TestFlight → ASC submission.**
 
 Any Claude session (Dan's, Denis's, mine, a future one) can check items off as work ships. If you see `[ ]` and you just shipped the thing, tick it. If you see `[x]` on something that's actually broken, flip it back and leave a one-line note.
 
@@ -8,28 +8,33 @@ Any Claude session (Dan's, Denis's, mine, a future one) can check items off as w
 
 ## 🚨 Apple Dev critical path (gates everything iOS-native)
 
-- [ ] Apple Developer enrollment **verified** (submitted, pending Apple) — **the bottleneck**
-- [ ] `VITE_GOOGLE_IOS_CLIENT_ID` provisioned in Vercel (Google Cloud → Credentials → iOS, Bundle `com.whatsgoodhere.app`)
-- [ ] Apple Team ID + Key ID + Services ID + `.p8` uploaded to Supabase Vault (gated on Apple Dev)
-- [ ] Supabase Auth → Apple provider configured (gated on Apple Dev)
-- [ ] `<TEAMID>` placeholder in `public/.well-known/apple-app-site-association` replaced with real Team ID (gated on Apple Dev)
-- [ ] Sign In with Apple capability added in Xcode → Signing & Capabilities (gated on Apple Dev)
-- [ ] `VITE_FEATURES_APPLE_SIGNIN=true` flipped in prod env (gated on Apple Dev)
-- [ ] TestFlight build uploaded + internal testers
+- [x] Apple Developer enrollment **verified** (cleared 2026-05-13) — gate is lifted
+- [x] `VITE_GOOGLE_IOS_CLIENT_ID` provisioned in Vercel
+- [x] Apple Team ID + Key ID + Services ID + `.p8` uploaded to Supabase Vault (Phase A/B, see `2026-05-07-b3-activate-execution-prep.md`)
+- [x] Supabase Auth → Apple provider configured (Phase B)
+- [x] `<TEAMID>` placeholder in `public/.well-known/apple-app-site-association` replaced with real Team ID (PR #149)
+- [x] Sign In with Apple capability added in Xcode → Signing & Capabilities (PR #157)
+- [x] `VITE_FEATURES_APPLE_SIGNIN=true` flipped in prod env (Track A / PR #151)
+- [partial] **Real-device smoke run on physical iPhone** — Dan walking through `2026-05-13-onDevice-smoke-runbook.md`, all green so far (2026-05-14)
+- [ ] **TestFlight build uploaded + internal testers** — next step once smoke completes
 - [ ] App Store review passed
-
-**2026-04-30 contingency call:** if Apple Dev hasn't cleared, evaluate PWA-primary fallback per plan Section 7.
 
 ## Native iOS app (Capacitor)
 
 - [x] Capacitor shell builds locally — simulator smoke passed 2026-04-20 (#62, #67–#72)
 - [x] Native auth lifecycle wired (Plan B B1 #79, B2 #85, B3-code #99, B4 #106)
-- [x] Universal links / AASA file shipped (B4 / PR #106) — placeholder Team ID until Apple Dev clears
-- [x] Apple revocation backend wired (B3-code / PR #99) — dormant until provider config
-- [x] Account deletion live + smoke-tested
-- [x] PR #122 merged (2026-05-03) — camera/photo permission strings + PrivacyInfo.xcprivacy in main at `2e46e47`
-- [ ] **Drag `ios/App/App/PrivacyInfo.xcprivacy` into Xcode App group** (1 click) — without this, file is in repo but not in app bundle
-- [ ] Real-device smoke run on physical iPhone (free provisioning works without paid Apple Dev — do this now, don't wait)
+- [x] Universal links / AASA file shipped (B4 / PR #106) — Team ID replaced post-Apple-Dev (PR #149)
+- [x] Apple revocation backend wired (B3-code / PR #99) + 15s timeout on Apple endpoint fetches (PR #157 / commit `311cc7d`)
+- [x] Account deletion live + Apple identity lookup via Auth Admin API (commit `e328a8e`)
+- [x] PR #122 merged (2026-05-03) — camera/photo permission strings
+- [x] **`PrivacyInfo.xcprivacy` registered in Xcode App group** — PR #157 re-registered the file with fresh fileRef UUIDs
+- [x] **New WGH brand identity shipped** across iOS launcher icon, splash, favicon, og-image, in-app Seal (PRs #157 / #158 / #159) — iteration: wide-rim plate (#158), Fraunces opsz force (#160), PNG-baked wgh to defeat iOS WebKit optical-sizing override (#161)
+- [x] iOS safe-area double-padding fixed — `contentInset: 'never'` + body-level CSS env() (PR #157, Codex-confirmed)
+- [x] Capgo Apple plugin field-name fix — `result.idToken` + `result.profile?.user` (commit `4551d9f` — was failing real-device with "Missing identityToken")
+- [x] Reset password universal link parsing — `parseAuthUrl` now recognizes `/reset-password` redirect paths (commit `e6e8e82`)
+- [x] Dish modal "rate now?" prompt suppression when already rated this session (commit `99945ec`)
+- [x] User's own review surfaces on public Dish page (commit `092d47e`)
+- [partial] **Real-device smoke run on physical iPhone** — see [§ Apple Dev critical path](#-apple-dev-critical-path-gates-everything-ios-native) above; walking `2026-05-13-onDevice-smoke-runbook.md`, all green so far
 
 ## Core experience
 
@@ -78,10 +83,12 @@ Any Claude session (Dan's, Denis's, mine, a future one) can check items off as w
 - [x] Privacy nutrition labels pre-filled
 - [x] Submission checklist sequenced
 - [ ] App name reserved in ASC (verify "What's Good Here" available — Dan, when ASC accessible)
-- [ ] Description (≤4000 chars) — needs Dan's voice
-- [ ] Demo account created with rated dishes + photo + favorite
-- [ ] Screenshots captured (6.7" iPhone, 5 shots — capture AFTER brand refresh ships)
-- [ ] Virtual business address signed up (Stable / Anytime Mailbox, ~$10–30/mo) — Privacy/Terms blocker
+- [x] **Description (≤4000 chars) drafted in Dan's voice** — `docs/superpowers/specs/2026-05-13-app-store-description.md` (PR #163)
+- [x] Demo account exists — `walshdaniel143+wghdemo@gmail.com` / `WGH33!` with 5 rated dishes + name set (reviewer notes already reflect actual state; no photo/favorite claim)
+- [partial] **Screenshots (6.7" iPhone, 4 of 5 shots captured)** — `docs/superpowers/specs/2026-05-13-screenshots/` (PR #163). Missing `04-profile-journal.png` — requires auth, Dan to AirDrop from device build
+- [ ] Virtual business address signed up (Stable / Anytime Mailbox, ~$10–30/mo) — Privacy/Terms blocker (legal copy currently email-only)
+- [ ] Real phone number in App Review Information field (placeholder still in submission-day doc)
+- [x] **On-device smoke runbook drafted** — `docs/superpowers/specs/2026-05-13-onDevice-smoke-runbook.md` (PR #163, Codex-reviewed)
 
 ## Google Places TOS (submission risks per `project_google_places_compliance`)
 
@@ -91,7 +98,7 @@ Any Claude session (Dan's, Denis's, mine, a future one) can check items off as w
 ## Marketing / launch content
 
 - [ ] Landing copy final
-- [ ] Social share assets (OG images verified — note: brand-refresh session is currently regenerating these)
+- [x] Social share assets — OG image regenerated to match new brand (PR #157)
 - [ ] Launch post drafted — where is it going?
 - [ ] First 100 users plan — who, how, when
 


### PR DESCRIPTION
## Summary

Reconciles `LAUNCH-READINESS.md` + `CURRENT_FOCUS.md` with where we actually are 2026-05-14.

**Key state changes:**
- Apple Dev verification CLEARED (2026-05-13) — the 3-week critical-path gate is lifted
- Real-device smoke runbook Sections A (cold launch + browse) and B (auth) GREEN per Dan
- PRs #157, #158, #159, #160, #161, #162, #163 plus a handful of standalone commits all shipped 5/12 → 5/13

**Files changed:** docs only, no code.

## Test plan
- [x] Headers reflect 11 days remaining + Apple Dev cleared
- [x] All Apple Dev critical-path boxes ticked
- [x] Recent shipped work section in CURRENT_FOCUS reflects 5/12 → 5/14 work
- [x] Reference docs table promotes the three 2026-05-13 paste-ready docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)