### PR TITLE
fix(audit): tier A — vote cache invalidation + log/storage hardening

### DIFF
--- a/src/api/jitterApi.js
+++ b/src/api/jitterApi.js
@@ -73,7 +73,10 @@ export const jitterApi = {
         profile: data.profile || null,
       }
     } catch (err) {
-      logger.warn('Attestation failed (non-critical):', err)
+      // Escalate to error so a sustained JITTEr server outage surfaces in
+      // Sentry — otherwise we'd ship un-attested votes silently for hours.
+      // Callers still treat null as non-blocking; the badge_hash is optional.
+      logger.error('Attestation failed (non-critical):', err)
       return null
     }
   },

--- a/src/api/placesApi.js
+++ b/src/api/placesApi.js
@@ -29,7 +29,6 @@ export const placesApi = {
       if (response.error) {
         const errMsg = response.error?.message || response.error?.context?.message || String(response.error)
         logger.error('Places autocomplete edge function error:', errMsg, response.error)
-        logger.warn('Places autocomplete failed:', errMsg)
         // Graceful degradation for search — don't break local results
         return []
       }
@@ -37,7 +36,6 @@ export const placesApi = {
       // Check if the response itself contains an error (edge function returned 200 with error body)
       if (response.data?.error) {
         logger.error('Places autocomplete API error:', response.data.error)
-        logger.warn('Places autocomplete API error:', response.data.error)
         return []
       }
 

--- a/src/hooks/useVote.js
+++ b/src/hooks/useVote.js
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { votesApi } from '../api/votesApi'
 import { logger } from '../utils/logger'
 
@@ -7,6 +8,7 @@ export function useVote() {
   const [error, setError] = useState(null)
   // Track in-flight requests per dish to prevent double submissions
   const inFlightRef = useRef(new Set())
+  const queryClient = useQueryClient()
 
   // Submit rating_10 and optional review text in one call.
   // Binary "would order again" vote was removed Apr 2026 — rating alone is the signal.
@@ -31,6 +33,22 @@ export function useVote() {
         badgeHash,
       })
 
+      // Vote success — invalidate dependent caches so rankings, dish detail,
+      // user vote lists, client-side dish search, and community-average
+      // stats reflect the new state without a manual page refresh. React
+      // Query treats these prefixes as parents, so all child queries
+      // (e.g. ['dishes', 'ranked', ...]) refetch.
+      //
+      // communityAvgs has a 30-min staleTime in useUserVotes and feeds the
+      // profile standout picks / category comparison. Updating an existing
+      // rating doesn't change the user's ratedDishIds, so without explicit
+      // invalidation here profile stats can lag a vote by half an hour.
+      queryClient.invalidateQueries({ queryKey: ['dishes'] })
+      queryClient.invalidateQueries({ queryKey: ['dish'] })
+      queryClient.invalidateQueries({ queryKey: ['userVotes'] })
+      queryClient.invalidateQueries({ queryKey: ['allDishes'] })
+      queryClient.invalidateQueries({ queryKey: ['communityAvgs'] })
+
       return { success: true }
     } catch (err) {
       logger.error('Error submitting vote:', err)
@@ -40,7 +58,7 @@ export function useVote() {
       inFlightRef.current.delete(dishId)
       setSubmitting(inFlightRef.current.size > 0)
     }
-  }, [])
+  }, [queryClient])
 
   const getUserVotes = async () => {
     try {

--- a/src/hooks/useVote.test.js
+++ b/src/hooks/useVote.test.js
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createElement } from 'react'
 import { renderHook, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useVote } from '../hooks/useVote'
 import { votesApi } from '../api/votesApi'
 
@@ -12,6 +14,17 @@ vi.mock('../api/votesApi', () => ({
   },
 }))
 
