### PR TITLE
feat(nudge): post-rating photo nudge for logged-in users without an avatar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,6 +316,7 @@ Defined in `src/index.css`. Light theme only ("Appetite"). Use `var(--color-*)` 
 | `whats-good-here-auth` | (Supabase SDK) | Supabase auth session |
 | `whats-good-here-location-permission` | `LOCATION_PERMISSION` | Geolocation permission state |
 | `whats-good-here-email` | `EMAIL_CACHE` | Cached email for auth |
+| `wgh_has_seen_photo_nudge` | `HAS_SEEN_PHOTO_NUDGE` | Post-rating profile-photo nudge has been shown |
 
 ### 4.10 All Hooks (check before building new ones)
 | Hook | Purpose |

--- a/src/components/AddPhotoNudge.jsx
+++ b/src/components/AddPhotoNudge.jsx
@@ -1,0 +1,170 @@
+import { useState, useRef } from 'react'
+import { toast } from 'sonner'
+import { profileApi } from '../api/profileApi'
+import { setStorageItem, STORAGE_KEYS } from '../lib/storage'
+import { logger } from '../utils/logger'
+import { useFocusTrap } from '../hooks/useFocusTrap'
+
+// Soft nudge shown to logged-in users without an avatar after a successful
+// rating. Identity scaffolding, not anti-bot gating — motivated bots can
+// always grab a generated face. Any close path (backdrop click, Escape,
+// "Maybe later", successful upload) marks HAS_SEEN_PHOTO_NUDGE so the
+// sheet never reappears.
+export function AddPhotoNudge({ isOpen, onClose, onUploaded }) {
+  const [uploading, setUploading] = useState(false)
+  const fileInputRef = useRef(null)
+
+  // Single close path: always mark-seen, then notify parent. Escape via
+  // useFocusTrap routes through this too, so keyboard users get the same
+  // "dismiss = never reappear" behavior as touch/click.
+  const closeAndMarkSeen = () => {
+    if (uploading) return
+    setStorageItem(STORAGE_KEYS.HAS_SEEN_PHOTO_NUDGE, '1')
+    onClose()
+  }
+
+  const modalRef = useFocusTrap(isOpen, closeAndMarkSeen)
+
+  const handlePick = () => {
+    if (uploading) return
+    fileInputRef.current?.click()
+  }
+
+  const handleFile = async (e) => {
+    const file = e.target.files?.[0]
+    e.target.value = ''
+    if (!file) return
+    setUploading(true)
+    try {
+      await profileApi.uploadAvatar(file)
+      setStorageItem(STORAGE_KEYS.HAS_SEEN_PHOTO_NUDGE, '1')
+      toast.success('Looking good.')
+      onUploaded?.()
+      onClose()
+    } catch (error) {
+      logger.error('Avatar upload from nudge failed:', error)
+      toast.error(error?.message || "Couldn't upload your photo.")
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50"
+      onClick={closeAndMarkSeen}
+      role="presentation"
+    >
+      <div className="absolute inset-0" style={{ background: 'rgba(0,0,0,0.6)' }} aria-hidden="true" />
+
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-photo-nudge-title"
+        className="absolute left-0 right-0 bottom-0 rounded-t-2xl flex flex-col"
+        style={{
+          background: 'var(--color-surface-elevated)',
+          maxHeight: '85vh',
+          paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div
+          style={{ width: 40, height: 4, background: 'var(--color-divider)', borderRadius: 2, margin: '8px auto 4px', flex: '0 0 auto' }}
+          aria-hidden="true"
+        />
+
+        <div
+          className="px-6 pt-2 pb-6 text-center"
+          style={{
+            flex: '1 1 auto',
+            minHeight: 0,
+            overflowY: 'auto',
+            WebkitOverflowScrolling: 'touch',
+            overscrollBehavior: 'contain',
+            touchAction: 'pan-y',
+          }}
+        >
+          <div
+            className="w-16 h-16 mx-auto rounded-full flex items-center justify-center mb-4"
+            style={{ background: 'var(--color-primary-muted)' }}
+            aria-hidden="true"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={1.8}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="w-8 h-8"
+              style={{ color: 'var(--color-primary)' }}
+            >
+              <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
+              <circle cx="12" cy="13" r="4" />
+            </svg>
+          </div>
+
+          <h2
+            id="add-photo-nudge-title"
+            style={{
+              fontFamily: "'Amatic SC', cursive",
+              fontSize: '40px',
+              color: 'var(--color-text-primary)',
+              lineHeight: 1,
+              marginBottom: 8,
+            }}
+          >
+            You&apos;re a real one.
+          </h2>
+          <p className="text-base px-2" style={{ color: 'var(--color-text-secondary)', marginBottom: 24 }}>
+            Add a face so people know who you are. Profiles with photos get followed more.
+          </p>
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/webp,image/heic"
+            onChange={handleFile}
+            style={{ display: 'none' }}
+            aria-hidden="true"
+          />
+
+          <button
+            type="button"
+            onClick={handlePick}
+            disabled={uploading}
+            className="w-full rounded-2xl py-3.5 font-bold mb-2"
+            style={{
+              background: 'var(--color-primary)',
+              color: 'var(--color-text-on-primary)',
+              opacity: uploading ? 0.7 : 1,
+            }}
+          >
+            {uploading ? 'Uploading…' : 'Add a photo'}
+          </button>
+
+          <button
+            type="button"
+            onClick={closeAndMarkSeen}
+            disabled={uploading}
+            className="w-full py-2 font-medium"
+            style={{
+              background: 'transparent',
+              color: 'var(--color-text-tertiary)',
+              fontSize: 14,
+            }}
+          >
+            Maybe later
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default AddPhotoNudge

--- a/src/components/ReviewFlow.jsx
+++ b/src/components/ReviewFlow.jsx
@@ -12,10 +12,14 @@ import { MAX_REVIEW_LENGTH } from '../constants/app'
 import {
   getPendingVoteFromStorage,
   clearPendingVoteStorage,
+  getStorageItem,
+  STORAGE_KEYS,
 } from '../lib/storage'
 import { logger } from '../utils/logger'
 import { hapticLight, hapticSuccess } from '../utils/haptics'
 import { PhotoUploadButton } from './PhotoUploadButton'
+import { AddPhotoNudge } from './AddPhotoNudge'
+import { useProfile } from '../hooks/useProfile'
 import { setBackButtonInterceptor, clearBackButtonInterceptor } from '../utils/backButtonInterceptor'
 import { validateUserContent } from '../lib/reviewBlocklist'
 
@@ -40,8 +44,11 @@ export function ReviewFlow({
   const navigate = useNavigate()
   const { user } = useAuth()
   const { submitVote, submitting } = useVote()
+  const { profile, refetch: refetchProfile } = useProfile(user?.id)
   const { getPurity, getJitterProfile, attachToTextarea, reset: resetPurity } = usePurityTracker()
   const jitterBoxRef = useRef(null)
+  const [photoNudgeOpen, setPhotoNudgeOpen] = useState(false)
+  const photoNudgeTimerRef = useRef(null)
 
   // Prior-vote state: used to prefill and to decide "Update" vs "Submit" label.
   const [priorRating, setPriorRating] = useState(null)
@@ -122,6 +129,14 @@ export function ReviewFlow({
       }
     }
   }, [reviewExpanded])
+
+  // Cancel pending photo-nudge timer on unmount so it doesn't fire into
+  // a torn-down component.
+  useEffect(() => {
+    return () => {
+      if (photoNudgeTimerRef.current) clearTimeout(photoNudgeTimerRef.current)
+    }
+  }, [])
 
   // Intercept browser back during unsaved drafts: prompt before leaving.
   useEffect(() => {
@@ -229,6 +244,15 @@ export function ReviewFlow({
     hapticSuccess()
     setAnnouncement('Rating saved')
     setTimeout(() => setAnnouncement(''), 1000)
+
+    // Identity scaffolding nudge: logged-in users without an avatar get one
+    // soft prompt to add a face after a successful rating. Delayed so the
+    // haptic + "Rating saved" announcement land first. The timer ref lets
+    // the unmount effect cancel a pending nudge if the user navigates away
+    // before it fires.
+    if (user && profile && !profile.avatar_url && !getStorageItem(STORAGE_KEYS.HAS_SEEN_PHOTO_NUDGE)) {
+      photoNudgeTimerRef.current = setTimeout(() => setPhotoNudgeOpen(true), 700)
+    }
 
     onVote?.()
   }
@@ -445,6 +469,12 @@ export function ReviewFlow({
           </svg>
         </button>
       )}
+
+      <AddPhotoNudge
+        isOpen={photoNudgeOpen}
+        onClose={() => setPhotoNudgeOpen(false)}
+        onUploaded={refetchProfile}
+      />
     </div>
   )
 }

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -163,6 +163,7 @@ export const STORAGE_KEYS = {
   LOCATION_PERMISSION: 'whats-good-here-location-permission',
   EMAIL_CACHE: 'whats-good-here-email',
   MAP_SELECTED_RESTAURANT: 'wgh_map_selected_restaurant', // sessionStorage — survives in-tab nav, cleared on tab close
+  HAS_SEEN_PHOTO_NUDGE: 'wgh_has_seen_photo_nudge',
 }
 
 // Pending vote storage helpers (survives OAuth redirect)

--- a/src/pages/RateYourMeal.jsx
+++ b/src/pages/RateYourMeal.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useAuth } from '../context/AuthContext'
@@ -14,6 +14,9 @@ import { LoginModal } from '../components/Auth/LoginModal'
 import { DishSelector, buildDishSections } from '../components/rate-meal/DishSelector'
 import { BatchRatingCard } from '../components/rate-meal/BatchRatingCard'
 import { BatchSummary } from '../components/rate-meal/BatchSummary'
+import { AddPhotoNudge } from '../components/AddPhotoNudge'
+import { useProfile } from '../hooks/useProfile'
+import { getStorageItem, STORAGE_KEYS } from '../lib/storage'
 
 function getDishClientId(dishId) {
   return 'dish-' + dishId
@@ -38,8 +41,11 @@ export function RateYourMeal() {
   var { user } = useAuth()
   var { location, radius } = useLocationContext()
   var { uploadPhoto, uploading, analyzing } = useDishPhotos()
+  var { profile, refetch: refetchProfile } = useProfile(user?.id)
 
   var [step, setStep] = useState('select')
+  var [photoNudgeOpen, setPhotoNudgeOpen] = useState(false)
+  var photoNudgeTimerRef = useRef(null)
   var [currentIndex, setCurrentIndex] = useState(0)
   var [searchQuery, setSearchQuery] = useState('')
   var [loginModalOpen, setLoginModalOpen] = useState(false)
@@ -67,6 +73,12 @@ export function RateYourMeal() {
       setLoginModalOpen(true)
     }
   }, [user])
+
+  useEffect(function () {
+    return function () {
+      if (photoNudgeTimerRef.current) clearTimeout(photoNudgeTimerRef.current)
+    }
+  }, [])
 
   var submitMutation = useMutation({
     mutationFn: async function () {
@@ -131,6 +143,10 @@ export function RateYourMeal() {
 
       queryClient.invalidateQueries({ queryKey: ['dishes'] })
       queryClient.invalidateQueries({ queryKey: ['restaurant', restaurantId] })
+
+      if (user && profile && !profile.avatar_url && !getStorageItem(STORAGE_KEYS.HAS_SEEN_PHOTO_NUDGE)) {
+        photoNudgeTimerRef.current = setTimeout(function () { setPhotoNudgeOpen(true) }, 700)
+      }
     },
     onError: function (error) {
       setUploadStatus('')
@@ -496,6 +512,11 @@ export function RateYourMeal() {
       <LoginModal
         isOpen={loginModalOpen}
         onClose={function () { setLoginModalOpen(false) }}
+      />
+      <AddPhotoNudge
+        isOpen={photoNudgeOpen}
+        onClose={function () { setPhotoNudgeOpen(false) }}
+        onUploaded={refetchProfile}
       />
     </>
   )


### PR DESCRIPTION
## Summary

- After a successful rating, logged-in users without a profile photo get a one-time soft nudge: bottom sheet with "Add a photo" and "Maybe later".
- "Add a photo" opens the file picker and uploads via the existing `profileApi.uploadAvatar` (same path as `HeroIdentityCard`). "Maybe later" dismisses.
- Every close path (backdrop, button, Escape, successful upload) marks `HAS_SEEN_PHOTO_NUDGE` so the sheet never reappears.
- Triggers from both single-vote (`ReviewFlow`) and batch-vote (`RateYourMeal`) success paths. 700ms delay so the haptic + "Rating saved" announcement land first.

## Framing

Identity scaffolding, not anti-bot gating. Motivated bots can grab generated faces. The real value is profiles feeling like real people — the actual product. The Jitter Protocol is the anti-bot layer.

## Review trail

Codex (gpt-5.3-codex, medium reasoning) caught and we fixed:
1. Escape via `useFocusTrap` bypassed mark-seen → routed Escape through the same `closeAndMarkSeen` handler as backdrop/button.
2. Untracked 700ms `setTimeout` could fire after unmount → tracked via `photoNudgeTimerRef`, cleared in unmount effect in both call sites.
3. Sheet had no inner scroll container → wrapped content with `flex: 1 1 auto`, `minHeight: 0`, `overflowY: 'auto'`, `WebkitOverflowScrolling: 'touch'`, `overscrollBehavior: 'contain'`, `touchAction: 'pan-y'` per the canonical pattern.

Second codex pass confirmed all three fixes closed out, no new issues.

## Out of scope (noted, not addressed here)

- `useProfile` 2-min cache means a narrow race where someone uploads an avatar elsewhere and then rates within 2 minutes could see the nudge once — they'd tap "Maybe later" and dismiss forever. Harmless edge case.
- `profileApi.uploadAvatar` doesn't route through the photo upload rate limiter. `HeroIdentityCard` doesn't either. Pre-existing pattern, separate concern.

## Test plan

- [ ] Log in as a user with no avatar, rate a dish on the Dish page — bottom sheet appears ~700ms after submit with "You're a real one." heading.
- [ ] Tap "Add a photo" → file picker opens → pick an image → upload completes → toast "Looking good." → sheet closes → profile avatar updates.
- [ ] Tap "Maybe later" → sheet closes → re-rate another dish → sheet does NOT reappear.
- [ ] Tap backdrop → sheet closes → re-rate → does NOT reappear.
- [ ] Press Escape (web/keyboard) → sheet closes → re-rate → does NOT reappear.
- [ ] Log in as a user WITH an avatar already → rate a dish → no nudge.
- [ ] Log out → rate via guest pending-vote flow → no nudge after login completes (only fires from inside ReviewFlow / RateYourMeal post-submit).
- [ ] Batch flow: rate multiple dishes via RateYourMeal → on success step, nudge appears once.
- [ ] Submit → quickly navigate away before 700ms → no warning in console (timer cleared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)