### PR TITLE
fix(audit): silent-failure hardening pass (PR A — items #1–4 from ultra-review)

### DIFF
--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -95,7 +95,7 @@ async function ensureDisplayName({ appleGivenName = null, appleFamilyName = null
   try {
     const { data: sessionData, error: sessionError } = await supabase.auth.getSession()
     if (sessionError) {
-      logger.warn('ensureDisplayName: getSession failed', sessionError)
+      logger.error('ensureDisplayName: getSession failed', sessionError)
       return
     }
     const user = sessionData?.session?.user
@@ -108,7 +108,7 @@ async function ensureDisplayName({ appleGivenName = null, appleFamilyName = null
       if (appleName) {
         const contentError = validateUserContent(appleName, 'Display name')
         if (contentError) {
-          logger.warn('ensureDisplayName: Apple-supplied name rejected by blocklist', {
+          logger.error('ensureDisplayName: Apple-supplied name rejected by blocklist', {
             reason: contentError,
           })
           // Fall through to Path B so user still gets a usable placeholder.
@@ -119,7 +119,7 @@ async function ensureDisplayName({ appleGivenName = null, appleFamilyName = null
             .eq('id', user.id)
             .or('display_name.is.null,display_name.like.eater-*')
           if (updateError) {
-            logger.warn('ensureDisplayName: Apple-name update failed', updateError)
+            logger.error('ensureDisplayName: Apple-name update failed', updateError)
           }
           return
         }
@@ -138,10 +138,10 @@ async function ensureDisplayName({ appleGivenName = null, appleFamilyName = null
       .eq('id', user.id)
       .is('display_name', null)
     if (updateError) {
-      logger.warn('ensureDisplayName: backfill update failed', updateError)
+      logger.error('ensureDisplayName: backfill update failed', updateError)
     }
   } catch (err) {
-    logger.warn('ensureDisplayName: unexpected error', err)
+    logger.error('ensureDisplayName: unexpected error', err)
   }
 }
 
@@ -311,7 +311,7 @@ export const authApi = {
           appleGivenName: appleRes.givenName,
           appleFamilyName: appleRes.familyName,
         }).catch((e) => {
-          logger.warn('ensureDisplayName failed', e)
+          logger.error('ensureDisplayName failed', e)
         })
 
         if (typeof appleRes.authorizationCode === 'string' && appleRes.authorizationCode.length > 0) {
@@ -707,6 +707,13 @@ export const authApi = {
    *
    * Best-effort: logs but never throws. Sign-out must not fail because the
    * plugin couldn't log out a provider we may not even have used.
+   *
+   * Failures are logged at ERROR level (→ Sentry in prod). A persistent
+   * failure here is the documented "switched user, got wrong account" bug —
+   * Capgo's social-login cache stays warm and the next SIWA tap silently
+   * reuses the previous Apple/Google identity. We can't easily surface to
+   * the user (signOut is fire-and-forget from AuthContext.signOut) but we
+   * must at minimum see it in production telemetry.
    */
   async signOutNative() {
     if (!Capacitor.isNativePlatform()) return
@@ -715,7 +722,7 @@ export const authApi = {
       // Clear both providers — cheap and avoids branching on which one we used.
       await Promise.all([logoutNative('google'), logoutNative('apple')])
     } catch (err) {
-      logger.warn('signOutNative failed', err)
+      logger.error('signOutNative failed', err)
     }
   },
 

--- a/src/api/followsApi.js
+++ b/src/api/followsApi.js
@@ -363,12 +363,13 @@ export const followsApi = {
       votesResult,
       badgesResult,
     ] = await Promise.all([
-      // 1. Get basic profile info
+      // 1. Get basic profile info. maybeSingle so a stale share link to a
+      // deleted user returns null cleanly instead of an unhandled PGRST116.
       supabase
         .from('profiles')
         .select('id, display_name, created_at')
         .eq('id', userId)
-        .single(),
+        .maybeSingle(),
       // 2. Get follower count
       supabase
         .from('follows')
@@ -404,8 +405,9 @@ export const followsApi = {
       supabase.rpc('get_user_badges', { p_user_id: userId, p_public_only: false }),
     ])
 
-    // Check for profile error (required)
-    if (profileResult.error) {
+    // Check for profile error or not-found. Callers (UserProfile page)
+    // surface "user not found" UI from a null return.
+    if (profileResult.error || !profileResult.data) {
       return null
     }
 

--- a/src/api/votesApi.js
+++ b/src/api/votesApi.js
@@ -436,28 +436,31 @@ export const votesApi = {
         .order('review_created_at', { ascending: false, nullsFirst: false })
         .limit(1)
 
-      if (error) {
-        logger.error('Error fetching smart snippet:', error)
-        return null // Graceful degradation
-      }
+      if (error) throw createClassifiedError(error)
 
       const review = data?.[0]
       if (!review) return null
 
-      // Enrich with profile display name
+      // Enrich with profile display name. The profile lookup is auxiliary —
+      // the snippet body itself is useful even without a name — so we log
+      // and continue on error rather than throw. A null result is fine —
+      // display_name is allowed null at the DB and the UI optional-chains it.
       if (review.user_id) {
-        const { data: profile } = await supabase
+        const { data: profile, error: profileError } = await supabase
           .from('profiles')
           .select('id, display_name')
           .eq('id', review.user_id)
           .maybeSingle()
+        if (profileError) {
+          logger.error('Smart snippet profile enrichment failed:', profileError)
+        }
         review.profiles = profile || { id: review.user_id, display_name: null }
       }
 
       return review
     } catch (error) {
       logger.error('Error fetching smart snippet:', error)
-      return null // Graceful degradation - don't break the UI
+      throw error.type ? error : createClassifiedError(error)
     }
   },
 
@@ -552,10 +555,7 @@ export const votesApi = {
         .select('id, name, restaurant_id')
         .eq('restaurant_id', restaurantId)
 
-      if (dishesError) {
-        logger.error('Error fetching restaurant dishes for reviews:', dishesError)
-        return []
-      }
+      if (dishesError) throw createClassifiedError(dishesError)
 
       const dishMap = Object.fromEntries((dishes || []).map(d => [d.id, d]))
       const dishIds = Object.keys(dishMap)
@@ -586,10 +586,7 @@ export const votesApi = {
 
       const { data, error } = await query
 
-      if (error) {
-        logger.error('Error fetching reviews for restaurant:', error)
-        return []
-      }
+      if (error) throw createClassifiedError(error)
 
       return (data || []).map(function (v) {
         return {
@@ -604,7 +601,7 @@ export const votesApi = {
       })
     } catch (error) {
       logger.error('Error fetching reviews for restaurant:', error)
-      return []
+      throw error.type ? error : createClassifiedError(error)
     }
   },
 
@@ -629,10 +626,7 @@ export const votesApi = {
         .order('review_created_at', { ascending: false, nullsFirst: false })
         .range(offset, offset + limit - 1)
 
-      if (error) {
-        logger.error('Error fetching reviews for user:', error)
-        return []
-      }
+      if (error) throw createClassifiedError(error)
 
       if (!data?.length) return []
 
@@ -662,7 +656,7 @@ export const votesApi = {
       }))
     } catch (error) {
       logger.error('Error fetching reviews for user:', error)
-      return []
+      throw error.type ? error : createClassifiedError(error)
     }
   },
 }

--- a/src/api/votesApi.test.js
+++ b/src/api/votesApi.test.js
@@ -553,7 +553,7 @@ describe('votesApi', () => {
       expect(result).toBeNull()
     })
 
-    it('should return null on error (graceful degradation)', async () => {
+    it('should throw classified error on supabase error (pre-launch hardening)', async () => {
       supabase.from.mockReturnValue({
         select: vi.fn().mockReturnValue({
           eq: vi.fn().mockReturnValue({
@@ -572,9 +572,9 @@ describe('votesApi', () => {
         }),
       })
 
-      const result = await votesApi.getSmartSnippetForDish('dish-1')
-
-      expect(result).toBeNull()
+      // Previously: silently returned null. Now: throws so React Query
+      // can surface an error state instead of rendering a blank quote.
+      await expect(votesApi.getSmartSnippetForDish('dish-1')).rejects.toThrow()
     })
   })
 
@@ -634,7 +634,7 @@ describe('votesApi', () => {
       expect(result).toEqual(mockReviews)
     })
 
-    it('should return empty array on error (graceful degradation)', async () => {
+    it('should throw classified error on supabase error (pre-launch hardening)', async () => {
       supabase.from.mockReturnValue({
         select: vi.fn().mockReturnValue({
           eq: vi.fn().mockReturnValue({
@@ -649,9 +649,9 @@ describe('votesApi', () => {
         }),
       })
 
-      const result = await votesApi.getReviewsForUser('user-1')
-
-      expect(result).toEqual([])
+      // Previously: silently returned []. Now: throws so React Query can
+      // surface "couldn't load reviews" instead of "no reviews yet".
+      await expect(votesApi.getReviewsForUser('user-1')).rejects.toThrow()
     })
   })
 })

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -88,7 +88,7 @@ export function AuthProvider({ children }) {
       // docstring for orderings).
       if (event === 'SIGNED_IN' && newUser) {
         authApi.ensureDisplayName().catch((err) => {
-          logger.warn('ensureDisplayName safety net failed', err)
+          logger.error('ensureDisplayName safety net failed', err)
         })
       }
 


### PR DESCRIPTION
## Summary
First of two pre-launch hardening PRs from today's multi-agent ultra-review. Addresses the 4 items that could plausibly affect Apple's reviewer or surface as user-visible bugs without diagnostic trail.

## Items in this PR

| # | File | Fix |
|---|---|---|
| 1 | `src/api/authApi.js` (`signOutNative`) | `logger.warn` → `logger.error` for failed Capgo logout. Documented the "switched user, got wrong account" bug this is the diagnostic surface for. |
| 2 | `src/api/authApi.js` (`ensureDisplayName`) + `src/context/AuthContext.jsx` | All `logger.warn` → `logger.error` (internal helper + both call-site `.catch` wrappers). `logger.warn` is not routed to Sentry in prod; silent NULL `display_name` was undetectable. |
| 3 | `src/api/votesApi.js` (3 funcs) | `getSmartSnippetForDish`, `getReviewsForRestaurant`, `getReviewsForUser` no longer silently return `null`/`[]` on supabase error. Throw via the canonical `createClassifiedError` pattern so React Query surfaces error state. Profile enrichment inside `getSmartSnippetForDish` kept best-effort but the previously-ignored error is now logged. Two test cases updated to assert `rejects`. |
| 4 | `src/api/followsApi.js` (`getUserProfile`) | `.single()` → `.maybeSingle()` per CLAUDE.md §1.5. Added explicit `!profileResult.data` null check. |

## Out of scope (PR B — coming next)
Items #5–8: blocklist-rejection UX, RestaurantMap.jsx sessionStorage CLAUDE.md §1.8 violation, AuthContext `supabase.signOut` direct call, dead jitter component cleanup.

## Codex review
Reviewed with `gpt-5.3-codex` at `high` effort. Surfaced 3 issues, all fixed before commit:
- Test contract drift on votesApi
- Smart snippet profile enrichment still silent on error
- Call-site catch wrappers still using `logger.warn`

## Test plan
- [x] `npm run build` passes
- [x] 67/67 vitest tests pass (`votesApi.test.js` + `authApi.test.js`)
- [ ] Smoke on production after merge: visit a restaurant detail page with reviews → reviews load; visit a deleted user's `/user/:id` → "user not found" state, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)