### PR TITLE
fix(user-profile): back button returns to dish/restaurant/feed

### DIFF
--- a/src/pages/UserProfile.jsx
+++ b/src/pages/UserProfile.jsx
@@ -521,16 +521,40 @@ export function UserProfile() {
     )
   }
 
+  const handleBack = () => {
+    if (window.history.length > 1) {
+      navigate(-1)
+    } else {
+      navigate('/')
+    }
+  }
+
   return (
     <div className="min-h-screen" style={{ background: 'var(--color-surface)' }}>
       <h1 className="sr-only">{profile.display_name}'s Profile</h1>
       {/* Header */}
       <div
-        className="relative px-4 pt-8 pb-6 overflow-hidden"
+        className="relative px-4 pt-4 pb-6 overflow-hidden"
         style={{
           background: 'var(--color-bg)',
         }}
       >
+        {/* Back button — returns to wherever the user came from (dish detail,
+            restaurant page, social feed, etc.). Falls back to home for direct
+            URL hits with no history. */}
+        <button
+          type="button"
+          onClick={handleBack}
+          className="flex items-center gap-1 text-sm font-medium mb-3"
+          style={{ color: 'var(--color-primary)' }}
+          aria-label="Go back"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+          </svg>
+          Back
+        </button>
+
         {/* Bottom divider */}
         <div
           className="absolute bottom-0 left-1/2 -translate-x-1/2 h-px"


### PR DESCRIPTION
## Summary
Add a Back button at the top of UserProfile's main render path. Calls \`navigate(-1)\` when browser history is available, falls back to \`/\` for direct URL hits.

## Why
When you tap a friend's avatar on a dish detail page (or restaurant page, or anywhere else linking to /user/<id>), you land on their profile with no way back to where you were. The dish you were considering is gone, the flow breaks.

The not-found / blocked-user states already had Back buttons. The main successful-render path was the one missing it — exactly the case you flagged.

## Test plan
- [x] \`npm run build\` — clean
- [ ] After merge: tap a friend on a dish-detail "Friends who rated" row → land on their profile → tap Back → should return to that dish
- [ ] Same flow from a restaurant detail page
- [ ] Direct visit to /user/<id> (no history) → tap Back → should land on /

🤖 Generated with [Claude Code](https://claude.com/claude-code)