### PR TITLE
fix(profile): stale follow count after following from another user's page

### DIFF
--- a/src/hooks/useFollowUser.js
+++ b/src/hooks/useFollowUser.js
@@ -1,0 +1,32 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { followsApi } from '../api/followsApi'
+
+/**
+ * follow/unfollow mutations that invalidate the followCounts cache for BOTH
+ * sides of the relationship. Without this, following someone on UserProfile
+ * leaves your own /profile page showing a stale count until you hard-refresh.
+ *
+ * Callers should still drive their own optimistic UI updates for the
+ * displayed profile's follower_count (that state lives in component state,
+ * not React Query). This hook handles the React Query layer only.
+ */
+export function useFollowUser() {
+  const qc = useQueryClient()
+
+  const invalidateFollowCounts = () => {
+    // Prefix match: invalidates ['followCounts', currentUserId] AND
+    // ['followCounts', targetUserId] without needing either id in scope.
+    qc.invalidateQueries({ queryKey: ['followCounts'] })
+  }
+
+  return {
+    follow: useMutation({
+      mutationFn: (targetUserId) => followsApi.follow(targetUserId),
+      onSuccess: invalidateFollowCounts,
+    }),
+    unfollow: useMutation({
+      mutationFn: (targetUserId) => followsApi.unfollow(targetUserId),
+      onSuccess: invalidateFollowCounts,
+    }),
+  }
+}

--- a/src/pages/UserProfile.jsx
+++ b/src/pages/UserProfile.jsx
@@ -5,6 +5,7 @@ import { useAuth } from '../context/AuthContext'
 import { logger } from '../utils/logger'
 import { getCompatColor } from '../utils/formatters'
 import { followsApi } from '../api/followsApi'
+import { useFollowUser } from '../hooks/useFollowUser'
 import { votesApi } from '../api/votesApi'
 import { FollowListModal } from '../components/FollowListModal'
 import { ProfileSkeleton } from '../components/Skeleton'
@@ -81,6 +82,7 @@ export function UserProfile() {
   useDocumentTitle(profile?.display_name ? `@${profile.display_name}` : null)
 
   const [followLoading, setFollowLoading] = useState(false)
+  const { follow: followMutation, unfollow: unfollowMutation } = useFollowUser()
   const [followListModal, setFollowListModal] = useState(null) // 'followers' | 'following' | null
   const [myRatings, setMyRatings] = useState({}) // { dishId: rating }
   const [userReviews, setUserReviews] = useState([])
@@ -324,10 +326,13 @@ export function UserProfile() {
 
     setFollowLoading(true)
     try {
+      // mutateAsync routes through useFollowUser so React Query invalidates
+      // ['followCounts'] on success — keeps your own /profile count fresh
+      // after following from somebody else's UserProfile page.
       if (wasFollowing) {
-        await followsApi.unfollow(userId)
+        await unfollowMutation.mutateAsync(userId)
       } else {
-        await followsApi.follow(userId)
+        await followMutation.mutateAsync(userId)
       }
     } catch (error) {
       logger.error('Failed to toggle follow:', error)


### PR DESCRIPTION
## Summary

Real bug Dan caught tonight: followed 2 people, /profile still showed 5 instead of 7 until hard refresh.

Root cause: `Profile.jsx` queries followCounts via React Query key `['followCounts', user?.id]`. `UserProfile.jsx` called `followsApi.follow/unfollow` directly, never invalidating that key.

Root fix (not a one-line patch at the call site): new `useFollowUser` hook wraps follow/unfollow as TanStack mutations; `onSuccess` invalidates the `['followCounts']` prefix (catches both your-following-count AND target user's-follower-count without needing either id in scope). UserProfile is the only current caller; future follow buttons get correct invalidation for free.

## Codex review (gpt-5.3-codex / high)

Confirmed:
- Prefix invalidation is right
- No race between local optimistic state and refetch (different layers)
- mutateAsync rollback in catch works correctly
- Keep follow/unfollow as separate mutations

Flagged a pre-existing optimistic-drift bug (rapid double-click) — out of scope, button already disables on `followLoading`.

## Test plan

- [x] `npm run build` passes
- [ ] Manual: follow someone from their profile → return to own /profile → count is correct (was the original repro)
- [ ] Unfollow same person → count decrements correctly
- [ ] Both followers and following counts on the target user's profile also stay correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)