### PR TITLE
fix(dish/auth): closed-restaurant banner + friendlier 'taken' copy

### DIFF
--- a/src/api/dishesApi.js
+++ b/src/api/dishesApi.js
@@ -508,7 +508,8 @@ export const dishesApi = {
             phone,
             website_url,
             toast_slug,
-            order_url
+            order_url,
+            is_open
           )
         `)
         .eq('id', dishId)

--- a/src/components/Auth/LoginModal.jsx
+++ b/src/components/Auth/LoginModal.jsx
@@ -473,7 +473,7 @@ export function LoginModal({ isOpen, onClose, pendingAction = null }) {
                   <p id="username-status" className="text-xs mt-1" style={{ color: 'var(--color-text-tertiary)' }}>Username must be at least 2 characters</p>
                 )}
                 {usernameStatus === 'taken' && (
-                  <p id="username-status" className="text-xs mt-1" style={{ color: 'var(--color-red)' }} role="alert">This username is taken</p>
+                  <p id="username-status" className="text-xs mt-1" style={{ color: 'var(--color-red)' }} role="alert">Someone already picked that one. Try another.</p>
                 )}
                 {usernameStatus === 'available' && (
                   <p id="username-status" className="text-xs mt-1" style={{ color: 'var(--color-emerald)' }}>Username available!</p>

--- a/src/hooks/useDishDetail.js
+++ b/src/hooks/useDishDetail.js
@@ -32,6 +32,7 @@ function transformDish(data) {
     order_url: data.restaurants?.order_url,
     toast_slug: data.restaurants?.toast_slug,
     restaurant_phone: data.restaurants?.phone,
+    restaurant_is_open: data.restaurants?.is_open !== false,
   }
 }
 

--- a/src/hooks/useDishDetail.js
+++ b/src/hooks/useDishDetail.js
@@ -32,7 +32,7 @@ function transformDish(data) {
     order_url: data.restaurants?.order_url,
     toast_slug: data.restaurants?.toast_slug,
     restaurant_phone: data.restaurants?.phone,
-    restaurant_is_open: data.restaurants?.is_open !== false,
+    restaurant_is_open: data.restaurants?.is_open ?? null,
   }
 }
 

--- a/src/pages/Dish.jsx
+++ b/src/pages/Dish.jsx
@@ -333,6 +333,23 @@ export function Dish() {
             parentDish={parentDish}
           />
 
+          {dish.restaurant_is_open === false && (
+            <div
+              className="mx-4 mt-3 mb-1 px-4 py-3 rounded-xl text-sm flex items-start gap-2"
+              style={{
+                background: 'var(--color-surface-elevated)',
+                border: '1px solid var(--color-divider)',
+                color: 'var(--color-text-secondary)',
+              }}
+              role="status"
+            >
+              <span aria-hidden="true">⚑</span>
+              <span>
+                <strong style={{ color: 'var(--color-text-primary)' }}>{dish.restaurant_name}</strong> is permanently closed. You can still rate this dish if you remember it.
+              </span>
+            </div>
+          )}
+
           {/* LAYER 2: THE ACTION — Rate CTA + inline rate flow */}
           <div className="p-4 space-y-3">
             <button

--- a/src/pages/Dish.jsx
+++ b/src/pages/Dish.jsx
@@ -345,7 +345,7 @@ export function Dish() {
             >
               <span aria-hidden="true">⚑</span>
               <span>
-                <strong style={{ color: 'var(--color-text-primary)' }}>{dish.restaurant_name}</strong> is permanently closed. You can still rate this dish if you remember it.
+                <strong style={{ color: 'var(--color-text-primary)' }}>{dish.restaurant_name}</strong> is closed right now. You can still rate this dish if you remember it.
               </span>
             </div>
           )}

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -584,7 +584,7 @@ export function Login() {
                     <p className="text-xs mt-1" style={{ color: 'var(--color-text-tertiary)' }}>Username must be at least 2 characters</p>
                   )}
                   {usernameStatus === 'taken' && (
-                    <p className="text-xs mt-1" style={{ color: 'var(--color-danger)' }}>This username is taken</p>
+                    <p className="text-xs mt-1" style={{ color: 'var(--color-danger)' }}>Someone already picked that one. Try another.</p>
                   )}
                   {usernameStatus === 'available' && (
                     <p className="text-xs mt-1" style={{ color: 'var(--color-success)' }}>Username available!</p>


### PR DESCRIPTION
## Summary
Two more post-launch sweep fixes.

### 1. Closed-restaurant banner on dish detail
We just hid Garde East (set \`is_open = false\` in the restaurants table). RPCs already filter on it so Garde East is gone from feed/search/map. But Garde East dish detail URLs still resolve — anyone landing from an old share link sees the page like normal with no signal the spot is closed.

Pulls \`is_open\` into \`dishesApi.getDishById\`'s restaurants select, surfaces it on the transformed dish object as \`restaurant_is_open\`, and renders a single line of context between \`DishHero\` and the Rate CTA when it's \`false\`.

Rate CTA stays available — someone who remembers the meal can still log a rating after closure.

### 2. Friendlier "taken" copy
"This username is taken" → "Someone already picked that one. Try another." Makes the action explicit instead of just diagnosing.

## Files
- \`src/api/dishesApi.js\` — add \`is_open\` to the restaurants select
- \`src/hooks/useDishDetail.js\` — pass it through as \`restaurant_is_open\`
- \`src/pages/Dish.jsx\` — render the banner between hero and CTA
- \`src/components/Auth/LoginModal.jsx\` + \`src/pages/Login.jsx\` — copy tweak

## Verification
- \`npm run build\` ✅ (8.12s)

## Test plan
- [ ] Open the dish detail for any Garde East dish → see a single-line "permanently closed" note above the Rate CTA
- [ ] Open a dish whose restaurant is still open → no banner
- [ ] Signup, type a known-taken username → see the new copy
- [ ] Rate flow still works on a closed-restaurant dish detail (someone logging a meal they remember)

🤖 Generated with [Claude Code](https://claude.com/claude-code)