### PR TITLE
fix(reviews): stop AI-estimated votes from leaking into review UI

### DIFF
--- a/src/api/votesApi.js
+++ b/src/api/votesApi.js
@@ -362,6 +362,7 @@ export const votesApi = {
         .eq('dish_id', dishId)
         .not('review_text', 'is', null)
         .neq('review_text', '')
+        .neq('source', 'ai_estimated')
         .order('review_created_at', { ascending: false, nullsFirst: false })
         .range(offset, offset + limit - 1)
 
@@ -430,6 +431,7 @@ export const votesApi = {
         .eq('dish_id', dishId)
         .not('review_text', 'is', null)
         .neq('review_text', '')
+        .neq('source', 'ai_estimated')
         .order('rating_10', { ascending: false, nullsFirst: false })
         .order('review_created_at', { ascending: false, nullsFirst: false })
         .limit(1)
@@ -572,6 +574,7 @@ export const votesApi = {
         .in('dish_id', dishIds)
         .not('review_text', 'is', null)
         .neq('review_text', '')
+        .neq('source', 'ai_estimated')
 
       if (sort === 'newest') {
         query = query.order('review_created_at', { ascending: false, nullsFirst: false })

--- a/src/api/votesApi.test.js
+++ b/src/api/votesApi.test.js
@@ -435,8 +435,10 @@ describe('votesApi', () => {
           eq: vi.fn().mockReturnValue({
             not: vi.fn().mockReturnValue({
               neq: vi.fn().mockReturnValue({
-                order: vi.fn().mockReturnValue({
-                  range: vi.fn().mockResolvedValue({ data: mockVoteRows, error: null }),
+                neq: vi.fn().mockReturnValue({
+                  order: vi.fn().mockReturnValue({
+                    range: vi.fn().mockResolvedValue({ data: mockVoteRows, error: null }),
+                  }),
                 }),
               }),
             }),
@@ -467,8 +469,10 @@ describe('votesApi', () => {
           eq: vi.fn().mockReturnValue({
             not: vi.fn().mockReturnValue({
               neq: vi.fn().mockReturnValue({
-                order: vi.fn().mockReturnValue({
-                  range: vi.fn().mockResolvedValue({ data: null, error: { message: 'Error' } }),
+                neq: vi.fn().mockReturnValue({
+                  order: vi.fn().mockReturnValue({
+                    range: vi.fn().mockResolvedValue({ data: null, error: { message: 'Error' } }),
+                  }),
                 }),
               }),
             }),
@@ -497,9 +501,11 @@ describe('votesApi', () => {
           eq: vi.fn().mockReturnValue({
             not: vi.fn().mockReturnValue({
               neq: vi.fn().mockReturnValue({
-                order: vi.fn().mockReturnValue({
+                neq: vi.fn().mockReturnValue({
                   order: vi.fn().mockReturnValue({
-                    limit: vi.fn().mockResolvedValue({ data: [mockVoteRow], error: null }),
+                    order: vi.fn().mockReturnValue({
+                      limit: vi.fn().mockResolvedValue({ data: [mockVoteRow], error: null }),
+                    }),
                   }),
                 }),
               }),
@@ -529,9 +535,11 @@ describe('votesApi', () => {
           eq: vi.fn().mockReturnValue({
             not: vi.fn().mockReturnValue({
               neq: vi.fn().mockReturnValue({
-                order: vi.fn().mockReturnValue({
+                neq: vi.fn().mockReturnValue({
                   order: vi.fn().mockReturnValue({
-                    limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+                    order: vi.fn().mockReturnValue({
+                      limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+                    }),
                   }),
                 }),
               }),
@@ -551,9 +559,11 @@ describe('votesApi', () => {
           eq: vi.fn().mockReturnValue({
             not: vi.fn().mockReturnValue({
               neq: vi.fn().mockReturnValue({
-                order: vi.fn().mockReturnValue({
+                neq: vi.fn().mockReturnValue({
                   order: vi.fn().mockReturnValue({
-                    limit: vi.fn().mockResolvedValue({ data: null, error: { message: 'Error' } }),
+                    order: vi.fn().mockReturnValue({
+                      limit: vi.fn().mockResolvedValue({ data: null, error: { message: 'Error' } }),
+                    }),
                   }),
                 }),
               }),

--- a/supabase/migrations/2026-05-15-suppress-ai-estimated-in-snippets.sql
+++ b/supabase/migrations/2026-05-15-suppress-ai-estimated-in-snippets.sql
@@ -1,0 +1,45 @@
+-- P0-3: stop AI-estimated reviews from leaking into user-visible review surfaces.
+-- The display-layer filter lives in src/api/votesApi.js (getReviewsForDish,
+-- getSmartSnippetForDish, getReviewsForRestaurant). This migration is the
+-- belt-and-suspenders patch for the server-side RPC `get_smart_snippet`, which
+-- is currently not called from src/ but remains exposed to other consumers
+-- (Edge Functions, future callers).
+--
+-- AI votes (source='ai_estimated') continue to contribute to ranking via the
+-- existing 0.5x weighting inside get_ranked_dishes and related aggregations.
+-- They just stop surfacing as fake "@WGH Community" review text.
+--
+-- Run this in the Supabase SQL Editor (Denis's project: vpioftosgdkyiwvhxewy)
+-- after the PR merges. Idempotent — CREATE OR REPLACE.
+
+CREATE OR REPLACE FUNCTION get_smart_snippet(p_dish_id UUID)
+RETURNS TABLE (
+  review_text TEXT, rating_10 DECIMAL, display_name TEXT,
+  user_id UUID, review_created_at TIMESTAMP WITH TIME ZONE
+) AS $$
+DECLARE v_viewer_id UUID := (select auth.uid());
+BEGIN
+  RETURN QUERY
+  SELECT v.review_text, v.rating_10, p.display_name, v.user_id, v.review_created_at
+  FROM votes v
+  INNER JOIN profiles p ON v.user_id = p.id
+  WHERE v.dish_id = p_dish_id
+    AND v.review_text IS NOT NULL AND v.review_text != ''
+    AND v.source != 'ai_estimated'
+    AND (v_viewer_id IS NULL OR NOT is_blocked_pair(v_viewer_id, v.user_id))
+  ORDER BY
+    CASE WHEN v.rating_10 >= 9 THEN 0 ELSE 1 END,
+    v.rating_10 DESC NULLS LAST,
+    v.review_created_at DESC NULLS LAST
+  LIMIT 1;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- Verify: should return rows only when the dish has at least one human-source
+-- review with non-empty text. AI-only dishes return zero rows.
+-- SELECT * FROM get_smart_snippet('<dish-uuid>');
+
+-- ROLLBACK:
+-- Restore the previous function body by removing the
+-- `AND v.source != 'ai_estimated'` clause. Equivalent body is in
+-- supabase/migrations/20260415_h3_ugc_reporting_blocking.sql §get_smart_snippet.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -5098,7 +5098,7 @@ GRANT EXECUTE ON FUNCTION get_open_reports(INT, BIGINT, TIMESTAMPTZ, UUID) TO au
 -- See migrations/20260415_h3_ugc_reporting_blocking.sql for the bodies.
 
 
--- get_smart_snippet — exclude reviews by blocked users
+-- get_smart_snippet — exclude reviews by blocked users and AI-estimated rows
 CREATE OR REPLACE FUNCTION get_smart_snippet(p_dish_id UUID)
 RETURNS TABLE (
   review_text TEXT, rating_10 DECIMAL, display_name TEXT,
@@ -5112,6 +5112,7 @@ BEGIN
   INNER JOIN profiles p ON v.user_id = p.id
   WHERE v.dish_id = p_dish_id
     AND v.review_text IS NOT NULL AND v.review_text != ''
+    AND v.source != 'ai_estimated'
     AND (v_viewer_id IS NULL OR NOT is_blocked_pair(v_viewer_id, v.user_id))
   ORDER BY
     CASE WHEN v.rating_10 >= 9 THEN 0 ELSE 1 END,


### PR DESCRIPTION
## Summary
- Filters \`source='ai_estimated'\` out of three user-visible review-fetch paths in \`votesApi\`: \`getReviewsForDish\`, \`getSmartSnippetForDish\`, \`getReviewsForRestaurant\`. AI votes still contribute their existing 0.5x weight to ranking via \`get_ranked_dishes\` — purely a display-layer fix, no data deletion, no schema change beyond an RPC patch.
- Patches the server-side \`get_smart_snippet\` Postgres RPC as belt-and-suspenders (nothing in \`src/\` calls it today, but other consumers could). Migration file is paste-ready: \`supabase/migrations/2026-05-15-suppress-ai-estimated-in-snippets.sql\`.
- Updates 5 mocked query chains in \`votesApi.test.js\` so the new \`.neq()\` link doesn't break CI.

## Why
P0-3 from the May 11 site audit (agent-phone issue #169). The \`seed-reviews\` Edge Function inserts \`ai_estimated\` votes from parsed Google reviews — meant for cold-start ranking signal, but accidentally surfaced as fake "@WGH Community" reviews on dish pages. Pan Seared Striped Bass showed 3 identical sentences because the seeder dedups by count, not by \`review_text\`. The trust tentpole of the product was being undermined by its own seeder.

Decision: keep AI votes for ranking weight; never display them as review text. Apple is reviewing the iOS binary right now, but the live web fallback is what reviewers actually visit — backend changes flow through immediately.

## Codex review caught
Initial diff was 2 lines in \`votesApi.js\`. \`gpt-5.4\` review flagged:
1. Missed \`getReviewsForRestaurant\` — fixed.
2. \`get_smart_snippet\` RPC's \`INNER JOIN profiles\` is not a reliable AI filter (\`handle_new_user()\` auto-creates profile rows for any \`auth.users\` entry) — fixed via the RPC patch + migration.
3. Existing unit-test mock chains needed the extra \`.neq\` link — fixed.

## Deployment
1. Merge this PR (Vercel auto-deploys web)
2. Paste \`supabase/migrations/2026-05-15-suppress-ai-estimated-in-snippets.sql\` into Supabase SQL Editor (Denis's project: \`vpioftosgdkyiwvhxewy\`)

## Test plan
- [x] \`npm test -- src/api/votesApi.test.js\` — 33/33 pass
- [x] \`npm run build\` — clean
- [x] \`npx eslint src/api/votesApi.js src/api/votesApi.test.js\` — only the pre-existing \`classifiedError\` redeclare error at :195, unrelated to this change
- [ ] After merge + RPC migration: visit \`/dish/<striped-bass-id>\` on live, confirm no "@WGH Community" reviews appear
- [ ] Confirm dish cards on home/restaurant pages don't show AI-generated snippets
- [ ] Confirm ranking order on home page is unchanged (AI votes still count toward rank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)