### PR TITLE
fix(ios): smoke-found UX fixes before TestFlight archive

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -102,6 +102,7 @@ function App() {
         expand={false}
         duration={4000}
         closeButton
+        offset="calc(env(safe-area-inset-top) + 16px)"
         toastOptions={{
           style: {
             padding: '16px',

--- a/src/components/playlists/AddDishSearchSheet.jsx
+++ b/src/components/playlists/AddDishSearchSheet.jsx
@@ -208,7 +208,7 @@ export function AddDishSearchSheet({ isOpen, onClose, playlistId, existingDishId
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-end"
+      className="fixed inset-0 z-[60] flex items-end"
       style={{ background: 'rgba(0,0,0,0.5)' }}
       onClick={function (e) { if (e.target === e.currentTarget) onClose() }}
       onKeyDown={function (e) { if (e.key === 'Escape') onClose() }}
@@ -219,7 +219,7 @@ export function AddDishSearchSheet({ isOpen, onClose, playlistId, existingDishId
         aria-modal="true"
         aria-label="Add dishes to playlist"
         className="w-full rounded-t-2xl flex flex-col"
-        style={{ background: 'var(--color-surface)', maxHeight: '85vh' }}
+        style={{ background: 'var(--color-surface)', height: '85vh' }}
       >
         {/* Grabber */}
         <div style={{ width: 40, height: 4, background: 'var(--color-divider)', borderRadius: 2, margin: '8px auto 0' }} />

--- a/src/components/playlists/AddToPlaylistSheet.jsx
+++ b/src/components/playlists/AddToPlaylistSheet.jsx
@@ -50,7 +50,7 @@ export function AddToPlaylistSheet({ isOpen, onClose, dishId, dishName, restaura
   return (
     <>
       <div
-        className="fixed inset-0 z-50"
+        className="fixed inset-0 z-[60]"
         style={{ background: 'rgba(0,0,0,0.5)' }}
         onClick={function (e) { if (e.target === e.currentTarget) onClose() }}
         onKeyDown={function (e) { if (e.key === 'Escape') onClose() }}

--- a/src/hooks/useFavorites.js
+++ b/src/hooks/useFavorites.js
@@ -88,7 +88,7 @@ export function useFavorites(userId) {
 
     try {
       await addMutation.mutateAsync(dishId)
-      toast.success('Moved to Heard it was Good Here', { duration: 2000 })
+      toast.success('Saved', { duration: 2000 })
       return { error: null }
     } catch (err) {
       toast.error('Could not save dish')
@@ -109,7 +109,7 @@ export function useFavorites(userId) {
 
     try {
       await removeMutation.mutateAsync(dishId)
-      toast('Removed from Heard it was Good Here', { duration: 2000 })
+      toast('Removed', { duration: 2000 })
       return { error: null }
     } catch (err) {
       toast.error('Could not remove dish')

--- a/src/pages/Dish.jsx
+++ b/src/pages/Dish.jsx
@@ -334,6 +334,7 @@ export function Dish() {
             dishName={dish.dish_name}
             photoUrl={photoUploaded.photo_url}
             status={photoUploaded.analysisResults?.status}
+            hasRated={!!priorVote}
             onRateNow={clearPhotoUploaded}
             onLater={clearPhotoUploaded}
           />

--- a/src/pages/UserProfile.jsx
+++ b/src/pages/UserProfile.jsx
@@ -712,7 +712,7 @@ export function UserProfile() {
             Share
           </button>
           {currentUser && !isOwnProfile && (
-            <div className="relative" ref={actionsMenuRef}>
+            <div className="relative" style={{ zIndex: 50 }} ref={actionsMenuRef}>
               <button
                 type="button"
                 onClick={() => setShowActionsMenu((v) => !v)}


### PR DESCRIPTION
## Summary

Batch of 7 cosmetic / interaction-layer fixes surfaced during the real-device smoke run on 2026-05-14, immediately before TestFlight archive.

## Fixes

- **`useFavorites.js`** — toast: `'Saved'` / `'Removed'` (was 'Moved/Removed from Heard it was Good Here', a relic from a prior multi-list pattern)
- **`Dish.jsx`** — `PhotoUploadConfirmation` receives `hasRated={!!priorVote}` so the post-photo "rate now?" re-prompt is suppressed when the user just rated. Wiring existed (commit `99945ec`) but only inside the retired DishModal.
- **`App.jsx`** — Toaster `offset="calc(env(safe-area-inset-top) + 16px)"` so toasts don't get clipped by the Dynamic Island / status bar.
- **`UserProfile.jsx`** — `zIndex: 50` on the actions-menu wrapper so the Report/Block dropdown sits above the sticky Journal/Playlists tab strip. Without this, "Block user" was painted under the tabs and invisible.
- **`AddDishSearchSheet.jsx`** — `height: '85vh'` (was `maxHeight`) + outer `z-[60]` (was `z-50`). `maxHeight` let the sheet shrink to content; `z-50` tied with BottomNav's `z-50` so the nav strip painted over the sheet's bottom.
- **`AddToPlaylistSheet.jsx`** — outer `z-[60]` for the same BottomNav collision.

## Smoke matrix (verified on this branch's synced web bundle)

- Section A (cold launch + anon browse) ✅
- Section B (auth — email, Apple first-time, Apple returning, Google) ✅
- Section C (rate, heart, photo camera, photo library, report, block) ✅
- Section D (Apple-relay account deletion — 5.1.1(v) gate) ✅
- Section E (regression sweep + ATT prompt absence) ✅

## Deployment status

No DB migrations, no infra changes. Web bundle only. `npm run build && npx cap sync ios` already run locally — TestFlight archive (next step) will include all fixes.

## Test plan

- [x] Rate a dish → "Your Review" card appears + correct toast copy
- [x] Heart a dish → toast says "Saved"
- [x] Unheart → toast says "Removed"
- [x] Take photo on a dish you've rated → no "rate now?" re-prompt afterward
- [x] Any toast → sits below the Dynamic Island, not clipped
- [x] User profile ⋯ menu → both "Report user" + "Block user" visible above the tab strip
- [x] Playlist page → tap "Add dish" → sheet opens at 85% of viewport, results list scrollable, BottomNav covered by sheet
- [x] Walk app for 60s → no ATT prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)