### PR TITLE
fix(follow-list): convert modal to bottom sheet so long lists scroll

### DIFF
--- a/src/components/FollowListModal.jsx
+++ b/src/components/FollowListModal.jsx
@@ -74,34 +74,39 @@ export function FollowListModal({ userId, type, onClose }) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      className="fixed inset-0 z-50"
       onClick={onClose}
       role="presentation"
     >
       {/* Backdrop */}
       <div className="absolute inset-0" style={{ background: 'rgba(0,0,0,0.6)' }} aria-hidden="true" />
 
-      {/* Modal */}
+      {/* Bottom sheet */}
       <div
         ref={modalRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="follow-list-title"
-        className="relative w-full max-w-md rounded-2xl overflow-hidden flex flex-col border"
+        className="absolute left-0 right-0 bottom-0 rounded-t-2xl flex flex-col"
         style={{
           background: 'var(--color-surface-elevated)',
-          maxHeight: 'calc(100vh - 120px)',
-          borderColor: 'var(--color-divider)',
-          boxShadow: 'none'
+          maxHeight: '85vh',
+          paddingBottom: 'env(safe-area-inset-bottom, 0px)',
         }}
         onClick={(e) => e.stopPropagation()}
       >
+        {/* Grabber */}
+        <div
+          style={{ width: 40, height: 4, background: 'var(--color-divider)', borderRadius: 2, margin: '8px auto 4px', flex: '0 0 auto' }}
+          aria-hidden="true"
+        />
+
         {/* Header */}
         <div
-          className="flex items-center justify-between px-4 py-4 border-b"
+          className="flex items-center justify-between px-4 py-3 border-b"
           style={{
             borderColor: 'var(--color-divider)',
-            background: 'var(--color-primary-muted)'
+            flex: '0 0 auto',
           }}
         >
           <h2 id="follow-list-title" className="text-lg font-bold" style={{ color: 'var(--color-text-primary)' }}>
@@ -119,8 +124,17 @@ export function FollowListModal({ userId, type, onClose }) {
           </button>
         </div>
 
-        {/* Content */}
-        <div className="flex-1 overflow-y-auto">
+        {/* Scrollable body */}
+        <div
+          style={{
+            flex: '1 1 auto',
+            minHeight: 0,
+            overflowY: 'auto',
+            WebkitOverflowScrolling: 'touch',
+            overscrollBehavior: 'contain',
+            touchAction: 'pan-y',
+          }}
+        >
           {loading ? (
             <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
               <div


### PR DESCRIPTION
## Summary

- Followers / Following modal couldn't scroll past ~one screen on iOS — same iOS Capacitor WebView issue that previously bit `AddToPlaylistSheet`.
- Converts the centered modal to the canonical bottom-sheet pattern: bottom-pinned, grabber, fixed header + dedicated scroll body with `minHeight: 0`, `WebkitOverflowScrolling: 'touch'`, `overscrollBehavior: 'contain'`, `touchAction: 'pan-y'`, and `env(safe-area-inset-bottom)` padding.
- Caps height at 85vh so the backdrop stays visible behind the sheet.

## Review trail

Reviewed in parallel by three review agents (reuse / quality / efficiency) plus codex CLI (gpt-5.3-codex, medium reasoning). Single fix surfaced and applied: removed a dead `onKeyDown` Escape handler on the `role="presentation"` wrapper (presentation divs aren't focusable; `useFocusTrap(true, onClose)` already handles Escape inside the modal).

## Out of scope (pre-existing, flagged for follow-up)

- `useEffect` + manual `fetch` instead of `useInfiniteQuery` — violates CLAUDE.md §1.4. Predates this PR.
- No `AbortController` on the in-flight fetch — rapid open/close can race two requests.
- Same bottom-sheet shell now duplicated across `AddToPlaylistSheet`, `AddDishSearchSheet`, `CreatePlaylistModal`, `JitterExplainer`, and this file. Only two of those carry the iOS scroll fix; a shared `BottomSheet` primitive would unify them and inoculate the others. Separate refactor PR.

## Test plan

- [ ] Open someone's profile with 10+ follows in followers/following list — confirm bottom sheet appears anchored to bottom with rounded top corners.
- [ ] Scroll the list to the bottom — confirm scrolling works smoothly on iOS Capacitor build.
- [ ] Tap a user row — confirm navigation to `/user/:id` and modal closes.
- [ ] Tap backdrop above the sheet — confirm modal closes.
- [ ] Tap the X button — confirm modal closes.
- [ ] Open on a profile with 0 follows — confirm empty state still renders ("No followers yet" / "Not following anyone yet").
- [ ] Open on a profile with enough follows to trigger pagination — confirm "Load More" button appears and works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)