### PR TITLE
fix(home): ice cream chalkboard routes to category, not single dish

### DIFF
--- a/src/components/home/HomeListMode.jsx
+++ b/src/components/home/HomeListMode.jsx
@@ -345,7 +345,7 @@ function ChalkboardSection({ topRestaurant, mostVotedDish, bestValueMeal, bestIc
           sub={bestIceCream.restaurant_name}
           stat={(bestIceCream.total_votes || 0) + ' votes \u00B7 rated ' + Number(bestIceCream.avg_rating || 0).toFixed(1)}
           cta={'best ice cream \u2192'}
-          onClick={function () { navigate('/dish/' + bestIceCream.dish_id) }}
+          onClick={function () { onExpandCategory('ice cream') }}
           bottomIcon="/categories/icons/ice-cream-melting.png"
         />
       )}


### PR DESCRIPTION
## Summary

Real bug Dan caught tonight: Board 6 chalkboard's CTA is "best ice cream →" (plural — "show me the options") but onClick routes to ONE specific dish. Mismatch.

Fix: one-line change to use the existing `onExpandCategory` prop, matching the pattern Board 1 (time-of-day) and Board 3 (Chowder) already use.

## Codex review (gpt-5.3-codex / high)

- Confirmed `ice cream` is the canonical category id (src/constants/categories.js, src/pages/Map.jsx)
- `onExpandCategory` shape matches Chowder's
- No surprise side effects — same expand+scroll behaviour as every other category trigger

Flagged a pre-existing quirk: `bestIceCream` candidate pool includes dessert items, but the destination tab is strict `ice cream` only. Not introduced by this fix, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)