### PR TITLE
fix(ios): set CFBundleName to WhatsGoodHere

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>WhatsGoodHere</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
Apple's binary preflight flags CFBundleName="App" (Capacitor default) as too generic. Override with literal value in Info.plist; CFBundleDisplayName stays "What's Good Here" (user-facing). Surgical — no Xcode target rename, no scheme/signing changes.

Caught at archive-time on 2026-05-14 via Xcode's "Resolve Initial Setup Issues" dialog before TestFlight upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)