### PR TITLE
fix(ux): distinguish Supabase outage from empty state

### DIFF
--- a/src/components/DataLoadError.jsx
+++ b/src/components/DataLoadError.jsx
@@ -1,0 +1,81 @@
+/**
+ * DataLoadError — shown when a top-level data fetch fails for a logged-in user.
+ *
+ * Purpose: distinguish "we couldn't reach the server" from "you have no data."
+ * Without this, a Supabase blip on profile/home reads like the user's account
+ * got wiped. See agent-phone audit #169 P0-1.
+ *
+ * Pass `fullPage` for a centered viewport-height layout (use on Profile when
+ * the entire page failed). Default is an inline banner.
+ */
+export function DataLoadError({ message, onRetry, fullPage = false }) {
+  const content = (
+    <div
+      className="flex flex-col items-center text-center px-6"
+      style={{ maxWidth: '420px', margin: '0 auto' }}
+    >
+      <div
+        className="flex items-center justify-center mb-4"
+        style={{
+          width: 56,
+          height: 56,
+          borderRadius: '50%',
+          background: 'rgba(220, 38, 38, 0.10)',
+        }}
+        aria-hidden="true"
+      >
+        <svg width="28" height="28" viewBox="0 0 24 24" fill="none">
+          <path
+            d="M12 8v4m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4a2 2 0 0 0-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3Z"
+            stroke="var(--color-danger)"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </div>
+      <h2
+        className="text-lg font-bold mb-2"
+        style={{ color: 'var(--color-text-primary)' }}
+      >
+        We couldn’t load your data
+      </h2>
+      <p
+        className="text-sm mb-5"
+        style={{ color: 'var(--color-text-secondary)', lineHeight: 1.5 }}
+      >
+        {message || 'This usually means a network blip. Your account is fine — try again in a moment.'}
+      </p>
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="px-5 py-2.5 rounded-xl font-semibold text-sm"
+          style={{
+            background: 'var(--color-primary)',
+            color: 'var(--color-text-on-primary, white)',
+          }}
+        >
+          Try again
+        </button>
+      )}
+    </div>
+  )
+
+  if (fullPage) {
+    return (
+      <div
+        className="flex items-center justify-center"
+        style={{ minHeight: '100dvh', background: 'var(--color-bg)' }}
+      >
+        {content}
+      </div>
+    )
+  }
+
+  return (
+    <div className="py-10 px-4">
+      {content}
+    </div>
+  )
+}

--- a/src/components/home/HomeListMode.jsx
+++ b/src/components/home/HomeListMode.jsx
@@ -4,6 +4,7 @@ import { BROWSE_CATEGORIES } from '../../constants/categories'
 import { DishSearch } from '../DishSearch'
 import { DishListItem } from '../DishListItem'
 import { EmptyState } from '../EmptyState'
