### PR TITLE
fix(profile): drop redundant "/10" on user profile ratings

### DIFF
--- a/src/pages/UserProfile.jsx
+++ b/src/pages/UserProfile.jsx
@@ -687,7 +687,7 @@ export function UserProfile() {
                   {ratingStyle.label}
                 </p>
                 <p className="text-xs mt-0.5" style={{ color: 'var(--color-text-tertiary)' }}>
-                  avg {ratingStyle.avgRating.toFixed(1)}/10
+                  avg {ratingStyle.avgRating.toFixed(1)}
                 </p>
               </div>
             )}
@@ -849,7 +849,7 @@ export function UserProfile() {
                   {standoutPicks.bestFind.dish_name}
                 </p>
                 <p className="text-xs" style={{ color: 'var(--color-text-secondary)' }}>
-                  {standoutPicks.bestFind.restaurant_name} &middot; {standoutPicks.bestFind.userRating}/10
+                  {standoutPicks.bestFind.restaurant_name} &middot; {standoutPicks.bestFind.userRating}
                 </p>
               </div>
             </div>
@@ -874,7 +874,7 @@ export function UserProfile() {
                   {standoutPicks.harshestTake.dish_name}
                 </p>
                 <p className="text-xs" style={{ color: 'var(--color-text-secondary)' }}>
-                  {standoutPicks.harshestTake.restaurant_name} &middot; {standoutPicks.harshestTake.userRating}/10 vs {standoutPicks.harshestTake.communityAvg.toFixed(1)} crowd
+                  {standoutPicks.harshestTake.restaurant_name} &middot; {standoutPicks.harshestTake.userRating} vs {standoutPicks.harshestTake.communityAvg.toFixed(1)} crowd
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Summary
Drops the visually-noisy `/10` suffix on three rating displays in `UserProfile.jsx`. Everyone using the app already knows the rating scale is 1–10; the suffix adds no information.

- `avg 8.7/10` → `avg 8.7`
- `Restaurant · 9/10` → `Restaurant · 9` (best find)
- `Restaurant · 9/10 vs 6.2 crowd` → `Restaurant · 9 vs 6.2 crowd` (hottest take)

## Test plan
- [x] `npm run build` passes
- [ ] Visual check on /user/:userId page after deploy: confirm rating values render cleanly without the suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)