### PR TITLE
fix(user-profile): surface Jitter card + unclip 3-dot menu

### DIFF
--- a/src/pages/UserProfile.jsx
+++ b/src/pages/UserProfile.jsx
@@ -534,7 +534,7 @@ export function UserProfile() {
       <h1 className="sr-only">{profile.display_name}'s Profile</h1>
       {/* Header */}
       <div
-        className="relative px-4 pt-4 pb-6 overflow-hidden"
+        className="relative px-4 pt-4 pb-6"
         style={{
           background: 'var(--color-bg)',
         }}
@@ -801,6 +801,20 @@ export function UserProfile() {
 
       </div>
 
+      {/* Review Fingerprint — surfaced near the top so visitors see the
+          trust context before diving into specific picks. Only renders for
+          users with jitter data (real humans, not the AI cold-start
+          aggregator). */}
+      {jitterBadgeData && (
+        <div className="px-4 pt-3">
+          <ProfileJitterCard
+            profile={jitterBadgeData}
+            displayName={profile.display_name}
+            isPublic
+          />
+        </div>
+      )}
+
       {/* Food Map */}
       {totalVotes > 0 && (
         <div className="px-4 pt-4">
@@ -865,17 +879,6 @@ export function UserProfile() {
               </div>
             </div>
           )}
-        </div>
-      )}
-
-      {/* Review Fingerprint — public view */}
-      {jitterBadgeData && (
-        <div className="px-4 pt-3">
-          <ProfileJitterCard
-            profile={jitterBadgeData}
-            displayName={profile.display_name}
-            isPublic
-          />
         </div>
       )}
 


### PR DESCRIPTION
## Summary
Two bugs on /user/<id> pages, both flagged in the field:

**1. Jitter card buried.** The Review Fingerprint card was rendering AFTER Food Map + Local List + Standout Picks — way down the page. Move it to right below the action buttons so it sits in the identity block where you'd actually look for it.

**2. Three-dot menu clipped.** The ••• dropdown (Report user / Block user) was getting cut off by \`overflow-hidden\` on the header. The menu's z-index was correct; the ancestor was clipping it. Remove \`overflow-hidden\` — the bottom divider is absolutely positioned at \`bottom: 0\` and doesn't need a clipping parent.

## Note on AI users
The "WGH Community" account has \`jitterBadgeData = null\` because the AI bot doesn't type. The card correctly stays hidden on that profile — only the placement of the card (when it exists) changed.

## Test plan
- [x] \`npm run build\` — clean
- [ ] Visit a real user's profile (Denis, Dan) → see the Review Fingerprint card right under the action buttons
- [ ] Tap ••• on someone else's profile → confirm Report/Block dropdown is fully visible, not clipped at the bottom
- [ ] Same on WGH Community → confirm no Jitter card renders (still correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)