### PR TITLE
fix(user-profile): include avatar_url in getUserProfile select

### DIFF
--- a/src/api/followsApi.js
+++ b/src/api/followsApi.js
@@ -348,7 +348,7 @@ export const followsApi = {
       // deleted user returns null cleanly instead of an unhandled PGRST116.
       supabase
         .from('profiles')
-        .select('id, display_name, created_at')
+        .select('id, display_name, avatar_url, created_at')
         .eq('id', userId)
         .maybeSingle(),
       // 2. Get follower count


### PR DESCRIPTION
## Summary

Real bug Dan caught tonight: Zack has an avatar, shows correctly in the Followers list modal but his /user/:userId page shows the orange-Z initial fallback.

One-line cause: `followsApi.getUserProfile` SELECT was missing `avatar_url`. Followers list uses a different SELECT that already included it. PR #194 ("avatar_url everywhere Phase 2") missed this code path.

UserProfile.jsx already renders `profile.avatar_url` at line 579 — component side was right, data side wasn't sending it.

## Codex audit (gpt-5.3-codex / high)

Reviewed the one-line fix + all ~11 other `from('profiles')` call sites across src/api. No other sibling holes:
- votesApi smart snippet path is intentionally text-only (no avatar rendered)
- authApi uses are username checks / updates, not avatar paths
- profileApi uses `select('*')` so it's always covered

RLS risk: none (column-level addition doesn't broaden row access).

## Test plan

- [ ] Visit a user profile of someone with an avatar — photo shows instead of initial fallback
- [ ] Visit a user profile of someone without an avatar — initial fallback still works (unchanged path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)