### PR TITLE
fix(auth): live 'too short' hint on username + Garde East SQL one-liner

### DIFF
--- a/src/components/Auth/LoginModal.jsx
+++ b/src/components/Auth/LoginModal.jsx
@@ -15,7 +15,7 @@ export function LoginModal({ isOpen, onClose, pendingAction = null }) {
   const [username, setUsername] = useState('')
   const [message, setMessage] = useState(null)
   const [mode, setMode] = useState('options') // 'options' | 'signin' | 'signup' | 'forgot'
-  const [usernameStatus, setUsernameStatus] = useState(null) // null | 'checking' | 'available' | 'taken'
+  const [usernameStatus, setUsernameStatus] = useState(null) // null | 'too-short' | 'checking' | 'available' | 'taken'
 
   // Check for pending vote from storage
   const hasPendingVote = getPendingVoteFromStorage() !== null
@@ -33,8 +33,12 @@ export function LoginModal({ isOpen, onClose, pendingAction = null }) {
 
   // Check username availability with debounce
   useEffect(() => {
-    if (mode !== 'signup' || !username || username.length < 2) {
+    if (mode !== 'signup' || !username) {
       setUsernameStatus(null)
+      return
+    }
+    if (username.length < 2) {
+      setUsernameStatus('too-short')
       return
     }
 
@@ -465,6 +469,9 @@ export function LoginModal({ isOpen, onClose, pendingAction = null }) {
                     </span>
                   )}
                 </div>
+                {usernameStatus === 'too-short' && (
+                  <p id="username-status" className="text-xs mt-1" style={{ color: 'var(--color-text-tertiary)' }}>Username must be at least 2 characters</p>
+                )}
                 {usernameStatus === 'taken' && (
                   <p id="username-status" className="text-xs mt-1" style={{ color: 'var(--color-red)' }} role="alert">This username is taken</p>
                 )}
@@ -508,7 +515,7 @@ export function LoginModal({ isOpen, onClose, pendingAction = null }) {
 
               <button
                 type="submit"
-                disabled={loading || usernameStatus === 'taken' || usernameStatus === 'checking'}
+                disabled={loading || usernameStatus === 'taken' || usernameStatus === 'checking' || usernameStatus === 'too-short'}
                 className="w-full px-6 py-4 font-semibold rounded-xl hover:opacity-90 active:scale-[0.98] transition-all disabled:opacity-50"
                 style={{ background: 'var(--color-primary)', color: 'var(--color-text-on-primary)' }}
               >

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -29,7 +29,7 @@ export function Login() {
   )
   const [showLogin, setShowLogin] = useState(isPostConfirmation) // Controls welcome vs login view
   const [mode, setMode] = useState(isPostConfirmation ? 'signin' : 'options') // 'options' | 'signin' | 'signup' | 'forgot'
-  const [usernameStatus, setUsernameStatus] = useState(null) // null | 'checking' | 'available' | 'taken'
+  const [usernameStatus, setUsernameStatus] = useState(null) // null | 'too-short' | 'checking' | 'available' | 'taken'
 
   // Redirect authenticated users to home (or where they came from)
   useEffect(() => {
@@ -55,8 +55,12 @@ export function Login() {
 
   // Check username availability with debounce
   useEffect(() => {
-    if (mode !== 'signup' || !username || username.length < 2) {
+    if (mode !== 'signup' || !username) {
       setUsernameStatus(null)
+      return
+    }
+    if (username.length < 2) {
+      setUsernameStatus('too-short')
       return
     }
 
@@ -576,6 +580,9 @@ export function Login() {
                       </span>
                     )}
                   </div>
+                  {usernameStatus === 'too-short' && (
+                    <p className="text-xs mt-1" style={{ color: 'var(--color-text-tertiary)' }}>Username must be at least 2 characters</p>
+                  )}
                   {usernameStatus === 'taken' && (
                     <p className="text-xs mt-1" style={{ color: 'var(--color-danger)' }}>This username is taken</p>
                   )}
@@ -619,7 +626,7 @@ export function Login() {
 
                 <button
                   type="submit"
-                  disabled={loading || usernameStatus === 'taken' || usernameStatus === 'checking'}
+                  disabled={loading || usernameStatus === 'taken' || usernameStatus === 'checking' || usernameStatus === 'too-short'}
                   className="w-full px-6 py-4 font-semibold rounded-xl hover:opacity-90 active:scale-[0.98] transition-all disabled:opacity-50"
                   style={{ background: 'var(--color-primary)', color: 'var(--color-text-on-primary)' }}
                 >


### PR DESCRIPTION
## Summary
Two small fixes from tonight's post-launch list.

### 1. Username "too short" live feedback
- Code: before, typing a 1-character username silently sat there with no feedback (no taken/available debounce check fires for <2 chars). Submit then returned a delayed error after the user thought their pick was rejected.
- After: a 1-character value shows the neutral hint "Username must be at least 2 characters" in the same slot the existing taken/available messages use. Submit is disabled while too-short.
- Files: \`src/components/Auth/LoginModal.jsx\`, \`src/pages/Login.jsx\` (both have the same pattern).

### 2. Garde East — restaurant closed (no code change in this PR)
Garde East shut down. It still appears as "highest rated restaurant" on the homepage and shows up in dish lists / search. Multiple RPCs already filter \`WHERE r.is_open = true\` so flipping the flag hides it everywhere.

**Run this in Supabase SQL Editor:**
\`\`\`sql
UPDATE restaurants
SET is_open = false
WHERE name ILIKE 'garde east%'
RETURNING id, name, is_open;
\`\`\`
Should return one row. Not part of this PR's diff — it's a data fix Dan runs in the dashboard.

## Verification
- \`npm run build\` ✅ (8.54s)
- \`npx eslint\` on the 2 changed files: clean

## Test plan
- [ ] Open the signup modal; type "z" → hint appears: "Username must be at least 2 characters"
- [ ] Type "zz" → hint disappears, ⏳ checking spinner appears, then ✓ or ✗
- [ ] Submit button disabled while typing 1 char or while checking
- [ ] After running the SQL: refresh the homepage — Garde East tile is gone, doesn't appear in dish lists or search

🤖 Generated with [Claude Code](https://claude.com/claude-code)