### PR TITLE
fix(legal): strip home address from Privacy + Terms, add Denis as co-operator

### DIFF
--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -40,8 +40,8 @@ export function Privacy() {
               Overview
             </h2>
             <p className="leading-relaxed mb-3" style={{ color: 'var(--color-text-secondary)' }}>
-              What's Good Here is operated by Daniel Walsh (Martha's Vineyard, Massachusetts).
-              Contact:{' '}
+              What's Good Here is operated by Daniel Walsh and Denis Gingras (Martha's Vineyard,
+              Massachusetts). Contact:{' '}
               <a
                 href="mailto:wghapp@wghapp.com"
                 className="font-medium"
@@ -49,7 +49,7 @@ export function Privacy() {
               >
                 wghapp@wghapp.com
               </a>
-              . Mailing address: Daniel Walsh, 134 Franklin Ter, Vineyard Haven, MA 02568.
+              . A mailing address is available on request.
             </p>
             <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
               What's Good Here ("we", "our", or "the app") is a community-driven food discovery
@@ -333,7 +333,7 @@ export function Privacy() {
             <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
               Contact Us
             </h2>
-            <p className="leading-relaxed mb-2" style={{ color: 'var(--color-text-secondary)' }}>
+            <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
               If you have questions about this Privacy Policy, please contact us at:{' '}
               <a
                 href="mailto:wghapp@wghapp.com"
@@ -342,12 +342,8 @@ export function Privacy() {
               >
                 wghapp@wghapp.com
               </a>
+              . A mailing address is available on request.
             </p>
-            <address className="not-italic leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
-              Daniel Walsh<br />
-              134 Franklin Ter<br />
-              Vineyard Haven, MA 02568
-            </address>
           </section>
         </div>
       </div>

--- a/src/pages/Terms.jsx
+++ b/src/pages/Terms.jsx
@@ -41,8 +41,8 @@ export function Terms() {
             </h2>
             <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
               These Terms of Service ("Terms") govern your use of the What's Good Here app and
-              website ("Service"), operated by Daniel Walsh. By using the Service, you agree to
-              these Terms. If you don't agree, please don't use the Service.
+              website ("Service"), operated by Daniel Walsh and Denis Gingras. By using the Service,
+              you agree to these Terms. If you don't agree, please don't use the Service.
             </p>
           </section>
 
@@ -205,7 +205,7 @@ export function Terms() {
                 If you downloaded the iOS app from the Apple App Store, you acknowledge:
               </p>
               <ul className="list-disc list-inside space-y-2">
-                <li>These Terms are between you and Daniel Walsh, not Apple. Apple is not responsible for the app or its content.</li>
+                <li>These Terms are between you and the operators of What's Good Here (Daniel Walsh and Denis Gingras), not Apple. Apple is not responsible for the app or its content.</li>
                 <li>You are granted a limited, non-transferable, non-exclusive license to install and use the app only on Apple-branded devices that you own or control, and as permitted by the App Store Terms of Service.</li>
                 <li>Apple has no obligation to provide maintenance or support for the app.</li>
                 <li>If the app fails to conform to any applicable warranty, you may notify Apple for a refund of the purchase price (if any). Apple has no other warranty obligations.</li>
@@ -266,7 +266,7 @@ export function Terms() {
             <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
               Contact Us
             </h2>
-            <p className="leading-relaxed mb-2" style={{ color: 'var(--color-text-secondary)' }}>
+            <p className="leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
               Questions about these Terms? Contact us at:{' '}
               <a
                 href="mailto:wghapp@wghapp.com"
@@ -275,12 +275,8 @@ export function Terms() {
               >
                 wghapp@wghapp.com
               </a>
+              . A mailing address is available on request.
             </p>
-            <address className="not-italic leading-relaxed" style={{ color: 'var(--color-text-secondary)' }}>
-              Daniel Walsh<br />
-              134 Franklin Ter<br />
-              Vineyard Haven, MA 02568
-            </address>
           </section>
         </div>
       </div>


### PR DESCRIPTION
## Summary
Two cleanups Dan flagged after launch — both on the public legal pages.

### 1. Home address removed
Both \`/privacy\` and \`/terms\` rendered Dan's home address ("134 Franklin Ter, Vineyard Haven, MA 02568") as the public mailing address. That's a private residence. Replaced with **"A mailing address is available on request."** The wghapp@wghapp.com contact email still serves all data-subject-request workflows (GDPR / CCPA), and Apple's privacy-policy requirement is for a contact, not a postal address.

### 2. Denis Gingras added as co-operator
"Operated by Daniel Walsh" → **"Operated by Daniel Walsh and Denis Gingras"** in both the overview clause and the Apple-app-specific Terms section ("These Terms are between you and..."). Denis has been a real co-creator from before the launch.

## Files
- \`src/pages/Privacy.jsx\` — overview clause + footer contact block
- \`src/pages/Terms.jsx\` — overview clause + Apple acknowledgment + footer contact block

## Follow-up (out of scope here)
A virtual business address (Stable / Anytime Mailbox, ~$10-30/mo) is still the right long-term move so "available on request" points at a real PO box, not Dan's home. Already in launch memory.

## Verification
- \`npm run build\` ✅
- \`grep -rn "Franklin\\|02568\\|Vineyard Haven, MA" src/\` returns nothing — clean

## Test plan
- [ ] Open /privacy → confirm no home address, contact line reads "A mailing address is available on request."
- [ ] Same on /terms
- [ ] Both pages mention "Daniel Walsh and Denis Gingras" in the operator clause
- [ ] mailto link still points at wghapp@wghapp.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)