### PR TITLE
feat(profile): re-add People tab on /profile for searching users

### DIFF
--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useAuth } from '../context/AuthContext'
@@ -58,6 +59,42 @@ export function Profile() {
   const [showLoginModal, setShowLoginModal] = useState(false)
   const [activeTab, setActiveTab] = useState('journal')
   const [createPlaylistOpen, setCreatePlaylistOpen] = useState(false)
+
+  // People-tab search state
+  const [peopleQuery, setPeopleQuery] = useState('')
+  const [peopleResults, setPeopleResults] = useState([])
+  const [peopleLoading, setPeopleLoading] = useState(false)
+
+  // Debounced people search — fires followsApi.searchUsers 350ms after typing stops.
+  // Skips queries shorter than 2 chars (matches the API's own guard).
+  useEffect(() => {
+    if (activeTab !== 'people') return
+    const q = peopleQuery.trim()
+    if (q.length < 2) {
+      setPeopleResults([])
+      setPeopleLoading(false)
+      return
+    }
+    setPeopleLoading(true)
+    let cancelled = false
+    const timer = setTimeout(async () => {
+      try {
+        const results = await followsApi.searchUsers(q, 20)
+        if (!cancelled) setPeopleResults(results)
+      } catch (error) {
+        if (!cancelled) {
+          logger.error('People search failed:', error)
+          setPeopleResults([])
+        }
+      } finally {
+        if (!cancelled) setPeopleLoading(false)
+      }
+    }, 350)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [peopleQuery, activeTab])
   const { playlists: myPlaylists } = useUserPlaylists(user?.id)
   const { playlists: savedPlaylists } = useFollowedPlaylists(!!user)
   const { data: followCounts = { followers: 0, following: 0 } } = useQuery({
@@ -285,7 +322,7 @@ export function Profile() {
             </div>
           )}
 
-          {/* Tabs: Journal / Playlists / Saved */}
+          {/* Tabs: Journal / Playlists / Saved / People */}
           <div
             className="flex"
             style={{
@@ -296,7 +333,7 @@ export function Profile() {
               zIndex: 10,
             }}
           >
-            {['journal', 'playlists', 'saved'].map((tab) => (
+            {['journal', 'playlists', 'saved', 'people'].map((tab) => (
               <button
                 key={tab}
                 onClick={() => setActiveTab(tab)}
@@ -392,6 +429,87 @@ export function Profile() {
                       playlist={p}
                       tombstone={p.visibility === 'unavailable'}
                     />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* --- People tab --- */}
+          {activeTab === 'people' && (
+            <div className="px-4 pt-4 pb-6">
+              <div className="relative mb-4">
+                <svg
+                  className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4"
+                  style={{ color: 'var(--color-text-tertiary)' }}
+                  fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+                  aria-hidden="true"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35M11 19a8 8 0 100-16 8 8 0 000 16z" />
+                </svg>
+                <input
+                  type="text"
+                  value={peopleQuery}
+                  onChange={(e) => setPeopleQuery(e.target.value)}
+                  placeholder="Search by name"
+                  autoFocus
+                  className="w-full pl-10 pr-3 py-3 rounded-xl focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] transition-colors"
+                  style={{
+                    background: 'var(--color-surface-elevated)',
+                    border: '1px solid var(--color-divider)',
+                    color: 'var(--color-text-primary)',
+                  }}
+                />
+              </div>
+
+              {peopleQuery.trim().length < 2 ? (
+                <div className="py-10 text-center" style={{ color: 'var(--color-text-tertiary)', fontSize: 14 }}>
+                  <div style={{ fontSize: 40, marginBottom: 12 }}>👋</div>
+                  Type a name to find people on the app
+                </div>
+              ) : peopleLoading ? (
+                <div className="flex items-center justify-center py-10" role="status" aria-label="Searching">
+                  <div
+                    className="w-6 h-6 border-2 rounded-full animate-spin"
+                    style={{ borderColor: 'var(--color-divider)', borderTopColor: 'var(--color-primary)' }}
+                    aria-hidden="true"
+                  />
+                </div>
+              ) : peopleResults.length === 0 ? (
+                <div className="py-10 text-center" style={{ color: 'var(--color-text-tertiary)', fontSize: 14 }}>
+                  No one matches &ldquo;{peopleQuery.trim()}&rdquo;
+                </div>
+              ) : (
+                <div className="divide-y" style={{ borderColor: 'var(--color-divider)' }}>
+                  {peopleResults.map((u) => (
+                    <Link
+                      key={u.id}
+                      to={`/user/${u.id}`}
+                      className="w-full flex items-center gap-3 px-1 py-3.5 transition-all hover:bg-black/5 active:scale-[0.99]"
+                    >
+                      <div
+                        className="w-11 h-11 rounded-full flex items-center justify-center font-bold flex-shrink-0"
+                        style={{ background: 'var(--color-primary)', color: 'var(--color-text-on-primary)' }}
+                      >
+                        {u.display_name?.charAt(0).toUpperCase() || '?'}
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <p className="font-medium truncate" style={{ color: 'var(--color-text-primary)' }}>
+                          {u.display_name || 'Anonymous'}
+                        </p>
+                        <p className="text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
+                          {u.follower_count} follower{u.follower_count === 1 ? '' : 's'}
+                        </p>
+                      </div>
+                      <svg
+                        className="w-4 h-4 flex-shrink-0"
+                        style={{ color: 'var(--color-text-tertiary)' }}
+                        fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+                        aria-hidden="true"
+                      >
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                      </svg>
+                    </Link>
                   ))}
                 </div>
               )}

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -447,12 +447,15 @@ export function Profile() {
                 >
                   <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35M11 19a8 8 0 100-16 8 8 0 000 16z" />
                 </svg>
+                <label htmlFor="people-search" className="sr-only">Search people</label>
                 <input
+                  id="people-search"
                   type="text"
                   value={peopleQuery}
                   onChange={(e) => setPeopleQuery(e.target.value)}
                   placeholder="Search by name"
                   autoFocus
+                  aria-label="Search people"
                   className="w-full pl-10 pr-3 py-3 rounded-xl focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] transition-colors"
                   style={{
                     background: 'var(--color-surface-elevated)',
@@ -480,38 +483,39 @@ export function Profile() {
                   No one matches &ldquo;{peopleQuery.trim()}&rdquo;
                 </div>
               ) : (
-                <div className="divide-y" style={{ borderColor: 'var(--color-divider)' }}>
+                <ul className="divide-y list-none p-0 m-0" style={{ borderColor: 'var(--color-divider)' }}>
                   {peopleResults.map((u) => (
-                    <Link
-                      key={u.id}
-                      to={`/user/${u.id}`}
-                      className="w-full flex items-center gap-3 px-1 py-3.5 transition-all hover:bg-black/5 active:scale-[0.99]"
-                    >
-                      <div
-                        className="w-11 h-11 rounded-full flex items-center justify-center font-bold flex-shrink-0"
-                        style={{ background: 'var(--color-primary)', color: 'var(--color-text-on-primary)' }}
+                    <li key={u.id}>
+                      <Link
+                        to={`/user/${u.id}`}
+                        className="w-full flex items-center gap-3 px-1 py-3.5 transition-all hover:bg-black/5 active:scale-[0.99]"
                       >
-                        {u.display_name?.charAt(0).toUpperCase() || '?'}
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <p className="font-medium truncate" style={{ color: 'var(--color-text-primary)' }}>
-                          {u.display_name || 'Anonymous'}
-                        </p>
-                        <p className="text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
-                          {u.follower_count} follower{u.follower_count === 1 ? '' : 's'}
-                        </p>
-                      </div>
-                      <svg
-                        className="w-4 h-4 flex-shrink-0"
-                        style={{ color: 'var(--color-text-tertiary)' }}
-                        fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
-                        aria-hidden="true"
-                      >
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-                      </svg>
-                    </Link>
+                        <div
+                          className="w-11 h-11 rounded-full flex items-center justify-center font-bold flex-shrink-0"
+                          style={{ background: 'var(--color-primary)', color: 'var(--color-text-on-primary)' }}
+                        >
+                          {u.display_name?.charAt(0).toUpperCase() || '?'}
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <p className="font-medium truncate" style={{ color: 'var(--color-text-primary)' }}>
+                            {u.display_name || 'Anonymous'}
+                          </p>
+                          <p className="text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
+                            {u.follower_count} follower{u.follower_count === 1 ? '' : 's'}
+                          </p>
+                        </div>
+                        <svg
+                          className="w-4 h-4 flex-shrink-0"
+                          style={{ color: 'var(--color-text-tertiary)' }}
+                          fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+                          aria-hidden="true"
+                        >
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                        </svg>
+                      </Link>
+                    </li>
                   ))}
-                </div>
+                </ul>
               )}
             </div>
           )}


### PR DESCRIPTION
## Summary
Restores a feature that was lost in a merge: the **People** tab on your own profile page. Search anyone on the app by display name, sorted by follower count.

The backend (\`followsApi.searchUsers\`) has existed since launch but had no UI hookup. This wires it up.

## What it looks like
- Fourth tab next to Journal / Playlists / Saved
- Autofocused search input at the top, magnifier icon left
- States: empty (👋 prompt), loading (spinner), no results, results list
- Each result: initial-avatar, name, follower count, chevron → tapping navigates to \`/user/:userId\`
- 350ms debounce on the search call, skips queries under 2 chars

## Files
- \`src/pages/Profile.jsx\` — only file touched

## Codex review applied (2nd commit on this branch)
- Added \`<label className="sr-only">\` + \`aria-label\` to the search input (was placeholder-only)
- Wrapped results in \`<ul>\`/\`<li>\` for proper list semantics
- **Tracked as follow-up:** \`followsApi.searchUsers\` applies \`.limit(20)\` to the SQL query before fetching follower counts and sorting in JS. So results are "first 20 profiles Postgres returns, then sorted" — not "top 20 by follower count." A high-follower user can be invisible if 20+ low-follower users alphabetically precede them. Pre-existing bug, not introduced here. Noted in launch memory; proper fix is server-side via RPC.

## Verification
- \`npm run build\` ✅

## Test plan
- [ ] Open /profile → see 4 tabs: Journal / Playlists / Saved / **People**
- [ ] Tap People → search field is autofocused, empty state shows
- [ ] Type "z" → no fetch (under 2 chars)
- [ ] Type "za" → spinner, then results or "No one matches"
- [ ] Tap a result → land on /user/:userId
- [ ] Backspace to clear → empty state returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)