### PR TITLE
feat(follow-list): redesigned followers/following modal — sticky search, infinite scroll, drag detents

### DIFF
--- a/docs/superpowers/plans/2026-05-16-follow-list-modal-redesign.md
+++ b/docs/superpowers/plans/2026-05-16-follow-list-modal-redesign.md
@@ -1,0 +1,1381 @@
+# Follow List Modal Redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the followers/following popup as a tall, gesture-driven bottom sheet with sticky server-side search, inline follow buttons, and smooth infinite scroll — backed by a new `search_user_follows` RPC and threaded through React Query.
+
+**Architecture:** New PL/pgSQL RPC for ranked, paginated search of a user's relationship. `followsApi` extended with `searchFollows` (routed via existing `getFollowers`/`getFollowing`) and `getFollowStatuses`. A new `useFollowList` hook centralizes React Query state for the modal. The modal itself is a full rewrite using `useInfiniteQuery`, `IntersectionObserver` rooted on the scroll container, and an extended `useFocusTrap` that accepts an `initialFocusRef`.
+
+**Tech Stack:** React 19, React Query v5 (`@tanstack/react-query`), Vitest, Vite, Tailwind (layout-only per CLAUDE.md §1.3), Supabase PL/pgSQL + PostgREST RPC, sonner (toasts).
+
+**Spec:** `docs/superpowers/specs/2026-05-16-follow-list-modal-redesign.md`
+
+**Standing rule per Dan:** Every task runs through `/codex-cli` before commit (`npx @openai/codex exec --skip-git-repo-check -m gpt-5.3-codex --config model_reasoning_effort="high" --sandbox read-only "review <files> for CLAUDE.md violations and bugs"`). Address any blockers/highs before committing.
+
+---
+
+## Task 1: Add `search_user_follows` RPC migration
+
+**Files:**
+- Create: `supabase/migrations/20260516_search_user_follows.sql`
+- Modify: `supabase/schema.sql` (append the same function definition)
+
+- [ ] **Step 1: Create the migration file**
+
+Create `supabase/migrations/20260516_search_user_follows.sql`:
+
+```sql
+-- search_user_follows: paginated alphabetical search of a user's
+-- followers or following list. Mirrors the hardening pattern in
+-- search_users_with_followers (input validation, limit clamp, security
+-- definer + locked search_path).
+--
+-- Returns (display_name, id) tuple-ordered rows for stable cursor pagination.
+
+CREATE OR REPLACE FUNCTION search_user_follows(
+  p_user_id UUID,
+  p_direction TEXT,
+  p_query TEXT,
+  p_cursor_name TEXT DEFAULT NULL,
+  p_cursor_id UUID DEFAULT NULL,
+  p_limit INT DEFAULT 20
+)
+RETURNS TABLE (
+  id UUID,
+  display_name TEXT,
+  avatar_url TEXT,
+  follower_count INT,
+  followed_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_limit INT := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 100);
+  v_query TEXT := NULLIF(TRIM(COALESCE(p_query, '')), '');
+BEGIN
+  IF p_direction NOT IN ('followers', 'following') THEN
+    RAISE EXCEPTION 'Invalid direction: %, must be followers or following', p_direction
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'p_user_id is required' USING ERRCODE = '22023';
+  END IF;
+
+  IF p_direction = 'followers' THEN
+    RETURN QUERY
+      SELECT p.id, p.display_name, p.avatar_url, p.follower_count,
+             f.created_at AS followed_at
+      FROM follows f
+      JOIN profiles p ON p.id = f.follower_id
+      WHERE f.followed_id = p_user_id
+        AND (v_query IS NULL OR p.display_name ILIKE '%' || v_query || '%')
+        AND (p_cursor_name IS NULL
+             OR (p.display_name, p.id) > (p_cursor_name, p_cursor_id))
+      ORDER BY p.display_name ASC, p.id ASC
+      LIMIT v_limit;
+  ELSE
+    RETURN QUERY
+      SELECT p.id, p.display_name, p.avatar_url, p.follower_count,
+             f.created_at AS followed_at
+      FROM follows f
+      JOIN profiles p ON p.id = f.followed_id
+      WHERE f.follower_id = p_user_id
+        AND (v_query IS NULL OR p.display_name ILIKE '%' || v_query || '%')
+        AND (p_cursor_name IS NULL
+             OR (p.display_name, p.id) > (p_cursor_name, p_cursor_id))
+      ORDER BY p.display_name ASC, p.id ASC
+      LIMIT v_limit;
+  END IF;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION search_user_follows(UUID, TEXT, TEXT, TEXT, UUID, INT) TO anon, authenticated;
+
+-- ROLLBACK:
+-- DROP FUNCTION IF EXISTS search_user_follows(UUID, TEXT, TEXT, TEXT, UUID, INT);
+```
+
+- [ ] **Step 2: Append same function to `supabase/schema.sql`**
+
+Use `Read` to find the section near the existing `search_users_with_followers` function (`grep -n "search_users_with_followers" supabase/schema.sql`). Append the `CREATE OR REPLACE FUNCTION search_user_follows(...)` block from Step 1 directly below it (without the `-- ROLLBACK:` comment — schema.sql holds canonical state, not history).
+
+- [ ] **Step 3: Run in Supabase SQL Editor**
+
+Open the Denis Supabase project dashboard → SQL Editor → paste the contents of `20260516_search_user_follows.sql` → Run. Expected: "Success. No rows returned."
+
+- [ ] **Step 4: Verify with a test call in SQL Editor**
+
+In the SQL Editor, run:
+
+```sql
+SELECT * FROM search_user_follows(
+  (SELECT id FROM profiles LIMIT 1),
+  'followers',
+  NULL,
+  NULL,
+  NULL,
+  5
+);
+```
+
+Expected: 0–5 rows or an empty result. **No error.** If the first profile has no followers, that's fine — confirms the function runs.
+
+Then test invalid direction:
+
+```sql
+SELECT * FROM search_user_follows(
+  '00000000-0000-0000-0000-000000000000',
+  'bogus',
+  NULL,
+  NULL,
+  NULL,
+  5
+);
+```
+
+Expected: ERROR `22023` "Invalid direction: bogus, must be followers or following".
+
+- [ ] **Step 5: Codex review**
+
+```bash
+npx @openai/codex exec --skip-git-repo-check -m gpt-5.3-codex --config model_reasoning_effort="high" --sandbox read-only "Review supabase/migrations/20260516_search_user_follows.sql for SQL bugs, planner concerns, missing validation, or differences from search_users_with_followers hardening." 2>/dev/null
+```
+
+Address blockers/highs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/20260516_search_user_follows.sql supabase/schema.sql
+git commit -m "feat(follows): add search_user_follows RPC for paginated relationship search"
+```
+
+---
+
+## Task 2: Extend `useFocusTrap` with `initialFocusRef` option
+
+**Files:**
+- Modify: `src/hooks/useFocusTrap.js`
+
+- [ ] **Step 1: Edit the hook signature and focus block**
+
+In `src/hooks/useFocusTrap.js`, update the hook signature and the focus effect. Read the file first, then apply this edit pattern to the relevant section (the `useEffect` near line 23):
+
+```js
+export function useFocusTrap(isOpen, onClose, { initialFocusRef } = {}) {
+  const containerRef = useRef(null)
+  const previousActiveElement = useRef(null)
+
+  // Store the previously focused element when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      previousActiveElement.current = document.activeElement
+    }
+  }, [isOpen])
+
+  // Focus initialFocusRef if provided, else first focusable element
+  useEffect(() => {
+    if (!isOpen || !containerRef.current) return
+
+    requestAnimationFrame(() => {
+      if (initialFocusRef?.current) {
+        initialFocusRef.current.focus({ preventScroll: true })
+        return
+      }
+      const focusableElements = getFocusableElements(containerRef.current)
+      if (focusableElements.length > 0) {
+        focusableElements[0].focus()
+      }
+    })
+  }, [isOpen, initialFocusRef])
+
+  // … rest of hook unchanged
+```
+
+**Critical:** the `= {}` default on the third arg is what keeps every existing 2-arg call site working. Without it, callers passing `undefined` would crash on destructuring.
+
+- [ ] **Step 2: Verify build still passes**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds. All existing modals using `useFocusTrap(isOpen, onClose)` continue to work because the new third arg defaults to `{}`.
+
+- [ ] **Step 3: Smoke-check one existing caller**
+
+```bash
+grep -rn "useFocusTrap" src/components src/pages --include="*.jsx" | head -5
+```
+
+Open one existing caller (e.g. `src/components/ReportModal.jsx` or whatever appears first) in `Read`, confirm it still calls `useFocusTrap(isOpen, onClose)` with two args. No changes needed there — the third arg defaults.
+
+- [ ] **Step 4: Codex review**
+
+```bash
+npx @openai/codex exec --skip-git-repo-check -m gpt-5.3-codex --config model_reasoning_effort="high" --sandbox read-only "Review src/hooks/useFocusTrap.js changes for backwards compatibility, race conditions in the focus effect, and any subtle bugs in the initialFocusRef handling." 2>/dev/null
+```
+
+Address blockers/highs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useFocusTrap.js
+git commit -m "feat(useFocusTrap): accept optional initialFocusRef to override auto-focus target"
+```
+
+---
+
+## Task 3: Add `getFollowStatuses` to `followsApi` (TDD)
+
+**Files:**
+- Modify: `src/api/followsApi.js`
+- Modify or Create: `src/api/followsApi.test.js` (check existence first with `ls src/api/followsApi.test.js`; if missing, create with the test module header pattern from `src/api/favoritesApi.test.js`)
+
+- [ ] **Step 1: Write failing tests**
+
+If `src/api/followsApi.test.js` doesn't exist, create it with:
+
+```js
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { followsApi } from './followsApi'
+
+vi.mock('../utils/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock('../lib/supabase', () => ({
+  supabase: {
+    auth: { getUser: vi.fn() },
+    from: vi.fn(),
+    rpc: vi.fn(),
+  },
+}))
+
+import { supabase } from '../lib/supabase'
+
+describe('followsApi', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+  afterEach(() => { vi.resetAllMocks() })
+})
+```
+
+Then either inside that file's outer `describe` (or in an existing file's appropriate location), add:
+
+```js
+describe('getFollowStatuses', () => {
+  it('returns empty Set when userIds is empty', async () => {
+    const result = await followsApi.getFollowStatuses([])
+    expect(result).toBeInstanceOf(Set)
+    expect(result.size).toBe(0)
+  })
+
+  it('returns empty Set when not authenticated', async () => {
+    supabase.auth.getUser.mockResolvedValue({ data: { user: null } })
+    const result = await followsApi.getFollowStatuses(['a', 'b'])
+    expect(result.size).toBe(0)
+  })
+
+  it('returns Set of followed IDs for authenticated user', async () => {
+    supabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'me' } } })
+    const inMock = vi.fn().mockResolvedValue({
+      data: [{ followed_id: 'a' }, { followed_id: 'c' }],
+      error: null,
+    })
+    const eqMock = vi.fn().mockReturnValue({ in: inMock })
+    const selectMock = vi.fn().mockReturnValue({ eq: eqMock })
+    supabase.from.mockReturnValue({ select: selectMock })
+
+    const result = await followsApi.getFollowStatuses(['a', 'b', 'c'])
+
+    expect(supabase.from).toHaveBeenCalledWith('follows')
+    expect(selectMock).toHaveBeenCalledWith('followed_id')
+    expect(eqMock).toHaveBeenCalledWith('follower_id', 'me')
+    expect(inMock).toHaveBeenCalledWith('followed_id', ['a', 'b', 'c'])
+    expect(result.has('a')).toBe(true)
+    expect(result.has('b')).toBe(false)
+    expect(result.has('c')).toBe(true)
+  })
+
+  it('throws classified error on supabase error', async () => {
+    supabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'me' } } })
+    const inMock = vi.fn().mockResolvedValue({ data: null, error: { message: 'boom', code: 'XX' } })
+    supabase.from.mockReturnValue({ select: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ in: inMock }) }) })
+
+    await expect(followsApi.getFollowStatuses(['a'])).rejects.toBeDefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+npm run test -- src/api/followsApi.test.js
+```
+
+Expected: 4 failing tests with `followsApi.getFollowStatuses is not a function`.
+
+- [ ] **Step 3: Implement `getFollowStatuses`**
+
+In `src/api/followsApi.js`, add the method inside the `followsApi` object (after `getFollowing`):
+
+```js
+/**
+ * Batch-check which of the given user IDs the current user follows.
+ * @param {string[]} userIds
+ * @returns {Promise<Set<string>>}
+ */
+async getFollowStatuses(userIds) {
+  if (!userIds?.length) return new Set()
+  try {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return new Set()
+
+    const { data, error } = await supabase
+      .from('follows')
+      .select('followed_id')
+      .eq('follower_id', user.id)
+      .in('followed_id', userIds)
+
+    if (error) throw createClassifiedError(error)
+    return new Set((data || []).map(r => r.followed_id))
+  } catch (error) {
+    logger.error('getFollowStatuses error:', error)
+    throw error.type ? error : createClassifiedError(error)
+  }
+},
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+npm run test -- src/api/followsApi.test.js
+```
+
+Expected: 4 passing tests for `getFollowStatuses`.
+
+- [ ] **Step 5: Codex review**
+
+```bash
+npx @openai/codex exec --skip-git-repo-check -m gpt-5.3-codex --config model_reasoning_effort="high" --sandbox read-only "Review src/api/followsApi.js (just the new getFollowStatuses method) and src/api/followsApi.test.js for: error classification per CLAUDE.md §1.2, empty-input handling, auth gate correctness, test mock realism. Be ruthless." 2>/dev/null
+```
+
+Address blockers/highs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/api/followsApi.js src/api/followsApi.test.js
+git commit -m "feat(followsApi): add getFollowStatuses for batched follow-state lookup"
+```
+
+---
+
+## Task 4: Add `searchFollows` to `followsApi` + route through `getFollowers`/`getFollowing` (TDD)
+
+**Files:**
+- Modify: `src/api/followsApi.js`
+- Modify: `src/api/followsApi.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `src/api/followsApi.test.js`:
+
+```js
+describe('searchFollows via getFollowers/getFollowing', () => {
+  it('returns empty result for empty query', async () => {
+    const result = await followsApi.getFollowers('user-1', { searchQuery: '' })
+    expect(result).toEqual({ users: [], hasMore: false })
+  })
+
+  it('returns empty result for whitespace-only query', async () => {
+    const result = await followsApi.getFollowing('user-1', { searchQuery: '   ' })
+    expect(result).toEqual({ users: [], hasMore: false })
+  })
+
+  it('returns empty result when sanitizer strips everything (e.g. %%)', async () => {
+    const result = await followsApi.getFollowers('user-1', { searchQuery: '%%' })
+    expect(result).toEqual({ users: [], hasMore: false })
+  })
+
+  it('calls RPC with correct args and maps rows for followers direction', async () => {
+    supabase.rpc.mockResolvedValue({
+      data: [
+        { id: 'a', display_name: 'Alice', avatar_url: null, follower_count: 5, followed_at: '2026-01-01' },
+        { id: 'b', display_name: 'Bob', avatar_url: 'x.jpg', follower_count: 0, followed_at: '2026-01-02' },
+      ],
+      error: null,
+    })
+
+    const result = await followsApi.getFollowers('user-1', { searchQuery: 'al', limit: 1 })
+
+    expect(supabase.rpc).toHaveBeenCalledWith('search_user_follows', expect.objectContaining({
+      p_user_id: 'user-1',
+      p_direction: 'followers',
+      p_query: 'al',
+      p_cursor_name: null,
+      p_cursor_id: null,
+      p_limit: 2, // limit + 1 for hasMore detection
+    }))
+    expect(result.users).toHaveLength(1)
+    expect(result.users[0].id).toBe('a')
+    expect(result.users[0].display_name).toBe('Alice')
+    expect(result.hasMore).toBe(true)
+  })
+
+  it('calls RPC with following direction when invoked via getFollowing', async () => {
+    supabase.rpc.mockResolvedValue({ data: [], error: null })
+    await followsApi.getFollowing('user-1', { searchQuery: 'al' })
+    expect(supabase.rpc).toHaveBeenCalledWith('search_user_follows', expect.objectContaining({
+      p_direction: 'following',
+    }))
+  })
+
+  it('passes through cursor object as p_cursor_name + p_cursor_id', async () => {
+    supabase.rpc.mockResolvedValue({ data: [], error: null })
+    await followsApi.getFollowers('user-1', {
+      searchQuery: 'al',
+      cursor: { display_name: 'Anna', id: 'cursor-id' },
+    })
+    expect(supabase.rpc).toHaveBeenCalledWith('search_user_follows', expect.objectContaining({
+      p_cursor_name: 'Anna',
+      p_cursor_id: 'cursor-id',
+    }))
+  })
+
+  it('throws classified error on RPC failure', async () => {
+    supabase.rpc.mockResolvedValue({ data: null, error: { message: 'boom', code: '42883' } })
+    await expect(followsApi.getFollowers('user-1', { searchQuery: 'al' })).rejects.toBeDefined()
+  })
+
+  it('falls back to recency cursor when searchQuery is absent', async () => {
+    // Verify it does NOT call rpc (uses .from('follows') instead)
+    const orderMock = vi.fn().mockReturnThis()
+    const limitMock = vi.fn().mockResolvedValue({ data: [], error: null })
+    supabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({ order: orderMock, lt: vi.fn().mockReturnThis() }),
+      }),
+    })
+    // Set up a chain that returns empty
+    const chain = { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), order: vi.fn().mockReturnThis(), limit: limitMock }
+    supabase.from.mockReturnValue(chain)
+
+    await followsApi.getFollowers('user-1')
+    expect(supabase.rpc).not.toHaveBeenCalled()
+    expect(supabase.from).toHaveBeenCalledWith('follows')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+npm run test -- src/api/followsApi.test.js
+```
+
+Expected: the new test block fails (RPC tests fail because no routing exists; empty-query tests may pass if existing code happens to return empty, but most fail).
+
+- [ ] **Step 3: Add `searchFollows` helper and route in `getFollowers`/`getFollowing`**
+
+In `src/api/followsApi.js`, after the existing `_paginateFollows` helper, add:
+
+```js
+/**
+ * Server-side ranked search of a user's followers/following list.
+ * Uses search_user_follows RPC with (display_name, id) cursor pagination.
+ */
+async function _searchFollows(userId, direction, { query, cursor = null, limit = 20 } = {}) {
+  try {
+    if (!query?.trim()) return { users: [], hasMore: false }
+    const sanitized = sanitizeSearchQuery(query, 50)
+    if (!sanitized || sanitized.length < 1) return { users: [], hasMore: false }
+
+    const { data, error } = await supabase.rpc('search_user_follows', {
+      p_user_id: userId,
+      p_direction: direction,
+      p_query: sanitized,
+      p_cursor_name: cursor?.display_name || null,
+      p_cursor_id: cursor?.id || null,
+      p_limit: limit + 1,
+    })
+    if (error) throw createClassifiedError(error)
+
+    const rows = data || []
+    const hasMore = rows.length > limit
+    const users = (hasMore ? rows.slice(0, limit) : rows).map(r => ({
+      id: r.id,
+      display_name: r.display_name || 'Anonymous',
+      avatar_url: r.avatar_url || null,
+      follower_count: r.follower_count || 0,
+      followed_at: r.followed_at,
+    }))
+    return { users, hasMore }
+  } catch (error) {
+    logger.error('searchFollows error:', error)
+    throw error.type ? error : createClassifiedError(error)
+  }
+}
+```
+
+Then change the existing `getFollowers` and `getFollowing` to route on `searchQuery`:
+
+```js
+async getFollowers(userId, options) {
+  if (options?.searchQuery) {
+    return _searchFollows(userId, 'followers', {
+      query: options.searchQuery,
+      cursor: options.cursor,
+      limit: options.limit,
+    })
+  }
+  return _paginateFollows(userId, 'followers', options)
+},
+
+async getFollowing(userId, options) {
+  if (options?.searchQuery) {
+    return _searchFollows(userId, 'following', {
+      query: options.searchQuery,
+      cursor: options.cursor,
+      limit: options.limit,
+    })
+  }
+  return _paginateFollows(userId, 'following', options)
+},
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+npm run test -- src/api/followsApi.test.js
+```
+
+Expected: all `searchFollows via getFollowers/getFollowing` tests pass, plus existing tests still pass.
+
+- [ ] **Step 5: Codex review**
+
+```bash
+npx @openai/codex exec --skip-git-repo-check -m gpt-5.3-codex --config model_reasoning_effort="high" --sandbox read-only "Review the _searchFollows helper and getFollowers/getFollowing routing in src/api/followsApi.js. Check: sanitization correctness, cursor shape passthrough, error classification, hasMore detection, fallback to _paginateFollows when no searchQuery." 2>/dev/null
+```
+
+Address blockers/highs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/api/followsApi.js src/api/followsApi.test.js
+git commit -m "feat(followsApi): server-side search via search_user_follows RPC"
+```
+
+---
+
+## Task 5: Create `useFollowList` hook
+
+**Files:**
+- Create: `src/hooks/useFollowList.js`
+
+- [ ] **Step 1: Write the hook**
+
+```js
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
+import { followsApi } from '../api/followsApi'
+import { sanitizeSearchQuery } from '../utils/sanitize'
+import { useAuth } from '../context/AuthContext'
+
+/**
+ * Centralizes server-state for FollowListModal.
+ * - Cursor-paginated recency list when no search query.
+ * - Alphabetical (display_name, id) cursor when searching.
+ * - Batched follow-state lookup keyed on viewer + sorted user IDs.
+ */
+export function useFollowList({ userId, type, searchQuery }) {
+  const direction = type // 'followers' | 'following'
+  const sanitizedSearch = sanitizeSearchQuery(searchQuery ?? '', 50)
+  const isSearching = !!sanitizedSearch && sanitizedSearch.length >= 1
+
+  // List mode — recency cursor
+  const listQuery = useInfiniteQuery({
+    queryKey: ['followList', userId, direction],
+    enabled: !isSearching && !!userId,
+    initialPageParam: null,
+    queryFn: ({ pageParam }) =>
+      direction === 'followers'
+        ? followsApi.getFollowers(userId, { cursor: pageParam })
+        : followsApi.getFollowing(userId, { cursor: pageParam }),
+    getNextPageParam: (last) => {
+      if (!last.hasMore || last.users.length === 0) return undefined
+      return last.users[last.users.length - 1].followed_at
+    },
+  })
+
+  // Search mode — alphabetical cursor
+  const searchQueryResult = useInfiniteQuery({
+    queryKey: ['followList', userId, direction, 'search', sanitizedSearch],
+    enabled: isSearching && !!userId,
+    initialPageParam: null,
+    queryFn: ({ pageParam }) =>
+      direction === 'followers'
+        ? followsApi.getFollowers(userId, { cursor: pageParam, searchQuery: sanitizedSearch })
+        : followsApi.getFollowing(userId, { cursor: pageParam, searchQuery: sanitizedSearch }),
+    getNextPageParam: (last) => {
+      if (!last.hasMore || last.users.length === 0) return undefined
+      const tail = last.users[last.users.length - 1]
+      return { display_name: tail.display_name, id: tail.id }
+    },
+  })
+
+  const active = isSearching ? searchQueryResult : listQuery
+  const users = active.data?.pages.flatMap(p => p.users) ?? []
+
+  // Follow statuses for visible users (sorted IDs + viewer for stable cache key)
+  const { user: viewer } = useAuth()
+  const viewerId = viewer?.id ?? 'anon'
+  const sortedUserIds = users.map(u => u.id).slice().sort()
+  const statusesQuery = useQuery({
+    queryKey: ['followStatuses', viewerId, sortedUserIds],
+    enabled: sortedUserIds.length > 0 && !!viewer,
+    queryFn: () => followsApi.getFollowStatuses(sortedUserIds),
+    staleTime: 30_000,
+  })
+
+  return {
+    users,
+    followingSet: statusesQuery.data ?? new Set(),
+    loading: active.isLoading,
+    loadingMore: active.isFetchingNextPage,
+    searching: isSearching && active.isFetching,
+    error: active.error,
+    hasMore: !!active.hasNextPage,
+    fetchMore: active.fetchNextPage,
+    refetch: active.refetch,
+    isSearching,
+  }
+}
+```
+
+- [ ] **Step 2: Verify build still passes**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds. Hook file compiles; no consumers yet.
+
+- [ ] **Step 3: Codex review**
+
+```bash
+npx @openai/codex exec --skip-git-repo-check -m gpt-5.3-codex --config model_reasoning_effort="high" --sandbox read-only "Review src/hooks/useFollowList.js for: queryKey stability, useInfiniteQuery getNextPageParam correctness for both cursor shapes, sanitizer placement, and the followStatuses cache key (does it actually prevent cross-viewer leaks). Also check that useAuth is the correct hook import path." 2>/dev/null
+```
+
+Address blockers/highs. **Verify** `useAuth` is exported from `src/context/AuthContext.js` — if not, find the correct import path with `grep -rn "export.*useAuth" src/context src/hooks`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hooks/useFollowList.js
+git commit -m "feat(useFollowList): React Query hook for follow-list pagination + search"
+```
+
+---
+
+## Task 6: Rewrite `FollowListModal` — structural skeleton + state
+
+**Files:**
+- Modify: `src/components/FollowListModal.jsx` (full rewrite)
+
+This task drops in the full rewrite WITHOUT the gesture/drag logic — that lands in Task 8. Goal here is to have a working modal with React Query + search + infinite scroll, fixed at half detent (75vh).
+
+- [ ] **Step 1: Replace the file**
+
+Read the current `src/components/FollowListModal.jsx`, then replace its contents with the new structure. The file needs to:
+
+1. Import `useFollowList`, `useFollowUser`, `useFocusTrap`, `useAuth`, `useNavigate`, `toast` from sonner, `sanitizeSearchQuery`.
+2. Manage local UI state: `searchInput`, `debouncedQuery`, `optimisticToggles`.
+3. Debounce `searchInput` → `debouncedQuery` (250ms).
+4. Pass `debouncedQuery` to `useFollowList`.
+5. Render: backdrop, fixed-height sheet (75vh), grabber, header with title + close, sticky search bar inside scroll container, list rows, sentinel for IntersectionObserver, states (loading/empty/error/search-no-results).
+
+Full file body:
+
+```jsx
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { toast } from 'sonner'
+import { useFollowList } from '../hooks/useFollowList'
+import { useFollowUser } from '../hooks/useFollowUser'
+import { useFocusTrap } from '../hooks/useFocusTrap'
+import { useAuth } from '../context/AuthContext'
+import { getUserMessage } from '../utils/errorHandler'
+
+export function FollowListModal({ userId, type, onClose }) {
+  const navigate = useNavigate()
+  const { user: viewer } = useAuth()
+  const isFollowers = type === 'followers'
+  const title = isFollowers ? 'Followers' : 'Following'
+
+  // Local UI state
+  const [searchInput, setSearchInput] = useState('')
+  const [debouncedQuery, setDebouncedQuery] = useState('')
+  const [optimisticToggles, setOptimisticToggles] = useState(() => new Set())
+
+  // Debounce search input
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQuery(searchInput), 250)
+    return () => clearTimeout(t)
+  }, [searchInput])
+
+  const {
+    users, followingSet, loading, loadingMore, searching,
+    error, hasMore, fetchMore, refetch, isSearching,
+  } = useFollowList({ userId, type, searchQuery: debouncedQuery })
+
+  const isFollowing = useCallback((id) => {
+    const base = followingSet.has(id)
+    return optimisticToggles.has(id) ? !base : base
+  }, [followingSet, optimisticToggles])
+
+  // Follow mutations (invalidates ['followCounts'] caches)
+  const { follow, unfollow } = useFollowUser()
+
+  const handleFollowToggle = useCallback((user) => {
+    if (!viewer) return
+    const currentlyFollowing = isFollowing(user.id)
+    // Optimistic flip
+    setOptimisticToggles(prev => {
+      const next = new Set(prev)
+      if (next.has(user.id)) next.delete(user.id)
+      else next.add(user.id)
+      return next
+    })
+    const mutation = currentlyFollowing ? unfollow : follow
+    mutation.mutate(user.id, {
+      onError: (err) => {
+        // Revert optimistic toggle
+        setOptimisticToggles(prev => {
+          const next = new Set(prev)
+          if (next.has(user.id)) next.delete(user.id)
+          else next.add(user.id)
+          return next
+        })
+        toast.error(getUserMessage(err, currentlyFollowing ? 'unfollowing' : 'following'))
+      },
+    })
+  }, [viewer, isFollowing, follow, unfollow])
+
+  const handleUserClick = (user) => { onClose(); navigate(`/user/${user.id}`) }
+
+  // Refs
+  const scrollContainerRef = useRef(null)
+  const sentinelRef = useRef(null)
+  const searchInputRef = useRef(null)
+  const modalRef = useFocusTrap(true, onClose, { initialFocusRef: searchInputRef })
+
+  // Infinite scroll observer — root is the inner scroll container
+  useEffect(() => {
+    if (!scrollContainerRef.current || !sentinelRef.current) return
+    if (error || !hasMore) return
+
+    const observer = new IntersectionObserver((entries) => {
+      const entry = entries[0]
+      if (entry.isIntersecting && hasMore && !loadingMore && !error) {
+        fetchMore()
+      }
+    }, {
+      root: scrollContainerRef.current,
+      rootMargin: '200px',
+    })
+    observer.observe(sentinelRef.current)
+    return () => observer.disconnect()
+  }, [hasMore, loadingMore, error, fetchMore, isSearching])
+
+  return (
+    <div className="fixed inset-0 z-50" onClick={onClose} role="presentation">
+      <div className="absolute inset-0" style={{ background: 'rgba(0,0,0,0.6)' }} aria-hidden="true" />
+
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="follow-list-title"
+        className="absolute left-0 right-0 bottom-0 rounded-t-2xl flex flex-col"
+        style={{
+          background: 'var(--color-surface-elevated)',
+          height: '75vh',
+          paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Grabber */}
+        <div
+          style={{ width: 40, height: 4, background: 'var(--color-divider)', borderRadius: 2, margin: '8px auto 4px', flex: '0 0 auto' }}
+          aria-hidden="true"
+        />
+
+        {/* Header */}
+        <div
+          className="flex items-center justify-between px-4 py-3 border-b"
+          style={{ borderColor: 'var(--color-divider)', flex: '0 0 auto' }}
+        >
+          <h2 id="follow-list-title" className="text-lg font-bold" style={{ color: 'var(--color-text-primary)' }}>
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-2 -mr-2 rounded-full"
+            style={{ color: 'var(--color-text-secondary)' }}
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Scrollable body */}
+        <div
+          ref={scrollContainerRef}
+          style={{
+            flex: '1 1 auto',
+            minHeight: 0,
+            overflowY: 'auto',
+            WebkitOverflowScrolling: 'touch',
+            overscrollBehavior: 'contain',
+            touchAction: 'pan-y',
+          }}
+        >
+          {/* Sticky search bar */}
+          <div
+            className="sticky top-0 z-10 px-4 pt-3 pb-2"
+            style={{ background: 'var(--color-surface-elevated)' }}
+          >
+            <div
+              className="flex items-center gap-2 px-3 rounded-full"
+              style={{
+                background: 'var(--color-bg)',
+                height: 40,
+                boxShadow: 'inset 0 1px 0 rgba(0,0,0,0.05)',
+              }}
+            >
+              {searching ? (
+                <div
+                  className="w-4 h-4 border-2 rounded-full animate-spin flex-shrink-0"
+                  style={{ borderColor: 'var(--color-divider)', borderTopColor: 'var(--color-text-tertiary)' }}
+                  aria-hidden="true"
+                />
+              ) : (
+                <svg className="w-4 h-4 flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }}
+                     fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35M10 17a7 7 0 100-14 7 7 0 000 14z" />
+                </svg>
+              )}
+              <input
+                ref={searchInputRef}
+                type="text"
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                placeholder={isFollowers ? 'Search followers' : 'Search following'}
+                className="flex-1 bg-transparent outline-none"
+                style={{ color: 'var(--color-text-primary)', fontSize: 16 }}
+                aria-label={`Search ${title.toLowerCase()}`}
+              />
+              {searchInput && (
+                <button
+                  type="button"
+                  onClick={() => { setSearchInput(''); searchInputRef.current?.focus() }}
+                  className="p-1 -mr-1 rounded-full"
+                  aria-label="Clear search"
+                >
+                  <svg className="w-4 h-4" style={{ color: 'var(--color-text-tertiary)' }}
+                       fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              )}
+            </div>
+          </div>
+
+          {/* Body content */}
+          {loading ? (
+            <SkeletonRows />
+          ) : error && users.length === 0 ? (
+            <ErrorState onRetry={refetch} />
+          ) : users.length === 0 ? (
+            <EmptyState type={type} isSearching={isSearching} query={debouncedQuery} />
+          ) : (
+            <>
+              <ul className="divide-y" style={{ borderColor: 'var(--color-divider)' }} aria-live="polite">
+                {users.map((user) => (
+                  <FollowRow
+                    key={user.id}
+                    user={user}
+                    isFollowing={isFollowing(user.id)}
+                    showFollowButton={!!viewer && viewer.id !== user.id}
+                    onRowClick={() => handleUserClick(user)}
+                    onFollowToggle={() => handleFollowToggle(user)}
+                  />
+                ))}
+              </ul>
+              {/* Sentinel for IntersectionObserver */}
+              <div ref={sentinelRef} aria-hidden="true" style={{ height: 1 }} />
+              {loadingMore && <LoadingMoreIndicator />}
+              {error && users.length > 0 && <LoadMoreErrorBanner onRetry={fetchMore} />}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function FollowRow({ user, isFollowing, showFollowButton, onRowClick, onFollowToggle }) {
+  const followerLabel = user.follower_count === 0
+    ? 'No followers yet'
+    : user.follower_count === 1
+      ? '1 follower'
+      : `${user.follower_count.toLocaleString()} followers`
+
+  return (
+    <li>
+      <div
+        role="link"
+        tabIndex={0}
+        aria-label={`${user.display_name} profile`}
+        onClick={onRowClick}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onRowClick() } }}
+        className="w-full flex items-center gap-3 px-4 py-3.5 cursor-pointer transition-colors hover:bg-black/[0.04] focus:outline-none focus-visible:bg-black/[0.04]"
+        style={{ minHeight: 64 }}
+      >
+        <div
+          className="w-11 h-11 rounded-full flex items-center justify-center font-bold flex-shrink-0 overflow-hidden"
+          style={{ background: 'var(--color-primary)', color: 'var(--color-text-on-primary)' }}
+        >
+          {user.avatar_url ? (
+            <img src={user.avatar_url} alt="" className="w-full h-full object-cover" draggable={false} />
+          ) : (
+            <span>{user.display_name?.charAt(0).toUpperCase() || '?'}</span>
+          )}
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <p className="truncate" style={{ color: 'var(--color-text-primary)', fontWeight: 500, fontSize: 16 }}>
+            {user.display_name || 'Anonymous'}
+          </p>
+          <p className="truncate" style={{ color: 'var(--color-text-tertiary)', fontSize: 13 }}>
+            {followerLabel}
+          </p>
+        </div>
+
+        {showFollowButton && (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); onFollowToggle() }}
+            aria-label={isFollowing ? `Unfollow ${user.display_name}` : `Follow ${user.display_name}`}
+            className="px-4 rounded-full transition-colors flex-shrink-0"
+            style={{
+              height: 32,
+              fontSize: 14,
+              fontWeight: 600,
+              background: isFollowing ? 'var(--color-surface-elevated)' : 'var(--color-primary)',
+              color: isFollowing ? 'var(--color-text-primary)' : 'var(--color-text-on-primary)',
+              border: isFollowing ? '1px solid var(--color-divider)' : 'none',
+            }}
+          >
+            {isFollowing ? 'Following' : 'Follow'}
+          </button>
+        )}
+      </div>
+    </li>
+  )
+}
+
+function SkeletonRows() {
+  return (
+    <div role="status" aria-label="Loading">
+      {[0, 1, 2, 3, 4].map(i => (
+        <div key={i} className="flex items-center gap-3 px-4 py-3.5" style={{ minHeight: 64 }}>
+          <div className="w-11 h-11 rounded-full skeleton-shimmer flex-shrink-0" />
+          <div className="flex-1 space-y-2">
+            <div className="h-4 rounded skeleton-shimmer" style={{ width: '60%' }} />
+            <div className="h-3 rounded skeleton-shimmer" style={{ width: '30%' }} />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function EmptyState({ type, isSearching, query }) {
+  if (isSearching) {
+    return (
+      <div className="py-12 px-6 text-center">
+        <p className="font-medium" style={{ color: 'var(--color-text-primary)', fontSize: 16 }}>
+          No one matches "{query}"
+        </p>
+        <p className="mt-1" style={{ color: 'var(--color-text-tertiary)', fontSize: 14 }}>
+          Try a different name.
+        </p>
+      </div>
+    )
+  }
+  const isFollowers = type === 'followers'
+  return (
+    <div className="py-12 px-6 text-center">
+      <p className="font-medium" style={{ color: 'var(--color-text-primary)', fontSize: 16 }}>
+        {isFollowers ? 'No followers yet' : 'Not following anyone yet'}
+      </p>
+      <p className="mt-1" style={{ color: 'var(--color-text-tertiary)', fontSize: 14 }}>
+        {isFollowers ? 'Share your profile to get discovered.' : 'Find people whose taste you trust on dish pages.'}
+      </p>
+    </div>
+  )
+}
+
+function ErrorState({ onRetry }) {
+  return (
+    <div className="py-12 px-6 text-center">
+      <p className="font-medium" style={{ color: 'var(--color-text-primary)', fontSize: 16 }}>
+        Couldn't load
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-3 px-4 py-2 rounded-full"
+        style={{
+          background: 'var(--color-primary)',
+          color: 'var(--color-text-on-primary)',
+          fontSize: 14,
+          fontWeight: 600,
+        }}
+      >
+        Tap to retry
+      </button>
+    </div>
+  )
+}
+
+function LoadingMoreIndicator() {
+  return (
+    <div className="flex items-center justify-center py-4" aria-hidden="true">
+      <div
+        className="w-5 h-5 border-2 rounded-full animate-spin"
+        style={{ borderColor: 'var(--color-divider)', borderTopColor: 'var(--color-primary)' }}
+      />
+    </div>
+  )
+}
+
+function LoadMoreErrorBanner({ onRetry }) {
+  return (
+    <div className="px-4 py-3 border-t" style={{ borderColor: 'var(--color-divider)' }}>
+      <button
+        type="button"
+        onClick={() => onRetry()}
+        className="w-full py-2 rounded-lg text-sm font-medium"
+        style={{
+          background: 'var(--color-bg)',
+          color: 'var(--color-text-primary)',
+          border: '1px solid var(--color-divider)',
+        }}
+      >
+        Couldn't load more. Tap to retry.
+      </button>
+    </div>
+  )
+}
+
+export default FollowListModal
+```
+
+- [ ] **Step 2: Add skeleton shimmer CSS**
+
+Open `src/index.css` and append (only if `.skeleton-shimmer` isn't already defined — check first):
+
+```css
+.skeleton-shimmer {
+  background: linear-gradient(
+    90deg,
+    var(--color-divider) 0%,
+    var(--color-surface) 50%,
+    var(--color-divider) 100%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.2s linear infinite;
+}
+
+@keyframes skeleton-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+```
+
+- [ ] **Step 3: Verify build + lint pass**
+
+```bash
+npm run build && npm run lint
+```
+
+Expected: both succeed. No new color classes (CLAUDE.md §1.3 — all colors via `var(--color-*)`).
+
+- [ ] **Step 4: Manual smoke — open the modal**
+
+```bash
+npm run dev
+```
+
+Navigate to `localhost:5173`, log in as a test user (see `SMOKE-TEST.md`), open `/profile`, tap "Followers" (or "Following"). Verify:
+- Sheet opens at 75vh height.
+- Search input has focus on open (cursor blinks in it without tapping).
+- Type a name → after 250ms results filter.
+- Tap a row → navigates to user profile.
+- Tap Follow on a row whose user you don't follow → button becomes "Following" without navigation; parent profile's "Following N" count updates after closing the sheet (React Query invalidation).
+
+If anything fails, stop and debug before continuing.
+
+- [ ] **Step 5: Codex review**
+
+```bash
+npx @openai/codex exec --skip-git-repo-check -m gpt-5.3-codex --config model_reasoning_effort="high" --sandbox read-only "Review src/components/FollowListModal.jsx and src/index.css changes for: CLAUDE.md §1.3 (no Tailwind color classes), button-in-button HTML, IntersectionObserver root correctness, sticky search bar inside scroll container behavior, accessibility, optimistic toggle correctness." 2>/dev/null
+```
+
+Address blockers/highs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/FollowListModal.jsx src/index.css
+git commit -m "feat(FollowListModal): rewrite with React Query, sticky search, infinite scroll, inline follow"
+```
+
+---
+
+## Task 7: Add drag-gesture detents (half ↔ full ↔ closed)
+
+**Files:**
+- Modify: `src/components/FollowListModal.jsx`
+
+- [ ] **Step 1: Add drag state + handlers**
+
+In `FollowListModal.jsx`, add to the component body (above the JSX return):
+
+```jsx
+const [sheetState, setSheetState] = useState('half') // 'half' | 'full' | 'closing'
+const [dragOffset, setDragOffset] = useState(0)
+const dragStartRef = useRef({ y: 0, t: 0, state: 'half' })
+
+const SHEET_HEIGHTS = { half: '75vh', full: '95vh' }
+const DRAG_THRESHOLD_PX = 50
+const DRAG_THRESHOLD_VELOCITY = 0.3 // px/ms
+
+const handleDragStart = useCallback((clientY) => {
+  dragStartRef.current = { y: clientY, t: performance.now(), state: sheetState }
+  setDragOffset(0)
+}, [sheetState])
+
+const handleDragMove = useCallback((clientY) => {
+  const delta = clientY - dragStartRef.current.y
+  setDragOffset(delta)
+}, [])
+
+const handleDragEnd = useCallback((clientY) => {
+  const delta = clientY - dragStartRef.current.y
+  const elapsed = performance.now() - dragStartRef.current.t
+  const velocity = elapsed > 0 ? Math.abs(delta) / elapsed : 0
+  const startState = dragStartRef.current.state
+  const crossed = Math.abs(delta) >= DRAG_THRESHOLD_PX || velocity >= DRAG_THRESHOLD_VELOCITY
+
+  if (crossed) {
+    if (delta < 0) {
+      // Dragged up
+      if (startState === 'half') setSheetState('full')
+      // already full → stay full
+    } else {
+      // Dragged down
+      if (startState === 'full') setSheetState('half')
+      else if (startState === 'half') {
+        setSheetState('closing')
+        setTimeout(onClose, 220) // matches animation duration
+      }
+    }
+  }
+  setDragOffset(0)
+}, [onClose])
+
+// Touch handlers (drag is anchored on the grabber + header zone)
+const onTouchStart = (e) => handleDragStart(e.touches[0].clientY)
+const onTouchMove = (e) => handleDragMove(e.touches[0].clientY)
+const onTouchEnd = (e) => handleDragEnd(e.changedTouches[0].clientY)
+
+// Tap the grabber to toggle detent (non-gesture fallback)
+const onGrabberClick = () => {
+  setSheetState(prev => prev === 'half' ? 'full' : 'half')
+}
+```
+
+- [ ] **Step 2: Update the sheet wrapper to use dynamic height + drag transform**
+
+Replace the sheet `<div>` opening tag (`<div ref={modalRef} role="dialog" …>`) with:
+
+```jsx
+<div
+  ref={modalRef}
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="follow-list-title"
+  className="absolute left-0 right-0 bottom-0 rounded-t-2xl flex flex-col"
+  style={{
+    background: 'var(--color-surface-elevated)',
+    height: SHEET_HEIGHTS[sheetState === 'closing' ? 'half' : sheetState],
+    transform: sheetState === 'closing'
+      ? 'translateY(100%)'
+      : `translateY(${Math.max(0, dragOffset)}px)`,
+    transition: dragOffset === 0
+      ? 'transform 280ms cubic-bezier(0.32, 0.72, 0, 1), height 280ms cubic-bezier(0.32, 0.72, 0, 1)'
+      : 'none',
+    paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+  }}
+  onClick={(e) => e.stopPropagation()}
+>
+```
+
+And replace the grabber `<div>` with:
+
+```jsx
+<div
+  onClick={onGrabberClick}
+  onTouchStart={onTouchStart}
+  onTouchMove={onTouchMove}
+  onTouchEnd={onTouchEnd}
+  style={{
+    flex: '0 0 auto',
+    padding: '8px 0 4px',
+    cursor: 'grab',
+    touchAction: 'none',
+  }}
+  aria-label="Drag to resize"
+  role="separator"
+>
+  <div
+    style={{ width: 40, height: 4, background: 'var(--color-divider)', borderRadius: 2, margin: '0 auto' }}
+    aria-hidden="true"
+  />
+</div>
+```
+
+Also attach the same `onTouchStart/Move/End` handlers to the header `<div>` so users can grab the title area too.
+
+- [ ] **Step 3: Verify build passes**
+
+```bash
+npm run build
+```
+
+Expected: success.
+
+- [ ] **Step 4: Manual smoke — gesture flow**
+
+```bash
+npm run dev
+```
+
+In a mobile-emulated browser (Chrome DevTools → Device Toolbar → iPhone 14 Pro, touch enabled):
+- Open modal → opens at half (75vh).
+- Drag grabber up → snaps to full (95vh).
+- Drag grabber down from full → snaps back to half.
+- Drag grabber down from half → snaps closed.
+- Tap grabber → toggles between half and full.
+- Tap backdrop → closes (existing behavior preserved via `onClose` on outer div).
+- ESC key → closes (`useFocusTrap` still handles this).
+
+If detent thresholds feel wrong on a real device, tune `DRAG_THRESHOLD_PX` or `DRAG_THRESHOLD_VELOCITY`. Default values are starting points.
+
+- [ ] **Step 5: Codex review**
+
+```bash
+npx @openai/codex exec --skip-git-repo-check -m gpt-5.3-codex --config model_reasoning_effort="high" --sandbox read-only "Review the drag-gesture handlers in src/components/FollowListModal.jsx for: race conditions between touchmove/touchend, dragOffset state thrashing on rapid drags, transition correctness, accessibility of the grabber as a drag-handle, and the closing animation timing (setTimeout vs CSS transition coupling)." 2>/dev/null
+```
+
+Address blockers/highs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/FollowListModal.jsx
+git commit -m "feat(FollowListModal): drag-gesture detents (half ↔ full ↔ closed)"
+```
+
+---
+
+## Task 8: Full SMOKE-TEST golden path + accessibility check
+
+**Files:**
+- (None — verification only)
+
+- [ ] **Step 1: Run unit tests**
+
+```bash
+npm run test -- src/api/followsApi.test.js
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run build + lint**
+
+```bash
+npm run build && npm run lint
+```
+
+Expected: both pass with no warnings on the touched files.
+
+- [ ] **Step 3: SMOKE-TEST golden path**
+
+Open `SMOKE-TEST.md`. Run through the followers/following sections (or, if no follower section exists, run the full social-related flows). Verify each manual case from the spec:
+
+- Open Profile → tap Followers → sheet opens at half detent, search input is focused.
+- Drag up → snaps to full.
+- Drag down → snaps back to half, then closed.
+- Type a name → results filter server-side after 250ms; alphabetical, paginated correctly past row 21+.
+- Tap Follow on a row → button toggles to Following without page navigation; parent profile's "Following N" count increments after sheet closes (via `useFollowUser` cache invalidation).
+- Scroll to bottom → next 20 rows load automatically.
+- Disconnect network (DevTools → Network → Offline) mid-follow → button reverts, sonner toast appears.
+- Disconnect mid-pagination → "Couldn't load" error state shows. Reconnect → tap retry button → resumes.
+
+- [ ] **Step 4: Accessibility check**
+
+In Chrome DevTools → Lighthouse → Accessibility, run an audit on the page with the modal open. Expected score ≥ 95. Verify with keyboard:
+- Tab from search input goes through rows + follow buttons + close.
+- ESC closes the modal.
+- Screen reader (VoiceOver on Mac: Cmd+F5) announces "Followers, dialog" and reads each row as a link.
+
+- [ ] **Step 5: Final codex review of all touched files**
+
+```bash
+npx @openai/codex exec --skip-git-repo-check -m gpt-5.3-codex --config model_reasoning_effort="high" --sandbox read-only "Final review pass on this branch's changes: src/components/FollowListModal.jsx, src/hooks/useFollowList.js, src/hooks/useFocusTrap.js, src/api/followsApi.js, src/api/followsApi.test.js, src/index.css, supabase/migrations/20260516_search_user_follows.sql, supabase/schema.sql. Look for: any remaining CLAUDE.md rule violations, dead code, leftover console.logs, unused imports, accessibility regressions, anything that wouldn't pass a senior code review." 2>/dev/null
+```
+
+Address blockers/highs.
+
+- [ ] **Step 6: Final commit if any review fixes**
+
+```bash
+git add -A
+git status
+git commit -m "fix(FollowListModal): final review polish"
+```
+
+(Skip if no changes from the final review pass.)
+
+---
+
+## Self-review checklist (run before declaring done)
+
+- [ ] Every spec section maps to a task above (RPC ✓ task 1, hook extension ✓ task 2, getFollowStatuses ✓ task 3, searchFollows ✓ task 4, useFollowList ✓ task 5, modal rewrite ✓ task 6, detents ✓ task 7, smoke ✓ task 8).
+- [ ] No `TBD`/`TODO`/`fill in later` placeholders anywhere in the plan.
+- [ ] Every code block is complete; nothing says "similar to above" without showing it.
+- [ ] Function and prop names are consistent across tasks (`useFollowList`, `getFollowStatuses`, `searchFollows`, `initialFocusRef`, `sheetState`).
+- [ ] Each task ends with codex review + commit.
+- [ ] Migration filename matches existing convention (`YYYYMMDD_description.sql`).
+- [ ] All new error paths use `throw error.type ? error : createClassifiedError(error)`.
+- [ ] No Tailwind color classes introduced; all colors via `var(--color-*)`.

--- a/docs/superpowers/specs/2026-05-16-follow-list-modal-redesign.md
+++ b/docs/superpowers/specs/2026-05-16-follow-list-modal-redesign.md
@@ -1,0 +1,476 @@
+# Follow List Modal Redesign
+
+**Date:** 2026-05-16 (revised after codex review)
+**Author:** Dan (with Claude)
+**Status:** Spec — pending implementation plan
+**Target:** Pre-Memorial Day polish (1.1 punch list)
+
+## Problem
+
+The current followers / following popup (`src/components/FollowListModal.jsx`) feels awkward:
+
+- A manual "Load More" button breaks scroll momentum every 20 rows.
+- No way to search — once a user has 50+ followers, finding one specific person means scroll-loading through every page.
+- Rows are minimal (avatar + name + chevron) with no inline action — you can't follow/unfollow without navigating to the user's profile.
+- Sheet is a static 85vh box with no drag affordance, despite the grabber suggesting otherwise.
+
+For a launch where social discovery matters, this surface needs to feel finished.
+
+## Goals
+
+1. Replace the Load More button with smooth infinite scroll.
+2. Add a sticky search bar that queries server-side across the user's entire follower/following list (paginated, fully reachable — no hidden tail).
+3. Allow follow / unfollow directly from a row, no navigation required.
+4. Make the sheet gesture-driven with snap detents (half / full / closed).
+5. Surface follower count per row as cheap social-proof signal.
+
+## Non-Goals (Deferred)
+
+- Taste compatibility % per row (needs batched RPC — Launch 2.0).
+- Mutual follows badge ("Followed by Jess + 3 others") — Launch 2.0.
+- Removing followers (admin-style eviction) — out of scope.
+- Refactor of unrelated profile screens — only this modal and its API + RPC.
+
+## Architecture
+
+### Files Touched
+
+- `src/components/FollowListModal.jsx` — full rewrite.
+- `src/api/followsApi.js` — extend `getFollowers` / `getFollowing` with `searchQuery` + cursor; add `getFollowStatuses`.
+- `src/hooks/useFollowList.js` — **NEW**. Wraps React Query for list + search.
+- `src/hooks/useFocusTrap.js` — small additive extension to accept `{ initialFocusRef }`.
+- `supabase/schema.sql` — add `search_user_follows` RPC.
+- `supabase/migrations/20260516_search_user_follows.sql` — **NEW**. Migration to deploy the RPC.
+
+No new routes. No new pages. No changes to provider hierarchy.
+
+### Schema Change — new RPC
+
+**Why:** existing two-query patterns (fetch IDs → `.in()` → `.ilike()`) break for two reasons codex flagged:
+
+1. PostgREST URL length cap means `.in('id', ids)` will fail once a user has more than a few hundred follows.
+2. Substring filter then `LIMIT 20` then alphabetical order reintroduces the exact bug `searchUsers` already fixed (a high-signal user is invisible if 20 lower-signal users sort alphabetically earlier).
+
+The new RPC mirrors `search_users_with_followers` (already in schema) but constrained to one user's relationship.
+
+```sql
+CREATE OR REPLACE FUNCTION search_user_follows(
+  p_user_id UUID,
+  p_direction TEXT,           -- 'followers' | 'following'
+  p_query TEXT,
+  p_cursor_name TEXT DEFAULT NULL,
+  p_cursor_id UUID DEFAULT NULL,
+  p_limit INT DEFAULT 20
+)
+RETURNS TABLE (
+  id UUID,
+  display_name TEXT,
+  avatar_url TEXT,
+  follower_count INT,
+  followed_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_limit INT := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 100);
+  v_query TEXT := NULLIF(TRIM(COALESCE(p_query, '')), '');
+BEGIN
+  IF p_direction NOT IN ('followers', 'following') THEN
+    RAISE EXCEPTION 'Invalid direction: %, must be followers or following', p_direction
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'p_user_id is required' USING ERRCODE = '22023';
+  END IF;
+
+  -- Two explicit branches (planner-friendly). Aliases qualify every column
+  -- (CLAUDE.md §1.5: RETURNS TABLE columns become variables inside the body).
+  IF p_direction = 'followers' THEN
+    RETURN QUERY
+      SELECT p.id, p.display_name, p.avatar_url, p.follower_count,
+             f.created_at AS followed_at
+      FROM follows f
+      JOIN profiles p ON p.id = f.follower_id
+      WHERE f.followed_id = p_user_id
+        AND (v_query IS NULL OR p.display_name ILIKE '%' || v_query || '%')
+        AND (p_cursor_name IS NULL
+             OR (p.display_name, p.id) > (p_cursor_name, p_cursor_id))
+      ORDER BY p.display_name ASC, p.id ASC
+      LIMIT v_limit;
+  ELSE
+    RETURN QUERY
+      SELECT p.id, p.display_name, p.avatar_url, p.follower_count,
+             f.created_at AS followed_at
+      FROM follows f
+      JOIN profiles p ON p.id = f.followed_id
+      WHERE f.follower_id = p_user_id
+        AND (v_query IS NULL OR p.display_name ILIKE '%' || v_query || '%')
+        AND (p_cursor_name IS NULL
+             OR (p.display_name, p.id) > (p_cursor_name, p_cursor_id))
+      ORDER BY p.display_name ASC, p.id ASC
+      LIMIT v_limit;
+  END IF;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION search_user_follows(UUID, TEXT, TEXT, TEXT, UUID, INT) TO anon, authenticated;
+```
+
+**Hardening parity with existing `search_users_with_followers` RPC:** input validation, `p_limit` clamp to `[1, 100]`, empty-string `p_query` treated as NULL.
+
+**Index reality for `ILIKE '%q%'`:** the existing `lower(display_name)` btree index does NOT accelerate substring search. v1 ships with a planned `Seq Scan` over `profiles` (filtered first by the `follows` JOIN — that's the actual selectivity gate). At current user volume (<2K profiles in prod) this is fast enough. **If the table grows past ~50K profiles**, add a trigram index in a follow-up migration:
+
+```sql
+-- Deferred — only when sequential ILIKE becomes slow:
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX idx_profiles_display_name_trgm ON profiles USING gin (display_name gin_trgm_ops);
+```
+
+Not part of this spec's deploy step.
+
+**Note on ordering:** in cursor (non-search) mode we keep the existing `created_at DESC` recency order from `_paginateFollows`. The new RPC only powers search, where alphabetical is the better affordance ("find Jess").
+
+**Rollback:**
+```sql
+-- ROLLBACK:
+-- DROP FUNCTION IF EXISTS search_user_follows(UUID, TEXT, TEXT, TEXT, UUID, INT);
+```
+
+(Pure additive — drop and revert client to non-search mode.)
+
+**Deploy step:** per CLAUDE.md §1.5, after `schema.sql` update, the function must be run in Supabase SQL Editor on Denis's project (`vpioftosgdkyiwvhxewy`) and verified with a test call before client work merges.
+
+### API Changes (`followsApi.js`)
+
+**1. `_paginateFollows` stays the recency cursor path** (no `searchQuery` parameter). Untouched behavior.
+
+**2. New `searchFollows(userId, direction, { query, cursor, limit })`** — thin RPC wrapper:
+
+```js
+async function searchFollows(userId, direction, { query, cursor = null, limit = 20 } = {}) {
+  try {
+    if (!query?.trim() || query.trim().length < 1) return { users: [], hasMore: false }
+    const sanitized = sanitizeSearchQuery(query, 50)
+    if (!sanitized) return { users: [], hasMore: false }
+
+    const { data, error } = await supabase.rpc('search_user_follows', {
+      p_user_id: userId,
+      p_direction: direction,
+      p_query: sanitized,
+      p_cursor_name: cursor?.display_name || null,
+      p_cursor_id: cursor?.id || null,
+      p_limit: limit + 1,
+    })
+    if (error) throw createClassifiedError(error)
+
+    const rows = data || []
+    const hasMore = rows.length > limit
+    const users = (hasMore ? rows.slice(0, limit) : rows).map(r => ({
+      id: r.id,
+      display_name: r.display_name || 'Anonymous',
+      avatar_url: r.avatar_url || null,
+      follower_count: r.follower_count || 0,
+      followed_at: r.followed_at,
+    }))
+    return { users, hasMore }
+  } catch (error) {
+    logger.error('searchFollows error:', error)
+    throw error.type ? error : createClassifiedError(error)
+  }
+}
+```
+
+**3. `getFollowers` / `getFollowing` route on `searchQuery` presence:**
+
+```js
+async getFollowers(userId, { cursor, searchQuery, limit } = {}) {
+  if (searchQuery) return searchFollows(userId, 'followers', { query: searchQuery, cursor, limit })
+  return _paginateFollows(userId, 'followers', { cursor, limit })
+},
+```
+
+(The `cursor` shape differs between modes: recency-cursor is a `created_at` timestamp; search-cursor is `{ display_name, id }`. The hook owns translating between them.)
+
+**4. New `getFollowStatuses(userIds)`** — returns `Set<string>` of IDs the current user follows:
+
+```js
+async getFollowStatuses(userIds) {
+  if (!userIds?.length) return new Set()
+  try {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return new Set()
+    const { data, error } = await supabase
+      .from('follows')
+      .select('followed_id')
+      .eq('follower_id', user.id)
+      .in('followed_id', userIds)
+    if (error) throw createClassifiedError(error)
+    return new Set((data || []).map(r => r.followed_id))
+  } catch (error) {
+    logger.error('getFollowStatuses error:', error)
+    throw error.type ? error : createClassifiedError(error)
+  }
+}
+```
+
+Followed list size for this call is bounded by the React Query page size (20–40), well under PostgREST limits. This `.in()` is safe.
+
+All new catch blocks use the `throw error.type ? error : createClassifiedError(error)` pattern per CLAUDE.md §1.2.
+
+### React Query Wiring (CLAUDE.md §1.4)
+
+**New hook `src/hooks/useFollowList.js`** owns all server-state for this modal. Component no longer holds `useState/useEffect` fetch state machines.
+
+```js
+export function useFollowList({ userId, type, searchQuery }) {
+  const direction = type // 'followers' | 'following'
+  // Sanitize once. Only enter search mode if there's still content after
+  // sanitization — '%%' becomes empty and falls back to recency list mode.
+  const sanitizedSearch = sanitizeSearchQuery(searchQuery ?? '', 50)
+  const isSearching = !!sanitizedSearch && sanitizedSearch.length >= 1
+
+  // List mode — recency cursor, infinite
+  const listQuery = useInfiniteQuery({
+    queryKey: ['followList', userId, direction],
+    enabled: !isSearching && !!userId,
+    queryFn: ({ pageParam }) =>
+      direction === 'followers'
+        ? followsApi.getFollowers(userId, { cursor: pageParam })
+        : followsApi.getFollowing(userId, { cursor: pageParam }),
+    initialPageParam: null,
+    getNextPageParam: (last) => {
+      if (!last.hasMore || last.users.length === 0) return undefined
+      return last.users[last.users.length - 1].followed_at
+    },
+  })
+
+  // Search mode — alphabetical cursor, infinite. Pass the SANITIZED query.
+  const searchQueryResult = useInfiniteQuery({
+    queryKey: ['followList', userId, direction, 'search', sanitizedSearch],
+    enabled: isSearching && !!userId,
+    queryFn: ({ pageParam }) =>
+      direction === 'followers'
+        ? followsApi.getFollowers(userId, { cursor: pageParam, searchQuery: sanitizedSearch })
+        : followsApi.getFollowing(userId, { cursor: pageParam, searchQuery: sanitizedSearch }),
+    initialPageParam: null,
+    getNextPageParam: (last) => {
+      if (!last.hasMore || last.users.length === 0) return undefined
+      const tail = last.users[last.users.length - 1]
+      return { display_name: tail.display_name, id: tail.id }
+    },
+  })
+
+  const active = isSearching ? searchQueryResult : listQuery
+  const users = active.data?.pages.flatMap(p => p.users) ?? []
+
+  // Follow statuses for visible users (batched, single round-trip per page set).
+  // Key includes viewer identity (auth state) AND sorted IDs (stable on reorder).
+  const { user: viewer } = useAuth()
+  const viewerId = viewer?.id ?? 'anon'
+  const sortedUserIds = users.map(u => u.id).slice().sort()
+  const statusesQuery = useQuery({
+    queryKey: ['followStatuses', viewerId, sortedUserIds],
+    enabled: sortedUserIds.length > 0 && !!viewer,
+    queryFn: () => followsApi.getFollowStatuses(sortedUserIds),
+    staleTime: 30_000,
+  })
+
+  return {
+    users,
+    followingSet: statusesQuery.data ?? new Set(),
+    loading: active.isLoading,
+    loadingMore: active.isFetchingNextPage,
+    error: active.error,
+    hasMore: !!active.hasNextPage,
+    fetchMore: active.fetchNextPage,
+    refetch: active.refetch,
+  }
+}
+```
+
+**Race control is free:** React Query keys debounced search by `searchQuery` — older response from a previous query doesn't write to current cache because the queryKey already changed.
+
+**Follow mutations use the existing `useFollowUser` hook** (`src/hooks/useFollowUser.js`). That hook already invalidates `['followCounts']` so the parent profile page's count updates after a follow toggle. The modal calls `follow.mutate(userId)` / `unfollow.mutate(userId)` and additionally updates a local `followingSet` for optimistic button state. On error, the mutation's `onError` callback reverts the local `followingSet` and shows a `toast.error()` (sonner, already used in `ReportModal.jsx`).
+
+### Component State
+
+With React Query owning server state, the component holds only UI state:
+
+```js
+const [searchInput, setSearchInput] = useState('')        // raw input
+const [debouncedQuery, setDebouncedQuery] = useState('')  // 250ms behind
+const [optimisticToggles, setOptimisticToggles] = useState(new Set())
+                                          // overlay on top of followingSet
+const [sheetState, setSheetState] = useState('half')      // 'half' | 'full' | 'closing'
+const [dragOffset, setDragOffset] = useState(0)
+```
+
+The effective `isFollowing(userId)` = `followingSet.has(id) XOR optimisticToggles.has(id)`.
+
+## UX & Visual
+
+### Sheet Form Factor
+
+- **Half detent (default):** `height: 75vh`, opens from bottom with `translateY` spring.
+- **Full detent:** `height: 95vh`, reached by dragging the grabber/header up past a 50px distance threshold OR a 0.3 px/ms velocity threshold (whichever fires first). Same threshold applies symmetrically to close gestures.
+- **Closed:** dragging down past threshold (or tapping backdrop, or ESC) closes the sheet.
+- **From full to closed:** requires two drags — full → half → closed. Prevents accidental dismissal.
+- **Animation:** CSS `transition: transform 280ms cubic-bezier(0.32, 0.72, 0, 1)` (iOS-feel). During active drag, transition is off and `transform` follows finger 1:1.
+- **Backdrop opacity:** scales linearly from 0.6 (at half/full) → 0 (at closed position) during drag.
+- **Grabber:** existing 40×4 pill stays; doubles as a tappable detent-toggle as a non-gesture fallback.
+
+### Sticky Search Bar
+
+- Sits just below the grabber, above the row list. `position: sticky; top: 0` inside the scroll container so it stays pinned during scroll. (The sheet's outer `flex flex-col` wraps a header chunk + a `flex-1 min-h-0 overflow-y-auto` scroll body. The search bar lives inside that scroll body as the first child with `sticky top-0` — verified to work; this is the same pattern used by Tailwind's own docs in nested-scroll modals.)
+- Visual: rounded-full pill, `background: var(--color-bg)`, soft inset shadow (1px inset top, no outer shadow), Outfit 400 16px input.
+- Left: inline search SVG (24-line stroke icon). The project does not depend on `lucide-react`; icons are inline SVG per existing pattern in `FollowListModal.jsx` close button.
+- Right: clear `×` button — visible only when `searchInput !== ''`; tapping clears and refocuses input.
+- Placeholder: `"Search followers"` / `"Search following"` depending on `type`.
+- Searching indicator: when `searchQueryResult.isFetching && isSearching`, replace the left icon with a 14px spinning ring; same color as text-tertiary.
+
+### Row Markup (HTML semantics fix)
+
+**Cannot nest `<button>` inside `<button>`.** Current row is `<button>`; new row needs an explicitly interactive wrapper that's not a button:
+
+```jsx
+<div
+  role="link"
+  tabIndex={0}
+  aria-label={`${user.display_name} profile`}
+  onClick={() => handleUserClick(user)}
+  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleUserClick(user); } }}
+  className="…"
+>
+  <Avatar … />
+  <IdentityBlock … />
+  <button
+    type="button"
+    onClick={(e) => { e.stopPropagation(); handleFollowToggle(user); }}
+    aria-label={isFollowing(user.id) ? `Unfollow ${user.display_name}` : `Follow ${user.display_name}`}
+  >
+    {isFollowing(user.id) ? 'Following' : 'Follow'}
+  </button>
+</div>
+```
+
+The `<div role="link">` is keyboard-focusable and announces as a link. The inner `<button>` is a real interactive button. No nested buttons. Tap target on the wrapper covers most of the row; the button has its own tap target on the right.
+
+### Row Visual
+
+- Height: 64px. Padding: `py-3.5 px-4`.
+- Layout: `flex items-center gap-3`.
+- **Avatar:** 44px circle. Existing avatar logic kept (image if present, otherwise primary-color circle with initial).
+- **Identity block (flex-1):**
+  - Display name: Outfit 500, 16px, `--color-text-primary`, truncate.
+  - Follower count: Outfit 400, 13px, `--color-text-tertiary`. Format: `"1 follower"` (singular) / `"87 followers"` (plural) / `"No followers yet"` (zero).
+- **Action button (right):** 32px-tall pill, padded `px-4`, Outfit 600 14px.
+  - `"Follow"` — filled `--color-primary`, `--color-text-on-primary`.
+  - `"Following"` — outline (1px `--color-divider`), `--color-text-primary`, background `--color-surface-elevated`.
+  - Hidden when the row IS the current user (can't follow yourself) or when not authenticated.
+- **No chevron** — the inline button makes intent clear; chevron felt clinical.
+- Hover: subtle warm-stone tint `rgba(0,0,0,0.04)` on the wrapper.
+- All colors via `var(--color-*)` per CLAUDE.md §1.3. No Tailwind color classes anywhere.
+
+### Infinite Scroll (replaces Load More button)
+
+- `IntersectionObserver` created in a `useEffect`.
+- **`root: scrollContainerRef.current`** — required, because the list scrolls inside the modal, not the viewport. Without this, intersection never fires reliably in the sheet.
+- `rootMargin: '200px'` — start fetching 200px before sentinel reaches the bottom edge.
+- Sentinel `<div ref={sentinelRef} aria-hidden />` placed after the last row.
+- Effect re-creates the observer when `scrollContainerRef.current` exists and on `isSearching` change (different mode, different pagination semantics).
+- Callback: when intersecting AND `hasMore` AND `!loadingMore` AND `!error` → `fetchMore()`. The `!error` gate prevents thrash on persistent failure: once a fetch fails, we mark `error` and DO NOT auto-retry from the observer. The user must scroll up and back down OR tap a manual "Tap to retry" pill that appears below the list, which clears the error and re-fires.
+- React Query's `fetchNextPage` is idempotent — calling it while `isFetchingNextPage` is true is a no-op, so the observer re-firing on append doesn't cause duplicate requests.
+
+### Focus Management
+
+**Hook extension required.** `useFocusTrap` currently calls `focusableElements[0].focus()` in a `requestAnimationFrame` on mount — that lands on the close button, which is wrong here. Racing it with a second `rAF` from the modal is fragile timing coupling. Cleaner fix:
+
+- Extend `useFocusTrap` to accept an optional `initialFocusRef`. **Critical: default the destructured options object so existing 2-arg callers don't break:**
+  ```js
+  export function useFocusTrap(isOpen, onClose, { initialFocusRef } = {}) { … }
+  ```
+  If `initialFocusRef` is provided, the auto-focus `rAF` calls `initialFocusRef.current?.focus({ preventScroll: true })` instead of `focusableElements[0].focus()`. Falls back to the original behavior when the ref is absent or its `.current` is null. No other behavior changes. All existing 2-arg call sites (e.g., other modals using the hook) keep working unchanged because the third arg defaults to `{}`.
+- Modal passes `{ initialFocusRef: searchInputRef }`. On open, focus lands on the search input. Skeleton + sticky bar guarantees the input exists at mount.
+- **DOM order fix:** the current modal has the close button in the header before the scroll body. To make Tab progression intuitive (search → results → close), the scroll body needs to come before the close button in DOM, or — simpler — move the close button into the header AFTER the rest of the header content with `order` CSS only being layout (not tab). Easiest path: keep DOM order as-is and accept that Tab from search goes through rows then loops back via the trap to close. Document this rather than over-engineer.
+- Tab cycle still trapped within modal via the hook's existing Shift+Tab/Tab boundary handling.
+
+### States
+
+- **Initial load:** 5 shimmering skeleton rows. Skeleton = `--color-divider` base block with a horizontal gradient sweep animation (1.2s linear loop). Avoids dead spinner-in-void feel.
+- **Empty followers:** centered editorial text. Headline (Outfit 500): `"No followers yet"`. Body (Outfit 400, tertiary): `"Share your profile to get discovered."` No emoji.
+- **Empty following:** Headline: `"Not following anyone yet"`. Body: `"Find people whose taste you trust on dish pages."`
+- **Search no results:** Headline: `"No one matches \"<query>\""`. Body: `"Try a different name."`
+- **Error (initial):** Headline: `"Couldn't load"`. Tappable pill beneath: `"Tap to retry"`. On tap, `refetch()`.
+- **Error (load more):** banner pill at list bottom: `"Couldn't load more. Tap to retry."` Tap re-fires `fetchMore()`. Auto-retry from observer disabled while error is set.
+
+### Accessibility
+
+- `useFocusTrap` retained with override (above).
+- `aria-live="polite"` region announces page loads ("Loaded 20 more followers").
+- ESC closes. Drag has tap-grabber fallback to toggle detents.
+- `role="dialog"`, `aria-modal="true"`, `aria-labelledby` retained.
+- Inner Follow buttons have full `aria-label`.
+
+## Edge Cases
+
+- **Empty `userIds` in `getFollowStatuses`:** returns empty Set without querying.
+- **Not authenticated viewing someone else's followers:** list renders (public), but Follow buttons hidden — `followingSet` is empty (current user is null).
+- **Viewing your own follower list:** Follow buttons appear on rows for users you don't follow; "Following" buttons on rows for users you do. Tapping unfollow on YOUR followers list does NOT remove them as a follower (deferred eviction feature) — it only changes whether you follow them back.
+- **Self-row in your following list:** impossible (you can't follow yourself) — no special handling needed.
+- **Self-row in your followers list:** also impossible.
+- **Profile fetch failure inside `_paginateFollows`:** existing fallback to `'Anonymous'` is retained.
+- **Sanitize search input:** route through `sanitizeSearchQuery` from `src/utils/sanitize.js` before passing to RPC.
+- **Toast for follow error rollback:** uses `sonner`'s `toast.error()` — the existing pattern in `ReportModal.jsx` and other modals.
+- **RPC not deployed yet on remote project:** during local dev before Dan runs the SQL, search calls will return `function does not exist`. Hook catches `error.code === '42883'` (undefined_function) specifically and falls back to a banner: "Search isn't available yet — try the full list." Removed once RPC is verified in production. (Implementation plan owns the timing.)
+- **Search query with only sanitizer-stripped chars (e.g. `%%`):** `useFollowList` sanitizes the input before deciding `isSearching`. If the sanitized output is empty, the hook stays in recency-list mode rather than entering an empty search state.
+
+## Performance Notes
+
+- New RPC is single-statement, indexed on `(follower_id)` and `(followed_id)` (existing) + `display_name` (need to verify; if missing, add `CREATE INDEX IF NOT EXISTS idx_profiles_display_name_lower ON profiles ((lower(display_name)))` and adjust RPC to use `lower()`).
+- `getFollowStatuses` queries up to ~40 IDs at a time (two pages worth). Indexed lookup, sub-10ms.
+- Skeleton rendering means LCP for the sheet is near-instant; real rows fade in on data arrival.
+
+## Testing
+
+- **Vitest unit:** extend `src/api/followsApi.test.js` (or create) covering: `searchFollows` happy path, empty query short-circuit, sanitizer-stripped query, RPC error classification.
+- **Manual smoke (per SMOKE-TEST.md):**
+  - Open Profile → tap Followers → sheet opens at half detent, search input is focused.
+  - Drag up → snaps to full.
+  - Drag down → snaps back to half, then closed.
+  - Type a name → results filter server-side after 250ms; alphabetical, paginated correctly through 21+.
+  - Tap Follow on a row → button toggles to Following without page navigation; parent profile's "Following N" count increments (via `useFollowUser` cache invalidation).
+  - Scroll to bottom → next 20 rows load automatically.
+  - Disconnect network mid-follow → button reverts, sonner toast appears.
+  - Disconnect mid-pagination → "Couldn't load more. Tap to retry." banner shows; tapping refires.
+
+## Open Questions Resolved During Brainstorm + Codex Review
+
+| Question | Decision |
+|---|---|
+| Search scope | Server-side, ranked, paginated, via new RPC `search_user_follows`. |
+| Row actions | Inline Follow/Unfollow button, separate from row wrapper (no nested `<button>`). |
+| Form factor | Tall bottom sheet with half/full detents, drag-driven. |
+| Row content | Avatar + name + follower count (singular/plural). |
+| Pagination | Infinite scroll via `IntersectionObserver` with `root` = scroll container. |
+| Data layer | React Query throughout (`useInfiniteQuery` + `useQuery` + `useMutation` via `useFollowUser`). |
+| Search result limit | Paginated alphabetically with `(display_name, id)` cursor — fully reachable, no hidden tail. |
+| Error retry on observer | Manual via "Tap to retry"; no auto-retry to prevent thrash. |
+| Focus on open | Override hook to land on search input. |
+
+## Implementation Order (preview for the plan)
+
+1. Add `search_user_follows` to `supabase/schema.sql` and `supabase/migrations/20260516_search_user_follows.sql`. Run in Supabase SQL Editor. Verify with test call.
+2. Extend `useFocusTrap` to accept `{ initialFocusRef }` option (additive).
+3. Extend `followsApi.js` — `searchFollows`, route in `getFollowers/getFollowing`, add `getFollowStatuses`. Each method uses the `throw error.type ? error : createClassifiedError(error)` catch pattern.
+4. Create `src/hooks/useFollowList.js` (React Query wrapper).
+5. Rewrite `FollowListModal.jsx` skeleton + state, hooked to `useFollowList`.
+6. Wire search bar + debounce + sanitize.
+7. Wire infinite scroll observer with `root: scrollContainerRef.current`.
+8. Wire follow/unfollow inline button via `useFollowUser` + optimistic `optimisticToggles` set.
+9. Wire detent gestures + animations.
+10. Add skeleton loading + empty/error states.
+11. Pass `initialFocusRef={searchInputRef}` to `useFocusTrap`.
+12. Manual smoke against SMOKE-TEST.md.
+
+Each step runs through `/codex-cli` individually before commit, per Dan's standing rule.

--- a/src/api/followsApi.js
+++ b/src/api/followsApi.js
@@ -229,7 +229,7 @@ export const followsApi = {
    * @param {string} userId - User ID
    * @param {Object} options - Pagination options
    * @param {number} options.limit - Max results per page (default 20)
-   * @param {string} options.cursor - Cursor for pagination (created_at of last item, or {display_name, id} for search)
+   * @param {string|{display_name: string, id: string}} options.cursor - Recency mode: created_at timestamp of last item. Search mode: {display_name, id} of last item.
    * @param {string} options.searchQuery - Optional query to filter the follow list
    * @returns {Promise<{users: Array, hasMore: boolean}>}
    */
@@ -256,7 +256,7 @@ export const followsApi = {
    * @param {string} userId - User ID
    * @param {Object} options - Pagination options
    * @param {number} options.limit - Max results per page (default 20)
-   * @param {string} options.cursor - Cursor for pagination (created_at of last item, or {display_name, id} for search)
+   * @param {string|{display_name: string, id: string}} options.cursor - Recency mode: created_at timestamp of last item. Search mode: {display_name, id} of last item.
    * @param {string} options.searchQuery - Optional query to filter the follow list
    * @returns {Promise<{users: Array, hasMore: boolean}>}
    */

--- a/src/api/followsApi.js
+++ b/src/api/followsApi.js
@@ -67,6 +67,53 @@ async function _paginateFollows(userId, direction, { limit = 20, cursor = null }
 }
 
 /**
+ * Server-side ranked search of a user's followers/following list.
+ * Uses search_user_follows RPC with (display_name, id) cursor pagination.
+ * @param {string} userId - User whose follow list to search
+ * @param {'followers'|'following'} direction - Which side of the follows table
+ * @param {Object} options
+ * @param {string} options.query - Raw user-typed query
+ * @param {{display_name: string, id: string}|null} options.cursor - Cursor from prior page
+ * @param {number} options.limit - Page size (default 20)
+ * @returns {Promise<{users: Array, hasMore: boolean}>}
+ */
+async function _searchFollows(userId, direction, { query, cursor = null, limit = 20 } = {}) {
+  try {
+    if (!query?.trim()) return { users: [], hasMore: false }
+    const sanitized = sanitizeSearchQuery(query, 50)
+    // After sanitization, % and _ become \% / \_. If the only "content" is escape
+    // sequences (no real searchable characters), there's nothing to match — bail
+    // out before hitting the RPC. Strip escaped LIKE/ILIKE metachars to check.
+    const searchable = sanitized.replace(/\\[%_\\]/g, '')
+    if (!sanitized || !searchable) return { users: [], hasMore: false }
+
+    const { data, error } = await supabase.rpc('search_user_follows', {
+      p_user_id: userId,
+      p_direction: direction,
+      p_query: sanitized,
+      p_cursor_name: cursor?.display_name || null,
+      p_cursor_id: cursor?.id || null,
+      p_limit: limit + 1,
+    })
+    if (error) throw createClassifiedError(error)
+
+    const rows = data || []
+    const hasMore = rows.length > limit
+    const users = (hasMore ? rows.slice(0, limit) : rows).map(r => ({
+      id: r.id,
+      display_name: r.display_name || 'Anonymous',
+      avatar_url: r.avatar_url || null,
+      follower_count: r.follower_count || 0,
+      followed_at: r.followed_at,
+    }))
+    return { users, hasMore }
+  } catch (error) {
+    logger.error('searchFollows error:', error)
+    throw error.type ? error : createClassifiedError(error)
+  }
+}
+
+/**
  * Follows API - Social connections
  */
 
@@ -176,26 +223,51 @@ export const followsApi = {
   },
 
   /**
-   * Get followers of a user with cursor-based pagination
+   * Get followers of a user with cursor-based pagination.
+   * When options.searchQuery is provided, routes to ranked server-side search
+   * (search_user_follows RPC); otherwise returns recency-ordered followers.
    * @param {string} userId - User ID
    * @param {Object} options - Pagination options
    * @param {number} options.limit - Max results per page (default 20)
-   * @param {string} options.cursor - Cursor for pagination (created_at of last item)
+   * @param {string} options.cursor - Cursor for pagination (created_at of last item, or {display_name, id} for search)
+   * @param {string} options.searchQuery - Optional query to filter the follow list
    * @returns {Promise<{users: Array, hasMore: boolean}>}
    */
   async getFollowers(userId, options) {
+    // String-presence check (not truthy) so callers can signal "search mode,
+    // empty input" by passing searchQuery: '' (a typed-then-cleared input
+    // box should not silently fall back to the unfiltered list).
+    // Explicit undefined/null still falls through to recency pagination —
+    // useful for hooks that conditionally build options objects.
+    if (options && typeof options.searchQuery === 'string') {
+      return _searchFollows(userId, 'followers', {
+        query: options.searchQuery,
+        cursor: options.cursor,
+        limit: options.limit,
+      })
+    }
     return _paginateFollows(userId, 'followers', options)
   },
 
   /**
-   * Get users that a user follows with cursor-based pagination
+   * Get users that a user follows with cursor-based pagination.
+   * When options.searchQuery is provided, routes to ranked server-side search
+   * (search_user_follows RPC); otherwise returns recency-ordered following list.
    * @param {string} userId - User ID
    * @param {Object} options - Pagination options
    * @param {number} options.limit - Max results per page (default 20)
-   * @param {string} options.cursor - Cursor for pagination (created_at of last item)
+   * @param {string} options.cursor - Cursor for pagination (created_at of last item, or {display_name, id} for search)
+   * @param {string} options.searchQuery - Optional query to filter the follow list
    * @returns {Promise<{users: Array, hasMore: boolean}>}
    */
   async getFollowing(userId, options) {
+    if (options && typeof options.searchQuery === 'string') {
+      return _searchFollows(userId, 'following', {
+        query: options.searchQuery,
+        cursor: options.cursor,
+        limit: options.limit,
+      })
+    }
     return _paginateFollows(userId, 'following', options)
   },
 

--- a/src/api/followsApi.js
+++ b/src/api/followsApi.js
@@ -151,6 +151,31 @@ export const followsApi = {
   },
 
   /**
+   * Batch-check which of the given user IDs the current user follows.
+   * @param {string[]} userIds
+   * @returns {Promise<Set<string>>}
+   */
+  async getFollowStatuses(userIds) {
+    if (!Array.isArray(userIds) || userIds.length === 0) return new Set()
+    try {
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) return new Set()
+
+      const { data, error } = await supabase
+        .from('follows')
+        .select('followed_id')
+        .eq('follower_id', user.id)
+        .in('followed_id', userIds)
+
+      if (error) throw createClassifiedError(error)
+      return new Set((data || []).map(r => r.followed_id))
+    } catch (error) {
+      logger.error('getFollowStatuses error:', error)
+      throw error.type ? error : createClassifiedError(error)
+    }
+  },
+
+  /**
    * Get followers of a user with cursor-based pagination
    * @param {string} userId - User ID
    * @param {Object} options - Pagination options

--- a/src/api/followsApi.test.js
+++ b/src/api/followsApi.test.js
@@ -88,4 +88,88 @@ describe('followsApi', () => {
       })
     })
   })
+
+  describe('searchFollows via getFollowers/getFollowing', () => {
+    it('returns empty result for empty query', async () => {
+      const result = await followsApi.getFollowers('user-1', { searchQuery: '' })
+      expect(result).toEqual({ users: [], hasMore: false })
+    })
+
+    it('returns empty result for whitespace-only query', async () => {
+      const result = await followsApi.getFollowing('user-1', { searchQuery: '   ' })
+      expect(result).toEqual({ users: [], hasMore: false })
+    })
+
+    it('returns empty result when sanitizer strips everything (e.g. %%)', async () => {
+      const result = await followsApi.getFollowers('user-1', { searchQuery: '%%' })
+      expect(result).toEqual({ users: [], hasMore: false })
+    })
+
+    it('calls RPC with correct args and maps rows for followers direction', async () => {
+      supabase.rpc.mockResolvedValue({
+        data: [
+          { id: 'a', display_name: 'Alice', avatar_url: null, follower_count: 5, followed_at: '2026-01-01' },
+          { id: 'b', display_name: 'Bob', avatar_url: 'x.jpg', follower_count: 0, followed_at: '2026-01-02' },
+        ],
+        error: null,
+      })
+
+      const result = await followsApi.getFollowers('user-1', { searchQuery: 'al', limit: 1 })
+
+      expect(supabase.rpc).toHaveBeenCalledWith('search_user_follows', expect.objectContaining({
+        p_user_id: 'user-1',
+        p_direction: 'followers',
+        p_query: 'al',
+        p_cursor_name: null,
+        p_cursor_id: null,
+        p_limit: 2, // limit + 1 for hasMore detection
+      }))
+      expect(result.users).toHaveLength(1)
+      expect(result.users[0].id).toBe('a')
+      expect(result.users[0].display_name).toBe('Alice')
+      expect(result.hasMore).toBe(true)
+    })
+
+    it('calls RPC with following direction when invoked via getFollowing', async () => {
+      supabase.rpc.mockResolvedValue({ data: [], error: null })
+      await followsApi.getFollowing('user-1', { searchQuery: 'al' })
+      expect(supabase.rpc).toHaveBeenCalledWith('search_user_follows', expect.objectContaining({
+        p_direction: 'following',
+      }))
+    })
+
+    it('passes through cursor object as p_cursor_name + p_cursor_id', async () => {
+      supabase.rpc.mockResolvedValue({ data: [], error: null })
+      await followsApi.getFollowers('user-1', {
+        searchQuery: 'al',
+        cursor: { display_name: 'Anna', id: 'cursor-id' },
+      })
+      expect(supabase.rpc).toHaveBeenCalledWith('search_user_follows', expect.objectContaining({
+        p_cursor_name: 'Anna',
+        p_cursor_id: 'cursor-id',
+      }))
+    })
+
+    it('throws classified error on RPC failure', async () => {
+      supabase.rpc.mockResolvedValue({ data: null, error: { message: 'boom', code: '42883' } })
+      await expect(followsApi.getFollowers('user-1', { searchQuery: 'al' }))
+        .rejects.toMatchObject({ type: expect.any(String) })
+    })
+
+    it('falls back to recency cursor when searchQuery is absent', async () => {
+      const chain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+        lt: vi.fn().mockReturnThis(),
+      }
+      supabase.from.mockReturnValue(chain)
+
+      await followsApi.getFollowers('user-1')
+
+      expect(supabase.rpc).not.toHaveBeenCalled()
+      expect(supabase.from).toHaveBeenCalledWith('follows')
+    })
+  })
 })

--- a/src/api/followsApi.test.js
+++ b/src/api/followsApi.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { followsApi } from './followsApi'
+
+vi.mock('../utils/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock('../lib/supabase', () => ({
+  supabase: {
+    auth: { getUser: vi.fn() },
+    from: vi.fn(),
+    rpc: vi.fn(),
+  },
+}))
+
+import { supabase } from '../lib/supabase'
+
+describe('followsApi', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+  afterEach(() => { vi.resetAllMocks() })
+
+  describe('getFollowStatuses', () => {
+    it('returns empty Set when userIds is empty (no auth or DB call)', async () => {
+      const result = await followsApi.getFollowStatuses([])
+      expect(result).toBeInstanceOf(Set)
+      expect(result.size).toBe(0)
+      expect(supabase.auth.getUser).not.toHaveBeenCalled()
+      expect(supabase.from).not.toHaveBeenCalled()
+    })
+
+    it('returns empty Set when userIds is not an array (defensive guard)', async () => {
+      const result = await followsApi.getFollowStatuses(null)
+      expect(result).toBeInstanceOf(Set)
+      expect(result.size).toBe(0)
+      expect(supabase.auth.getUser).not.toHaveBeenCalled()
+      expect(supabase.from).not.toHaveBeenCalled()
+    })
+
+    it('returns empty Set when not authenticated (no DB call)', async () => {
+      supabase.auth.getUser.mockResolvedValue({ data: { user: null } })
+      const result = await followsApi.getFollowStatuses(['a', 'b'])
+      expect(result.size).toBe(0)
+      expect(supabase.from).not.toHaveBeenCalled()
+    })
+
+    it('returns Set of followed IDs for authenticated user', async () => {
+      supabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'me' } } })
+      const inMock = vi.fn().mockResolvedValue({
+        data: [{ followed_id: 'a' }, { followed_id: 'c' }],
+        error: null,
+      })
+      const eqMock = vi.fn().mockReturnValue({ in: inMock })
+      const selectMock = vi.fn().mockReturnValue({ eq: eqMock })
+      supabase.from.mockReturnValue({ select: selectMock })
+
+      const result = await followsApi.getFollowStatuses(['a', 'b', 'c'])
+
+      expect(supabase.from).toHaveBeenCalledWith('follows')
+      expect(selectMock).toHaveBeenCalledWith('followed_id')
+      expect(eqMock).toHaveBeenCalledWith('follower_id', 'me')
+      expect(inMock).toHaveBeenCalledWith('followed_id', ['a', 'b', 'c'])
+      expect(result.has('a')).toBe(true)
+      expect(result.has('b')).toBe(false)
+      expect(result.has('c')).toBe(true)
+    })
+
+    it('throws classified error on supabase query error', async () => {
+      supabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'me' } } })
+      const inMock = vi.fn().mockResolvedValue({ data: null, error: { message: 'boom', code: 'XX' } })
+      supabase.from.mockReturnValue({
+        select: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ in: inMock }) })
+      })
+
+      // Must surface a classified error (CLAUDE §1.2) — assert .type is present
+      // so a regression to plain `throw error` is caught.
+      await expect(followsApi.getFollowStatuses(['a'])).rejects.toMatchObject({
+        type: expect.any(String),
+      })
+    })
+
+    it('throws classified error when auth.getUser itself rejects', async () => {
+      // Transport-level auth failure must not be swallowed as "anonymous user"
+      // — the catch block classifies and re-throws.
+      supabase.auth.getUser.mockRejectedValue(new Error('network unreachable'))
+
+      await expect(followsApi.getFollowStatuses(['a'])).rejects.toMatchObject({
+        type: expect.any(String),
+      })
+    })
+  })
+})

--- a/src/components/FollowListModal.jsx
+++ b/src/components/FollowListModal.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { memo, useState, useEffect, useRef, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import { useFollowList } from '../hooks/useFollowList'
@@ -6,6 +6,15 @@ import { useFollowUser } from '../hooks/useFollowUser'
 import { useFocusTrap } from '../hooks/useFocusTrap'
 import { useAuth } from '../context/AuthContext'
 import { getUserMessage } from '../utils/errorHandler'
+import { EmptyState } from './EmptyState'
+
+const SHEET_HEIGHTS = { half: '75vh', full: '95vh' }
+const SHEET_TRANSITION_MS = 280
+const DRAG_THRESHOLD_PX = 50
+const DRAG_THRESHOLD_VELOCITY = 0.3 // px/ms
+// Drag must move at least this far before we suppress the synthetic click.
+// Below this threshold we treat the gesture as a tap, letting onGrabberClick fire.
+const DRAG_CLICK_SUPPRESS_PX = 6
 
 export function FollowListModal({ userId, type, onClose }) {
   const navigate = useNavigate()
@@ -28,7 +37,7 @@ export function FollowListModal({ userId, type, onClose }) {
   }, [searchInput])
 
   const {
-    users, followingSet, loading, loadingMore, searching,
+    users, followingSet, loading, loadingMore, searchFetching,
     error, hasMore, fetchMore, refetch, isSearching,
   } = useFollowList({ userId, type, searchQuery: debouncedQuery })
 
@@ -49,28 +58,31 @@ export function FollowListModal({ userId, type, onClose }) {
     inFlightRef.current.delete(id)
   }, [])
 
-  const handleFollowToggle = useCallback((user) => {
+  const handleFollowToggle = useCallback((id) => {
     if (!viewer) return
-    if (inFlightRef.current.has(user.id)) return // ignore rapid double-clicks
-    const currentlyFollowing = isFollowing(user.id)
+    if (inFlightRef.current.has(id)) return // ignore rapid double-clicks
+    const currentlyFollowing = isFollowing(id)
     const nextState = !currentlyFollowing
-    inFlightRef.current.add(user.id)
+    inFlightRef.current.add(id)
     setPendingTargets(prev => {
       const next = new Map(prev)
-      next.set(user.id, nextState)
+      next.set(id, nextState)
       return next
     })
     const mutation = nextState ? follow : unfollow
-    mutation.mutate(user.id, {
-      onSuccess: () => clearPendingTarget(user.id),
+    mutation.mutate(id, {
+      onSuccess: () => clearPendingTarget(id),
       onError: (err) => {
-        clearPendingTarget(user.id)
+        clearPendingTarget(id)
         toast.error(getUserMessage(err, nextState ? 'following' : 'unfollowing'))
       },
     })
   }, [viewer, isFollowing, clearPendingTarget, follow, unfollow])
 
-  const handleUserClick = (user) => { onClose(); navigate(`/user/${user.id}`) }
+  const handleRowNavigate = useCallback((id) => {
+    onClose()
+    navigate(`/user/${id}`)
+  }, [onClose, navigate])
 
   const scrollContainerRef = useRef(null)
   const sentinelRef = useRef(null)
@@ -82,14 +94,6 @@ export function FollowListModal({ userId, type, onClose }) {
   const [dragOffset, setDragOffset] = useState(0)
   const dragStartRef = useRef({ y: 0, t: 0, state: 'half', active: false, didDrag: false })
   const closeTimerRef = useRef(null)
-
-  const SHEET_HEIGHTS = { half: '75vh', full: '95vh' }
-  const SHEET_TRANSITION_MS = 280
-  const DRAG_THRESHOLD_PX = 50
-  const DRAG_THRESHOLD_VELOCITY = 0.3 // px/ms
-  // Drag must move at least this far before we suppress the synthetic click.
-  // Below this threshold we treat the gesture as a tap, letting onGrabberClick fire.
-  const DRAG_CLICK_SUPPRESS_PX = 6
 
   // Clear any pending close timer on unmount to prevent stale onClose firing
   // after the parent has already torn the modal down.
@@ -303,7 +307,7 @@ export function FollowListModal({ userId, type, onClose }) {
                 boxShadow: 'inset 0 1px 0 rgba(0,0,0,0.05)',
               }}
             >
-              {searching ? (
+              {searchFetching ? (
                 <div
                   className="w-4 h-4 border-2 rounded-full animate-spin flex-shrink-0"
                   style={{ borderColor: 'var(--color-divider)', borderTopColor: 'var(--color-text-tertiary)' }}
@@ -323,7 +327,6 @@ export function FollowListModal({ userId, type, onClose }) {
                 placeholder={isFollowers ? 'Search followers' : 'Search following'}
                 className="flex-1 bg-transparent outline-none"
                 style={{ color: 'var(--color-text-primary)', fontSize: 16 }}
-                aria-label={`Search ${title.toLowerCase()}`}
               />
               {searchInput && (
                 <button
@@ -346,7 +349,7 @@ export function FollowListModal({ userId, type, onClose }) {
           ) : error && users.length === 0 ? (
             <ErrorState onRetry={refetch} />
           ) : users.length === 0 ? (
-            <EmptyState type={type} isSearching={isSearching} query={debouncedQuery} />
+            <FollowListEmpty type={type} isSearching={isSearching} query={debouncedQuery} />
           ) : (
             <>
               <ul className="divide-y" style={{ borderColor: 'var(--color-divider)' }}>
@@ -356,8 +359,8 @@ export function FollowListModal({ userId, type, onClose }) {
                     user={user}
                     isFollowing={isFollowing(user.id)}
                     showFollowButton={!!viewer && viewer.id !== user.id}
-                    onRowClick={() => handleUserClick(user)}
-                    onFollowToggle={() => handleFollowToggle(user)}
+                    onRowClick={handleRowNavigate}
+                    onFollowToggle={handleFollowToggle}
                   />
                 ))}
               </ul>
@@ -372,7 +375,7 @@ export function FollowListModal({ userId, type, onClose }) {
   )
 }
 
-function FollowRow({ user, isFollowing, showFollowButton, onRowClick, onFollowToggle }) {
+const FollowRow = memo(function FollowRow({ user, isFollowing, showFollowButton, onRowClick, onFollowToggle }) {
   const displayName = user.display_name || 'Anonymous'
   const followerLabel = user.follower_count === 0
     ? 'No followers yet'
@@ -380,14 +383,17 @@ function FollowRow({ user, isFollowing, showFollowButton, onRowClick, onFollowTo
       ? '1 follower'
       : `${user.follower_count.toLocaleString()} followers`
 
+  const handleClick = () => onRowClick(user.id)
+  const handleFollow = (e) => { e.stopPropagation(); onFollowToggle(user.id) }
+
   return (
     <li>
       <div
         role="link"
         tabIndex={0}
         aria-label={`${displayName} profile`}
-        onClick={onRowClick}
-        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onRowClick() } }}
+        onClick={handleClick}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onRowClick(user.id) } }}
         className="w-full flex items-center gap-3 px-4 py-3.5 cursor-pointer transition-colors hover:bg-black/[0.04] focus:outline-none focus-visible:bg-black/[0.04]"
         style={{ minHeight: 64 }}
       >
@@ -414,7 +420,7 @@ function FollowRow({ user, isFollowing, showFollowButton, onRowClick, onFollowTo
         {showFollowButton && (
           <button
             type="button"
-            onClick={(e) => { e.stopPropagation(); onFollowToggle() }}
+            onClick={handleFollow}
             onKeyDown={(e) => {
               // Prevent Enter/Space from bubbling to row container and triggering navigation
               if (e.key === 'Enter' || e.key === ' ') e.stopPropagation()
@@ -436,7 +442,7 @@ function FollowRow({ user, isFollowing, showFollowButton, onRowClick, onFollowTo
       </div>
     </li>
   )
-}
+})
 
 function SkeletonRows() {
   return (
@@ -454,29 +460,21 @@ function SkeletonRows() {
   )
 }
 
-function EmptyState({ type, isSearching, query }) {
+function FollowListEmpty({ type, isSearching, query }) {
   if (isSearching) {
     return (
-      <div className="py-12 px-6 text-center">
-        <p className="font-medium" style={{ color: 'var(--color-text-primary)', fontSize: 16 }}>
-          No one matches &quot;{query}&quot;
-        </p>
-        <p className="mt-1" style={{ color: 'var(--color-text-tertiary)', fontSize: 14 }}>
-          Try a different name.
-        </p>
-      </div>
+      <EmptyState
+        title={`No one matches "${query}"`}
+        subtitle="Try a different name."
+      />
     )
   }
   const isFollowers = type === 'followers'
   return (
-    <div className="py-12 px-6 text-center">
-      <p className="font-medium" style={{ color: 'var(--color-text-primary)', fontSize: 16 }}>
-        {isFollowers ? 'No followers yet' : 'Not following anyone yet'}
-      </p>
-      <p className="mt-1" style={{ color: 'var(--color-text-tertiary)', fontSize: 14 }}>
-        {isFollowers ? 'Share your profile to get discovered.' : 'Find people whose taste you trust on dish pages.'}
-      </p>
-    </div>
+    <EmptyState
+      title={isFollowers ? 'No followers yet' : 'Not following anyone yet'}
+      subtitle={isFollowers ? 'Share your profile to get discovered.' : 'Find people whose taste you trust on dish pages.'}
+    />
   )
 }
 
@@ -525,7 +523,7 @@ function LoadMoreErrorBanner({ onRetry }) {
     <div className="px-4 py-3 border-t" style={{ borderColor: 'var(--color-divider)' }}>
       <button
         type="button"
-        onClick={() => onRetry()}
+        onClick={onRetry}
         className="w-full py-2 rounded-lg text-sm font-medium"
         style={{
           background: 'var(--color-bg)',

--- a/src/components/FollowListModal.jsx
+++ b/src/components/FollowListModal.jsx
@@ -1,87 +1,104 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { followsApi } from '../api/followsApi'
+import { toast } from 'sonner'
+import { useFollowList } from '../hooks/useFollowList'
+import { useFollowUser } from '../hooks/useFollowUser'
 import { useFocusTrap } from '../hooks/useFocusTrap'
+import { useAuth } from '../context/AuthContext'
+import { getUserMessage } from '../utils/errorHandler'
 
-/**
- * Modal to display followers or following list with pagination
- */
 export function FollowListModal({ userId, type, onClose }) {
   const navigate = useNavigate()
-  const [users, setUsers] = useState([])
-  const [loading, setLoading] = useState(true)
-  const [loadingMore, setLoadingMore] = useState(false)
-  const [error, setError] = useState(null)
-  const [hasMore, setHasMore] = useState(false)
-  const [cursor, setCursor] = useState(null)
-
+  const { user: viewer } = useAuth()
   const isFollowers = type === 'followers'
   const title = isFollowers ? 'Followers' : 'Following'
 
-  // Initial fetch
+  const [searchInput, setSearchInput] = useState('')
+  const [debouncedQuery, setDebouncedQuery] = useState('')
+  // Map of userId -> intended follow state (true=following, false=not following).
+  // Cleared per-user on mutation settle (success or error). Latest click wins;
+  // out-of-order callbacks only clear their own user entry.
+  const [pendingTargets, setPendingTargets] = useState(() => new Map())
+  // Per-user in-flight guard prevents stacking duplicate mutations.
+  const inFlightRef = useRef(new Set())
+
   useEffect(() => {
-    async function fetchUsers() {
-      setLoading(true)
-      setError(null)
-      setUsers([])
-      setCursor(null)
-      try {
-        const result = isFollowers
-          ? await followsApi.getFollowers(userId)
-          : await followsApi.getFollowing(userId)
-        setUsers(result.users)
-        setHasMore(result.hasMore)
-        if (result.users.length > 0) {
-          setCursor(result.users[result.users.length - 1].followed_at)
-        }
-      } catch {
-        setError('Unable to load. Please try again.')
-      } finally {
-        setLoading(false)
+    const t = setTimeout(() => setDebouncedQuery(searchInput), 250)
+    return () => clearTimeout(t)
+  }, [searchInput])
+
+  const {
+    users, followingSet, loading, loadingMore, searching,
+    error, hasMore, fetchMore, refetch, isSearching,
+  } = useFollowList({ userId, type, searchQuery: debouncedQuery })
+
+  const isFollowing = useCallback((id) => {
+    if (pendingTargets.has(id)) return pendingTargets.get(id)
+    return followingSet.has(id)
+  }, [followingSet, pendingTargets])
+
+  const { follow, unfollow } = useFollowUser()
+
+  const clearPendingTarget = useCallback((id) => {
+    setPendingTargets(prev => {
+      if (!prev.has(id)) return prev
+      const next = new Map(prev)
+      next.delete(id)
+      return next
+    })
+    inFlightRef.current.delete(id)
+  }, [])
+
+  const handleFollowToggle = useCallback((user) => {
+    if (!viewer) return
+    if (inFlightRef.current.has(user.id)) return // ignore rapid double-clicks
+    const currentlyFollowing = isFollowing(user.id)
+    const nextState = !currentlyFollowing
+    inFlightRef.current.add(user.id)
+    setPendingTargets(prev => {
+      const next = new Map(prev)
+      next.set(user.id, nextState)
+      return next
+    })
+    const mutation = nextState ? follow : unfollow
+    mutation.mutate(user.id, {
+      onSuccess: () => clearPendingTarget(user.id),
+      onError: (err) => {
+        clearPendingTarget(user.id)
+        toast.error(getUserMessage(err, nextState ? 'following' : 'unfollowing'))
+      },
+    })
+  }, [viewer, isFollowing, clearPendingTarget, follow, unfollow])
+
+  const handleUserClick = (user) => { onClose(); navigate(`/user/${user.id}`) }
+
+  const scrollContainerRef = useRef(null)
+  const sentinelRef = useRef(null)
+  const searchInputRef = useRef(null)
+  const modalRef = useFocusTrap(true, onClose, { initialFocusRef: searchInputRef })
+
+  // Infinite scroll observer rooted on the scroll container
+  useEffect(() => {
+    if (!scrollContainerRef.current || !sentinelRef.current) return
+    if (error || !hasMore) return
+
+    const observer = new IntersectionObserver((entries) => {
+      const entry = entries[0]
+      if (entry.isIntersecting && hasMore && !loadingMore && !error) {
+        fetchMore()
       }
-    }
-    fetchUsers()
-  }, [userId, isFollowers])
-
-  // Load more handler
-  const handleLoadMore = useCallback(async () => {
-    if (loadingMore || !hasMore || !cursor) return
-
-    setLoadingMore(true)
-    try {
-      const result = isFollowers
-        ? await followsApi.getFollowers(userId, { cursor })
-        : await followsApi.getFollowing(userId, { cursor })
-
-      setUsers(prev => [...prev, ...result.users])
-      setHasMore(result.hasMore)
-      if (result.users.length > 0) {
-        setCursor(result.users[result.users.length - 1].followed_at)
-      }
-    } catch {
-      // Silently fail on load more - user can retry
-    } finally {
-      setLoadingMore(false)
-    }
-  }, [userId, isFollowers, cursor, hasMore, loadingMore])
-
-  const handleUserClick = (user) => {
-    onClose()
-    navigate(`/user/${user.id}`)
-  }
-
-  const modalRef = useFocusTrap(true, onClose)
+    }, {
+      root: scrollContainerRef.current,
+      rootMargin: '200px',
+    })
+    observer.observe(sentinelRef.current)
+    return () => observer.disconnect()
+  }, [hasMore, loadingMore, error, fetchMore, isSearching])
 
   return (
-    <div
-      className="fixed inset-0 z-50"
-      onClick={onClose}
-      role="presentation"
-    >
-      {/* Backdrop */}
+    <div className="fixed inset-0 z-50" onClick={onClose} role="presentation">
       <div className="absolute inset-0" style={{ background: 'rgba(0,0,0,0.6)' }} aria-hidden="true" />
 
-      {/* Bottom sheet */}
       <div
         ref={modalRef}
         role="dialog"
@@ -90,29 +107,25 @@ export function FollowListModal({ userId, type, onClose }) {
         className="absolute left-0 right-0 bottom-0 rounded-t-2xl flex flex-col"
         style={{
           background: 'var(--color-surface-elevated)',
-          maxHeight: '85vh',
+          height: '75vh',
           paddingBottom: 'env(safe-area-inset-bottom, 0px)',
         }}
         onClick={(e) => e.stopPropagation()}
       >
-        {/* Grabber */}
         <div
           style={{ width: 40, height: 4, background: 'var(--color-divider)', borderRadius: 2, margin: '8px auto 4px', flex: '0 0 auto' }}
           aria-hidden="true"
         />
 
-        {/* Header */}
         <div
           className="flex items-center justify-between px-4 py-3 border-b"
-          style={{
-            borderColor: 'var(--color-divider)',
-            flex: '0 0 auto',
-          }}
+          style={{ borderColor: 'var(--color-divider)', flex: '0 0 auto' }}
         >
           <h2 id="follow-list-title" className="text-lg font-bold" style={{ color: 'var(--color-text-primary)' }}>
             {title}
           </h2>
           <button
+            type="button"
             onClick={onClose}
             className="p-2 -mr-2 rounded-full"
             style={{ color: 'var(--color-text-secondary)' }}
@@ -124,8 +137,8 @@ export function FollowListModal({ userId, type, onClose }) {
           </button>
         </div>
 
-        {/* Scrollable body */}
         <div
+          ref={scrollContainerRef}
           style={{
             flex: '1 1 auto',
             minHeight: 0,
@@ -135,105 +148,243 @@ export function FollowListModal({ userId, type, onClose }) {
             touchAction: 'pan-y',
           }}
         >
-          {loading ? (
-            <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
-              <div
-                className="w-6 h-6 border-2 rounded-full animate-spin"
-                style={{ borderColor: 'var(--color-divider)', borderTopColor: 'var(--color-primary)' }}
-                aria-hidden="true"
+          <div
+            className="sticky top-0 z-10 px-4 pt-3 pb-2"
+            style={{ background: 'var(--color-surface-elevated)' }}
+          >
+            <div
+              className="flex items-center gap-2 px-3 rounded-full"
+              style={{
+                background: 'var(--color-bg)',
+                height: 40,
+                boxShadow: 'inset 0 1px 0 rgba(0,0,0,0.05)',
+              }}
+            >
+              {searching ? (
+                <div
+                  className="w-4 h-4 border-2 rounded-full animate-spin flex-shrink-0"
+                  style={{ borderColor: 'var(--color-divider)', borderTopColor: 'var(--color-text-tertiary)' }}
+                  aria-hidden="true"
+                />
+              ) : (
+                <svg className="w-4 h-4 flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }}
+                     fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35M10 17a7 7 0 100-14 7 7 0 000 14z" />
+                </svg>
+              )}
+              <input
+                ref={searchInputRef}
+                type="text"
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                placeholder={isFollowers ? 'Search followers' : 'Search following'}
+                className="flex-1 bg-transparent outline-none"
+                style={{ color: 'var(--color-text-primary)', fontSize: 16 }}
+                aria-label={`Search ${title.toLowerCase()}`}
               />
-              <span className="sr-only">Loading...</span>
-            </div>
-          ) : error ? (
-            <div className="py-12 text-center">
-              <div className="text-4xl mb-2">⚠️</div>
-              <p className="text-sm" style={{ color: 'var(--color-text-secondary)' }}>
-                {error}
-              </p>
-            </div>
-          ) : users.length === 0 ? (
-            <div className="py-12 text-center">
-              <div className="text-4xl mb-2">
-                {isFollowers ? '👥' : '🔍'}
-              </div>
-              <p className="text-sm" style={{ color: 'var(--color-text-secondary)' }}>
-                {isFollowers ? 'No followers yet' : 'Not following anyone yet'}
-              </p>
-            </div>
-          ) : (
-            <div>
-              <div className="divide-y" style={{ borderColor: 'var(--color-divider)' }}>
-                {users.map((user) => (
-                  <button
-                    key={user.id}
-                    onClick={() => handleUserClick(user)}
-                    className="w-full flex items-center gap-3 px-4 py-3.5 transition-all text-left hover:bg-black/5 active:scale-[0.99]"
-                  >
-                    {/* Avatar */}
-                    <div
-                      className="w-11 h-11 rounded-full flex items-center justify-center font-bold flex-shrink-0 overflow-hidden"
-                      style={{ background: 'var(--color-primary)', color: 'var(--color-text-on-primary)' }}
-                    >
-                      {user.avatar_url ? (
-                        <img src={user.avatar_url} alt="" className="w-full h-full object-cover" draggable={false} />
-                      ) : (
-                        <span>{user.display_name?.charAt(0).toUpperCase() || '?'}</span>
-                      )}
-                    </div>
-
-                    {/* Info */}
-                    <div className="flex-1 min-w-0">
-                      <p className="font-medium truncate" style={{ color: 'var(--color-text-primary)' }}>
-                        {user.display_name || 'Anonymous'}
-                      </p>
-                    </div>
-
-                    {/* Arrow */}
-                    <svg
-                      className="w-4 h-4 flex-shrink-0"
-                      style={{ color: 'var(--color-text-tertiary)' }}
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-                    </svg>
-                  </button>
-                ))}
-              </div>
-
-              {/* Load More Button */}
-              {hasMore && (
-                <div className="p-4 border-t" style={{ borderColor: 'var(--color-divider)' }}>
-                  <button
-                    onClick={handleLoadMore}
-                    disabled={loadingMore}
-                    className="w-full py-2.5 rounded-xl font-medium text-sm transition-all"
-                    style={{
-                      background: 'var(--color-primary)',
-                      color: 'var(--color-text-on-primary)',
-                      opacity: loadingMore ? 0.7 : 1
-                    }}
-                  >
-                    {loadingMore ? (
-                      <span className="flex items-center justify-center gap-2">
-                        <div
-                          className="w-4 h-4 border-2 rounded-full animate-spin"
-                          style={{ borderColor: 'rgba(255,255,255,0.4)', borderTopColor: 'var(--color-text-on-primary)' }}
-                        />
-                        Loading...
-                      </span>
-                    ) : (
-                      'Load More'
-                    )}
-                  </button>
-                </div>
+              {searchInput && (
+                <button
+                  type="button"
+                  onClick={() => { setSearchInput(''); searchInputRef.current?.focus() }}
+                  className="p-1 -mr-1 rounded-full"
+                  aria-label="Clear search"
+                >
+                  <svg className="w-4 h-4" style={{ color: 'var(--color-text-tertiary)' }}
+                       fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
               )}
             </div>
+          </div>
+
+          {loading ? (
+            <SkeletonRows />
+          ) : error && users.length === 0 ? (
+            <ErrorState onRetry={refetch} />
+          ) : users.length === 0 ? (
+            <EmptyState type={type} isSearching={isSearching} query={debouncedQuery} />
+          ) : (
+            <>
+              <ul className="divide-y" style={{ borderColor: 'var(--color-divider)' }} aria-live="polite">
+                {users.map((user) => (
+                  <FollowRow
+                    key={user.id}
+                    user={user}
+                    isFollowing={isFollowing(user.id)}
+                    showFollowButton={!!viewer && viewer.id !== user.id}
+                    onRowClick={() => handleUserClick(user)}
+                    onFollowToggle={() => handleFollowToggle(user)}
+                  />
+                ))}
+              </ul>
+              <div ref={sentinelRef} aria-hidden="true" style={{ height: 1 }} />
+              {loadingMore && <LoadingMoreIndicator />}
+              {error && users.length > 0 && <LoadMoreErrorBanner onRetry={fetchMore} />}
+            </>
           )}
         </div>
       </div>
+    </div>
+  )
+}
+
+function FollowRow({ user, isFollowing, showFollowButton, onRowClick, onFollowToggle }) {
+  const followerLabel = user.follower_count === 0
+    ? 'No followers yet'
+    : user.follower_count === 1
+      ? '1 follower'
+      : `${user.follower_count.toLocaleString()} followers`
+
+  return (
+    <li>
+      <div
+        role="link"
+        tabIndex={0}
+        aria-label={`${user.display_name} profile`}
+        onClick={onRowClick}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onRowClick() } }}
+        className="w-full flex items-center gap-3 px-4 py-3.5 cursor-pointer transition-colors hover:bg-black/[0.04] focus:outline-none focus-visible:bg-black/[0.04]"
+        style={{ minHeight: 64 }}
+      >
+        <div
+          className="w-11 h-11 rounded-full flex items-center justify-center font-bold flex-shrink-0 overflow-hidden"
+          style={{ background: 'var(--color-primary)', color: 'var(--color-text-on-primary)' }}
+        >
+          {user.avatar_url ? (
+            <img src={user.avatar_url} alt="" className="w-full h-full object-cover" draggable={false} />
+          ) : (
+            <span>{user.display_name?.charAt(0).toUpperCase() || '?'}</span>
+          )}
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <p className="truncate" style={{ color: 'var(--color-text-primary)', fontWeight: 500, fontSize: 16 }}>
+            {user.display_name || 'Anonymous'}
+          </p>
+          <p className="truncate" style={{ color: 'var(--color-text-tertiary)', fontSize: 13 }}>
+            {followerLabel}
+          </p>
+        </div>
+
+        {showFollowButton && (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); onFollowToggle() }}
+            onKeyDown={(e) => {
+              // Prevent Enter/Space from bubbling to row container and triggering navigation
+              if (e.key === 'Enter' || e.key === ' ') e.stopPropagation()
+            }}
+            aria-label={isFollowing ? `Unfollow ${user.display_name}` : `Follow ${user.display_name}`}
+            className="px-4 rounded-full transition-colors flex-shrink-0"
+            style={{
+              height: 32,
+              fontSize: 14,
+              fontWeight: 600,
+              background: isFollowing ? 'var(--color-surface-elevated)' : 'var(--color-primary)',
+              color: isFollowing ? 'var(--color-text-primary)' : 'var(--color-text-on-primary)',
+              border: isFollowing ? '1px solid var(--color-divider)' : 'none',
+            }}
+          >
+            {isFollowing ? 'Following' : 'Follow'}
+          </button>
+        )}
+      </div>
+    </li>
+  )
+}
+
+function SkeletonRows() {
+  return (
+    <div role="status" aria-label="Loading">
+      {[0, 1, 2, 3, 4].map(i => (
+        <div key={i} className="flex items-center gap-3 px-4 py-3.5" style={{ minHeight: 64 }}>
+          <div className="w-11 h-11 rounded-full skeleton-shimmer flex-shrink-0" />
+          <div className="flex-1 space-y-2">
+            <div className="h-4 rounded skeleton-shimmer" style={{ width: '60%' }} />
+            <div className="h-3 rounded skeleton-shimmer" style={{ width: '30%' }} />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function EmptyState({ type, isSearching, query }) {
+  if (isSearching) {
+    return (
+      <div className="py-12 px-6 text-center">
+        <p className="font-medium" style={{ color: 'var(--color-text-primary)', fontSize: 16 }}>
+          No one matches &quot;{query}&quot;
+        </p>
+        <p className="mt-1" style={{ color: 'var(--color-text-tertiary)', fontSize: 14 }}>
+          Try a different name.
+        </p>
+      </div>
+    )
+  }
+  const isFollowers = type === 'followers'
+  return (
+    <div className="py-12 px-6 text-center">
+      <p className="font-medium" style={{ color: 'var(--color-text-primary)', fontSize: 16 }}>
+        {isFollowers ? 'No followers yet' : 'Not following anyone yet'}
+      </p>
+      <p className="mt-1" style={{ color: 'var(--color-text-tertiary)', fontSize: 14 }}>
+        {isFollowers ? 'Share your profile to get discovered.' : 'Find people whose taste you trust on dish pages.'}
+      </p>
+    </div>
+  )
+}
+
+function ErrorState({ onRetry }) {
+  return (
+    <div className="py-12 px-6 text-center">
+      <p className="font-medium" style={{ color: 'var(--color-text-primary)', fontSize: 16 }}>
+        Couldn&apos;t load
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-3 px-4 py-2 rounded-full"
+        style={{
+          background: 'var(--color-primary)',
+          color: 'var(--color-text-on-primary)',
+          fontSize: 14,
+          fontWeight: 600,
+        }}
+      >
+        Tap to retry
+      </button>
+    </div>
+  )
+}
+
+function LoadingMoreIndicator() {
+  return (
+    <div className="flex items-center justify-center py-4" aria-hidden="true">
+      <div
+        className="w-5 h-5 border-2 rounded-full animate-spin"
+        style={{ borderColor: 'var(--color-divider)', borderTopColor: 'var(--color-primary)' }}
+      />
+    </div>
+  )
+}
+
+function LoadMoreErrorBanner({ onRetry }) {
+  return (
+    <div className="px-4 py-3 border-t" style={{ borderColor: 'var(--color-divider)' }}>
+      <button
+        type="button"
+        onClick={() => onRetry()}
+        className="w-full py-2 rounded-lg text-sm font-medium"
+        style={{
+          background: 'var(--color-bg)',
+          color: 'var(--color-text-primary)',
+          border: '1px solid var(--color-divider)',
+        }}
+      >
+        Couldn&apos;t load more. Tap to retry.
+      </button>
     </div>
   )
 }

--- a/src/components/FollowListModal.jsx
+++ b/src/components/FollowListModal.jsx
@@ -373,6 +373,7 @@ export function FollowListModal({ userId, type, onClose }) {
 }
 
 function FollowRow({ user, isFollowing, showFollowButton, onRowClick, onFollowToggle }) {
+  const displayName = user.display_name || 'Anonymous'
   const followerLabel = user.follower_count === 0
     ? 'No followers yet'
     : user.follower_count === 1
@@ -384,7 +385,7 @@ function FollowRow({ user, isFollowing, showFollowButton, onRowClick, onFollowTo
       <div
         role="link"
         tabIndex={0}
-        aria-label={`${user.display_name} profile`}
+        aria-label={`${displayName} profile`}
         onClick={onRowClick}
         onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onRowClick() } }}
         className="w-full flex items-center gap-3 px-4 py-3.5 cursor-pointer transition-colors hover:bg-black/[0.04] focus:outline-none focus-visible:bg-black/[0.04]"
@@ -397,13 +398,13 @@ function FollowRow({ user, isFollowing, showFollowButton, onRowClick, onFollowTo
           {user.avatar_url ? (
             <img src={user.avatar_url} alt="" className="w-full h-full object-cover" draggable={false} />
           ) : (
-            <span>{user.display_name?.charAt(0).toUpperCase() || '?'}</span>
+            <span>{displayName.charAt(0).toUpperCase()}</span>
           )}
         </div>
 
         <div className="flex-1 min-w-0">
           <p className="truncate" style={{ color: 'var(--color-text-primary)', fontWeight: 500, fontSize: 16 }}>
-            {user.display_name || 'Anonymous'}
+            {displayName}
           </p>
           <p className="truncate" style={{ color: 'var(--color-text-tertiary)', fontSize: 13 }}>
             {followerLabel}
@@ -418,7 +419,7 @@ function FollowRow({ user, isFollowing, showFollowButton, onRowClick, onFollowTo
               // Prevent Enter/Space from bubbling to row container and triggering navigation
               if (e.key === 'Enter' || e.key === ' ') e.stopPropagation()
             }}
-            aria-label={isFollowing ? `Unfollow ${user.display_name}` : `Follow ${user.display_name}`}
+            aria-label={isFollowing ? `Unfollow ${displayName}` : `Follow ${displayName}`}
             className="px-4 rounded-full transition-colors flex-shrink-0"
             style={{
               height: 32,

--- a/src/components/FollowListModal.jsx
+++ b/src/components/FollowListModal.jsx
@@ -77,7 +77,11 @@ export function FollowListModal({ userId, type, onClose }) {
   const searchInputRef = useRef(null)
   const modalRef = useFocusTrap(true, onClose, { initialFocusRef: searchInputRef })
 
-  // Infinite scroll observer rooted on the scroll container
+  // Infinite scroll observer, rooted on the scroll container. The effect
+  // re-creates the observer on each settle so it can immediately re-evaluate
+  // whether the sentinel is still in view; this auto-chains pagination when
+  // the user is anchored at the bottom of a short list. The !loadingMore
+  // guard inside the callback prevents stacking duplicate fetches mid-flight.
   useEffect(() => {
     if (!scrollContainerRef.current || !sentinelRef.current) return
     if (error || !hasMore) return
@@ -206,7 +210,7 @@ export function FollowListModal({ userId, type, onClose }) {
             <EmptyState type={type} isSearching={isSearching} query={debouncedQuery} />
           ) : (
             <>
-              <ul className="divide-y" style={{ borderColor: 'var(--color-divider)' }} aria-live="polite">
+              <ul className="divide-y" style={{ borderColor: 'var(--color-divider)' }}>
                 {users.map((user) => (
                   <FollowRow
                     key={user.id}
@@ -361,10 +365,16 @@ function ErrorState({ onRetry }) {
 
 function LoadingMoreIndicator() {
   return (
-    <div className="flex items-center justify-center py-4" aria-hidden="true">
+    <div
+      className="flex items-center justify-center py-4"
+      role="status"
+      aria-live="polite"
+      aria-label="Loading more"
+    >
       <div
         className="w-5 h-5 border-2 rounded-full animate-spin"
         style={{ borderColor: 'var(--color-divider)', borderTopColor: 'var(--color-primary)' }}
+        aria-hidden="true"
       />
     </div>
   )

--- a/src/components/FollowListModal.jsx
+++ b/src/components/FollowListModal.jsx
@@ -223,7 +223,7 @@ export function FollowListModal({ userId, type, onClose }) {
             ? 'translateY(100%)'
             : `translateY(${Math.max(0, dragOffset)}px)`,
           transition: dragOffset === 0
-            ? 'transform 280ms cubic-bezier(0.32, 0.72, 0, 1), height 280ms cubic-bezier(0.32, 0.72, 0, 1)'
+            ? `transform ${SHEET_TRANSITION_MS}ms cubic-bezier(0.32, 0.72, 0, 1), height ${SHEET_TRANSITION_MS}ms cubic-bezier(0.32, 0.72, 0, 1)`
             : 'none',
           paddingBottom: 'env(safe-area-inset-bottom, 0px)',
         }}

--- a/src/components/FollowListModal.jsx
+++ b/src/components/FollowListModal.jsx
@@ -77,6 +77,113 @@ export function FollowListModal({ userId, type, onClose }) {
   const searchInputRef = useRef(null)
   const modalRef = useFocusTrap(true, onClose, { initialFocusRef: searchInputRef })
 
+  // Sheet detents
+  const [sheetState, setSheetState] = useState('half') // 'half' | 'full' | 'closing'
+  const [dragOffset, setDragOffset] = useState(0)
+  const dragStartRef = useRef({ y: 0, t: 0, state: 'half', active: false, didDrag: false })
+  const closeTimerRef = useRef(null)
+
+  const SHEET_HEIGHTS = { half: '75vh', full: '95vh' }
+  const SHEET_TRANSITION_MS = 280
+  const DRAG_THRESHOLD_PX = 50
+  const DRAG_THRESHOLD_VELOCITY = 0.3 // px/ms
+  // Drag must move at least this far before we suppress the synthetic click.
+  // Below this threshold we treat the gesture as a tap, letting onGrabberClick fire.
+  const DRAG_CLICK_SUPPRESS_PX = 6
+
+  // Clear any pending close timer on unmount to prevent stale onClose firing
+  // after the parent has already torn the modal down.
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) {
+        clearTimeout(closeTimerRef.current)
+        closeTimerRef.current = null
+      }
+    }
+  }, [])
+
+  const resetDragState = useCallback(() => {
+    dragStartRef.current = { ...dragStartRef.current, active: false }
+    setDragOffset(0)
+  }, [])
+
+  const handleDragStart = useCallback((clientY) => {
+    dragStartRef.current = {
+      y: clientY,
+      t: performance.now(),
+      state: sheetState,
+      active: true,
+      didDrag: false,
+    }
+    setDragOffset(0)
+  }, [sheetState])
+
+  const handleDragMove = useCallback((clientY) => {
+    if (!dragStartRef.current.active) return
+    const delta = clientY - dragStartRef.current.y
+    if (Math.abs(delta) > DRAG_CLICK_SUPPRESS_PX) {
+      dragStartRef.current.didDrag = true
+    }
+    setDragOffset(delta)
+  }, [])
+
+  const handleDragEnd = useCallback((clientY) => {
+    if (!dragStartRef.current.active) {
+      setDragOffset(0)
+      return
+    }
+    const delta = clientY - dragStartRef.current.y
+    const elapsed = performance.now() - dragStartRef.current.t
+    const velocity = elapsed > 0 ? Math.abs(delta) / elapsed : 0
+    const startState = dragStartRef.current.state
+    const crossed = Math.abs(delta) >= DRAG_THRESHOLD_PX || velocity >= DRAG_THRESHOLD_VELOCITY
+
+    if (crossed) {
+      if (delta < 0) {
+        // Dragged up
+        if (startState === 'half') setSheetState('full')
+        // already full → stay full
+      } else {
+        // Dragged down
+        if (startState === 'full') setSheetState('half')
+        else if (startState === 'half') {
+          setSheetState('closing')
+          if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
+          closeTimerRef.current = setTimeout(() => {
+            closeTimerRef.current = null
+            onClose()
+          }, SHEET_TRANSITION_MS)
+        }
+      }
+    }
+    dragStartRef.current.active = false
+    setDragOffset(0)
+  }, [onClose])
+
+  const onTouchStart = (e) => handleDragStart(e.touches[0].clientY)
+  const onTouchMove = (e) => handleDragMove(e.touches[0].clientY)
+  const onTouchEnd = (e) => handleDragEnd(e.changedTouches[0].clientY)
+  // Reset cleanly if the OS aborts the gesture (e.g., system swipe, call).
+  const onTouchCancel = () => resetDragState()
+
+  const onGrabberClick = () => {
+    // Suppress synthetic click that follows a touch drag on the same element.
+    if (dragStartRef.current.didDrag) {
+      dragStartRef.current.didDrag = false
+      return
+    }
+    setSheetState(prev => prev === 'half' ? 'full' : 'half')
+  }
+
+  const onGrabberKeyDown = (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      setSheetState(prev => prev === 'half' ? 'full' : 'half')
+    } else if (e.key === 'Escape') {
+      onClose()
+    }
+  }
+
   // Infinite scroll observer, rooted on the scroll container. The effect
   // re-creates the observer on each settle so it can immediately re-evaluate
   // whether the sentinel is still in view; this auto-chains pagination when
@@ -111,19 +218,51 @@ export function FollowListModal({ userId, type, onClose }) {
         className="absolute left-0 right-0 bottom-0 rounded-t-2xl flex flex-col"
         style={{
           background: 'var(--color-surface-elevated)',
-          height: '75vh',
+          height: SHEET_HEIGHTS[sheetState === 'closing' ? 'half' : sheetState],
+          transform: sheetState === 'closing'
+            ? 'translateY(100%)'
+            : `translateY(${Math.max(0, dragOffset)}px)`,
+          transition: dragOffset === 0
+            ? 'transform 280ms cubic-bezier(0.32, 0.72, 0, 1), height 280ms cubic-bezier(0.32, 0.72, 0, 1)'
+            : 'none',
           paddingBottom: 'env(safe-area-inset-bottom, 0px)',
         }}
         onClick={(e) => e.stopPropagation()}
       >
-        <div
-          style={{ width: 40, height: 4, background: 'var(--color-divider)', borderRadius: 2, margin: '8px auto 4px', flex: '0 0 auto' }}
-          aria-hidden="true"
-        />
+        <button
+          type="button"
+          onClick={onGrabberClick}
+          onKeyDown={onGrabberKeyDown}
+          onTouchStart={onTouchStart}
+          onTouchMove={onTouchMove}
+          onTouchEnd={onTouchEnd}
+          onTouchCancel={onTouchCancel}
+          style={{
+            flex: '0 0 auto',
+            padding: '8px 0 4px',
+            cursor: 'grab',
+            touchAction: 'none',
+            background: 'transparent',
+            border: 'none',
+            width: '100%',
+            display: 'block',
+          }}
+          aria-label={sheetState === 'full' ? 'Collapse sheet' : 'Expand sheet'}
+          aria-expanded={sheetState === 'full'}
+        >
+          <div
+            style={{ width: 40, height: 4, background: 'var(--color-divider)', borderRadius: 2, margin: '0 auto' }}
+            aria-hidden="true"
+          />
+        </button>
 
         <div
           className="flex items-center justify-between px-4 py-3 border-b"
-          style={{ borderColor: 'var(--color-divider)', flex: '0 0 auto' }}
+          style={{ borderColor: 'var(--color-divider)', flex: '0 0 auto', touchAction: 'none' }}
+          onTouchStart={onTouchStart}
+          onTouchMove={onTouchMove}
+          onTouchEnd={onTouchEnd}
+          onTouchCancel={onTouchCancel}
         >
           <h2 id="follow-list-title" className="text-lg font-bold" style={{ color: 'var(--color-text-primary)' }}>
             {title}

--- a/src/hooks/useFocusTrap.js
+++ b/src/hooks/useFocusTrap.js
@@ -6,9 +6,11 @@ import { useEffect, useRef, useCallback } from 'react'
  *
  * @param {boolean} isOpen - Whether the modal is open
  * @param {Function} onClose - Callback to close the modal
+ * @param {Object} [options] - Optional configuration
+ * @param {Object} [options.initialFocusRef] - Ref to focus when modal opens (overrides first-focusable default)
  * @returns {Object} - ref to attach to the modal container
  */
-export function useFocusTrap(isOpen, onClose) {
+export function useFocusTrap(isOpen, onClose, { initialFocusRef } = {}) {
   const containerRef = useRef(null)
   const previousActiveElement = useRef(null)
 
@@ -23,14 +25,20 @@ export function useFocusTrap(isOpen, onClose) {
   useEffect(() => {
     if (!isOpen || !containerRef.current) return
 
-    const focusableElements = getFocusableElements(containerRef.current)
-    if (focusableElements.length > 0) {
-      // Small delay to ensure modal is fully rendered
-      requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      if (initialFocusRef?.current) {
+        initialFocusRef.current.focus({ preventScroll: true })
+        return
+      }
+      // Re-check containerRef.current — it may have been unmounted between
+      // scheduling and running the frame (fast open→close transitions).
+      if (!containerRef.current) return
+      const focusableElements = getFocusableElements(containerRef.current)
+      if (focusableElements.length > 0) {
         focusableElements[0].focus()
-      })
-    }
-  }, [isOpen])
+      }
+    })
+  }, [isOpen, initialFocusRef])
 
   // Restore focus when modal closes
   useEffect(() => {

--- a/src/hooks/useFocusTrap.js
+++ b/src/hooks/useFocusTrap.js
@@ -48,6 +48,19 @@ export function useFocusTrap(isOpen, onClose, { initialFocusRef } = {}) {
     }
   }, [isOpen])
 
+  // Also restore focus on unmount — many callers (e.g. FollowListModal) toggle
+  // visibility by conditional render rather than flipping `isOpen` to false,
+  // so the effect above never fires. Without this cleanup, keyboard focus is
+  // orphaned on <body> after the modal goes away.
+  useEffect(() => {
+    return () => {
+      if (previousActiveElement.current && typeof previousActiveElement.current.focus === 'function') {
+        previousActiveElement.current.focus()
+        previousActiveElement.current = null
+      }
+    }
+  }, [])
+
   // Handle keyboard events
   const handleKeyDown = useCallback((e) => {
     if (!isOpen) return

--- a/src/hooks/useFollowList.js
+++ b/src/hooks/useFollowList.js
@@ -1,6 +1,6 @@
+import { useMemo } from 'react'
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import { followsApi } from '../api/followsApi'
-import { sanitizeSearchQuery } from '../utils/sanitize'
 import { useAuth } from '../context/AuthContext'
 
 /**
@@ -12,18 +12,12 @@ import { useAuth } from '../context/AuthContext'
  * @param {{ userId: string, type: 'followers' | 'following', searchQuery: string }} params
  */
 export function useFollowList({ userId, type, searchQuery }) {
-  const direction = type // 'followers' | 'following'
-  // Sanitizer is used here ONLY to decide whether the input contains anything
-  // searchable (after trim + LIKE-escape, is there real content?). The raw
-  // trimmed query is what we pass to the API — `_searchFollows` sanitizes
-  // again before hitting Postgres, and double-sanitizing would over-escape
-  // backslashes (`a_b` → `a\_b` → `a\\\_b`).
+  const direction = type
+  // We pass the trimmed (un-escaped) query to the API; _searchFollows is the
+  // single source of truth for LIKE-escape and wildcard-only short-circuit.
+  // Double-sanitizing would over-escape backslashes (`a_b` → `a\_b` → `a\\\_b`).
   const trimmedSearch = (searchQuery ?? '').trim()
-  const sanitizedProbe = sanitizeSearchQuery(trimmedSearch, 50)
-  // Strip escaped LIKE metachars: if nothing is left, the input was purely
-  // wildcards like `%%` — treat as not-searching and fall back to recency.
-  const searchableProbe = sanitizedProbe.replace(/\\[%_\\]/g, '')
-  const isSearching = !!searchableProbe && searchableProbe.length >= 1
+  const isSearching = trimmedSearch.length > 0
 
   // Recency list mode (no search) — cursor on followed_at
   const listQuery = useInfiniteQuery({
@@ -40,8 +34,7 @@ export function useFollowList({ userId, type, searchQuery }) {
     },
   })
 
-  // Search mode — alphabetical (display_name, id) cursor. Pass the TRIMMED
-  // (un-escaped) query — API sanitizes for LIKE before hitting Postgres.
+  // Search mode — alphabetical (display_name, id) cursor
   const searchQueryResult = useInfiniteQuery({
     queryKey: ['followList', userId, direction, 'search', trimmedSearch],
     enabled: isSearching && !!userId,
@@ -58,12 +51,14 @@ export function useFollowList({ userId, type, searchQuery }) {
   })
 
   const active = isSearching ? searchQueryResult : listQuery
-  const users = active.data?.pages.flatMap(p => p.users) ?? []
+  const pages = active.data?.pages
+  const users = useMemo(() => pages?.flatMap(p => p.users) ?? [], [pages])
 
-  // Follow statuses for visible users — keyed on viewer + sorted IDs for stable cache
+  // Follow statuses for visible users — keyed on viewer + sorted IDs so the
+  // cache key is stable across result reorderings.
   const { user: viewer } = useAuth()
   const viewerId = viewer?.id ?? 'anon'
-  const sortedUserIds = users.map(u => u.id).slice().sort()
+  const sortedUserIds = useMemo(() => users.map(u => u.id).sort(), [users])
   const statusesQuery = useQuery({
     queryKey: ['followStatuses', viewerId, sortedUserIds],
     enabled: sortedUserIds.length > 0 && !!viewer,
@@ -76,7 +71,7 @@ export function useFollowList({ userId, type, searchQuery }) {
     followingSet: statusesQuery.data ?? new Set(),
     loading: active.isLoading,
     loadingMore: active.isFetchingNextPage,
-    searching: isSearching && active.isFetching,
+    searchFetching: isSearching && active.isFetching,
     error: active.error,
     hasMore: !!active.hasNextPage,
     fetchMore: active.fetchNextPage,

--- a/src/hooks/useFollowList.js
+++ b/src/hooks/useFollowList.js
@@ -1,0 +1,86 @@
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
+import { followsApi } from '../api/followsApi'
+import { sanitizeSearchQuery } from '../utils/sanitize'
+import { useAuth } from '../context/AuthContext'
+
+/**
+ * Centralizes server-state for FollowListModal.
+ * - Cursor-paginated recency list when no search query.
+ * - Alphabetical (display_name, id) cursor when searching.
+ * - Batched follow-state lookup keyed on viewer + sorted user IDs.
+ *
+ * @param {{ userId: string, type: 'followers' | 'following', searchQuery: string }} params
+ */
+export function useFollowList({ userId, type, searchQuery }) {
+  const direction = type // 'followers' | 'following'
+  // Sanitizer is used here ONLY to decide whether the input contains anything
+  // searchable (after trim + LIKE-escape, is there real content?). The raw
+  // trimmed query is what we pass to the API — `_searchFollows` sanitizes
+  // again before hitting Postgres, and double-sanitizing would over-escape
+  // backslashes (`a_b` → `a\_b` → `a\\\_b`).
+  const trimmedSearch = (searchQuery ?? '').trim()
+  const sanitizedProbe = sanitizeSearchQuery(trimmedSearch, 50)
+  // Strip escaped LIKE metachars: if nothing is left, the input was purely
+  // wildcards like `%%` — treat as not-searching and fall back to recency.
+  const searchableProbe = sanitizedProbe.replace(/\\[%_\\]/g, '')
+  const isSearching = !!searchableProbe && searchableProbe.length >= 1
+
+  // Recency list mode (no search) — cursor on followed_at
+  const listQuery = useInfiniteQuery({
+    queryKey: ['followList', userId, direction],
+    enabled: !isSearching && !!userId,
+    initialPageParam: null,
+    queryFn: ({ pageParam }) =>
+      direction === 'followers'
+        ? followsApi.getFollowers(userId, { cursor: pageParam })
+        : followsApi.getFollowing(userId, { cursor: pageParam }),
+    getNextPageParam: (last) => {
+      if (!last.hasMore || last.users.length === 0) return undefined
+      return last.users[last.users.length - 1].followed_at
+    },
+  })
+
+  // Search mode — alphabetical (display_name, id) cursor. Pass the TRIMMED
+  // (un-escaped) query — API sanitizes for LIKE before hitting Postgres.
+  const searchQueryResult = useInfiniteQuery({
+    queryKey: ['followList', userId, direction, 'search', trimmedSearch],
+    enabled: isSearching && !!userId,
+    initialPageParam: null,
+    queryFn: ({ pageParam }) =>
+      direction === 'followers'
+        ? followsApi.getFollowers(userId, { cursor: pageParam, searchQuery: trimmedSearch })
+        : followsApi.getFollowing(userId, { cursor: pageParam, searchQuery: trimmedSearch }),
+    getNextPageParam: (last) => {
+      if (!last.hasMore || last.users.length === 0) return undefined
+      const tail = last.users[last.users.length - 1]
+      return { display_name: tail.display_name, id: tail.id }
+    },
+  })
+
+  const active = isSearching ? searchQueryResult : listQuery
+  const users = active.data?.pages.flatMap(p => p.users) ?? []
+
+  // Follow statuses for visible users — keyed on viewer + sorted IDs for stable cache
+  const { user: viewer } = useAuth()
+  const viewerId = viewer?.id ?? 'anon'
+  const sortedUserIds = users.map(u => u.id).slice().sort()
+  const statusesQuery = useQuery({
+    queryKey: ['followStatuses', viewerId, sortedUserIds],
+    enabled: sortedUserIds.length > 0 && !!viewer,
+    queryFn: () => followsApi.getFollowStatuses(sortedUserIds),
+    staleTime: 30_000,
+  })
+
+  return {
+    users,
+    followingSet: statusesQuery.data ?? new Set(),
+    loading: active.isLoading,
+    loadingMore: active.isFetchingNextPage,
+    searching: isSearching && active.isFetching,
+    error: active.error,
+    hasMore: !!active.hasNextPage,
+    fetchMore: active.fetchNextPage,
+    refetch: active.refetch,
+    isSearching,
+  }
+}

--- a/src/hooks/useFollowUser.js
+++ b/src/hooks/useFollowUser.js
@@ -13,20 +13,24 @@ import { followsApi } from '../api/followsApi'
 export function useFollowUser() {
   const qc = useQueryClient()
 
-  const invalidateFollowCounts = () => {
+  const invalidateOnFollowChange = () => {
     // Prefix match: invalidates ['followCounts', currentUserId] AND
     // ['followCounts', targetUserId] without needing either id in scope.
     qc.invalidateQueries({ queryKey: ['followCounts'] })
+    // Also invalidate batched follow-status lookups (FollowListModal etc.).
+    // Without this, follow buttons inside the modal stay stale until staleTime
+    // expires (30s) or window refocuses.
+    qc.invalidateQueries({ queryKey: ['followStatuses'] })
   }
 
   return {
     follow: useMutation({
       mutationFn: (targetUserId) => followsApi.follow(targetUserId),
-      onSuccess: invalidateFollowCounts,
+      onSuccess: invalidateOnFollowChange,
     }),
     unfollow: useMutation({
       mutationFn: (targetUserId) => followsApi.unfollow(targetUserId),
-      onSuccess: invalidateFollowCounts,
+      onSuccess: invalidateOnFollowChange,
     }),
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1187,7 +1187,8 @@
   .animate-badge-bounce-in,
   .animate-rank-fade-out,
   .animate-rarity-glow,
-  .animate-legendary-shimmer {
+  .animate-legendary-shimmer,
+  .skeleton-shimmer {
     animation: none;
   }
 
@@ -1270,4 +1271,20 @@ input.outline-none:focus-visible {
    =========================== */
 .wgh-map-tiles {
   filter: brightness(1.0) contrast(1.02);
+}
+
+.skeleton-shimmer {
+  background: linear-gradient(
+    90deg,
+    var(--color-divider) 0%,
+    var(--color-surface) 50%,
+    var(--color-divider) 100%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.2s linear infinite;
+}
+
+@keyframes skeleton-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
 }

--- a/supabase/migrations/20260516_search_user_follows.sql
+++ b/supabase/migrations/20260516_search_user_follows.sql
@@ -1,0 +1,74 @@
+-- search_user_follows: paginated alphabetical search of a user's
+-- followers or following list. Mirrors the hardening pattern in
+-- search_users_with_followers (input validation, limit clamp, security
+-- definer + locked search_path).
+--
+-- Returns (display_name, id) tuple-ordered rows for stable cursor pagination.
+
+CREATE OR REPLACE FUNCTION search_user_follows(
+  p_user_id UUID,
+  p_direction TEXT,
+  p_query TEXT,
+  p_cursor_name TEXT DEFAULT NULL,
+  p_cursor_id UUID DEFAULT NULL,
+  p_limit INT DEFAULT 20
+)
+RETURNS TABLE (
+  id UUID,
+  display_name TEXT,
+  avatar_url TEXT,
+  follower_count INT,
+  followed_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_limit INT := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 100);
+  v_query TEXT := NULLIF(TRIM(COALESCE(p_query, '')), '');
+  -- Cursor is "active" only when both halves are present. A half-set cursor
+  -- would make the tuple comparison (display_name, id) > (cursor_name, NULL)
+  -- evaluate to NULL — filtering every row out (empty-page bug). Treat any
+  -- partial cursor as "no cursor" so callers degrade gracefully.
+  v_use_cursor BOOLEAN := (p_cursor_name IS NOT NULL AND p_cursor_id IS NOT NULL);
+BEGIN
+  IF p_direction NOT IN ('followers', 'following') THEN
+    RAISE EXCEPTION 'Invalid direction: %, must be followers or following', p_direction
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'p_user_id is required' USING ERRCODE = '22023';
+  END IF;
+
+  IF p_direction = 'followers' THEN
+    RETURN QUERY
+      SELECT p.id, p.display_name, p.avatar_url, p.follower_count,
+             f.created_at AS followed_at
+      FROM follows f
+      JOIN profiles p ON p.id = f.follower_id
+      WHERE f.followed_id = p_user_id
+        AND (v_query IS NULL OR p.display_name ILIKE '%' || v_query || '%')
+        AND (NOT v_use_cursor
+             OR (p.display_name, p.id) > (p_cursor_name, p_cursor_id))
+      ORDER BY p.display_name ASC, p.id ASC
+      LIMIT v_limit;
+  ELSE
+    RETURN QUERY
+      SELECT p.id, p.display_name, p.avatar_url, p.follower_count,
+             f.created_at AS followed_at
+      FROM follows f
+      JOIN profiles p ON p.id = f.followed_id
+      WHERE f.follower_id = p_user_id
+        AND (v_query IS NULL OR p.display_name ILIKE '%' || v_query || '%')
+        AND (NOT v_use_cursor
+             OR (p.display_name, p.id) > (p_cursor_name, p_cursor_id))
+      ORDER BY p.display_name ASC, p.id ASC
+      LIMIT v_limit;
+  END IF;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION search_user_follows(UUID, TEXT, TEXT, TEXT, UUID, INT) TO anon, authenticated;
+
+-- ROLLBACK:
+-- DROP FUNCTION IF EXISTS search_user_follows(UUID, TEXT, TEXT, TEXT, UUID, INT);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1416,6 +1416,77 @@ RETURNS BOOLEAN LANGUAGE SQL STABLE SET search_path = public AS $$
   SELECT EXISTS(SELECT 1 FROM follows WHERE follower_id = follower AND followed_id = followed);
 $$;
 
+-- search_user_follows: paginated alphabetical search of a user's
+-- followers or following list. Mirrors the hardening pattern in
+-- search_users_with_followers (input validation, limit clamp, security
+-- definer + locked search_path).
+--
+-- Returns (display_name, id) tuple-ordered rows for stable cursor pagination.
+CREATE OR REPLACE FUNCTION search_user_follows(
+  p_user_id UUID,
+  p_direction TEXT,
+  p_query TEXT,
+  p_cursor_name TEXT DEFAULT NULL,
+  p_cursor_id UUID DEFAULT NULL,
+  p_limit INT DEFAULT 20
+)
+RETURNS TABLE (
+  id UUID,
+  display_name TEXT,
+  avatar_url TEXT,
+  follower_count INT,
+  followed_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_limit INT := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 100);
+  v_query TEXT := NULLIF(TRIM(COALESCE(p_query, '')), '');
+  -- Cursor is "active" only when both halves are present. A half-set cursor
+  -- would make the tuple comparison (display_name, id) > (cursor_name, NULL)
+  -- evaluate to NULL — filtering every row out (empty-page bug). Treat any
+  -- partial cursor as "no cursor" so callers degrade gracefully.
+  v_use_cursor BOOLEAN := (p_cursor_name IS NOT NULL AND p_cursor_id IS NOT NULL);
+BEGIN
+  IF p_direction NOT IN ('followers', 'following') THEN
+    RAISE EXCEPTION 'Invalid direction: %, must be followers or following', p_direction
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'p_user_id is required' USING ERRCODE = '22023';
+  END IF;
+
+  IF p_direction = 'followers' THEN
+    RETURN QUERY
+      SELECT p.id, p.display_name, p.avatar_url, p.follower_count,
+             f.created_at AS followed_at
+      FROM follows f
+      JOIN profiles p ON p.id = f.follower_id
+      WHERE f.followed_id = p_user_id
+        AND (v_query IS NULL OR p.display_name ILIKE '%' || v_query || '%')
+        AND (NOT v_use_cursor
+             OR (p.display_name, p.id) > (p_cursor_name, p_cursor_id))
+      ORDER BY p.display_name ASC, p.id ASC
+      LIMIT v_limit;
+  ELSE
+    RETURN QUERY
+      SELECT p.id, p.display_name, p.avatar_url, p.follower_count,
+             f.created_at AS followed_at
+      FROM follows f
+      JOIN profiles p ON p.id = f.followed_id
+      WHERE f.follower_id = p_user_id
+        AND (v_query IS NULL OR p.display_name ILIKE '%' || v_query || '%')
+        AND (NOT v_use_cursor
+             OR (p.display_name, p.id) > (p_cursor_name, p_cursor_id))
+      ORDER BY p.display_name ASC, p.id ASC
+      LIMIT v_limit;
+  END IF;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION search_user_follows(UUID, TEXT, TEXT, TEXT, UUID, INT) TO anon, authenticated;
+
 -- Get friends' votes for a dish (with category expertise)
 CREATE OR REPLACE FUNCTION get_friends_votes_for_dish(
   p_user_id UUID,


### PR DESCRIPTION
## Summary

Full rewrite of `FollowListModal` for the Memorial Day 1.1 launch polish.

- **Sticky server-side search** at the top of the scroll container, debounced 250ms — handles 100+ followers via the new `search_user_follows` Postgres RPC with `(display_name, id)` cursor pagination.
- **Inline Follow/Unfollow button** per row with optimistic toggle + per-user in-flight guard + rollback on error (sonner toast).
- **Infinite scroll** via `IntersectionObserver` (root: scroll container) — replaces the old "Load More" button.
- **Drag-gesture detents** — opens at half (75vh), drag-up snaps to full (95vh), drag-down dismisses; tap grabber as keyboard/non-gesture fallback.
- **React Query throughout** — `useInfiniteQuery` for list + search, `useQuery` for batched follow-status lookup keyed on viewer + sorted IDs (prevents cross-viewer stale cache).
- **Full state coverage** — skeleton shimmer, empty (different copy for empty list vs no-search-results), initial-load error with retry, load-more error banner.
- Spec: `docs/superpowers/specs/2026-05-16-follow-list-modal-redesign.md`
- Plan: `docs/superpowers/plans/2026-05-16-follow-list-modal-redesign.md`

## Review trail

- **3 codex passes** on the spec before approval (caught alphabetical-pre-limit bias bug, double-sanitization, missing `useFollowUser` integration, cache-key cross-viewer leak — all addressed)
- **Per-task codex** on each of 8 implementation tasks (caught button-in-button keyboard race, optimistic-toggle XOR bug, 220ms/280ms timer drift risk, half-set cursor empty-page bug, touchcancel handler missing)
- **Spec + code-quality reviewers** after every task
- **Simplify pass** at the end — reused shared `EmptyState`, memoized rows, single-source sanitizer

## Deployment status

**⚠️ MIGRATION NOT YET DEPLOYED.** Run the migration in Denis's Supabase project (`vpioftosgdkyiwvhxewy`) → SQL Editor before merging:

\`\`\`
supabase/migrations/20260516_search_user_follows.sql
\`\`\`

The client gracefully falls back to recency mode for empty-query lists, but search will throw `function does not exist (42883)` until the RPC is live. Verify with:

\`\`\`sql
SELECT * FROM search_user_follows(
  (SELECT id FROM profiles LIMIT 1),
  'followers', NULL, NULL, NULL, 5
);
\`\`\`

Should return 0–5 rows or an empty set with no error.

## Test plan

### Desktop / Chrome DevTools mobile emulation
- [ ] Open Profile → tap Followers → sheet opens at half detent (75vh); search input has focus
- [ ] Type a name → results filter server-side after 250ms (alphabetical, paginated)
- [ ] Clear search → falls back to recency list mode
- [ ] Scroll to bottom → next 20 rows auto-load
- [ ] Tap Follow on a row → button flips to Following without page navigation; closes sheet → parent profile's "Following N" count incremented
- [ ] Tap row → navigates to `/user/:id` profile
- [ ] Drag grabber up → snaps to full detent (95vh)
- [ ] Drag grabber down from full → snaps back to half
- [ ] Drag grabber down from half → dismisses
- [ ] Tap grabber → toggles half ↔ full
- [ ] Tap backdrop → dismisses
- [ ] Press Escape → dismisses

### Edge cases
- [ ] Empty followers list → "No followers yet" + editorial subcopy
- [ ] Empty following list → "Not following anyone yet" + subcopy
- [ ] Search returns nothing → "No one matches \"xyz\"" + try-different-name subcopy
- [ ] Disconnect network mid-follow → button reverts + sonner toast
- [ ] Disconnect network mid-pagination → "Couldn't load more. Tap to retry." banner
- [ ] Empty search box (typed-then-cleared) → empty results (doesn't silently show unfiltered list)
- [ ] `%%` or whitespace-only search → falls back to recency mode

### Regression checks
- [ ] Other modals using `useFocusTrap` (LoginModal, ReportModal, DishModal, etc.) still work — no behavior change because the new `initialFocusRef` arg defaults to `{}`
- [ ] `useFollowUser` callers (UserProfile follow button) still invalidate `followCounts` correctly — added `followStatuses` invalidation should be additive

### Real device (iOS Safari)
- [ ] Drag gesture feel — thresholds 50px / 0.3 px/ms — adjust if jumpy
- [ ] Touchmove render-thrash on long lists (100+ rows) — watch for jank during active drag
- [ ] VoiceOver announces row as link + Follow button as separate control

🤖 Generated with [Claude Code](https://claude.com/claude-code)