### PR TITLE
fix(menu-refresh): promote neutral-score image on menu pages with no candidates

### DIFF
--- a/supabase/functions/menu-refresh/menu-candidates.test.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.test.ts
@@ -191,6 +191,66 @@ describe('discoverMenuCandidates', () => {
     const out = discoverMenuCandidates(html, 'https://x.com/')
     expect(out.map(c => c.url)).toEqual([])
   })
+
+  // Menu-context fallback for neutral-score images (Port Hunter case)
+  it('promotes neutral-score image when on /menu page and no scored image exists', () => {
+    const html = '<img src="https://cdn.x.com/Screen+Shot+2025-05-20.png">'
+    const out = discoverMenuCandidates(html, 'https://x.com/menu')
+    expect(out).toHaveLength(1)
+    expect(out[0].url).toBe('https://cdn.x.com/Screen+Shot+2025-05-20.png')
+    expect(out[0].score).toBe(0)
+  })
+
+  it('does NOT promote neutral-score image when NOT on a menu page', () => {
+    const html = '<img src="https://cdn.x.com/Screen+Shot+2025-05-20.png">'
+    const out = discoverMenuCandidates(html, 'https://x.com/about')
+    expect(out).toEqual([])
+  })
+
+  it('does NOT promote any image when one ALREADY scored above zero', () => {
+    const html = `
+      <img src="https://cdn.x.com/dinner-menu.png">
+      <img src="https://cdn.x.com/Screen+Shot+2025-05-20.png">
+    `
+    const out = discoverMenuCandidates(html, 'https://x.com/menu')
+    expect(out.map(c => c.url)).toEqual(['https://cdn.x.com/dinner-menu.png'])
+  })
+
+  it('promotes only the TOP neutral image, not multiples (caps vision budget)', () => {
+    const html = `
+      <img src="https://cdn.x.com/photo1.jpg">
+      <img src="https://cdn.x.com/photo2.jpg">
+      <img src="https://cdn.x.com/photo3.jpg">
+    `
+    const out = discoverMenuCandidates(html, 'https://x.com/menu')
+    expect(out).toHaveLength(1)
+    expect(out[0].url).toBe('https://cdn.x.com/photo1.jpg')
+  })
+
+  it('negative-keyword image (logo) is NOT promoted by the fallback', () => {
+    const html = '<img src="https://cdn.x.com/site-logo.png">'
+    const out = discoverMenuCandidates(html, 'https://x.com/menu')
+    expect(out).toEqual([])
+  })
+
+  it('cancellation-to-zero image (positive + negative) is NOT promoted', () => {
+    // 'menu' (+5) + 'food' (+3) + 'giftcards' (-8) = 0 BUT a negative keyword
+    // fired. Don't promote — it's a gift card menu image, not a food menu.
+    const html = '<img src="https://cdn.x.com/menu-food-giftcards.png">'
+    const out = discoverMenuCandidates(html, 'https://x.com/menu')
+    expect(out).toEqual([])
+  })
+
+  it('does NOT fire neutral-image fallback when ANY PDF candidate exists', () => {
+    // PDF is cheaper per token and more likely the actual menu. Leave the
+    // image alone — extractor will fall through to text/sub-page if PDF fails.
+    const html = `
+      <a href="/uploads/menu-83fa.pdf">Menu</a>
+      <img src="https://cdn.x.com/Screen+Shot.png">
+    `
+    const out = discoverMenuCandidates(html, 'https://x.com/menu')
+    expect(out.map(c => c.url)).toEqual(['https://x.com/uploads/menu-83fa.pdf'])
+  })
 })
 
 describe('findSubMenuPages', () => {

--- a/supabase/functions/menu-refresh/menu-candidates.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.ts
@@ -107,9 +107,10 @@ function normalize(s: string): string {
   return safeDecode(s).replace(/_/g, ' ')
 }
 
-export function scoreCandidate(url: string, context: string = ''): { score: number; evidence: string } {
+export function scoreCandidate(url: string, context: string = ''): { score: number; evidence: string; hasNegative: boolean } {
   const decoded = `${normalize(url)} ${normalize(context)}`
   let score = 0
+  let hasNegative = false
   const hits: string[] = []
   for (const { pattern, weight } of POSITIVE_KEYWORDS) {
     if (pattern.test(decoded)) {
@@ -120,10 +121,11 @@ export function scoreCandidate(url: string, context: string = ''): { score: numb
   for (const { pattern, weight } of NEGATIVE_KEYWORDS) {
     if (pattern.test(decoded)) {
       score += weight
+      hasNegative = true
       hits.push(`${weight}:${pattern.source}`)
     }
   }
-  return { score, evidence: hits.join(' ') }
+  return { score, evidence: hits.join(' '), hasNegative }
 }
 
 interface RawMatch {
@@ -325,19 +327,55 @@ export function findSubMenuPages(html: string, baseUrl: string, max = 4): string
  * - Images require score > 0 (vision is per-pixel-token expensive; without a real
  *   menu signal we'd burn budget on logos/heroes/galleries).
  *
+ * Menu-context fallback (last resort): if the base URL pathname is clearly a
+ * menu page (matches SUB_MENU_PATH_PATTERNS) AND no image cleared the > 0
+ * threshold, promote the top neutral-score image (score === 0, no negative
+ * keywords). Catches restaurants who upload their menu as a screenshot to
+ * Squarespace/Wix with a generic filename like `Screen+Shot+2025-05-20.png`
+ * that has no menu keyword for the scorer to latch onto. Capped to the single
+ * top neutral image so we don't burn vision budget on gallery pages.
+ *
  * Caller decides per-type caps.
  */
 export function discoverMenuCandidates(html: string, baseUrl: string): MenuCandidate[] {
   const raw = extractRawMatches(html, baseUrl)
   const candidates: MenuCandidate[] = []
+  const neutralImages: MenuCandidate[] = []
   for (const r of raw) {
     const type = classifyType(r.url)
     if (!type) continue
-    const { score, evidence } = scoreCandidate(r.url, r.context)
+    const { score, evidence, hasNegative } = scoreCandidate(r.url, r.context)
     const passes = type === 'pdf' ? score >= 0 : score > 0
-    if (!passes) continue
-    candidates.push({ url: r.url, type, score, source: r.source, evidence })
+    if (passes) {
+      candidates.push({ url: r.url, type, score, source: r.source, evidence })
+    } else if (type === 'image' && score === 0 && !hasNegative) {
+      // Truly unsignaled image (no positive keywords AND no negative keywords
+      // matched). Eligible for the menu-context fallback below. Explicit
+      // hasNegative check matters because score === 0 could also come from
+      // positive+negative cancellation (menu+giftcards = +5-8 = -3 nope,
+      // but menu+food+giftcards = +5+3-8 = 0 — we DO NOT want to try those).
+      neutralImages.push({ url: r.url, type, score, source: r.source, evidence })
+    }
   }
+
+  // Only fire fallback when there are NO other candidates of any type. If a
+  // scored image or even a score-0 PDF exists, prefer those — they're either
+  // higher-confidence (scored image) or cheaper per token (PDF). We don't
+  // want to slot a vision-mode neutral image ahead of a real candidate on
+  // tie-break inside tryAssetExtraction.
+  if (candidates.length === 0 && neutralImages.length > 0) {
+    try {
+      const basePath = new URL(baseUrl).pathname
+      if (SUB_MENU_PATH_PATTERNS.some(p => p.test(basePath))) {
+        // Top neutral in extractor order (anchors → imgs → generic attrs).
+        // Don't burn vision budget on gallery pages — single image only.
+        candidates.push(neutralImages[0])
+      }
+    } catch {
+      // Bad baseUrl — skip the fallback rather than crash.
+    }
+  }
+
   // Sort by score desc; for tie-breaks (e.g. multiple score-0 PDFs) preserve order.
   candidates.sort((a, b) => b.score - a.score)
   return candidates


### PR DESCRIPTION
## Summary

Port Hunter (and any other Squarespace/Wix restaurant uploading their menu as a screenshot like \`Screen+Shot+2025-05-20.png\`) was dead-lettering forever. Image scores 0 in candidate discovery — no \"menu\"/\"dinner\"/\"lunch\" keyword in the URL or anchor context — and image threshold is strict (\`score > 0\`) because vision is expensive.

Fix: on a menu-context URL (\`/menu\`, \`/lunch\`, \`/dinner\`, \`/brunch\`, \`/breakfast\`) with NO other candidates, promote the top neutral-score image as last resort. Tightly gated.

## Codex (gpt-5.3-codex / high)

Caught 2 MEDIUMs in v1, both applied:
- \`score === 0\` could come from positive+negative cancellation (\`menu+food+giftcards\` = 0). Added \`hasNegative\` to \`scoreCandidate\` return so the fallback can require both score 0 AND no negative match.
- Original \`!hasMenuImage\` check would let the fallback image steal priority from a score-0 PDF via the extractor's \`tryImagesFirst\` tiebreak. Tightened to \`candidates.length === 0\` — fallback only fires when nothing else exists.

## Test plan

- [x] 54 menu-candidates tests pass (47 existing + 7 new)
- [ ] Deploy edge function + re-trigger Port Hunter → expect dishes_found > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)