### PR TITLE
feat(brand): use Seal variant='icon' everywhere — match iOS app icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,9 @@ blob-report/
 # Auto-generated build artifacts
 public/bundle-stats.html
 
-# Claude Code scheduled tasks
+# Claude Code scheduled tasks + session state — match at any depth
 .claude/scheduled_tasks.lock
+**/.claude/
 
 # Capacitor / iOS build artifacts
 # We commit the Xcode project, Podfile, and Podfile.lock (for reproducible

--- a/src/.claude/scheduled_tasks.lock
+++ b/src/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"e6ff2fd3-76f2-4c45-b1f6-a6f7534851e0","pid":48329,"procStart":"Tue May 12 22:46:35 2026","acquiredAt":1778851862291}

--- a/src/.claude/scheduled_tasks.lock
+++ b/src/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"e6ff2fd3-76f2-4c45-b1f6-a6f7534851e0","pid":48329,"procStart":"Tue May 12 22:46:35 2026","acquiredAt":1778851862291}

--- a/src/components/Auth/WelcomeModal.jsx
+++ b/src/components/Auth/WelcomeModal.jsx
@@ -112,7 +112,7 @@ export function WelcomeModal() {
         <div className="relative z-10 text-center px-8">
           {/* Logo — the plate, matches splash page */}
           <div className="flex justify-center" style={{ marginBottom: '12px', position: 'relative', zIndex: 2 }}>
-            <Seal size={88} />
+            <Seal size={88} variant="icon" />
           </div>
 
           {/* Brand name — Amatic SC, matches home + login + splash */}
@@ -211,7 +211,7 @@ export function WelcomeModal() {
           {/* Step icon */}
           {currentStep.id === 'welcome' ? (
             <div className="flex justify-center mb-6">
-              <Seal size={72} />
+              <Seal size={72} variant="icon" />
             </div>
           ) : (
             <div

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -14,9 +14,7 @@ export function TopBar() {
 
         <Seal
           size={36}
-          showRing={false}
-          plateColor="var(--color-surface)"
-          monoColor="var(--color-primary)"
+          variant="icon"
           ariaLabel="What's Good Here"
         />
 

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -15,6 +15,8 @@ export function TopBar() {
         <Seal
           size={36}
           variant="icon"
+          showBackground={false}
+          showRim={false}
           ariaLabel="What's Good Here"
         />
 

--- a/src/components/WelcomeSplash.jsx
+++ b/src/components/WelcomeSplash.jsx
@@ -53,10 +53,7 @@ export function WelcomeSplash() {
       <Seal
         className="wgh-splash__seal"
         size={160}
-        plateColor="var(--color-surface)"
-        monoColor="var(--color-primary)"
-        ringColor="var(--color-surface)"
-        borderColor="var(--color-surface)"
+        variant="icon"
       />
       <div className="wgh-splash__wordmark">
         <span className="wgh-splash__line">What&rsquo;s</span>

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -232,7 +232,7 @@ export function Login() {
             {/* Logo + Brand */}
             <div className="flex flex-col items-center mb-8">
               <div style={{ marginBottom: '14px', position: 'relative', zIndex: 2 }}>
-                <Seal size={88} ariaLabel="What's Good Here" />
+                <Seal size={88} variant="icon" ariaLabel="What's Good Here" />
               </div>
               <h1
                 style={{
@@ -346,7 +346,7 @@ export function Login() {
           <div className="flex-1 flex flex-col items-center justify-center px-6 pb-12">
             {/* Logo */}
             <div className="flex justify-center mb-6">
-              <Seal size={64} showRing={false} ariaLabel="What's Good Here" />
+              <Seal size={64} variant="icon" ariaLabel="What's Good Here" />
             </div>
 
             {/* Heading */}

--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -30,7 +30,7 @@ export function Privacy() {
       {/* Content */}
       <div className="max-w-2xl mx-auto px-4 py-8">
         <div className="flex justify-center mb-6">
-          <Seal size={96} ariaLabel="What's Good Here" />
+          <Seal size={96} variant="icon" ariaLabel="What's Good Here" />
         </div>
         <div className="rounded-2xl p-6 space-y-6" style={{ background: 'var(--color-surface-elevated)', border: '1px solid var(--color-divider)' }}>
           <p className="text-sm" style={{ color: 'var(--color-text-tertiary)' }}>Last updated: April 18, 2026</p>

--- a/src/pages/ResetPassword.jsx
+++ b/src/pages/ResetPassword.jsx
@@ -98,7 +98,7 @@ export function ResetPassword() {
     >
       {/* Logo */}
       <div className="mb-6">
-        <Seal size={96} ariaLabel="What's Good Here" />
+        <Seal size={96} variant="icon" ariaLabel="What's Good Here" />
       </div>
 
       {/* Heading */}

--- a/src/pages/Support.jsx
+++ b/src/pages/Support.jsx
@@ -30,7 +30,7 @@ export function Support() {
       {/* Content */}
       <div className="max-w-2xl mx-auto px-4 py-8">
         <div className="flex justify-center mb-6">
-          <Seal size={96} ariaLabel="What's Good Here" />
+          <Seal size={96} variant="icon" ariaLabel="What's Good Here" />
         </div>
         <div className="rounded-2xl p-6 space-y-6" style={{ background: 'var(--color-surface-elevated)', border: '1px solid var(--color-divider)' }}>
           <section>

--- a/src/pages/Terms.jsx
+++ b/src/pages/Terms.jsx
@@ -30,7 +30,7 @@ export function Terms() {
       {/* Content */}
       <div className="max-w-2xl mx-auto px-4 py-8">
         <div className="flex justify-center mb-6">
-          <Seal size={96} ariaLabel="What's Good Here" />
+          <Seal size={96} variant="icon" ariaLabel="What's Good Here" />
         </div>
         <div className="rounded-2xl p-6 space-y-6" style={{ background: 'var(--color-surface-elevated)', border: '1px solid var(--color-divider)' }}>
           <p className="text-sm" style={{ color: 'var(--color-text-tertiary)' }}>Last updated: April 18, 2026</p>

--- a/src/pages/Waitlist.jsx
+++ b/src/pages/Waitlist.jsx
@@ -68,7 +68,7 @@ export default function Waitlist() {
         style={{ maxWidth: '560px', margin: '0 auto', width: '100%' }}
       >
         <div className="mb-8">
-          <Seal size={88} ariaLabel="What's Good Here" />
+          <Seal size={88} variant="icon" ariaLabel="What's Good Here" />
         </div>
 
         <h1


### PR DESCRIPTION
## Summary
Every in-app brand mark now uses the same look as the iOS launcher icon — coral square BG + cream plate + coral inner-rim line + coral italic "wgh" with the -8° tilt. Only \`LocalsPicksBanner\` was using it before; everywhere else defaulted to \`monogram\` (the inverse — coral disc with cream wgh), which is the visual fork Dan flagged.

## What changed
11 \`<Seal>\` call sites switched to \`variant="icon"\`:
- TopBar (replaces a hand-rolled "icon-but-not-quite" override)
- WelcomeSplash (drops three legacy ring/border overrides)
- WelcomeModal (two places — main logo + welcome-step icon)
- Privacy / Terms / Support / ResetPassword / Waitlist
- Login (two places)

\`LocalsPicksBanner\` already had \`variant="icon"\` and is unchanged. The Seal component itself wasn't touched.

## Codex review applied
Codex caught that switching TopBar to plain \`variant="icon"\` shrinks the plate ~12% at \`size=36\` (the icon variant's viewBox grows from \`12 12 176 176\` to \`0 0 200 200\` to make room for the square BG, but the square is invisible against the coral header). Fixed in commit 3 by passing \`showBackground={false} showRim={false}\` on TopBar only — keeps the launcher colors, restores the original plate size for the 36px tight slot. Other call sites are 64–160px and have headroom for the full launcher treatment, so they're untouched.

## Tiny side cleanup (commit 2)
The first commit accidentally checked in a \`src/.claude/scheduled_tasks.lock\` Claude session-state file because the existing gitignore pattern was top-level only. Commit 2 untracks the file and tightens the rule to \`**/.claude/\` so it matches at any depth.

## Verification
- \`npm run build\` ✅ (all three commits)
- Codex review: 1 change-X applied (TopBar size), 4 ship-as-is

## Test plan
- [ ] Open the app → TopBar logo size matches what it was before (no shrink), but the plate now has cream BG + coral wgh instead of coral disc + cream wgh
- [ ] Welcome splash, login, privacy, terms, support, reset, waitlist, welcome modal → all show the full launcher-icon look (coral square + cream plate + inner rim + coral wgh)
- [ ] Compare any of these side-by-side with your iOS home-screen app icon — should look like the same mark at a different size

🤖 Generated with [Claude Code](https://claude.com/claude-code)