### PR TITLE
fix(follow-list): hide Follow button on viewer's own Following list

### DIFF
--- a/src/components/FollowListModal.jsx
+++ b/src/components/FollowListModal.jsx
@@ -84,6 +84,15 @@ export function FollowListModal({ userId, type, onClose }) {
     navigate(`/user/${id}`)
   }, [onClose, navigate])
 
+  // The Follow button reflects whether YOU follow each row. On YOUR OWN
+  // Following list every row is followed by definition — the label adds no
+  // information, so hide it; unfollowing requires navigating to the profile.
+  const viewerOwnsFollowingList = type === 'following' && viewer?.id === userId
+  const showFollowButton = useCallback(
+    (rowUserId) => !!viewer && viewer.id !== rowUserId && !viewerOwnsFollowingList,
+    [viewer, viewerOwnsFollowingList],
+  )
+
   const scrollContainerRef = useRef(null)
   const sentinelRef = useRef(null)
   const searchInputRef = useRef(null)
@@ -358,7 +367,7 @@ export function FollowListModal({ userId, type, onClose }) {
                     key={user.id}
                     user={user}
                     isFollowing={isFollowing(user.id)}
-                    showFollowButton={!!viewer && viewer.id !== user.id}
+                    showFollowButton={showFollowButton(user.id)}
                     onRowClick={handleRowNavigate}
                     onFollowToggle={handleFollowToggle}
                   />


### PR DESCRIPTION
## Summary

iOS smoke flagged: every row of your own Following list showed a "Following" pill, which is data-free (by definition every row is followed). Hide it.

Behavior matrix:

| Context | Follow button visible? |
|---|---|
| Your own Followers list | Yes (some you follow back, some you don't) |
| Your own Following list | **No** (this PR's fix) |
| Other user's Followers list | Yes (whether YOU follow each row) |
| Other user's Following list | Yes (whether YOU follow each row) |

Unfollow path on your own Following list is now: tap row → user profile → unfollow there.

## Test plan

- [ ] Open YOUR Profile → tap Following → rows have NO Follow button
- [ ] Open YOUR Profile → tap Followers → rows DO have button (Follow or Following depending on whether you follow back)
- [ ] Open someone else's profile → tap their Following or Followers → rows DO have button reflecting whether YOU follow each row

🤖 Generated with [Claude Code](https://claude.com/claude-code)