### PR TITLE
fix(profile): show real review count on identity card, separate from rhythm samples

### DIFF
--- a/src/components/TrustBadge.jsx
+++ b/src/components/TrustBadge.jsx
@@ -53,7 +53,7 @@ export function TrustBadge({ type, size = 'sm', profileData, warScore }) {
     },
     building: {
       label: 'Building trust',
-      blurb: 'Write a few more reviews to earn a Verified Human badge.',
+      blurb: 'Keep writing longer reviews so the typing rhythm signal can form — that’s what earns a Verified Human badge.',
       color: 'var(--color-text-tertiary)',
       bg: 'rgba(156, 163, 175, 0.12)',
     },

--- a/src/components/jitter/ProfileJitterCard.jsx
+++ b/src/components/jitter/ProfileJitterCard.jsx
@@ -63,7 +63,7 @@ export function ProfileJitterCard({ profile, user, userProfile, displayName, isP
 
         {/* Headline stats — friendly labels */}
         <div className={hasPrivateData ? 'grid grid-cols-3 gap-3 text-center mt-3' : 'grid grid-cols-2 gap-3 text-center mt-3'}>
-          <StatCell label="Reviews" value={profile.review_count || 0} />
+          <StatCell label="Verified" value={profile.review_count || 0} />
           <StatCell
             label="Rhythm"
             value={profile.consistency_score != null
@@ -138,17 +138,19 @@ function StatCell({ label, value }) {
 }
 
 // Plain-English status copy keyed to tier. Kept in sync with the matching
-// helper in HeroIdentityCard (used in the own-profile inline panel).
+// helper in HeroIdentityCard (used in the own-profile inline panel). Tier
+// thresholds count rhythm samples, not raw reviews — short reviews don't
+// emit enough keystrokes to build the signal.
 function getOwnerBlurb(profile) {
-  const reviews = profile?.review_count || 0
+  const rhythmSamples = profile?.review_count || 0
   const consistency = Number(profile?.consistency_score) || 0
-  if (reviews >= 15 && consistency >= 0.6) {
+  if (rhythmSamples >= 15 && consistency >= 0.6) {
     return 'You’re a Trusted Reviewer. Your votes carry extra weight in our rankings because your typing rhythm is steady and consistent.'
   }
-  if (reviews >= 5 && consistency >= 0.4) {
+  if (rhythmSamples >= 5 && consistency >= 0.4) {
     return 'You’re a Verified Human. Your reviews are confirmed to be typed by a real person. Keep writing to reach Trusted Reviewer status.'
   }
-  return 'You’re just getting started. Write a few more reviews and your typing rhythm will earn you a Verified Human badge.'
+  return 'You’re just getting started. Write longer reviews so your typing rhythm can be captured — once we have enough rhythm samples, you’ll earn a Verified Human badge.'
 }
 
 // Friendly rhythm label from consistency score

--- a/src/components/profile/HeroIdentityCard.jsx
+++ b/src/components/profile/HeroIdentityCard.jsx
@@ -274,7 +274,7 @@ export function HeroIdentityCard({
               </span>
               <div className="mt-1.5">
                 <div className="font-bold" style={{ color: 'var(--color-text-primary)', fontSize: '18px', lineHeight: 1 }}>
-                  {jitterProfile.review_count || 0}
+                  {stats?.reviewCount ?? 0}
                 </div>
                 <div style={{ color: 'var(--color-text-tertiary)', fontSize: '10px', marginTop: '2px' }}>reviews</div>
               </div>
@@ -328,19 +328,20 @@ export function HeroIdentityCard({
   )
 }
 
-// Plain-English status copy for the profile owner. Branches on review count
-// + consistency_score so a brand-new user doesn't see "you're verified" and
-// a long-time reviewer doesn't get told to "keep writing".
+// Plain-English status copy for the profile owner. Branches on rhythm-sample
+// count + consistency_score, not raw review count \u2014 short reviews don't
+// collect enough keystrokes to build a rhythm signal, so a user can write
+// many reviews and still be "Building" until their typing pattern emerges.
 function getOwnerBlurb(jitterProfile) {
-  var reviews = jitterProfile?.review_count || 0
+  var rhythmSamples = jitterProfile?.review_count || 0
   var consistency = Number(jitterProfile?.consistency_score) || 0
-  if (reviews >= 15 && consistency >= 0.6) {
+  if (rhythmSamples >= 15 && consistency >= 0.6) {
     return 'You\u2019re a Trusted Reviewer. Your votes carry extra weight in our rankings because your typing rhythm is steady and consistent.'
   }
-  if (reviews >= 5 && consistency >= 0.4) {
+  if (rhythmSamples >= 5 && consistency >= 0.4) {
     return 'You\u2019re a Verified Human. Your reviews are confirmed to be typed by a real person. Keep writing to reach Trusted Reviewer status.'
   }
-  return 'You\u2019re just getting started. Write a few more reviews and your typing rhythm will earn you a Verified Human badge.'
+  return 'You\u2019re just getting started. Write longer reviews so your typing rhythm can be captured \u2014 once we have enough rhythm samples, you\u2019ll earn a Verified Human badge.'
 }
 
 export default HeroIdentityCard

--- a/src/hooks/useUserVotes.js
+++ b/src/hooks/useUserVotes.js
@@ -152,6 +152,12 @@ function computeCategoryComparison(data, communityAvgs) {
 function calculateStats(data) {
   const totalVotes = data.length
 
+  // Real review count = votes that carried written review text. Distinct from
+  // jitter_profiles.review_count, which only increments when a review was
+  // long enough to emit a keystroke-rhythm sample. The two diverge for short
+  // reviews — see HeroIdentityCard for the user-facing split.
+  const reviewCount = data.filter(v => v.review_text && v.review_text.trim().length > 0).length
+
   // Average rating
   const ratingsWithValue = data.filter(v => v.rating_10 != null)
   const avgRating = ratingsWithValue.length > 0
@@ -228,6 +234,7 @@ function calculateStats(data) {
 
   return {
     totalVotes,
+    reviewCount,
     avgRating,
     ratingVariance,
     categoryConcentration,
@@ -245,6 +252,7 @@ function calculateStats(data) {
 
 const DEFAULT_STATS = {
   totalVotes: 0,
+  reviewCount: 0,
   avgRating: null,
   ratingVariance: 0,
   categoryConcentration: 0,


### PR DESCRIPTION
## The bug

Profile's identity card showed e.g. "1 reviews" for a user who wrote 5+ reviews. The number was reading `jitter_profiles.review_count` — which the SQL trigger increments on every `jitter_samples` insert, not every review. Short reviews don't collect enough keystrokes to emit a rhythm sample, so the count diverges from the real review total.

## What changed

**Two concepts, properly split:**

| Surface | Was | Now |
|---|---|---|
| HeroIdentityCard "reviews" number (own profile) | `jitterProfile.review_count` | `stats.reviewCount` (real count of votes with non-empty `review_text`) |
| HeroIdentityCard tier logic (Building/Verified/Trusted) | `jitterProfile.review_count` | unchanged — variable renamed to `rhythmSamples` for clarity |
| ProfileJitterCard "Reviews" StatCell (public view) | label="Reviews" | label="Verified" |
| ProfileJitterCard owner blurb | "write a few more reviews..." | "write longer reviews so your typing rhythm can be captured..." |
| HeroIdentityCard owner blurb | same stale copy | same fix |
| TrustBadge "Building trust" blurb | "write a few more reviews to earn..." | "keep writing longer reviews so the typing rhythm signal can form..." |
| TrustBadge "N verified review(s)" | unchanged — already accurate (rhythm-verified) |  |

`useUserVotes.calculateStats` now emits `reviewCount` alongside `totalVotes`.

## Review trail

Two codex passes (gpt-5.3-codex, medium reasoning):
- First pass caught two more surfaces with the same labeling bug (ProfileJitterCard, TrustBadge popover wording).
- Second pass caught the stale "Building trust" blurb on TrustBadge.
- All findings addressed.

## Test plan

- [ ] Log in as a user with 5+ reviews — confirm "X reviews" on profile now matches actual count.
- [ ] Confirm tier badge (Building / Verified / Trusted) still gates on rhythm samples, not raw reviews (a user with 10 short reviews can still be "Building").
- [ ] Open another user's profile — confirm the "Verified" StatCell shows the rhythm-verified count, label reads "Verified" not "Reviews".
- [ ] Hover/tap a "Building trust" badge on a review attribution — confirm the blurb now mentions typing rhythm, not just "more reviews".

🤖 Generated with [Claude Code](https://claude.com/claude-code)