### PR TITLE
fix(seo): per-page document.title via useDocumentTitle hook

### DIFF
--- a/src/hooks/useDocumentTitle.js
+++ b/src/hooks/useDocumentTitle.js
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+
+const BASE_TITLE = "What's Good Here"
+
+/**
+ * Sets document.title to `${title} — What's Good Here`, restoring the bare
+ * BASE_TITLE on unmount. Pass `null` or an empty string while data is loading
+ * (e.g. waiting on a dish or restaurant name) — the title stays as BASE_TITLE
+ * until you have something specific to surface.
+ *
+ * Web only: iOS Capacitor users don't see this. SEO crawlers and shared-link
+ * previews are the audience.
+ */
+export function useDocumentTitle(title) {
+  useEffect(() => {
+    document.title = title ? `${title} — ${BASE_TITLE}` : BASE_TITLE
+    return () => { document.title = BASE_TITLE }
+  }, [title])
+}

--- a/src/pages/Dish.jsx
+++ b/src/pages/Dish.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { capture } from '../lib/analytics'
 import { logger } from '../utils/logger'
 import { useAuth } from '../context/AuthContext'
@@ -38,6 +39,12 @@ export function Dish() {
     handlePhotoUploaded, handleVote, clearPhotoUploaded,
     refetchDish,
   } = useDishDetail(dishId, user)
+
+  useDocumentTitle(
+    dish?.dish_name
+      ? (dish.restaurant_name ? `${dish.dish_name} at ${dish.restaurant_name}` : dish.dish_name)
+      : null
+  )
 
   const [loginModalOpen, setLoginModalOpen] = useState(false)
   const [playlistSheetOpen, setPlaylistSheetOpen] = useState(false)