+// useVote now uses useQueryClient to invalidate cached queries after a
+// successful vote. Tests need a QueryClientProvider around the rendered hook.
+// Using createElement (instead of JSX) so this file stays .test.js — no
+// rename or build-config change needed.
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return ({ children }) => createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
 describe('useVote Hook', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -21,7 +34,7 @@ describe('useVote Hook', () => {
     it('calls votesApi.submitVote with positional args minus wouldOrderAgain', async () => {
       votesApi.submitVote.mockResolvedValueOnce({ success: true })
 
-      const { result } = renderHook(() => useVote())
+      const { result } = renderHook(() => useVote(), { wrapper: makeWrapper() })
 
       let response
       await act(async () => {
@@ -44,7 +57,7 @@ describe('useVote Hook', () => {
       const error = new Error('Not authenticated')
       votesApi.submitVote.mockRejectedValueOnce(error)
 
-      const { result } = renderHook(() => useVote())
+      const { result } = renderHook(() => useVote(), { wrapper: makeWrapper() })
 
       let response
       await act(async () => {
@@ -64,7 +77,7 @@ describe('useVote Hook', () => {
       })
       votesApi.submitVote.mockReturnValueOnce(apiPromise)
 
-      const { result } = renderHook(() => useVote())
+      const { result } = renderHook(() => useVote(), { wrapper: makeWrapper() })
 
       expect(result.current.submitting).toBe(false)
 
@@ -90,7 +103,7 @@ describe('useVote Hook', () => {
     it('should handle votes without an explicit rating', async () => {
       votesApi.submitVote.mockResolvedValueOnce({ success: true })
 
-      const { result } = renderHook(() => useVote())
+      const { result } = renderHook(() => useVote(), { wrapper: makeWrapper() })
 
       await act(async () => {
         await result.current.submitVote('dish-1')
@@ -106,6 +119,51 @@ describe('useVote Hook', () => {
         badgeHash: null,
       })
     })
+
+    it('invalidates dependent query caches on success', async () => {
+      votesApi.submitVote.mockResolvedValueOnce({ success: true })
+
+      // Build a wrapper backed by a known QueryClient so we can spy on it.
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      })
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+      const wrapper = ({ children }) =>
+        createElement(QueryClientProvider, { client: queryClient }, children)
+
+      const { result } = renderHook(() => useVote(), { wrapper })
+
+      await act(async () => {
+        await result.current.submitVote('dish-1', 9)
+      })
+
+      // All keys vote outcomes depend on. Regressions here would let
+      // rankings, profile stats, or community averages drift stale until
+      // manual refetch.
+      const invalidatedKeys = invalidateSpy.mock.calls.map(([arg]) => arg.queryKey[0])
+      expect(invalidatedKeys).toEqual(
+        expect.arrayContaining(['dishes', 'dish', 'userVotes', 'allDishes', 'communityAvgs'])
+      )
+    })
+
+    it('does NOT invalidate caches when the API rejects', async () => {
+      votesApi.submitVote.mockRejectedValueOnce(new Error('boom'))
+
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      })
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+      const wrapper = ({ children }) =>
+        createElement(QueryClientProvider, { client: queryClient }, children)
+
+      const { result } = renderHook(() => useVote(), { wrapper })
+
+      await act(async () => {
+        await result.current.submitVote('dish-1', 9)
+      })
+
+      expect(invalidateSpy).not.toHaveBeenCalled()
+    })
   })
 
   describe('getUserVotes', () => {
@@ -116,7 +174,7 @@ describe('useVote Hook', () => {
       }
       votesApi.getUserVotes.mockResolvedValueOnce(mockVotes)
 
-      const { result } = renderHook(() => useVote())
+      const { result } = renderHook(() => useVote(), { wrapper: makeWrapper() })
 
       let votes
       await act(async () => {
@@ -130,7 +188,7 @@ describe('useVote Hook', () => {
     it('should return empty object on error', async () => {
       votesApi.getUserVotes.mockRejectedValueOnce(new Error('Network error'))
 
-      const { result } = renderHook(() => useVote())
+      const { result } = renderHook(() => useVote(), { wrapper: makeWrapper() })
 
       let votes
       await act(async () => {

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -1,12 +1,48 @@
 import { logger } from '../utils/logger'
 
 /**
- * Cached localStorage wrapper
- * Avoids repeated synchronous reads from localStorage
+ * Cached localStorage / sessionStorage wrapper.
+ *
+ * Two responsibilities:
+ *   1. In-memory cache so repeated reads avoid synchronous storage I/O.
+ *   2. Graceful degradation when storage is unavailable (private browsing,
+ *      Safari quota, sandboxed iframes). On the FIRST failure we log once
+ *      and stay silent for the rest of the session — otherwise a single
+ *      root cause would flood Sentry with thousands of duplicate events
+ *      from the same interaction loop. We DO keep trying the underlying
+ *      storage on each call so that a transient quota error doesn't lock
+ *      reads permanently for the session; only the logging is deduped.
+ *
+ * The cache is updated even when persistence fails, so the current session
+ * still behaves correctly. The data just won't survive a tab reload —
+ * which is the expected private-browsing experience.
  */
 
 const cache = new Map()
 const sessionCache = new Map()
+
+// Once-per-session log dedupe. Flip true on first failure; subsequent
+// failures are still attempted but no longer logged.
+let _localStorageWarned = false
+let _sessionStorageWarned = false
+
+function _warnLocalStorageOnce(err, op) {
+  if (_localStorageWarned) return
+  _localStorageWarned = true
+  logger.warn(
+    `localStorage unavailable (${op}). In-memory cache only for this session — data won't survive reload.`,
+    err
+  )
+}
+
+function _warnSessionStorageOnce(err, op) {
+  if (_sessionStorageWarned) return
+  _sessionStorageWarned = true
+  logger.warn(
+    `sessionStorage unavailable (${op}). In-tab state will not survive navigation.`,
+    err
+  )
+}
 
 /**
  * Get item from localStorage with in-memory caching
@@ -21,22 +57,24 @@ export function getStorageItem(key) {
     const value = localStorage.getItem(key)
     cache.set(key, value)
     return value
-  } catch {
+  } catch (err) {
+    _warnLocalStorageOnce(err, 'get')
     return null
   }
 }
 
 /**
- * Set item in localStorage and update cache
+ * Set item in localStorage and update cache. The cache is updated even on
+ * persistence failure so the current session sees consistent state.
  * @param {string} key - Storage key
  * @param {string} value - Value to store
  */
 export function setStorageItem(key, value) {
+  cache.set(key, value)
   try {
     localStorage.setItem(key, value)
-    cache.set(key, value)
-  } catch {
-    // localStorage may be unavailable in private browsing
+  } catch (err) {
+    _warnLocalStorageOnce(err, 'set')
   }
 }
 
@@ -45,11 +83,11 @@ export function setStorageItem(key, value) {
  * @param {string} key - Storage key
  */
 export function removeStorageItem(key) {
+  cache.delete(key)
   try {
     localStorage.removeItem(key)
-    cache.delete(key)
-  } catch {
-    // localStorage may be unavailable
+  } catch (err) {
+    _warnLocalStorageOnce(err, 'remove')
   }
 }
 
@@ -66,7 +104,8 @@ export function getSessionItem(key) {
     const value = sessionStorage.getItem(key)
     sessionCache.set(key, value)
     return value
-  } catch {
+  } catch (err) {
+    _warnSessionStorageOnce(err, 'get')
     return null
   }
 }
@@ -77,11 +116,11 @@ export function getSessionItem(key) {
  * @param {string} value - Value to store
  */
 export function setSessionItem(key, value) {
+  sessionCache.set(key, value)
   try {
     sessionStorage.setItem(key, value)
-    sessionCache.set(key, value)
-  } catch {
-    // sessionStorage may be unavailable in private browsing
+  } catch (err) {
+    _warnSessionStorageOnce(err, 'set')
   }
 }
 
@@ -90,11 +129,11 @@ export function setSessionItem(key, value) {
  * @param {string} key - Storage key
  */
 export function removeSessionItem(key) {
+  sessionCache.delete(key)
   try {
     sessionStorage.removeItem(key)
-    sessionCache.delete(key)
-  } catch {
-    // sessionStorage may be unavailable in private browsing
+  } catch (err) {
+    _warnSessionStorageOnce(err, 'remove')
   }
 }
 
@@ -128,49 +167,46 @@ export const STORAGE_KEYS = {
 
 // Pending vote storage helpers (survives OAuth redirect)
 const PENDING_VOTE_KEY = 'whats_good_here_pending_vote'
+const PENDING_VOTE_TTL_MS = 5 * 60 * 1000
 
 /**
- * Get pending vote from storage if recent (within 5 minutes)
+ * Get pending vote from storage if recent (within 5 minutes).
+ * Routes through the wrappers above so storage failures use the same
+ * dedupe-once logging path.
  */
 export function getPendingVoteFromStorage() {
+  const stored = getStorageItem(PENDING_VOTE_KEY)
+  if (!stored) return null
   try {
-    const stored = localStorage.getItem(PENDING_VOTE_KEY)
-    if (stored) {
-      const parsed = JSON.parse(stored)
-      // Check if it's recent (within 5 minutes) to avoid stale data
-      if (Date.now() - parsed.timestamp < 5 * 60 * 1000) {
-        return parsed
-      }
-      localStorage.removeItem(PENDING_VOTE_KEY)
+    const parsed = JSON.parse(stored)
+    if (Date.now() - parsed.timestamp < PENDING_VOTE_TTL_MS) {
+      return parsed
     }
+    removeStorageItem(PENDING_VOTE_KEY)
+    return null
   } catch (error) {
-    logger.warn('Unable to read pending vote from storage', error)
+    // Corrupt value (manual tamper, partial write, schema drift). Clear it
+    // so we don't keep failing to parse the same garbage every read.
+    logger.warn('Pending vote storage value malformed; clearing.', error)
+    removeStorageItem(PENDING_VOTE_KEY)
+    return null
   }
-  return null
 }
 
 /**
  * Save pending vote to storage
  */
 export function setPendingVoteToStorage(dishId, vote) {
-  try {
-    localStorage.setItem(PENDING_VOTE_KEY, JSON.stringify({
-      dishId,
-      vote,
-      timestamp: Date.now()
-    }))
-  } catch (error) {
-    logger.warn('Unable to persist pending vote to storage', error)
-  }
+  setStorageItem(PENDING_VOTE_KEY, JSON.stringify({
+    dishId,
+    vote,
+    timestamp: Date.now(),
+  }))
 }
 
 /**
  * Clear pending vote from storage
  */
 export function clearPendingVoteStorage() {
-  try {
-    localStorage.removeItem(PENDING_VOTE_KEY)
-  } catch (error) {
-    logger.warn('Unable to clear pending vote from storage', error)
-  }
+  removeStorageItem(PENDING_VOTE_KEY)
 }


### PR DESCRIPTION
## Summary
Third hardening PR from the ultra-review. Items #11, #12, #14 from the punch list.

## Items

| # | Fix |
|---|---|
| 11 | `useVote` invalidates `['dishes']`, `['dish']`, `['userVotes']`, `['allDishes']`, `['communityAvgs']` on successful submit. Previously rankings/profile stats stayed stale until manual refetch. |
| 12 | `lib/storage.js` 6 empty catches replaced with once-per-session dedupe logging + always-update-cache fix. Private-browsing won't flood Sentry; in-memory cache stays consistent across sessions where persistence fails. Pending-vote helpers routed through the wrappers. |
| 14 | `jitterApi.attestReview` `warn`→`error`; `placesApi.autocomplete` duplicate-log cleanup. `adminApi.isAdmin` intentionally untouched (already at error, deny-by-default is the right security posture). |

## Codex review
Reviewed with `gpt-5.3-codex` at `high` effort. Three findings, all addressed in this commit:
- `['communityAvgs']` invalidation missing (30-min staleTime in `useUserVotes`)
- Storage "disable-forever" too aggressive for transient write failures (reworked to dedupe logging only; underlying storage is still attempted)
- Test gap (added 2 invalidation tests)

## Test plan
- [x] 452/452 vitest tests pass (added 2 in `useVote.test.js`)
- [x] `npm run build` clean
- [ ] Post-merge smoke: vote on a dish, confirm rankings + profile stats refresh without page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)