### PR TITLE
feat(profile): profile picture upload (your own profile, MVP)

### DIFF
--- a/src/api/profileApi.js
+++ b/src/api/profileApi.js
@@ -2,6 +2,11 @@ import { supabase } from '../lib/supabase'
 import { createClassifiedError } from '../utils/errorHandler'
 import { validateUserContent } from '../lib/reviewBlocklist'
 import { logger } from '../utils/logger'
+import { stripExifAndReencode, resizeToSquareJpeg } from '../utils/imageAnalysis'
+
+const AVATAR_ALLOWED_MIME = ['image/jpeg', 'image/png', 'image/webp', 'image/heic']
+const AVATAR_MAX_BYTES = 5 * 1024 * 1024
+const AVATAR_MAX_EDGE = 400
 
 /**
  * Profile API - Centralized data fetching and mutation for user profiles
@@ -183,6 +188,82 @@ export const profileApi = {
       return await this.createProfile(providerName)
     } catch (error) {
       logger.error('Error getting or creating profile:', error)
+      throw error.type ? error : createClassifiedError(error)
+    }
+  },
+
+  /**
+   * Upload a new avatar for the current authenticated user. Strips EXIF,
+   * center-crops to a square, resizes to AVATAR_MAX_EDGE, uploads to the
+   * 'avatars' bucket at `<user_id>/avatar.jpg`, then updates
+   * profiles.avatar_url with a cache-busted public URL so browsers and the
+   * service worker don't shadow the new file.
+   *
+   * TODO: gate uploads through the photo-moderate Edge Function (already
+   * used by src/api/dishPhotosApi.js for dish photos). Avatars currently
+   * skip that pass; revisit before opening to general users at scale.
+   *
+   * @param {File} file - Image file from <input type="file"> or drop
+   * @returns {Promise<{ url: string }>} The new avatar URL (cache-busted)
+   */
+  async uploadAvatar(file) {
+    try {
+      if (!file || !(file instanceof File)) {
+        throw new Error('Invalid file provided')
+      }
+      if (!AVATAR_ALLOWED_MIME.includes(file.type)) {
+        throw new Error('Please choose a JPEG, PNG, WebP, or HEIC image.')
+      }
+      if (file.size > AVATAR_MAX_BYTES) {
+        throw new Error('That image is over 5MB. Please choose a smaller photo.')
+      }
+
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) {
+        throw new Error('You must be logged in to upload an avatar.')
+      }
+
+      let processed
+      try {
+        const stripped = await stripExifAndReencode(file)
+        processed = await resizeToSquareJpeg(stripped, AVATAR_MAX_EDGE)
+      } catch (err) {
+        logger.warn('Avatar processing failed', { type: file.type, err })
+        throw new Error("Couldn't process this image. Please try a different photo.")
+      }
+
+      const path = `${user.id}/avatar.jpg`
+      const { error: uploadError } = await supabase.storage
+        .from('avatars')
+        .upload(path, processed, {
+          upsert: true,
+          contentType: 'image/jpeg',
+        })
+
+      if (uploadError) {
+        throw createClassifiedError(uploadError)
+      }
+
+      const { data: { publicUrl } } = supabase.storage
+        .from('avatars')
+        .getPublicUrl(path)
+
+      // Cache-bust on every upload — the path is stable, so without ?v=<ts>
+      // browsers and the service worker keep showing the old avatar.
+      const cacheBustedUrl = `${publicUrl}?v=${Date.now()}`
+
+      const { error: updateError } = await supabase
+        .from('profiles')
+        .update({ avatar_url: cacheBustedUrl })
+        .eq('id', user.id)
+
+      if (updateError) {
+        throw createClassifiedError(updateError)
+      }
+
+      return { url: cacheBustedUrl }
+    } catch (error) {
+      logger.error('Error uploading avatar:', error)
       throw error.type ? error : createClassifiedError(error)
     }
   },

--- a/src/api/profileApi.js
+++ b/src/api/profileApi.js
@@ -2,7 +2,7 @@ import { supabase } from '../lib/supabase'
 import { createClassifiedError } from '../utils/errorHandler'
 import { validateUserContent } from '../lib/reviewBlocklist'
 import { logger } from '../utils/logger'
-import { stripExifAndReencode, resizeToSquareJpeg } from '../utils/imageAnalysis'
+import { resizeToSquareJpeg } from '../utils/imageAnalysis'
 
 const AVATAR_ALLOWED_MIME = ['image/jpeg', 'image/png', 'image/webp', 'image/heic']
 const AVATAR_MAX_BYTES = 5 * 1024 * 1024
@@ -223,10 +223,12 @@ export const profileApi = {
         throw new Error('You must be logged in to upload an avatar.')
       }
 
