### PR TITLE
feat(avatars): moderate avatar uploads + codex hardening

### DIFF
--- a/src/api/profileApi.js
+++ b/src/api/profileApi.js
@@ -195,13 +195,12 @@ export const profileApi = {
   /**
    * Upload a new avatar for the current authenticated user. Strips EXIF,
    * center-crops to a square, resizes to AVATAR_MAX_EDGE, uploads to the
-   * 'avatars' bucket at `<user_id>/avatar.jpg`, then updates
-   * profiles.avatar_url with a cache-busted public URL so browsers and the
-   * service worker don't shadow the new file.
-   *
-   * TODO: gate uploads through the photo-moderate Edge Function (already
-   * used by src/api/dishPhotosApi.js for dish photos). Avatars currently
-   * skip that pass; revisit before opening to general users at scale.
+   * 'avatars' bucket at `<user_id>/avatar.jpg`, runs the upload through the
+   * photo-moderate Edge Function (only the `is_unsafe` flag — `is_food_photo`
+   * is dish-specific), then updates profiles.avatar_url with a cache-busted
+   * public URL so browsers and the service worker don't shadow the new file.
+   * Fail-closed: any moderation error rejects the upload and removes the
+   * orphan from storage.
    *
    * @param {File} file - Image file from <input type="file"> or drop
    * @returns {Promise<{ url: string }>} The new avatar URL (cache-busted)
@@ -249,6 +248,35 @@ export const profileApi = {
       const { data: { publicUrl } } = supabase.storage
         .from('avatars')
         .getPublicUrl(path)
+
+      // Pre-display moderation. Sonnet fetches the URL we hand it, so we use
+      // the plain publicUrl (no cache-buster query param yet). The Edge
+      // Function's allowlist accepts URLs from the avatars bucket too (see
+      // supabase/functions/photo-moderate/index.ts). For avatars we ONLY
+      // enforce `is_unsafe` — the is_food_photo flag is a dish-specific check
+      // and would obviously reject every selfie.
+      //
+      // Fail closed: if the function errors, or the response is missing
+      // is_unsafe, treat as unsafe. Better to refuse than to publish an
+      // unmoderated avatar.
+      const { data: modResult, error: modError } = await supabase.functions.invoke(
+        'photo-moderate',
+        { body: { photo_url: publicUrl } }
+      )
+      const isUnsafe = modError || !modResult || modResult.is_unsafe === true
+      if (isUnsafe) {
+        const { error: removeError } = await supabase.storage.from('avatars').remove([path])
+        if (removeError) {
+          logger.error('photo-moderate: failed to remove rejected avatar from storage', {
+            path, removeError,
+          })
+        }
+        const userMessage = (modResult && modResult.reason)
+          || "Couldn't verify your photo. Please try a different one."
+        if (modError) logger.error('photo-moderate invoke failed (avatar):', modError)
+        else logger.warn('avatar rejected by moderation:', { reason: modResult?.reason })
+        throw new Error(userMessage)
+      }
 
       // Cache-bust on every upload — the path is stable, so without ?v=<ts>
       // browsers and the service worker keep showing the old avatar.

--- a/src/api/profileApi.js
+++ b/src/api/profileApi.js
@@ -249,38 +249,43 @@ export const profileApi = {
         .from('avatars')
         .getPublicUrl(path)
 
-      // Pre-display moderation. Sonnet fetches the URL we hand it, so we use
-      // the plain publicUrl (no cache-buster query param yet). The Edge
-      // Function's allowlist accepts URLs from the avatars bucket too (see
-      // supabase/functions/photo-moderate/index.ts). For avatars we ONLY
-      // enforce `is_unsafe` — the is_food_photo flag is a dish-specific check
-      // and would obviously reject every selfie.
+      // Cache-bust on every upload. Two roles:
+      //   1) When stored in profiles.avatar_url, the query param prevents
+      //      browsers and the service worker from showing the prior file.
+      //   2) Handed to the photo-moderate Edge Function below, the same
+      //      unique-per-upload URL prevents Sonnet from receiving a stale
+      //      cached copy from the storage CDN at the (stable) path.
+      const cacheBustedUrl = `${publicUrl}?v=${Date.now()}`
+
+      // Pre-display moderation. For avatars we ONLY enforce `is_unsafe` —
+      // the is_food_photo flag is a dish-specific check and would obviously
+      // reject every selfie.
       //
-      // Fail closed: if the function errors, or the response is missing
-      // is_unsafe, treat as unsafe. Better to refuse than to publish an
-      // unmoderated avatar.
+      // Fail closed: only accept when modResult.is_unsafe is STRICTLY
+      // `false`. A missing field, a wrong type, an empty object, or any
+      // invoke error are all treated as unsafe. Better to refuse than
+      // publish an unmoderated avatar.
       const { data: modResult, error: modError } = await supabase.functions.invoke(
         'photo-moderate',
-        { body: { photo_url: publicUrl } }
+        { body: { photo_url: cacheBustedUrl } }
       )
-      const isUnsafe = modError || !modResult || modResult.is_unsafe === true
-      if (isUnsafe) {
+      const passedModeration = !modError
+        && modResult
+        && typeof modResult.is_unsafe === 'boolean'
+        && modResult.is_unsafe === false
+      if (!passedModeration) {
         const { error: removeError } = await supabase.storage.from('avatars').remove([path])
         if (removeError) {
           logger.error('photo-moderate: failed to remove rejected avatar from storage', {
             path, removeError,
           })
         }
-        const userMessage = (modResult && modResult.reason)
+        const userMessage = (modResult && typeof modResult.reason === 'string' && modResult.reason)
           || "Couldn't verify your photo. Please try a different one."
         if (modError) logger.error('photo-moderate invoke failed (avatar):', modError)
         else logger.warn('avatar rejected by moderation:', { reason: modResult?.reason })
         throw new Error(userMessage)
       }
-
-      // Cache-bust on every upload — the path is stable, so without ?v=<ts>
-      // browsers and the service worker keep showing the old avatar.
-      const cacheBustedUrl = `${publicUrl}?v=${Date.now()}`
 
       const { error: updateError } = await supabase
         .from('profiles')

--- a/supabase/functions/photo-moderate/index.ts
+++ b/supabase/functions/photo-moderate/index.ts
@@ -177,23 +177,32 @@ serve(async (req) => {
       headers: { ...cors, 'Content-Type': 'application/json' },
     })
   }
-  // Allowlist: only URLs from THIS project's dish-photos bucket. Without this,
-  // any authenticated user could ask us to moderate arbitrary internet images.
-  const allowedPrefix = supabaseUrl ? `${supabaseUrl}/storage/v1/object/public/dish-photos/` : ''
-  if (!allowedPrefix || !photoUrl.startsWith(allowedPrefix)) {
-    return new Response(JSON.stringify({ error: 'photo_url must point to the dish-photos bucket' }), {
+  // Allowlist: only URLs from THIS project's dish-photos OR avatars buckets.
+  // Without this, any authenticated user could ask us to moderate arbitrary
+  // internet images and burn Anthropic tokens.
+  const dishPrefix = supabaseUrl ? `${supabaseUrl}/storage/v1/object/public/dish-photos/` : ''
+  const avatarPrefix = supabaseUrl ? `${supabaseUrl}/storage/v1/object/public/avatars/` : ''
+  let matchedPrefix = ''
+  if (dishPrefix && photoUrl.startsWith(dishPrefix)) {
+    matchedPrefix = dishPrefix
+  } else if (avatarPrefix && photoUrl.startsWith(avatarPrefix)) {
+    matchedPrefix = avatarPrefix
+  }
+  if (!matchedPrefix) {
+    return new Response(JSON.stringify({ error: 'photo_url must point to the dish-photos or avatars bucket' }), {
       status: 400,
       headers: { ...cors, 'Content-Type': 'application/json' },
     })
   }
 
-  // Ownership check. Upload paths are `{user_id}/{dish_id}.jpg`, so the
-  // first path segment after the bucket prefix is the owner's UUID.
-  // Reject mismatches — without this, any authenticated user could ask us
-  // to moderate any other user's photo (still bucket-scoped, but they
-  // could enumerate URLs and burn tokens at someone else's expense, plus
-  // it leaks no-cost photo existence checks).
-  const tail = photoUrl.slice(allowedPrefix.length)
+  // Ownership check. Upload paths are `{user_id}/{dish_id}.jpg` (dish-photos)
+  // or `{user_id}/avatar.jpg` (avatars) — in both buckets the first path
+  // segment after the bucket prefix is the owner's UUID. Reject mismatches —
+  // without this, any authenticated user could ask us to moderate any other
+  // user's photo (still bucket-scoped, but they could enumerate URLs and burn
+  // tokens at someone else's expense, plus it leaks no-cost photo existence
+  // checks).
+  const tail = photoUrl.slice(matchedPrefix.length)
   const ownerSegment = tail.split('/')[0]
   if (ownerSegment !== authUser.id) {
     return new Response(JSON.stringify({ error: 'Photo does not belong to caller' }), {

--- a/supabase/functions/photo-moderate/index.ts
+++ b/supabase/functions/photo-moderate/index.ts
@@ -180,18 +180,48 @@ serve(async (req) => {
   // Allowlist: only URLs from THIS project's dish-photos OR avatars buckets.
   // Without this, any authenticated user could ask us to moderate arbitrary
   // internet images and burn Anthropic tokens.
-  const dishPrefix = supabaseUrl ? `${supabaseUrl}/storage/v1/object/public/dish-photos/` : ''
-  const avatarPrefix = supabaseUrl ? `${supabaseUrl}/storage/v1/object/public/avatars/` : ''
-  let matchedPrefix = ''
-  if (dishPrefix && photoUrl.startsWith(dishPrefix)) {
-    matchedPrefix = dishPrefix
-  } else if (avatarPrefix && photoUrl.startsWith(avatarPrefix)) {
-    matchedPrefix = avatarPrefix
-  }
-  if (!matchedPrefix) {
-    return new Response(JSON.stringify({ error: 'photo_url must point to the dish-photos or avatars bucket' }), {
+  //
+  // Parse with `new URL` rather than substring-matching. Substring matching
+  // is brittle to path-traversal sequences like `..` and to query-string
+  // tricks. URL parsing normalizes the origin separately from the path so
+  // we can assert origin == supabaseUrl exactly, then walk the pathname
+  // segments without trusting their textual form.
+  let parsedUrl: URL
+  try {
+    parsedUrl = new URL(photoUrl)
+  } catch {
+    return new Response(JSON.stringify({ error: 'photo_url is not a valid URL' }), {
       status: 400,
       headers: { ...cors, 'Content-Type': 'application/json' },
+    })
+  }
+  const expectedOrigin = supabaseUrl ? new URL(supabaseUrl).origin : ''
+  if (!expectedOrigin || parsedUrl.origin !== expectedOrigin) {
+    return new Response(JSON.stringify({ error: 'photo_url must come from this Supabase project' }), {
+      status: 400,
+      headers: { ...cors, 'Content-Type': 'application/json' },
+    })
+  }
+  // Strip leading slash and split. Empty segments (consecutive slashes) and
+  // path-traversal markers ('.', '..') are rejected so we can't be tricked
+  // into addressing a different file from what the textual path appears
+  // to claim. Expected layout for both buckets:
+  //   /storage/v1/object/public/<bucket>/<user_id>/<filename>
+  const segments = parsedUrl.pathname.replace(/^\/+/, '').split('/')
+  if (segments.some(s => s === '' || s === '.' || s === '..')) {
+    return new Response(JSON.stringify({ error: 'photo_url has invalid path segments' }), {
+      status: 400, headers: { ...cors, 'Content-Type': 'application/json' },
+    })
+  }
+  const [s0, s1, s2, s3, bucket, ownerSegment] = segments
+  if (s0 !== 'storage' || s1 !== 'v1' || s2 !== 'object' || s3 !== 'public') {
+    return new Response(JSON.stringify({ error: 'photo_url must point to a public storage object' }), {
+      status: 400, headers: { ...cors, 'Content-Type': 'application/json' },
+    })
+  }
+  if (bucket !== 'dish-photos' && bucket !== 'avatars') {
+    return new Response(JSON.stringify({ error: 'photo_url must point to the dish-photos or avatars bucket' }), {
+      status: 400, headers: { ...cors, 'Content-Type': 'application/json' },
     })
   }
 
@@ -202,9 +232,7 @@ serve(async (req) => {
   // user's photo (still bucket-scoped, but they could enumerate URLs and burn
   // tokens at someone else's expense, plus it leaks no-cost photo existence
   // checks).
-  const tail = photoUrl.slice(matchedPrefix.length)
-  const ownerSegment = tail.split('/')[0]
-  if (ownerSegment !== authUser.id) {
+  if (!ownerSegment || ownerSegment !== authUser.id) {
     return new Response(JSON.stringify({ error: 'Photo does not belong to caller' }), {
       status: 403, headers: { ...cors, 'Content-Type': 'application/json' },
     })


### PR DESCRIPTION
## Summary
Closes the moderation gap in the Phase-1 avatar flow (#189 had a TODO acknowledging it). Avatar uploads now go through the same \`photo-moderate\` Edge Function dish photos use. Codex caught three concrete issues during review and they're all fixed in commit 2.

## ⚠️ Two deploy steps after merge (in this order)
1. **Edge Function:** \`supabase functions deploy photo-moderate --project-ref vpioftosgdkyiwvhxewy\` (needs your CLI access token). Without this, the LIVE function still has the dish-photos-only allowlist and every avatar upload will fail with 400.
2. **Vercel auto-deploys** the web client when this merges.

Order matters — deploy the Edge Function FIRST so by the time the web client lands, the function accepts avatars.

## Edge Function changes (\`photo-moderate\`)
- Allowlist now accepts \`dish-photos\` AND \`avatars\` buckets.
- Codex hardening: parse photo_url with \`new URL()\` instead of \`startsWith()\` + \`slice()\`. Assert \`parsedUrl.origin === expectedOrigin\` exactly, walk pathname segments, reject empty / \`.\` / \`..\` segments before bucket check. Harder to fool with path-traversal or query-string tricks.

## API changes (\`profileApi.uploadAvatar\`)
- Calls photo-moderate between storage upload and DB write.
- **Avatars enforce \`is_unsafe\` only** — \`is_food_photo\` is dish-specific and would reject every selfie.
- **Fail-closed**: only accepts \`typeof modResult.is_unsafe === 'boolean' && modResult.is_unsafe === false\`. Codex caught that the prior check accepted \`{}\` payloads — fixed.
- **Moderate the cache-busted URL**: passes \`?v=<ts>\` to Sonnet so the storage CDN can't serve a stale copy on re-upload at the stable \`<user_id>/avatar.jpg\` path.
- TODO comment from #189 removed.

## Codex follow-ups deferred (in launch memory)
- 429 from photo-moderate surfaces as generic "couldn't verify" instead of distinct rate-limit UX.
- No unit tests for the new moderation branches yet.

## Verification
- \`npm run build\` ✅

## Test plan
- [ ] Deploy the Edge Function via CLI BEFORE merging the PR
- [ ] Upload a normal selfie → succeeds, profile shows new photo
- [ ] Upload an obviously unsafe image (test with something innocuous like a screenshot of a meme that contains text/violence imagery if you want to confirm fail-closed) → friendly error, no avatar saved
- [ ] Network-interrupt mid-moderation → orphan in storage is cleaned up, friendly error
- [ ] Dish photo uploads still work unchanged (the Edge Function allowlist now matches both buckets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)