### PR TITLE
feat(ios): expand Universal Links to cover all app-content routes

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -5,11 +5,31 @@
       {
         "appIDs": ["K447QTHBR9.com.whatsgoodhere.app"],
         "paths": [
+          "/",
+          "/dish/*",
+          "/restaurants",
+          "/restaurants/*",
+          "/user/*",
+          "/profile",
+          "/playlist/*",
+          "/locals",
+          "/locals/*",
+          "/my-list",
           "/auth/*",
           "/reset-password",
           "/reset-password/*"
         ],
         "components": [
+          { "/": "/", "comment": "Homepage (map + list dual mode) — open app" },
+          { "/": "/dish/*", "comment": "Dish detail — open app" },
+          { "/": "/restaurants", "comment": "Restaurants list — open app" },
+          { "/": "/restaurants/*", "comment": "Restaurant detail / rate / reviews — open app" },
+          { "/": "/user/*", "comment": "Public user profile — open app" },
+          { "/": "/profile", "comment": "Own profile — open app" },
+          { "/": "/playlist/*", "comment": "Playlist — open app" },
+          { "/": "/locals", "comment": "Locals lists hub — open app" },
+          { "/": "/locals/*", "comment": "Locals curator page — open app" },
+          { "/": "/my-list", "comment": "My list — open app" },
           { "/": "/auth/*", "comment": "Auth callbacks — open app" },
           { "/": "/reset-password", "comment": "Password reset — open app" },
           { "/": "/reset-password/*", "comment": "Password reset with query — open app" }


### PR DESCRIPTION
## Summary

Universal Links were scoped to `/auth/*` and `/reset-password*` only. Shared wghapp.com links and future QR codes for dish/restaurant/profile pages were opening in Safari even for users who had the native app installed.

Expanded the `apple-app-site-association` to include all primary app-content routes:

| Path | Why |
|---|---|
| `/` | Homepage (map + list dual mode) |
| `/dish/*` | Dish detail |
| `/restaurants`, `/restaurants/*` | List + detail + rate + reviews |
| `/user/*` | Public profile |
| `/profile` | Own profile |
| `/playlist/*` | Playlist |
| `/locals`, `/locals/*` | Locals lists hub + curator pages |
| `/my-list` | Personal list |

Excluded intentionally (marketing / legal / browser-friendly auth): `/privacy`, `/terms`, `/support`, `/for-restaurants`, `/how-reviews-work`, `/jitter`, `/waitlist`, `/login`, `/admin`, `/manage`, `/invite/*`, `/curator-invite/*`.

## No native rebuild needed

`ios/App/App/App.entitlements` already declares `applinks:wghapp.com`. The entitlements describe *what domains the app cares about*; this file describes *what paths on that domain trigger the app*. Only the second changed.

## Propagation

Apple's aASA CDN caches with 24-48h propagation. Once this merges and deploys to wghapp.com, users with the app installed will pick up the new paths on the next iOS refresh cycle. New installs get the latest immediately.

## Review trail

Reviewed by codex (gpt-5.3-codex). JSON syntax + appID format valid. Only flagged items were pre-existing entries this PR doesn't touch (a comment on `/reset-password/*` that mentions "query" but matches path segments — separate concern, leaving alone for small-focused-diff).

## Test plan

After 24-48h propagation:
- [ ] Send yourself a wghapp.com/dish/{id} link via iMessage — tap it → opens in the native app (not Safari).
- [ ] Same for /restaurants/{id}, /user/{id}, /profile, /playlist/{id}, /locals/{id}.
- [ ] Verify /privacy, /terms still open in Safari (intentionally web-first).
- [ ] On a device without the app installed — confirm all links still work in Safari as the PWA.
- [ ] After QR codes are built later: confirm they open the app via the same Universal Links plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)