### PR TITLE
feat(avatars): surface avatar_url everywhere users appear (Phase 2)

### DIFF
--- a/src/api/followsApi.js
+++ b/src/api/followsApi.js
@@ -44,7 +44,7 @@ async function _paginateFollows(userId, direction, { limit = 20, cursor = null }
   const userIds = results.map(f => f[selectCol])
   const { data: profiles, error: profileError } = await supabase
     .from('profiles')
-    .select('id, display_name, follower_count')
+    .select('id, display_name, avatar_url, follower_count')
     .in('id', userIds)
 
   if (profileError) {
@@ -58,6 +58,7 @@ async function _paginateFollows(userId, direction, { limit = 20, cursor = null }
   const users = results.map(f => ({
     id: f[selectCol],
     display_name: profileMap[f[selectCol]]?.display_name || 'Anonymous',
+    avatar_url: profileMap[f[selectCol]]?.avatar_url || null,
     follower_count: profileMap[f[selectCol]]?.follower_count || 0,
     followed_at: f.created_at,
   }))

--- a/src/api/votesApi.js
+++ b/src/api/votesApi.js
@@ -377,7 +377,7 @@ export const votesApi = {
       const userIds = [...new Set(data.map(v => v.user_id).filter(Boolean))]
       const [profileResult, jitterResult] = userIds.length
         ? await Promise.all([
-            supabase.from('profiles').select('id, display_name').in('id', userIds),
+            supabase.from('profiles').select('id, display_name, avatar_url').in('id', userIds),
             supabase.rpc('get_jitter_badges', { p_user_ids: userIds }),
           ])
         : [{ data: [] }, { data: [] }]

--- a/src/components/FollowListModal.jsx
+++ b/src/components/FollowListModal.jsx
@@ -157,10 +157,14 @@ export function FollowListModal({ userId, type, onClose }) {
                   >
                     {/* Avatar */}
                     <div
-                      className="w-11 h-11 rounded-full flex items-center justify-center font-bold flex-shrink-0"
+                      className="w-11 h-11 rounded-full flex items-center justify-center font-bold flex-shrink-0 overflow-hidden"
                       style={{ background: 'var(--color-primary)', color: 'var(--color-text-on-primary)' }}
                     >
-                      {user.display_name?.charAt(0).toUpperCase() || '?'}
+                      {user.avatar_url ? (
+                        <img src={user.avatar_url} alt="" className="w-full h-full object-cover" draggable={false} />
+                      ) : (
+                        <span>{user.display_name?.charAt(0).toUpperCase() || '?'}</span>
+                      )}
                     </div>
 
                     {/* Info */}

--- a/src/components/dish/DishEvidence.jsx
+++ b/src/components/dish/DishEvidence.jsx
@@ -154,7 +154,7 @@ export function DishEvidence({
                     style={{ minWidth: minWidth + 'px' }}
                   >
                     <div
-                      className="rounded-full flex items-center justify-center font-bold"
+                      className="rounded-full flex items-center justify-center font-bold overflow-hidden"
                       style={{
                         width: avatarSize + 'px',
                         height: avatarSize + 'px',
@@ -163,7 +163,11 @@ export function DishEvidence({
                         fontSize: avatarFont + 'px',
                       }}
                     >
-                      {vote.display_name?.charAt(0).toUpperCase() || '?'}
+                      {vote.avatar_url ? (
+                        <img src={vote.avatar_url} alt="" className="w-full h-full object-cover" draggable={false} />
+                      ) : (
+                        <span>{vote.display_name?.charAt(0).toUpperCase() || '?'}</span>
+                      )}
                     </div>
                     <span style={{
                       fontSize: nameSize + 'px',
@@ -300,10 +304,14 @@ export function DishEvidence({
                     <div className="flex items-start gap-2 mb-2.5">
                       <Link to={'/user/' + review.user_id} className="flex items-center gap-3 min-w-0 flex-1">
                         <div
-                          className="w-11 h-11 rounded-full flex items-center justify-center font-bold text-sm flex-shrink-0"
+                          className="w-11 h-11 rounded-full flex items-center justify-center font-bold text-sm flex-shrink-0 overflow-hidden"
                           style={{ background: 'var(--color-primary)', color: 'var(--color-text-on-primary)' }}
                         >
-                          {review.profiles?.display_name?.charAt(0).toUpperCase() || '?'}
+                          {review.profiles?.avatar_url ? (
+                            <img src={review.profiles.avatar_url} alt="" className="w-full h-full object-cover" draggable={false} />
+                          ) : (
+                            <span>{review.profiles?.display_name?.charAt(0).toUpperCase() || '?'}</span>
+                          )}
                         </div>
                         <div className="min-w-0">
                           <span className="flex items-center gap-1.5">

--- a/src/components/restaurants/RestaurantDishes.jsx
+++ b/src/components/restaurants/RestaurantDishes.jsx
@@ -131,7 +131,7 @@ export function RestaurantDishes({ dishes, loading, error, searchQuery = '', fri
                 <Link
                   key={friend.user_id}
                   to={`/user/${friend.user_id}`}
-                  className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold ring-2"
+                  className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold ring-2 overflow-hidden"
                   style={{
                     background: 'var(--color-primary)',
                     color: 'var(--color-text-on-primary)',
@@ -139,7 +139,11 @@ export function RestaurantDishes({ dishes, loading, error, searchQuery = '', fri
                     zIndex: 3 - i,
                   }}
                 >
-                  {friend.display_name?.charAt(0).toUpperCase() || '?'}
+                  {friend.avatar_url ? (
+                    <img src={friend.avatar_url} alt="" className="w-full h-full object-cover" draggable={false} />
+                  ) : (
+                    <span>{friend.display_name?.charAt(0).toUpperCase() || '?'}</span>
+                  )}
                 </Link>
               ))
             })()}

--- a/supabase/migrations/20260516_friends_votes_rpcs_avatar_url.sql
+++ b/supabase/migrations/20260516_friends_votes_rpcs_avatar_url.sql
@@ -1,0 +1,79 @@
+-- Extend get_friends_votes_for_dish and get_friends_votes_for_restaurant
+-- to include avatar_url, so the dish-detail and restaurant-detail friend
+-- chips can render profile pictures instead of initial-only circles.
+--
+-- Pure additive change to the RETURNS TABLE shape — existing consumers that
+-- ignore the new column keep working.
+--
+-- See supabase/schema.sql for the prior shape and SECURITY DEFINER /
+-- access-control logic — both preserved verbatim here.
+
+CREATE OR REPLACE FUNCTION get_friends_votes_for_dish(
+  p_user_id UUID,
+  p_dish_id UUID
+)
+RETURNS TABLE (
+  user_id UUID, display_name TEXT, avatar_url TEXT, rating_10 DECIMAL(3, 1),
+  voted_at TIMESTAMPTZ, category_expertise TEXT
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  IF auth.role() <> 'service_role' AND (select auth.uid()) IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'Access denied';
+  END IF;
+
+  RETURN QUERY
+  SELECT p.id, p.display_name, p.avatar_url, v.rating_10, v.created_at,
+    CASE
+      WHEN EXISTS (SELECT 1 FROM user_badges ub WHERE ub.user_id = p.id
+                   AND ub.badge_key = 'authority_' || REPLACE(d.category, ' ', '_')) THEN 'authority'
+      WHEN EXISTS (SELECT 1 FROM user_badges ub WHERE ub.user_id = p.id
+                   AND ub.badge_key = 'specialist_' || REPLACE(d.category, ' ', '_')) THEN 'specialist'
+      ELSE NULL
+    END
+  FROM follows f
+  JOIN profiles p ON p.id = f.followed_id
+  JOIN votes v ON v.user_id = f.followed_id AND v.dish_id = p_dish_id
+  JOIN dishes d ON d.id = p_dish_id
+  WHERE f.follower_id = p_user_id
+    AND NOT is_blocked_pair(p_user_id, f.followed_id)
+  ORDER BY v.created_at DESC;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION get_friends_votes_for_restaurant(
+  p_user_id UUID,
+  p_restaurant_id UUID
+)
+RETURNS TABLE (
+  user_id UUID, display_name TEXT, avatar_url TEXT, dish_id UUID, dish_name TEXT,
+  rating_10 DECIMAL(3, 1), voted_at TIMESTAMPTZ, category_expertise TEXT
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  IF auth.role() <> 'service_role' AND (select auth.uid()) IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'Access denied';
+  END IF;
+
+  RETURN QUERY
+  SELECT p.id, p.display_name, p.avatar_url, d.id, d.name, v.rating_10, v.created_at,
+    CASE
+      WHEN EXISTS (SELECT 1 FROM user_badges ub WHERE ub.user_id = p.id
+                   AND ub.badge_key = 'authority_' || REPLACE(d.category, ' ', '_')) THEN 'authority'
+      WHEN EXISTS (SELECT 1 FROM user_badges ub WHERE ub.user_id = p.id
+                   AND ub.badge_key = 'specialist_' || REPLACE(d.category, ' ', '_')) THEN 'specialist'
+      ELSE NULL
+    END
+  FROM follows f
+  JOIN profiles p ON p.id = f.followed_id
+  JOIN votes v ON v.user_id = f.followed_id
+  JOIN dishes d ON d.id = v.dish_id AND d.restaurant_id = p_restaurant_id
+  WHERE f.follower_id = p_user_id
+    AND NOT is_blocked_pair(p_user_id, f.followed_id)
+  ORDER BY d.name, v.created_at DESC;
+END;
+$$;
+
+-- No SQL rollback needed — CREATE OR REPLACE FUNCTION is idempotent and the
+-- prior signature is preserved in supabase/schema.sql (lines ~5140 and ~5175).
+-- To revert: re-run the version from schema.sql.

--- a/supabase/migrations/20260516_friends_votes_rpcs_avatar_url.sql
+++ b/supabase/migrations/20260516_friends_votes_rpcs_avatar_url.sql
@@ -2,11 +2,20 @@
 -- to include avatar_url, so the dish-detail and restaurant-detail friend
 -- chips can render profile pictures instead of initial-only circles.
 --
--- Pure additive change to the RETURNS TABLE shape — existing consumers that
--- ignore the new column keep working.
+-- Existing consumers that ignore the new column keep working.
+--
+-- IMPORTANT: Postgres CREATE OR REPLACE FUNCTION cannot change a function's
+-- RETURNS TABLE shape — adding a column is treated as changing the return
+-- type and fails with "cannot change return type of existing function." So
+-- we DROP first, then create, matching the pattern used the last time these
+-- two RPCs changed shape (supabase/migrations/2026-04-13-binary-vote-
+-- removal-phase-2.sql lines 419 and 449).
 --
 -- See supabase/schema.sql for the prior shape and SECURITY DEFINER /
 -- access-control logic — both preserved verbatim here.
+
+DROP FUNCTION IF EXISTS get_friends_votes_for_dish(UUID, UUID);
+DROP FUNCTION IF EXISTS get_friends_votes_for_restaurant(UUID, UUID);
 
 CREATE OR REPLACE FUNCTION get_friends_votes_for_dish(
   p_user_id UUID,
@@ -74,6 +83,9 @@ BEGIN
 END;
 $$;
 
--- No SQL rollback needed — CREATE OR REPLACE FUNCTION is idempotent and the
--- prior signature is preserved in supabase/schema.sql (lines ~5140 and ~5175).
--- To revert: re-run the version from schema.sql.
+-- ROLLBACK: drop these and re-run the prior signatures from supabase/schema.sql
+-- (lines ~5140 and ~5175 — five-column return for the dish RPC, seven-column for
+-- the restaurant RPC, both without avatar_url).
+-- DROP FUNCTION IF EXISTS get_friends_votes_for_dish(UUID, UUID);
+-- DROP FUNCTION IF EXISTS get_friends_votes_for_restaurant(UUID, UUID);
+-- Then re-create from schema.sql.


### PR DESCRIPTION
## Summary
Phase 1 (#189) shipped profile pictures only on the user's own hero. Phase 2 fans the avatar out to every other surface that shows a user, so when you upload a face you actually see it across the app.

## Surfaces updated
- **FollowListModal** — followers / following list rows
- **DishEvidence** — friend-vote chips on dish hero AND review-card avatars further down
- **RestaurantDishes** — "X friends have been here" chip stack
- (People-search results on the profile page already picked up avatars from the prior \`searchUsers\` change)

## ⚠️ Dashboard step BEFORE merge
**Run \`supabase/migrations/20260516_friends_votes_rpcs_avatar_url.sql\` in the Supabase SQL Editor.** The two friend-votes RPCs (\`get_friends_votes_for_dish\` and \`get_friends_votes_for_restaurant\`) need their RETURNS TABLE shape extended with \`avatar_url\`. Without it, the dish-hero and restaurant-detail chips silently fall back to the initial circle — code works either way, but the actual avatar won't render.

## Migration safety
First commit on this branch used \`CREATE OR REPLACE FUNCTION\` — that won't work because Postgres can't change a function's return-type signature in-place. Second commit (\`64288e1\`) caught this on self-review and added \`DROP FUNCTION IF EXISTS\` first, matching the pattern used the last time these RPCs changed shape (\`2026-04-13-binary-vote-removal-phase-2.sql\` lines 419/449).

## Files
- \`supabase/migrations/20260516_friends_votes_rpcs_avatar_url.sql\` — new
- \`src/api/votesApi.js\` — \`getReviewsForDish\` profile select gains \`avatar_url\`
- \`src/api/followsApi.js\` — \`_paginateFollows\` select + mapped user object gain \`avatar_url\`
- \`src/components/FollowListModal.jsx\` — img-or-initial
- \`src/components/dish/DishEvidence.jsx\` — img-or-initial in two places
- \`src/components/restaurants/RestaurantDishes.jsx\` — img-or-initial

## Intentionally NOT updated
- \`UserProfile.jsx\` blocked-user view — when you've blocked someone, the page is about your decision, not their identity. Showing their face there felt off.

## Codex review
Tried; hung again (fourth time tonight on this codex install). Did the self-review covering: migration shape-change (CAUGHT — fixed in 2nd commit), \`overflow-hidden\` on every img-bearing parent (verified all 4 new surfaces), \`alt=""\` on decorative avatar imgs (correct pattern), positional vs named column access on RPC results (supabase-js returns named objects, safe).

## Verification
- \`npm run build\` ✅
- All updated parents have \`overflow-hidden\` so img doesn't bleed out of the rounded circle

## Test plan
- [ ] Run the migration in Supabase SQL Editor → expect 0 errors (DROP + CREATE flow)
- [ ] Open another user's followers / following modal → see their photos
- [ ] Open a dish detail with friend-votes → friend chips show photos
- [ ] Scroll to reviews on a dish detail → review-card avatars show photos
- [ ] Open a restaurant where friends have been → chip stack shows photos
- [ ] Users without an avatar still render the initial circle on every surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)