+import { DataLoadError } from '../DataLoadError'
 import { LocationBanner } from '../LocationBanner'
 import { LocalsPicksBanner, Top10Carousel } from './'
 export const HomeListMode = memo(function HomeListMode({
@@ -11,6 +12,8 @@ export const HomeListMode = memo(function HomeListMode({
   searchQuery,
   searchLoading,
   rankedLoading,
+  rankedError,
+  rankedRefetch,
   activeDishes,
   allRankedDishes,
   expandedCategory,
@@ -188,6 +191,11 @@ export const HomeListMode = memo(function HomeListMode({
               <Top10Carousel ref={carouselRef} dishes={allRankedDishes} onCategoryChange={onCategoryChange} />
             </div>
           </>
+        ) : rankedError ? (
+          <DataLoadError
+            message={rankedError.message}
+            onRetry={rankedRefetch}
+          />
         ) : (
           <div className="px-4 pt-4">
             <EmptyState emoji="🍽️" title="No dishes found nearby" />

--- a/src/hooks/useProfile.js
+++ b/src/hooks/useProfile.js
@@ -7,7 +7,7 @@ import { logger } from '../utils/logger'
 export function useProfile(userId) {
   const queryClient = useQueryClient()
 
-  const { data: profile, isLoading: loading, error } = useQuery({
+  const { data: profile, isLoading: loading, error, refetch } = useQuery({
     queryKey: ['profile', userId],
     queryFn: async () => {
       // API uses auth.getUser() internally for security
@@ -40,6 +40,7 @@ export function useProfile(userId) {
     profile: profile ?? null,
     loading: userId ? loading : false,
     error: error ? { message: getUserMessage(error, 'loading profile') } : null,
+    refetch,
     updateProfile,
   }
 }

--- a/src/pages/Map.jsx
+++ b/src/pages/Map.jsx
@@ -128,6 +128,8 @@ export function Map() {
   var rankedData = useDishes(location, radius, null, null, null)
   var rankedDishes = rankedData.dishes
   var rankedLoading = rankedData.loading || rankedData.isFetching
+  var rankedError = rankedData.error
+  var rankedRefetch = rankedData.refetch
 
   var selectedCategoryLabel = selectedCategory
     ? BROWSE_CATEGORIES.find(function (c) { return c.id === selectedCategory })
@@ -316,6 +318,8 @@ export function Map() {
           searchQuery={searchQuery}
           searchLoading={searchLoading}
           rankedLoading={rankedLoading}
+          rankedError={rankedError}
+          rankedRefetch={rankedRefetch}
           activeDishes={activeDishes}
           allRankedDishes={allRanked}
           expandedCategory={expandedCategory}

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -13,6 +13,7 @@ import { DishModal } from '../components/DishModal'
 import { LoginModal } from '../components/Auth/LoginModal'
 import { FollowListModal } from '../components/FollowListModal'
 import { ProfileSkeleton } from '../components/Skeleton'
+import { DataLoadError } from '../components/DataLoadError'
 import { CameraIcon } from '../components/CameraIcon'
 import { PlaylistStripCard } from '../components/playlists/PlaylistStripCard'
 import { PlaylistGridCard } from '../components/playlists/PlaylistGridCard'
@@ -31,7 +32,7 @@ export function Profile() {
   const [newName, setNewName] = useState('')
   const [nameStatus, setNameStatus] = useState(null) // null | 'checking' | 'available' | 'taken' | 'same'
 
-  const { profile, updateProfile } = useProfile(user?.id)
+  const { profile, error: profileError, loading: profileLoading, refetch: refetchProfile } = useProfile(user?.id)
   const { ratedDishes, stats, loading: votesLoading, refetch: refetchVotes } = useUserVotes(user?.id)
   const { dishes: unratedDishes, count: unratedCount, refetch: refetchUnrated } = useUnratedDishes(user?.id)
 
@@ -145,6 +146,23 @@ export function Profile() {
 
   if (loading) {
     return <ProfileSkeleton />
+  }
+
+  // Distinguish "your account looks fine but the server is unreachable"
+  // from "you genuinely have no data yet". If the profile fetch errored
+  // and we have no profile to render, show the error instead of the
+  // empty-state UI that would otherwise look like the account was wiped.
+  if (user && !profileLoading && profileError && !profile) {
+    return (
+      <DataLoadError
+        fullPage
+        message={profileError.message}
+        onRetry={() => {
+          refetchProfile?.()
+          refetchVotes?.()
+        }}
+      />
+    )
   }
 
   return (

--- a/src/pages/UserProfile.jsx
+++ b/src/pages/UserProfile.jsx
@@ -10,6 +10,7 @@ import { followsApi } from '../api/followsApi'
 import { votesApi } from '../api/votesApi'
 import { FollowListModal } from '../components/FollowListModal'
 import { ProfileSkeleton } from '../components/Skeleton'
+import { DataLoadError } from '../components/DataLoadError'
 import { FoodMap, JournalFeed, LocalListCard } from '../components/profile'
 import { useUserPlaylists } from '../hooks/useUserPlaylists'
 import { PlaylistStripCard } from '../components/playlists/PlaylistStripCard'
@@ -432,6 +433,19 @@ export function UserProfile() {
 
   if (loading) {
     return <ProfileSkeleton />
+  }
+
+  // Distinguish "user not found" (404 — actually missing) from
+  // "failed to load profile" (network/server — Supabase blip).
+  // Without this split, a transient outage looks like a deleted account.
+  if (error === 'Failed to load profile') {
+    return (
+      <DataLoadError
+        fullPage
+        message="We couldn't reach the server. This profile is still there — try again in a moment."
+        onRetry={() => window.location.reload()}
+      />
+    )
   }
 
   if (error || !profile) {


### PR DESCRIPTION
## Summary
- New \`DataLoadError\` component (\`src/components/DataLoadError.jsx\`) — plain-English error UI for "we couldn't reach the server" with optional Try-again button. Inline + fullPage variants.
- Profile.jsx full-page gate: when \`useProfile\` errors and no cached profile, show DataLoadError instead of the empty-state UI that would otherwise read as "your account got wiped."
- UserProfile.jsx error split: 404 "User not found" keeps existing copy; network "Failed to load profile" now shows DataLoadError.
- Map.jsx home: when ranked-dishes query fails, show DataLoadError instead of "No dishes found nearby" (audit's exact regression).
- \`useProfile\` now returns \`refetch\` so the retry button works.

## Why
Audit #169 P0-1. With Denis signed in (12 reviews, journal, playlists), a Supabase blip caused:
- Profile header → "D · Set your name · 0 followers · 0 following"
- Journal → "No dishes here yet — Start rating dishes to build your food journal"
- Saved/Playlists → empty
- Home → "No dishes found nearby"

A real user reads this as "my account is wiped." This PR makes the difference clear: "Your account is fine — try again in a moment."

## Out of scope (good follow-ups)
Per-section error gating inside Profile (journal, playlists). The page-level gate catches the worst case (full empty profile) and leaves partial-failure to a more careful follow-up — each section's empty/error/loading state needs distinct copy and the hooks need consistent error surfacing.

## Test plan
- [x] \`npm run build\` — clean, 8.52s (precache 164)
- [x] \`npm test\` — 449/450 pass (1 pre-existing nativeAuth failure unrelated)
- [x] DataLoadError component renders both variants without errors
- [ ] After merge: block \`*.supabase.co\` in DevTools while on /profile (signed in), confirm DataLoadError renders full-page with Try-again button
- [ ] Same on /user/<id> for someone else's profile
- [ ] Same on / (home) — confirm error UI replaces "No dishes found nearby"
- [ ] Tap Try-again with network restored — confirm data loads

## Note
Codex review attempted four times today across high/medium/low effort — all hung past timeout. OpenAI Codex API appears to be having issues. This PR is human-verified only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)