### PR TITLE
feat(home): swap text wordmark for bare coral wgh PNG on homepage

### DIFF
--- a/src/components/home/HomeListMode.jsx
+++ b/src/components/home/HomeListMode.jsx
@@ -59,26 +59,24 @@ export const HomeListMode = memo(function HomeListMode({
     >
       {/* Fixed header: brand + search + chips */}
       <div style={{ flexShrink: 0, background: 'var(--color-bg)', zIndex: 10, paddingTop: 'env(safe-area-inset-top, 0px)' }}>
-        {/* Brand header */}
+        {/* Brand header — coral wgh wordmark (no plate, no square: confidence
+            to let the mark stand on its own). PNG is 1600×640 (≈2.5:1
+            aspect); width controls the visual size. Map page already has an
+            <h1 className="sr-only">What's Good Here</h1> so the screen-reader
+            label here is the alt text. */}
         <div className="text-center pt-4 pb-1">
-          <h2 style={{
-            fontFamily: "'Amatic SC', cursive",
-            fontSize: '42px',
-            fontWeight: 700,
-            color: 'var(--color-text-primary)',
-            letterSpacing: '0.04em',
-            lineHeight: 1,
-            margin: 0,
-          }}>
-            What's <span style={{ color: 'var(--color-primary)' }}>Good</span> Here
-          </h2>
+          <img
+            src="/wgh-mark-coral.png"
+            alt="What's Good Here"
+            style={{ display: 'block', margin: '0 auto', width: '180px', height: 'auto' }}
+          />
           <p style={{
             fontSize: '10px',
             fontWeight: 600,
             color: '#999',
             letterSpacing: '0.15em',
             textTransform: 'uppercase',
-            margin: '5px 0 0',
+            margin: '8px 0 0',
           }}>
             Top-rated dishes near you
           </p>


### PR DESCRIPTION
## Summary

Web-only preview of the v1.2 homepage wordmark idea — replaces the Amatic SC text \"What's Good Here\" H2 with the bare coral \`wgh\` PNG, no plate or square frame (those created a bullseye effect in mockups).

Shipping to web only; iOS catches it in v1.2 since v1.1 is already in Apple review. Easy revert if Dan doesn't like it in real device viewing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)