### PR TITLE
fix(auth): handle email confirmation code exchange on web

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,6 +39,7 @@ const RateYourMeal = lazyWithRetry(() => import('./pages/RateYourMeal'), 'RateYo
 const Profile = lazyWithRetry(() => import('./pages/Profile'), 'Profile')
 const Admin = lazyWithRetry(() => import('./pages/Admin'), 'Admin')
 const Login = lazyWithRetry(() => import('./pages/Login'), 'Login')
+const AuthCallback = lazyWithRetry(() => import('./pages/AuthCallback'), 'AuthCallback')
 const Privacy = lazyWithRetry(() => import('./pages/Privacy'), 'Privacy')
 const Terms = lazyWithRetry(() => import('./pages/Terms'), 'Terms')
 const Support = lazyWithRetry(() => import('./pages/Support'), 'Support')
@@ -134,6 +135,7 @@ function App() {
               <Route path="/profile" element={<ProtectedRoute><Layout><Profile /></Layout></ProtectedRoute>} />
               <Route path="/user/:userId" element={<Layout><UserProfile /></Layout>} />
               <Route path="/login" element={<Login />} />
+              <Route path="/auth/callback" element={<AuthCallback />} />
               <Route path="/reset-password" element={<ResetPassword />} />
               <Route path="/auth/cross-device" element={<CrossDevicePkce />} />
               <Route path="/admin" element={<ProtectedRoute><Admin /></ProtectedRoute>} />

--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -444,6 +444,7 @@ export const authApi = {
         email,
         password,
         options: {
+          emailRedirectTo: buildWebRedirectUrl('/auth/callback?type=signup'),
           data: {
             display_name: username,
           },

--- a/src/pages/AuthCallback.jsx
+++ b/src/pages/AuthCallback.jsx
@@ -1,0 +1,84 @@
+import { useEffect, useRef } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { authApi } from '../api/authApi'
+import { logger } from '../utils/logger'
+
+export function AuthCallback() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const hasAttemptedExchangeRef = useRef(false)
+
+  useEffect(() => {
+    if (hasAttemptedExchangeRef.current) return
+    hasAttemptedExchangeRef.current = true
+
+    const code = searchParams.get('code')
+    const type = searchParams.get('type') || 'signup'
+
+    if (!code) {
+      navigate('/login', {
+        replace: true,
+        state: {
+          authError: 'link_invalid',
+          authErrorMessage: 'We could not read that confirmation link. Please request a new one.',
+        },
+      })
+      return
+    }
+
+    let cancelled = false
+
+    const runExchange = async () => {
+      try {
+        const { error } = await authApi.exchangeCodeForSession(code)
+        if (cancelled) return
+
+        if (error) {
+          const msg = String(error.message || '').toLowerCase()
+          if (msg.includes('code verifier') || msg.includes('verifier not found')) {
+            navigate('/auth/cross-device', { replace: true, state: { type } })
+            return
+          }
+          navigate('/login', { replace: true, state: { authError: 'link_expired' } })
+          return
+        }
+
+        navigate('/', { replace: true })
+      } catch (error) {
+        if (cancelled) return
+        logger.warn('AuthCallback exchangeCodeForSession failed', error)
+        const msg = String(error?.message || '').toLowerCase()
+        if (msg.includes('code verifier') || msg.includes('verifier not found')) {
+          navigate('/auth/cross-device', { replace: true, state: { type } })
+          return
+        }
+        navigate('/login', { replace: true, state: { authError: 'link_expired' } })
+      }
+    }
+
+    runExchange()
+
+    return () => {
+      cancelled = true
+    }
+  }, [navigate, searchParams])
+
+  return (
+    <div
+      className="min-h-screen flex items-center justify-center px-6"
+      style={{ background: 'var(--color-bg, var(--color-surface))', color: 'var(--color-text-primary)' }}
+    >
+      <div className="flex flex-col items-center gap-3" role="status" aria-live="polite">
+        <div
+          className="w-8 h-8 border-2 rounded-full animate-spin"
+          style={{ borderColor: 'var(--color-divider)', borderTopColor: 'var(--color-primary)' }}
+          aria-hidden="true"
+        />
+        <p className="text-sm" style={{ color: 'var(--color-text-secondary)' }}>
+          Confirming your email…
+        </p>
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
Web signups have been silently broken since launch. When a user clicks "Confirm Email" from a Yahoo / Gmail / Twitter / Slack in-app browser (or any web browser), Supabase redirects them to \`https://wghapp.com/?code=PKCE_CODE\`. React Router matches \`/\`, MapPage renders — and nothing exchanges the code. Session never persists, email stays unconfirmed, user is locked out.

The native iOS app works because \`AuthLifecycle.jsx\` handles \`appUrlOpen\` and calls \`exchangeCodeForSession\`. That path is gated by \`Capacitor.isNativePlatform()\`, so web never ran it.

## Changes
- \`src/api/authApi.js\` — pass \`emailRedirectTo: buildWebRedirectUrl('/auth/callback?type=signup')\` in the \`supabase.auth.signUp\` call.
- \`src/pages/AuthCallback.jsx\` — new page. Reads \`?code=\` on mount, calls \`authApi.exchangeCodeForSession\`, navigates to \`/\` on success. Mirrors the cross-device PKCE heuristic from \`AuthLifecycle.jsx:55-70\` (routes to \`/auth/cross-device\` when the local verifier is missing). \`useRef\` guard prevents StrictMode's double-effect from double-spending the one-time code.
- \`src/App.jsx\` — register lazy route \`/auth/callback\` (bare, no Layout, no ProtectedRoute — same pattern as \`/login\` and \`/auth/cross-device\`).

## Dashboard follow-up (out of scope here)
Supabase dashboard → **Authentication → URL Configuration → Redirect URLs** must include \`https://wghapp.com/auth/callback\` for the redirect to be honored. Without that the link will still fail. This commit only fixes the code; the dashboard tweak is a separate action.

## Verification
- \`npm run build\` ✅ (8.98s, PWA generated)
- \`npx vitest run src/components/profile/JournalCard.test.jsx\` ✅ (8/8)
- \`npx eslint\` on changed files: only the pre-existing \`react-refresh/only-export-components\` warning in \`App.jsx\`

## Test plan
- [ ] Add \`https://wghapp.com/auth/callback\` to Supabase Redirect URLs
- [ ] Sign up at wghapp.com with a fresh email
- [ ] Open the email, tap Confirm
- [ ] Land on \`/auth/callback\` with the spinner, then redirect to \`/\` logged in
- [ ] Repeat in Yahoo Mail's in-app browser to verify the original repro case
- [ ] Confirm Sign in with Apple / Google still work (they use a different path)
- [ ] On native iOS, the existing \`AuthLifecycle\` flow still handles confirmation links (unchanged)

Does not affect iOS 1.0 already on the App Store — that build can't pick up this fix until 1.0.1. But the App Store version uses Universal Links into the native app, so iOS users were never hitting this bug anyway. **Web users are the ones unblocked by this PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)