### PR TITLE
fix(search): rank user search server-side by follower count

### DIFF
--- a/src/api/followsApi.js
+++ b/src/api/followsApi.js
@@ -301,49 +301,29 @@ export const followsApi = {
     try {
       if (!query?.trim() || query.length < 2) return []
 
-      // Sanitize query to prevent SQL injection via LIKE patterns
+      // Sanitize query to prevent SQL injection via LIKE patterns (defense in
+      // depth — the RPC also trims and the ILIKE pattern itself is parameterized).
       const sanitized = sanitizeSearchQuery(query, 50)
       if (!sanitized || sanitized.length < 2) return []
 
-      const { data, error } = await supabase
-        .from('profiles')
-        .select('id, display_name, avatar_url')
-        .ilike('display_name', `%${sanitized}%`)
-        .limit(limit)
+      // Server-side ranked search. Joins follower counts inline and orders
+      // before LIMIT, so the top-N really is the top-N by follower count.
+      // Prior client-side approach pre-limited the substring match and then
+      // sorted in JS — a high-follower user could be invisible if 20+ low-
+      // follower users alphabetically preceded them.
+      const { data, error } = await supabase.rpc('search_users_with_followers', {
+        p_query: sanitized,
+        p_limit: limit,
+      })
 
       if (error) {
         logger.error('Error searching users:', error)
         throw createClassifiedError(error)
       }
 
-      if (!data || data.length === 0) return []
-
-      // Get follower counts in a single query (avoid N+1)
-      const userIds = data.map(u => u.id)
-      const { data: followCounts, error: followError } = await supabase
-        .from('follows')
-        .select('followed_id')
-        .in('followed_id', userIds)
-
-      if (followError) {
-        logger.error('Error fetching follower counts:', followError)
-        // Graceful degradation - return users without counts
-        return data.map(user => ({ ...user, follower_count: 0 }))
-      }
-
-      // Count followers per user in memory (small dataset - max 10 users)
-      const countMap = {}
-      followCounts?.forEach(f => {
-        countMap[f.followed_id] = (countMap[f.followed_id] || 0) + 1
-      })
-
-      const usersWithCounts = data.map(user => ({
-        ...user,
-        follower_count: countMap[user.id] || 0,
-      }))
-
-      // Sort by follower count descending
-      return usersWithCounts.sort((a, b) => b.follower_count - a.follower_count)
+      // RPC returns rows shaped exactly as the consumer expects: id,
+      // display_name, avatar_url, follower_count.
+      return data || []
     } catch (err) {
       logger.error('Unexpected error in searchUsers:', err)
       throw err

--- a/supabase/migrations/20260516_search_users_with_followers_rpc.sql
+++ b/supabase/migrations/20260516_search_users_with_followers_rpc.sql
@@ -1,0 +1,72 @@
+-- search_users_with_followers: server-side ranked user search.
+--
+-- Replaces the client-side approach in followsApi.searchUsers which:
+--   1. Pulled the first 20 substring matches from profiles (in whatever
+--      order Postgres returned them — effectively arbitrary).
+--   2. Fetched follower counts for those 20 in a second query.
+--   3. Sorted by follower count in JS.
+--
+-- The bug: step (1) limited BEFORE we knew follower counts, so a high-
+-- follower user could be invisible if 20+ low-follower users alphabetically
+-- preceded them on the substring match.
+--
+-- This RPC computes follower counts inline via a left join on a counts
+-- subquery, orders by follower_count DESC then display_name ASC, and
+-- applies the LIMIT only at the very end. Results are now actually the top-
+-- N matches by follower count.
+--
+-- Caller-side sanitization (sanitizeSearchQuery, ILIKE-safe) is still
+-- applied in followsApi before invoking this — same defense-in-depth as
+-- before.
+
+CREATE OR REPLACE FUNCTION search_users_with_followers(
+  p_query TEXT,
+  p_limit INT DEFAULT 20
+)
+RETURNS TABLE (
+  id UUID,
+  display_name TEXT,
+  avatar_url TEXT,
+  follower_count BIGINT
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  -- Guard: require auth. Anonymous user search isn't a feature we offer.
+  IF (select auth.uid()) IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+
+  -- Guard: require a non-trivial query so we don't return the entire user
+  -- table when called with empty / 1-char input.
+  IF p_query IS NULL OR length(trim(p_query)) < 2 THEN
+    RETURN;
+  END IF;
+
+  -- Guard: clamp the limit. 100 is plenty for any UI surface; preventing
+  -- accidental "show me everyone" calls.
+  IF p_limit IS NULL OR p_limit < 1 THEN
+    p_limit := 20;
+  ELSIF p_limit > 100 THEN
+    p_limit := 100;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    p.id,
+    p.display_name,
+    p.avatar_url,
+    COALESCE(c.follower_count, 0)::BIGINT AS follower_count
+  FROM profiles p
+  LEFT JOIN (
+    SELECT followed_id, COUNT(*) AS follower_count
+    FROM follows
+    GROUP BY followed_id
+  ) c ON c.followed_id = p.id
+  WHERE p.display_name ILIKE '%' || trim(p_query) || '%'
+  ORDER BY follower_count DESC, p.display_name ASC
+  LIMIT p_limit;
+END;
+$$;
+
+-- ROLLBACK:
+-- DROP FUNCTION IF EXISTS search_users_with_followers(TEXT, INT);


### PR DESCRIPTION
## Summary
Codex flagged this during the People-tab review (PR #188). The bug: \`followsApi.searchUsers\` pulled the first 20 substring matches from \`profiles\`, THEN fetched follower counts, THEN sorted in JS. The LIMIT happened BEFORE the ranking — so a user with 100 followers could be invisible if 20+ low-follower users alphabetically preceded them.

This PR makes the rank actually correct.

## Files
- \`supabase/migrations/20260516_search_users_with_followers_rpc.sql\` — new \`search_users_with_followers(p_query, p_limit)\` RPC. Joins follower-count subquery, orders by \`follower_count DESC, display_name ASC\`, applies LIMIT only at the end.
- \`src/api/followsApi.js\` — \`searchUsers\` now calls the RPC. Same return shape (id, display_name, avatar_url, follower_count). Same caller-side \`sanitizeSearchQuery\` defense-in-depth.

## ⚠️ Dashboard step before merge
**Run \`supabase/migrations/20260516_search_users_with_followers_rpc.sql\` in the Supabase SQL Editor.** Without it the RPC doesn't exist and the \`.rpc()\` call returns an error.

## Safety guards on the RPC
- Requires \`auth.uid()\` (no anonymous user search)
- Returns immediately if the query is < 2 chars
- Clamps limit to ≤ 100 server-side

## Verification
- \`npm run build\` ✅

## Test plan
- [ ] Run migration in Supabase SQL Editor
- [ ] On /profile, type a 2+ char query in the people search at top
- [ ] Top result is the user with the highest follower count matching the substring (not whoever Postgres happened to return first)
- [ ] User with 0 followers still appears, just ranked lower
- [ ] No-match query returns "No one matches" empty state, not an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)