+      // resizeToSquareJpeg does both: canvas drawing strips EXIF metadata
+      // and applies EXIF orientation, then re-encodes as JPEG. No need for a
+      // separate strip pass — avoids double-encoding quality loss.
       let processed
       try {
-        const stripped = await stripExifAndReencode(file)
-        processed = await resizeToSquareJpeg(stripped, AVATAR_MAX_EDGE)
+        processed = await resizeToSquareJpeg(file, AVATAR_MAX_EDGE)
       } catch (err) {
         logger.warn('Avatar processing failed', { type: file.type, err })
         throw new Error("Couldn't process this image. Please try a different photo.")
@@ -258,6 +260,19 @@ export const profileApi = {
         .eq('id', user.id)
 
       if (updateError) {
+        // Compensating delete — without this we leak a storage object every time
+        // the DB update fails (network blip, RLS misconfig). Best-effort: log on
+        // failure but still surface the original DB error to the user.
+        const { error: cleanupError } = await supabase.storage
+          .from('avatars')
+          .remove([path])
+        if (cleanupError) {
+          logger.error('Avatar storage cleanup after DB failure failed', {
+            path,
+            cleanupError,
+            updateError,
+          })
+        }
         throw createClassifiedError(updateError)
       }
 

--- a/src/components/profile/HeroIdentityCard.jsx
+++ b/src/components/profile/HeroIdentityCard.jsx
@@ -1,4 +1,7 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
+import { toast } from 'sonner'
+import { profileApi } from '../../api/profileApi'
+import { logger } from '../../utils/logger'
 
 /**
  * Hero Identity Card for the Profile page
@@ -30,8 +33,32 @@ export function HeroIdentityCard({
   handleSaveName,
   setFollowListModal,
   jitterProfile,
+  onAvatarUpdated,
 }) {
   const [jitterExpanded, setJitterExpanded] = useState(false)
+  const [avatarUploading, setAvatarUploading] = useState(false)
+  const fileInputRef = useRef(null)
+
+  const handleAvatarPick = () => {
+    if (avatarUploading) return
+    fileInputRef.current?.click()
+  }
+
+  const handleAvatarChange = async (e) => {
+    const file = e.target.files?.[0]
+    e.target.value = '' // allow re-selecting the same file later
+    if (!file) return
+    setAvatarUploading(true)
+    try {
+      await profileApi.uploadAvatar(file)
+      onAvatarUpdated?.()
+    } catch (error) {
+      logger.error('Avatar upload failed:', error)
+      toast.error(error?.message || "Couldn't upload your photo.")
+    } finally {
+      setAvatarUploading(false)
+    }
+  }
   const jitterData = jitterProfile?.profile_data || {}
   const hasJitterDetail = !!(jitterProfile && Object.keys(jitterData).length > 0)
 
@@ -53,16 +80,53 @@ export function HeroIdentityCard({
 
       {/* Avatar + Name row */}
       <div className="flex items-center gap-4">
-        <div
-          className="w-20 h-20 rounded-full flex items-center justify-center text-2xl font-bold flex-shrink-0"
+        <button
+          type="button"
+          onClick={handleAvatarPick}
+          disabled={avatarUploading}
+          aria-label={profile?.avatar_url ? 'Change profile picture' : 'Add profile picture'}
+          className="relative w-20 h-20 rounded-full flex items-center justify-center text-2xl font-bold flex-shrink-0 overflow-hidden p-0 active:scale-95 transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
           style={{
             background: 'var(--color-primary)',
             color: 'var(--color-text-on-primary)',
             boxShadow: '0 0 0 3px var(--color-primary-muted)',
+            border: 'none',
           }}
         >
-          {profile?.display_name?.charAt(0).toUpperCase() || user.email?.charAt(0).toUpperCase()}
-        </div>
+          {profile?.avatar_url ? (
+            <img
+              src={profile.avatar_url}
+              alt=""
+              className="w-full h-full object-cover"
+              draggable={false}
+            />
+          ) : (
+            <span>
+              {profile?.display_name?.charAt(0).toUpperCase() || user.email?.charAt(0).toUpperCase()}
+            </span>
+          )}
+          {avatarUploading && (
+            <span
+              className="absolute inset-0 flex items-center justify-center"
+              style={{ background: 'rgba(0, 0, 0, 0.35)' }}
+              aria-live="polite"
+            >
+              <span
+                className="w-6 h-6 border-2 rounded-full animate-spin"
+                style={{ borderColor: 'rgba(255,255,255,0.35)', borderTopColor: '#fff' }}
+                aria-hidden="true"
+              />
+              <span className="sr-only">Uploading…</span>
+            </span>
+          )}
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          onChange={handleAvatarChange}
+          className="hidden"
+        />
 
         <div className="flex-1 min-w-0">
           {/* Display Name */}

--- a/src/components/profile/HeroIdentityCard.jsx
+++ b/src/components/profile/HeroIdentityCard.jsx
@@ -85,6 +85,7 @@ export function HeroIdentityCard({
           onClick={handleAvatarPick}
           disabled={avatarUploading}
           aria-label={profile?.avatar_url ? 'Change profile picture' : 'Add profile picture'}
+          aria-busy={avatarUploading}
           className="relative w-20 h-20 rounded-full flex items-center justify-center text-2xl font-bold flex-shrink-0 overflow-hidden p-0 active:scale-95 transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
           style={{
             background: 'var(--color-primary)',
@@ -120,12 +121,25 @@ export function HeroIdentityCard({
             </span>
           )}
         </button>
+        {/* iOS Safari sometimes fails to open the picker when the trigger
+            input is display:none. Visually-hidden (off-screen, but still in
+            the layout / focusable) reliably opens the native picker. */}
         <input
           ref={fileInputRef}
           type="file"
           accept="image/*"
           onChange={handleAvatarChange}
-          className="hidden"
+          style={{
+            position: 'absolute',
+            width: 1,
+            height: 1,
+            padding: 0,
+            margin: -1,
+            overflow: 'hidden',
+            clip: 'rect(0, 0, 0, 0)',
+            whiteSpace: 'nowrap',
+            border: 0,
+          }}
         />
 
         <div className="flex-1 min-w-0">

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -226,6 +226,7 @@ export function Profile() {
             handleSaveName={handleSaveName}
             setFollowListModal={setFollowListModal}
             jitterProfile={jitterProfile}
+            onAvatarUpdated={refetchProfile}
           />
 
           {/* Food Story chalkboard — your food identity at a glance */}

--- a/src/utils/imageAnalysis.js
+++ b/src/utils/imageAnalysis.js
@@ -38,6 +38,39 @@ export async function stripExifAndReencode(file, { quality = 0.92 } = {}) {
 }
 
 /**
+ * Center-crop a file to a square and re-encode as JPEG at the given max
+ * dimension. Used for avatars — output is always image/jpeg, square,
+ * at most `maxDim` × `maxDim`. Smaller source images are not upscaled.
+ *
+ * @param {File} file
+ * @param {number} maxDim - Maximum output edge length, px
+ * @returns {Promise<File>} New File 'avatar.jpg' (image/jpeg)
+ */
+export async function resizeToSquareJpeg(file, maxDim) {
+  const img = await loadImageFromFile(file)
+  const srcW = img.naturalWidth || img.width
+  const srcH = img.naturalHeight || img.height
+  const square = Math.min(srcW, srcH)
+  const sx = (srcW - square) / 2
+  const sy = (srcH - square) / 2
+  const out = Math.min(maxDim, square)
+  const canvas = document.createElement('canvas')
+  canvas.width = out
+  canvas.height = out
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('Canvas 2D context unavailable')
+  ctx.drawImage(img, sx, sy, square, square, 0, 0, out, out)
+  const blob = await new Promise(resolve =>
+    canvas.toBlob(resolve, 'image/jpeg', 0.9)
+  )
+  if (!blob) throw new Error('Image re-encoding failed')
+  return new File([blob], 'avatar.jpg', {
+    type: 'image/jpeg',
+    lastModified: Date.now(),
+  })
+}
+
+/**
  * Load an image file into an HTMLImageElement
  */
 function loadImageFromFile(file) {

--- a/supabase/migrations/20260516_avatars_bucket_rls.sql
+++ b/supabase/migrations/20260516_avatars_bucket_rls.sql
@@ -1,0 +1,65 @@
+-- Storage bucket + RLS policies for user profile avatars.
+-- Path convention: avatars/<user_id>/avatar.jpg
+-- See src/api/profileApi.js uploadAvatar for the app-side path construction.
+--
+-- Mirrors the dish-photos bucket setup at 20260414_dish_photos_bucket_rls.sql.
+-- Public read so avatars render for logged-out viewers. Path-prefix isolation
+-- on INSERT/UPDATE/DELETE so user A can never write into user B's folder
+-- (the prior dish-photos exploit — see that file's notes — does not apply here
+-- because we never create a permissive owner-only INSERT policy in the first
+-- place).
+
+-- 1. Bucket
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'avatars',
+  'avatars',
+  true,
+  5242880,
+  ARRAY['image/jpeg', 'image/png', 'image/webp', 'image/heic']
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- 2. Public read (anyone can fetch a public avatar URL)
+DROP POLICY IF EXISTS "avatar_public_read" ON storage.objects;
+CREATE POLICY "avatar_public_read" ON storage.objects
+  FOR SELECT USING (bucket_id = 'avatars');
+
+-- 3. Authenticated users can INSERT only into their own folder
+DROP POLICY IF EXISTS "avatar_upload_own" ON storage.objects;
+CREATE POLICY "avatar_upload_own" ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- 4. Authenticated users can UPDATE their own objects (upsert path).
+--    WITH CHECK mirrors USING to block renaming `name` into another user's folder.
+DROP POLICY IF EXISTS "avatar_update_own" ON storage.objects;
+CREATE POLICY "avatar_update_own" ON storage.objects
+  FOR UPDATE TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  )
+  WITH CHECK (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- 5. Authenticated users can DELETE their own objects
+DROP POLICY IF EXISTS "avatar_delete_own" ON storage.objects;
+CREATE POLICY "avatar_delete_own" ON storage.objects
+  FOR DELETE TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- ROLLBACK:
+-- DROP POLICY IF EXISTS "avatar_public_read" ON storage.objects;
+-- DROP POLICY IF EXISTS "avatar_upload_own"  ON storage.objects;
+-- DROP POLICY IF EXISTS "avatar_update_own"  ON storage.objects;
+-- DROP POLICY IF EXISTS "avatar_delete_own"  ON storage.objects;
+-- DELETE FROM storage.buckets WHERE id = 'avatars';


### PR DESCRIPTION
## Summary
Re-adds profile pictures, lost in a prior merge. Tap your own avatar on \`/profile\` → pick from the camera roll → file gets EXIF-stripped, square-cropped, resized to 400px, uploaded to a new \`avatars\` storage bucket, and surfaced via \`profiles.avatar_url\`.

**Phase 1 only — display in HeroIdentityCard.** Phase 2 will surface the avatar across FollowListModal, the new People tab, DishEvidence, and \`/user/:userId\`.

## ⚠️ Dashboard step required before this deploys
**Run the new migration in the Supabase SQL Editor:** \`supabase/migrations/20260516_avatars_bucket_rls.sql\`. Without it, uploads will fail with RLS errors / 404s. The migration creates the bucket + four policies (public read, per-user-folder INSERT/UPDATE/DELETE) and includes a \`-- ROLLBACK:\` block per the CLAUDE.md migration rule.

## Files
- \`supabase/migrations/20260516_avatars_bucket_rls.sql\` — new bucket + RLS, mirrors \`20260414_dish_photos_bucket_rls.sql\`
- \`src/utils/imageAnalysis.js\` — adds \`resizeToSquareJpeg(file, maxDim)\` helper
- \`src/api/profileApi.js\` — adds \`uploadAvatar(file)\` method
- \`src/components/profile/HeroIdentityCard.jsx\` — tap-to-upload UI
- \`src/pages/Profile.jsx\` — wires \`onAvatarUpdated={refetchProfile}\` into the card

## Codex review applied (2nd commit on this branch)
- **Dropped the double JPEG encode**: \`resizeToSquareJpeg\` already strips EXIF + applies orientation via canvas drawing, so the prior \`stripExifAndReencode\` pass was redundant
- **Compensating delete** if the profile-row update fails after storage upload (no more orphan files)
- **Replaced \`display:none\` file input** with visually-hidden CSS — iOS Safari sometimes refuses to open the native picker when the trigger input is \`display:none\`
- **Added \`aria-busy\`** on the avatar button while uploading

## Codex follow-ups (out of scope here, tracked in launch memory)
- No \`photo-moderate\` Edge Function gating for avatars — explicit TODO in the code
- Bucket RLS allows any filename under \`<user_id>/\`, not just \`avatar.jpg\` — matches dish-photos parent policy; tighten both together later if needed

## Verification
- \`npm run build\` ✅ (8s)
- \`npx eslint\` on changed files: only the pre-existing \`updateProfile is not defined\` error in Profile.jsx (unrelated to this PR)

## Test plan
- [ ] Run the migration in Supabase SQL Editor — confirm the \`avatars\` bucket appears under Storage with the four policies
- [ ] On \`/profile\`, tap your avatar circle → native picker opens → choose any photo
- [ ] Spinner overlay appears during upload, then the new avatar renders without page reload
- [ ] Pick a non-image file → friendly error toast
- [ ] Pick a >5MB file → friendly error toast
- [ ] Confirm \`profiles.avatar_url\` row in the DB has the cache-busted URL (\`?v=<ts>\`)
- [ ] Confirm the previous initial-letter fallback still renders for users without an avatar

🤖 Generated with [Claude Code](https://claude.com/claude-code)