--- a/src/pages/ForRestaurants.jsx
+++ b/src/pages/ForRestaurants.jsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
 /**
  * ForRestaurants — pitch page for door-knocking.
@@ -6,6 +7,7 @@ import { useNavigate } from 'react-router-dom'
  * No auth, no data fetching, pure persuasion.
  */
 export function ForRestaurants() {
+  useDocumentTitle('For restaurants')
   var navigate = useNavigate()
 
   return (

--- a/src/pages/HowReviewsWork.jsx
+++ b/src/pages/HowReviewsWork.jsx
@@ -1,7 +1,9 @@
 import { useNavigate } from 'react-router-dom'
 import { TrustBadge } from '../components/TrustBadge'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
 export function HowReviewsWork() {
+  useDocumentTitle('How reviews work')
   const navigate = useNavigate()
 
   return (

--- a/src/pages/JitterLanding.jsx
+++ b/src/pages/JitterLanding.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { JITTER_TIERS } from '../constants/jitter'
 import { jitterApi } from '../api/jitterApi'
 import { logger } from '../utils/logger'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
 /**
  * JitterLanding — standalone explainer page.
@@ -9,6 +10,7 @@ import { logger } from '../utils/logger'
  * Route: /jitter
  */
 export default function JitterLanding() {
+  useDocumentTitle('Jitter — every review is verified human')
   return (
     <div style={{ background: 'var(--color-bg)', minHeight: '100vh' }}>
       <HookSection />

--- a/src/pages/Locals.jsx
+++ b/src/pages/Locals.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useLocalPicksConsensus } from '../hooks/useLocalPicksConsensus'
 import { useLocalPicksCurators } from '../hooks/useLocalPicksCurators'
 import { useLocalPicksSearch } from '../hooks/useLocalPicksSearch'
@@ -93,6 +94,7 @@ var SEARCH_INPUT = {
 var EMPTY = { textAlign: 'center', padding: '20px 0', fontSize: '12px', color: 'var(--color-text-tertiary)', fontWeight: 500 }
 
 export function Locals() {
+  useDocumentTitle('Locals’ picks')
   var navigate = useNavigate()
   var [activeTab, setActiveTab] = useState('read')
 

--- a/src/pages/LocalsCurator.jsx
+++ b/src/pages/LocalsCurator.jsx
@@ -1,6 +1,7 @@
 import { useNavigate, useParams } from 'react-router-dom'
 import { useLocalListDetail } from '../hooks/useLocalListDetail'
 import { LocalsPicksStamp } from '../components/home/LocalsPicksStamp'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
 var PAGE = {
   background: 'linear-gradient(180deg, var(--color-paper-cream-light) 0%, var(--color-paper-cream-dark) 100%)',
@@ -41,6 +42,7 @@ var NOTE = { fontSize: '12.5px', color: 'var(--color-text-secondary)', lineHeigh
 var EMPTY = { textAlign: 'center', padding: '40px 0', fontSize: '13px', color: 'var(--color-text-tertiary)' }
 
 export function LocalsCurator() {
+  useDocumentTitle('A local’s picks')
   var { userId } = useParams()
   var navigate = useNavigate()
   var { items, loading, error } = useLocalListDetail(userId)

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -8,10 +8,12 @@ import { Seal } from '../components/Seal'
 import { FEATURES } from '../constants/features'
 import { getAuthUrlType } from '../utils/authUrlType'
 import { SignInWithAppleButton } from '../components/Auth/SignInWithAppleButton'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
 // SECURITY: Email is NOT persisted to storage to prevent XSS exposure of PII
 
 export function Login() {
+  useDocumentTitle('Sign in')
   const navigate = useNavigate()
   const location = useLocation()
   const { user } = useAuth()

--- a/src/pages/Map.jsx
+++ b/src/pages/Map.jsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef, useEffect, useMemo, lazy, Suspense } from 'react'
 import { useNavigate, useLocation, useSearchParams } from 'react-router-dom'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useLocationContext } from '../context/LocationContext'
 import { useDishes } from '../hooks/useDishes'
 import { useDishSearch } from '../hooks/useDishSearch'
@@ -19,6 +20,8 @@ var RestaurantMap = lazy(function () {
 })
 
 export function Map() {
+  useDocumentTitle('Top dishes on Martha’s Vineyard')
+
   var navigate = useNavigate()
   var routeLocation = useLocation()
   var [searchParams] = useSearchParams()

--- a/src/pages/MyList.jsx
+++ b/src/pages/MyList.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useMyLocalList } from '../hooks/useMyLocalList'
 import { useDishSearch } from '../hooks/useDishSearch'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { getCategoryEmoji } from '../constants/categories'
 import { logger } from '../utils/logger'
 
@@ -18,6 +19,7 @@ function snapshot(tagline, items) {
 }
 
 export function MyList() {
+  useDocumentTitle('Your top 10')
   var navigate = useNavigate()
   var location = useLocation()
   var { listMeta, dishes, loading, error, saveList, saving } = useMyLocalList()

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,6 +1,8 @@
 import { Link } from 'react-router-dom'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
 export function NotFound() {
+  useDocumentTitle('Page not found')
   return (
     <div
       className="min-h-screen flex items-center justify-center p-6"

--- a/src/pages/Playlist.jsx
+++ b/src/pages/Playlist.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useParams, Link, useNavigate } from 'react-router-dom'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { usePlaylistDetail } from '../hooks/usePlaylistDetail'
 import { usePlaylistMutations } from '../hooks/usePlaylistMutations'
 import { useAuth } from '../context/AuthContext'
@@ -18,6 +19,9 @@ export function Playlist() {
   const { playlist, loading, error } = usePlaylistDetail(id)
   const { follow, unfollow, removeDish } = usePlaylistMutations()
   const [searchSheetOpen, setSearchSheetOpen] = useState(false)
+
+  useDocumentTitle(playlist?.playlist_name || null)
+
 
   const items = playlist?.items || []
   const existingDishIds = useMemo(() => items.map((i) => i.dish_id), [items])

--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -1,7 +1,9 @@
 import { useNavigate } from 'react-router-dom'
 import { Seal } from '../components/Seal'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
 export function Privacy() {
+  useDocumentTitle('Privacy policy')
   const navigate = useNavigate()
 
   return (

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useAuth } from '../context/AuthContext'
 import { logger } from '../utils/logger'
 import { authApi } from '../api/authApi'
@@ -26,6 +27,8 @@ import { jitterApi } from '../api/jitterApi'
 // SECURITY: Email is NOT persisted to storage to prevent XSS exposure of PII
 
 export function Profile() {
+  useDocumentTitle('Your food journal')
+
   const { user, loading } = useAuth()
   const [editingName, setEditingName] = useState(false)
   const [newName, setNewName] = useState('')

--- a/src/pages/RestaurantDetail.jsx
+++ b/src/pages/RestaurantDetail.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { capture } from '../lib/analytics'
 import { useAuth } from '../context/AuthContext'
 import { ReportModal } from '../components/ReportModal'
@@ -34,6 +35,8 @@ export function RestaurantDetail() {
   const [restaurant, setRestaurant] = useState(null)
   const [loadingRestaurant, setLoadingRestaurant] = useState(true)
   const [fetchError, setFetchError] = useState(null)
+
+  useDocumentTitle(restaurant?.name || null)
 
   const [activeTab, setActiveTab] = useState(null) // null = auto-detect
   const [dishSearchQuery, setDishSearchQuery] = useState('')

--- a/src/pages/RestaurantReviews.jsx
+++ b/src/pages/RestaurantReviews.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { votesApi } from '../api/votesApi'
 import { restaurantsApi } from '../api/restaurantsApi'
 import { logger } from '../utils/logger'
@@ -20,6 +21,9 @@ export function RestaurantReviews() {
   var [restaurant, setRestaurant] = useState(null)
   var [reviews, setReviews] = useState([])
   var [loading, setLoading] = useState(true)
+
+  useDocumentTitle(restaurant?.name ? `Reviews — ${restaurant.name}` : null)
+
   var [fetchError, setFetchError] = useState(null)
   var [sortBy, setSortBy] = useState('newest')
   var [reportTarget, setReportTarget] = useState(null)

--- a/src/pages/Restaurants.jsx
+++ b/src/pages/Restaurants.jsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { capture } from '../lib/analytics'
 import { useAuth } from '../context/AuthContext'
 import { useLocationContext } from '../context/LocationContext'
@@ -22,6 +23,8 @@ function bayesianScore(avgRating, totalVotes) {
 }
 
 export function Restaurants() {
+  useDocumentTitle('Restaurants on Martha’s Vineyard')
+
   var user = useAuth().user
   var navigate = useNavigate()
   var ctx = useLocationContext()

--- a/src/pages/Support.jsx
+++ b/src/pages/Support.jsx
@@ -1,7 +1,9 @@
 import { useNavigate } from 'react-router-dom'
 import { Seal } from '../components/Seal'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
 export function Support() {
+  useDocumentTitle('Support')
   const navigate = useNavigate()
 
   return (

--- a/src/pages/Terms.jsx
+++ b/src/pages/Terms.jsx
@@ -1,7 +1,9 @@
 import { useNavigate } from 'react-router-dom'
 import { Seal } from '../components/Seal'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
 export function Terms() {
+  useDocumentTitle('Terms of service')
   const navigate = useNavigate()
 
   return (

--- a/src/pages/UserProfile.jsx
+++ b/src/pages/UserProfile.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useRef } from 'react'
 import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useAuth } from '../context/AuthContext'
 import { logger } from '../utils/logger'
 import { getCompatColor } from '../utils/formatters'
@@ -78,6 +79,9 @@ export function UserProfile() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [isFollowing, setIsFollowing] = useState(false)
+
+  useDocumentTitle(profile?.display_name ? `@${profile.display_name}` : null)
+
   const [followLoading, setFollowLoading] = useState(false)
   const [followListModal, setFollowListModal] = useState(null) // 'followers' | 'following' | null
   const [myRatings, setMyRatings] = useState({}) // { dishId: rating }


### PR DESCRIPTION
## Summary
- New \`useDocumentTitle\` hook in \`src/hooks/useDocumentTitle.js\` — sets \`<title> — What's Good Here\` on mount, restores base on unmount, accepts null while data is loading
- 19 pages wired up: dish/restaurant/playlist/user-profile get dynamic titles; legal, info, and auth pages get static titles
- No new dependencies. Pure web change — iOS Capacitor users don't see this; SEO crawlers and shared-link tab labels are the audience

## Why
The May 11 site audit (#169 P1-3) called out that every page on prod has the same \`<title>\` of "What's Good Here." That's a real SEO miss for a content-heavy app and makes shared-link previews + browser tab/history navigation unreadable.

## Examples
- Home → "Top dishes on Martha's Vineyard — What's Good Here"
- /dish/<id> → "Pan Seared Striped Bass at Garde East — What's Good Here"
- /privacy → "Privacy policy — What's Good Here"
- /user/<id> → "@<display_name> — What's Good Here"
- /jitter → "Jitter — every review is verified human — What's Good Here"

## Skipped (intentional)
Low-traffic auth/admin/private flow pages: Browse (about to be retired in #169), ResetPassword, AcceptInvite, AcceptCuratorInvite, CrossDevicePkce, Waitlist, Admin, RateYourMeal, ManageRestaurant. Easy to add later if needed.

## Out of scope
Open Graph / Twitter card meta tags are already handled server-side by \`api/og-image.ts\` and \`api/share.ts\` for bot crawlers, so this PR is just for the rendered \`<title>\`.

## Test plan
- [x] \`npm test\` — 449/450 pass (1 pre-existing nativeAuth failure unrelated)
- [x] \`npm run build\` — clean, 7.56s; precache 164 entries
- [x] Local browser smoke on /, /privacy, /dish/<id> — all show distinct titles
- [ ] After merge, view 3-4 routes in browser, confirm title updates as you navigate
- [ ] Confirm a dynamic-title page (e.g. /dish/<id>) shows the base "What's Good Here" briefly while loading, then the full title once data lands

## Note
Codex review attempted four times today across high/medium/low effort — all hung past timeout. OpenAI Codex API appears to be having issues. This PR is human-verified only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)