### PR TITLE
feat(profile): drop Food Map + make Food Story items linkable

### DIFF
--- a/src/hooks/useUserVotes.js
+++ b/src/hooks/useUserVotes.js
@@ -80,6 +80,7 @@ function computeStandoutPicks(data, communityAvgs) {
       dish_id: dishId,
       dish_name: vote.dishes.name,
       category: vote.dishes.category,
+      restaurant_id: vote.dishes.restaurants?.id,
       restaurant_name: vote.dishes.restaurants?.name,
       userRating: vote.rating_10,
       communityAvg: community.avg,
@@ -193,17 +194,21 @@ function calculateStats(data) {
     ? catValues.reduce((sum, c) => sum + Math.pow(c / catTotal, 2), 0)
     : 0
 
-  // Favorite restaurant (most votes) + visit count
+  // Favorite restaurant (most votes) + visit count + id (for linking)
   const restaurantCounts = {}
+  const restaurantIdByName = {}
   data.forEach(v => {
     const name = v.dishes.restaurants?.name
+    const id = v.dishes.restaurants?.id
     if (name) {
       restaurantCounts[name] = (restaurantCounts[name] || 0) + 1
+      if (id && !restaurantIdByName[name]) restaurantIdByName[name] = id
     }
   })
   const restaurantsSorted = Object.entries(restaurantCounts).sort((a, b) => b[1] - a[1])
   const favoriteRestaurant = restaurantsSorted.length > 0 ? restaurantsSorted[0][0] : null
   const favoriteRestaurantCount = restaurantsSorted.length > 0 ? restaurantsSorted[0][1] : 0
+  const favoriteRestaurantId = favoriteRestaurant ? restaurantIdByName[favoriteRestaurant] : null
 
   // Count unique restaurants
   const uniqueRestaurants = Object.keys(restaurantCounts).length
@@ -231,6 +236,7 @@ function calculateStats(data) {
     ratingStyle,
     favoriteRestaurant,
     favoriteRestaurantCount,
+    favoriteRestaurantId,
     uniqueRestaurants,
     categoryCounts,
     recentMeals,
@@ -247,6 +253,7 @@ const DEFAULT_STATS = {
   ratingStyle: null,
   favoriteRestaurant: null,
   favoriteRestaurantCount: 0,
+  favoriteRestaurantId: null,
   uniqueRestaurants: 0,
   categoryCounts: {},
   recentMeals: [],

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -361,31 +361,58 @@ export function Profile() {
                     </span>
                   </div>
                 )}
-                {/* Most loyal */}
+                {/* Most loyal — links to the restaurant when we have the id */}
                 {stats.favoriteRestaurant && (
-                  <div className="flex justify-between items-baseline" style={{ padding: '5px 0', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
+                  <div className="flex justify-between items-baseline gap-3" style={{ padding: '5px 0', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
                     <span style={{ fontSize: '11px', color: 'rgba(255,255,255,0.4)', fontWeight: 500 }}>Most loyal</span>
-                    <span style={{ fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'rgba(255,255,255,0.88)' }}>
-                      {stats.favoriteRestaurant} &middot; {stats.favoriteRestaurantCount} {stats.favoriteRestaurantCount === 1 ? 'dish' : 'dishes'}
-                    </span>
+                    {stats.favoriteRestaurantId ? (
+                      <Link
+                        to={`/restaurants/${stats.favoriteRestaurantId}`}
+                        style={{ fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'rgba(255,255,255,0.88)' }}
+                      >
+                        {stats.favoriteRestaurant} &middot; {stats.favoriteRestaurantCount} {stats.favoriteRestaurantCount === 1 ? 'dish' : 'dishes'}
+                      </Link>
+                    ) : (
+                      <span style={{ fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'rgba(255,255,255,0.88)' }}>
+                        {stats.favoriteRestaurant} &middot; {stats.favoriteRestaurantCount} {stats.favoriteRestaurantCount === 1 ? 'dish' : 'dishes'}
+                      </span>
+                    )}
                   </div>
                 )}
-                {/* Best find */}
+                {/* Best find — links to the dish */}
                 {stats.standoutPicks && stats.standoutPicks.bestFind && (
-                  <div className="flex justify-between items-baseline" style={{ padding: '5px 0', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
+                  <div className="flex justify-between items-baseline gap-3" style={{ padding: '5px 0', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
                     <span style={{ fontSize: '11px', color: 'rgba(255,255,255,0.4)', fontWeight: 500 }}>Best find</span>
-                    <span style={{ fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'var(--color-accent-gold)' }}>
-                      {stats.standoutPicks.bestFind.dish_name} &middot; {stats.standoutPicks.bestFind.userRating}
-                    </span>
+                    {stats.standoutPicks.bestFind.dish_id ? (
+                      <Link
+                        to={`/dish/${stats.standoutPicks.bestFind.dish_id}`}
+                        style={{ fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'var(--color-accent-gold)' }}
+                      >
+                        {stats.standoutPicks.bestFind.dish_name} &middot; {stats.standoutPicks.bestFind.userRating}
+                      </Link>
+                    ) : (
+                      <span style={{ fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'var(--color-accent-gold)' }}>
+                        {stats.standoutPicks.bestFind.dish_name} &middot; {stats.standoutPicks.bestFind.userRating}
+                      </span>
+                    )}
                   </div>
                 )}
-                {/* Hot take */}
+                {/* Hot take — links to the dish */}
                 {stats.standoutPicks && stats.standoutPicks.harshestTake && (
-                  <div className="flex justify-between items-baseline" style={{ padding: '5px 0' }}>
+                  <div className="flex justify-between items-baseline gap-3" style={{ padding: '5px 0' }}>
                     <span style={{ fontSize: '11px', color: 'rgba(255,255,255,0.4)', fontWeight: 500 }}>Hot take</span>
-                    <span style={{ fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'rgba(255,255,255,0.88)' }}>
-                      {stats.standoutPicks.harshestTake.dish_name} &middot; You: {stats.standoutPicks.harshestTake.userRating} &middot; Crowd: {(stats.standoutPicks.harshestTake.communityAvg ?? 0).toFixed(1)}
-                    </span>
+                    {stats.standoutPicks.harshestTake.dish_id ? (
+                      <Link
+                        to={`/dish/${stats.standoutPicks.harshestTake.dish_id}`}
+                        style={{ fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'rgba(255,255,255,0.88)' }}
+                      >
+                        {stats.standoutPicks.harshestTake.dish_name} &middot; You: {stats.standoutPicks.harshestTake.userRating} &middot; Crowd: {(stats.standoutPicks.harshestTake.communityAvg ?? 0).toFixed(1)}
+                      </Link>
+                    ) : (
+                      <span style={{ fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'rgba(255,255,255,0.88)' }}>
+                        {stats.standoutPicks.harshestTake.dish_name} &middot; You: {stats.standoutPicks.harshestTake.userRating} &middot; Crowd: {(stats.standoutPicks.harshestTake.communityAvg ?? 0).toFixed(1)}
+                      </span>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/pages/UserProfile.jsx
+++ b/src/pages/UserProfile.jsx
@@ -9,7 +9,7 @@ import { votesApi } from '../api/votesApi'
 import { FollowListModal } from '../components/FollowListModal'
 import { ProfileSkeleton } from '../components/Skeleton'
 import { DataLoadError } from '../components/DataLoadError'
-import { FoodMap, JournalFeed, LocalListCard } from '../components/profile'
+import { JournalFeed, LocalListCard } from '../components/profile'
 import { useUserPlaylists } from '../hooks/useUserPlaylists'
 import { PlaylistStripCard } from '../components/playlists/PlaylistStripCard'
 import { PlaylistGridCard } from '../components/playlists/PlaylistGridCard'
@@ -257,7 +257,9 @@ export function UserProfile() {
           const comparisons = ratedVotes
             .filter(v => v.dish?.id && communityAvgs[v.dish.id]?.count >= MIN_COMMUNITY)
             .map(v => ({
+              dish_id: v.dish.id,
               dish_name: v.dish.name,
+              restaurant_id: v.dish.restaurant_id,
               restaurant_name: v.dish.restaurant_name,
               userRating: v.rating,
               communityAvg: communityAvgs[v.dish.id].avg,
@@ -342,29 +344,22 @@ export function UserProfile() {
 
   // Handle share profile
   // Compute stats from recent votes — single "My Ratings" shelf, sorted by recency.
-  const { uniqueRestaurants, foodMapStats, ratingStyle, favoriteRestaurant, favoriteRestaurantCount } = useMemo(() => {
+  const { totalVotes, ratingStyle, favoriteRestaurant, favoriteRestaurantCount, favoriteRestaurantId } = useMemo(() => {
     if (!profile?.recent_votes?.length) {
-      return { uniqueRestaurants: 0, foodMapStats: { totalVotes: 0, uniqueRestaurants: 0, categoryCounts: {} }, ratingStyle: null, favoriteRestaurant: null, favoriteRestaurantCount: 0 }
+      return { totalVotes: 0, ratingStyle: null, favoriteRestaurant: null, favoriteRestaurantCount: 0, favoriteRestaurantId: null }
     }
-    const restaurantNames = new Set()
     const restaurantCounts = {}
-    const catCounts = {}
+    const restaurantIdByName = {}
     const ratings = []
     profile.recent_votes.forEach(vote => {
       const isRated = vote.rating != null
       const restName = vote.dish?.restaurant_name
-      if (restName) {
-        // Food Map keeps the broader "visited" semantics — uniqueRestaurants
-        // is "have I been there," not "have I rated something there."
-        restaurantNames.add(restName)
-        // Most loyal counts only rated votes — photo-only / saved-only
-        // entries shouldn't read as loyalty.
-        if (isRated) {
-          restaurantCounts[restName] = (restaurantCounts[restName] || 0) + 1
-        }
-      }
-      if (vote.dish?.category) {
-        catCounts[vote.dish.category] = (catCounts[vote.dish.category] || 0) + 1
+      const restId = vote.dish?.restaurant_id
+      // Most loyal counts only rated votes — photo-only / saved-only
+      // entries shouldn't read as loyalty.
+      if (restName && isRated) {
+        restaurantCounts[restName] = (restaurantCounts[restName] || 0) + 1
+        if (restId && !restaurantIdByName[restName]) restaurantIdByName[restName] = restId
       }
       if (isRated) {
         ratings.push(vote.rating)
@@ -398,15 +393,11 @@ export function UserProfile() {
     }
 
     return {
-      uniqueRestaurants: restaurantNames.size,
-      foodMapStats: {
-        totalVotes: profile.recent_votes.length,
-        uniqueRestaurants: restaurantNames.size,
-        categoryCounts: catCounts,
-      },
+      totalVotes: profile.recent_votes.length,
       ratingStyle: style,
       favoriteRestaurant: favRest,
       favoriteRestaurantCount: favCount,
+      favoriteRestaurantId: favRest ? (restaurantIdByName[favRest] || null) : null,
     }
   }, [profile?.recent_votes])
 
@@ -478,8 +469,6 @@ export function UserProfile() {
       </div>
     )
   }
-
-  const totalVotes = foodMapStats.totalVotes
 
   if (viewerHasBlocked) {
     return (
@@ -795,39 +784,60 @@ export function UserProfile() {
               </div>
             )}
             {favoriteRestaurant && (
-              <div className="flex justify-between items-baseline" style={{ padding: '5px 0', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
+              <div className="flex justify-between items-baseline gap-3" style={{ padding: '5px 0', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
                 <span style={{ fontSize: '11px', color: 'rgba(255,255,255,0.4)', fontWeight: 500 }}>Most loyal</span>
-                <span style={{ fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'rgba(255,255,255,0.88)' }}>
-                  {favoriteRestaurant} &middot; {favoriteRestaurantCount} {favoriteRestaurantCount === 1 ? 'dish' : 'dishes'}
-                </span>
+                {favoriteRestaurantId ? (
+                  <Link
+                    to={`/restaurants/${favoriteRestaurantId}`}
+                    style={{ fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'rgba(255,255,255,0.88)' }}
+                  >
+                    {favoriteRestaurant} &middot; {favoriteRestaurantCount} {favoriteRestaurantCount === 1 ? 'dish' : 'dishes'}
+                  </Link>
+                ) : (
+                  <span style={{ fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'rgba(255,255,255,0.88)' }}>
+                    {favoriteRestaurant} &middot; {favoriteRestaurantCount} {favoriteRestaurantCount === 1 ? 'dish' : 'dishes'}
+                  </span>
+                )}
               </div>
             )}
             {standoutPicks.bestFind && (
-              <div className="flex justify-between items-baseline" style={{ padding: '5px 0', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
+              <div className="flex justify-between items-baseline gap-3" style={{ padding: '5px 0', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
                 <span style={{ fontSize: '11px', color: 'rgba(255,255,255,0.4)', fontWeight: 500 }}>Best find</span>
-                <span style={{ fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'var(--color-accent-gold)' }}>
-                  {standoutPicks.bestFind.dish_name} &middot; {standoutPicks.bestFind.userRating}
-                </span>
+                {standoutPicks.bestFind.dish_id ? (
+                  <Link
+                    to={`/dish/${standoutPicks.bestFind.dish_id}`}
+                    style={{ fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'var(--color-accent-gold)' }}
+                  >
+                    {standoutPicks.bestFind.dish_name} &middot; {standoutPicks.bestFind.userRating}
+                  </Link>
+                ) : (
+                  <span style={{ fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'var(--color-accent-gold)' }}>
+                    {standoutPicks.bestFind.dish_name} &middot; {standoutPicks.bestFind.userRating}
+                  </span>
+                )}
               </div>
             )}
             {standoutPicks.harshestTake && (
-              <div className="flex justify-between items-baseline" style={{ padding: '5px 0' }}>
+              <div className="flex justify-between items-baseline gap-3" style={{ padding: '5px 0' }}>
                 <span style={{ fontSize: '11px', color: 'rgba(255,255,255,0.4)', fontWeight: 500 }}>Hot take</span>
-                <span style={{ fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'rgba(255,255,255,0.88)' }}>
-                  {standoutPicks.harshestTake.dish_name} &middot; Them: {standoutPicks.harshestTake.userRating} &middot; Crowd: {(standoutPicks.harshestTake.communityAvg ?? 0).toFixed(1)}
-                </span>
+                {standoutPicks.harshestTake.dish_id ? (
+                  <Link
+                    to={`/dish/${standoutPicks.harshestTake.dish_id}`}
+                    style={{ fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'rgba(255,255,255,0.88)' }}
+                  >
+                    {standoutPicks.harshestTake.dish_name} &middot; Them: {standoutPicks.harshestTake.userRating} &middot; Crowd: {(standoutPicks.harshestTake.communityAvg ?? 0).toFixed(1)}
+                  </Link>
+                ) : (
+                  <span style={{ fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'rgba(255,255,255,0.88)' }}>
+                    {standoutPicks.harshestTake.dish_name} &middot; Them: {standoutPicks.harshestTake.userRating} &middot; Crowd: {(standoutPicks.harshestTake.communityAvg ?? 0).toFixed(1)}
+                  </span>
+                )}
               </div>
             )}
           </div>
         </div>
       )}
 
-      {/* Food Map */}
-      {totalVotes > 0 && (
-        <div className="px-4 pt-4">
-          <FoodMap stats={foodMapStats} title={`${profile.display_name}'s Food Map`} />
-        </div>
-      )}
 
       {/* Local List */}
       {localList.items.length > 0 && (


### PR DESCRIPTION
## Summary
Two related profile-page changes per Dan's call:

1. **Drop the Food Map block** from UserProfile. The Food Story chalkboard already does the heavier lifting (identity — rating style, most loyal, best find, hot take). The Food Map's "X of 181 restaurants visited / Y of 20 categories explored" was visual padding that competed for attention without adding to the identity picture.
2. **Make Food Story rows linkable.** Tapping "Most loyal" navigates to that restaurant's page. Tapping "Best find" or "Hot take" navigates to the dish. Both your own profile and other users' profiles get this.

## Back behavior
Both \`Dish.jsx\` (\`handleBack\`) and \`RestaurantDetail.jsx\` (\`navigate(-1)\`) already render an in-page back arrow that uses browser history. Tapping a Food Story row → land on the destination → tap the existing back arrow → return to the profile. No new back-button code introduced.

## Files
- \`src/pages/UserProfile.jsx\` — drop FoodMap import + render block, trim useMemo, add favoriteRestaurantId, wrap chalkboard rows in \`<Link>\`
- \`src/pages/Profile.jsx\` — wrap chalkboard rows in \`<Link>\` (own profile)
- \`src/hooks/useUserVotes.js\` — add \`restaurant_id\` to standoutPicks comparisons, add \`favoriteRestaurantId\` to returned stats

## Defensive linking
Each row falls back to a plain \`<span>\` when the id is missing — never renders a broken \`<Link to="/dish/undefined">\`. This guards against older cached data shapes that don't carry IDs.

## Verification
- \`npm run build\` ✅

## Test plan
- [ ] Visit your own profile → tap "Most loyal" → land on that restaurant's detail page → tap back arrow → return to profile
- [ ] Same with "Best find" and "Hot take" → both land on the dish detail page
- [ ] Visit another user's profile (\`/user/:id\`) → confirm the Food Map section is gone, the Food Story chalkboard is the only stats block
- [ ] Tap a chalkboard row on someone else's profile → land on the destination → back returns to their profile
- [ ] Confirm a user with 0 ratings or no community-matched dishes still renders cleanly (no broken-link fallback paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)