### PR TITLE
fix(follows): backfill + maintain follower_count / following_count

### DIFF
--- a/supabase/migrations/20260516_fix_follower_count_trigger.sql
+++ b/supabase/migrations/20260516_fix_follower_count_trigger.sql
@@ -1,0 +1,77 @@
+-- Fix: profiles.follower_count and following_count have been stale since
+-- launch because the protect_profile_fields BEFORE-UPDATE trigger
+-- unconditionally reverts those columns to their OLD values — including
+-- when the legitimate update_follow_counts trigger tries to maintain them
+-- on follow/unfollow. Every counter increment has been silently dropped.
+--
+-- This migration:
+-- 1. Teaches protect_profile_fields to honor a session-local opt-in flag
+--    'app.allow_follow_count_update' (same pattern as the existing
+--    'app.allow_curator_grant' opt-in for is_local_curator).
+-- 2. Updates update_follow_counts to set that flag before updating.
+-- 3. One-time backfills follower_count and following_count from the
+--    follows table for every profile.
+--
+-- Direct client UPDATEs to profiles still cannot tamper with these
+-- columns because the client session doesn't set the flag.
+
+-- 1. Updated profile-fields guard
+CREATE OR REPLACE FUNCTION protect_profile_fields()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF current_setting('app.allow_follow_count_update', true) IS DISTINCT FROM 'true' THEN
+    NEW.follower_count := OLD.follower_count;
+    NEW.following_count := OLD.following_count;
+  END IF;
+  IF current_setting('app.allow_curator_grant', true) IS DISTINCT FROM 'true' THEN
+    NEW.is_local_curator := OLD.is_local_curator;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 2. Trigger now opts in before issuing its UPDATE
+CREATE OR REPLACE FUNCTION update_follow_counts()
+RETURNS TRIGGER LANGUAGE plpgsql SET search_path = public AS $$
+BEGIN
+  -- Transaction-local flag (set_config third arg `true`) — visible to all
+  -- statements in this transaction but cleared on commit/rollback, so it
+  -- doesn't leak to other sessions. Anyone wrapping a long transaction
+  -- around their own UPDATE could see the bypass, but a regular client
+  -- can't set this flag without explicit SECURITY DEFINER plumbing.
+  PERFORM set_config('app.allow_follow_count_update', 'true', true);
+  IF TG_OP = 'INSERT' THEN
+    UPDATE profiles SET following_count = following_count + 1 WHERE id = NEW.follower_id;
+    UPDATE profiles SET follower_count = follower_count + 1 WHERE id = NEW.followed_id;
+    RETURN NEW;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE profiles SET following_count = GREATEST(0, following_count - 1) WHERE id = OLD.follower_id;
+    UPDATE profiles SET follower_count = GREATEST(0, follower_count - 1) WHERE id = OLD.followed_id;
+    RETURN OLD;
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+-- 3. One-time backfill of stale counts.
+-- LOCK follows in SHARE mode for the duration of the DO block so the
+-- snapshot is consistent — without this, a concurrent follow could land
+-- after the COUNT(*) reads but before the backfill UPDATE completes,
+-- causing the new follow's trigger increment to be overwritten by the
+-- backfill's stale total.
+DO $$
+BEGIN
+  PERFORM set_config('app.allow_follow_count_update', 'true', true);
+  LOCK TABLE follows IN SHARE MODE;
+  UPDATE profiles p
+  SET
+    follower_count = COALESCE((SELECT COUNT(*) FROM follows WHERE followed_id = p.id), 0),
+    following_count = COALESCE((SELECT COUNT(*) FROM follows WHERE follower_id = p.id), 0);
+END $$;
+
+-- ROLLBACK:
+-- This migration corrects stale data; reverting the function definitions
+-- would stop new counts from being maintained but leave the backfilled
+-- numbers in place (they would simply drift again over time). No data
+-- loss in either direction. To revert the function bodies, restore the
+-- pre-migration versions from schema.sql history.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -619,14 +619,21 @@ CREATE POLICY "profiles_update_own" ON profiles FOR UPDATE
   WITH CHECK ((select auth.uid()) = id);
 -- Protected fields (is_local_curator, follower_count, following_count) are guarded by
 -- protect_profile_fields_trigger (BEFORE UPDATE) instead of RLS to avoid infinite recursion.
--- accept_curator_invite opts in via set_config('app.allow_curator_grant', 'true', true) so
--- its is_local_curator update isn't reverted; direct client UPDATEs don't set it, so users
--- can't self-grant.
+-- Two transaction-local opt-in flags let server-side code legitimately update protected
+-- columns; direct client UPDATEs don't set the flags, so users can't self-grant:
+--   - app.allow_curator_grant     → permits is_local_curator update (accept_curator_invite)
+--   - app.allow_follow_count_update → permits follower_count/following_count update
+--                                     (update_follow_counts trigger on follows)
 CREATE OR REPLACE FUNCTION protect_profile_fields()
 RETURNS TRIGGER AS $$
 BEGIN
-  NEW.follower_count := OLD.follower_count;
-  NEW.following_count := OLD.following_count;
+  -- follower_count / following_count: client-protected, but the
+  -- update_follow_counts trigger opts in via 'app.allow_follow_count_update'
+  -- when maintaining the counters on follow/unfollow.
+  IF current_setting('app.allow_follow_count_update', true) IS DISTINCT FROM 'true' THEN
+    NEW.follower_count := OLD.follower_count;
+    NEW.following_count := OLD.following_count;
+  END IF;
   IF current_setting('app.allow_curator_grant', true) IS DISTINCT FROM 'true' THEN
     NEW.is_local_curator := OLD.is_local_curator;
   END IF;
@@ -2238,9 +2245,12 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
 -- =============================================
 
 -- 13a. Update follow counts on follow/unfollow
+-- Opts into the protect_profile_fields bypass via the
+-- 'app.allow_follow_count_update' transaction-local flag.
 CREATE OR REPLACE FUNCTION update_follow_counts()
 RETURNS TRIGGER LANGUAGE plpgsql SET search_path = public AS $$
 BEGIN
+  PERFORM set_config('app.allow_follow_count_update', 'true', true);
   IF TG_OP = 'INSERT' THEN
     UPDATE profiles SET following_count = following_count + 1 WHERE id = NEW.follower_id;
     UPDATE profiles SET follower_count = follower_count + 1 WHERE id = NEW.followed_id;


### PR DESCRIPTION
## The bug

iOS smoke caught this: most rows on Dan's Following list showed "No followers yet" even though he follows them. Root cause is a years-old data bug the new modal exposed.

`protect_profile_fields` (BEFORE UPDATE on profiles) unconditionally reverts `follower_count` and `following_count` to their OLD values. The `update_follow_counts` trigger that fires after follow/unfollow has been silently dropping every counter update. **Every user's count has been stuck at 0 since the protection trigger was added.**

## The fix

Mirror the existing `app.allow_curator_grant` opt-in pattern:
- `protect_profile_fields` now honors `app.allow_follow_count_update`
- `update_follow_counts` sets that flag (transaction-local) before issuing its UPDATE
- One-time backfill recomputes both columns from the `follows` table
- `LOCK TABLE follows IN SHARE MODE` inside the DO block closes the race with concurrent writes during the backfill

Direct client UPDATEs can't set the flag, so the protection against client-side tampering is preserved.

## Review trail

- Codex pass 1: caught 3 issues (backfill race, misleading comment, missing schema.sql header note)
- Codex pass 2: clean

## Deployment

⚠️ **Migration not deployed.** Run `supabase/migrations/20260516_fix_follower_count_trigger.sql` in Denis's Supabase SQL Editor before/after merge — either order works because the only client behavior change is the count finally showing real numbers.

Verify with:

\`\`\`sql
-- Should all be non-zero for users who actually have followers
SELECT id, display_name, follower_count, following_count
FROM profiles
WHERE follower_count > 0 OR following_count > 0
LIMIT 10;

-- Sanity check: follower_count matches actual follows
SELECT
  (SELECT COUNT(*) FROM follows WHERE followed_id = (SELECT id FROM profiles WHERE follower_count > 0 LIMIT 1))
  = (SELECT follower_count FROM profiles WHERE follower_count > 0 LIMIT 1);
\`\`\`

## Test plan

- [ ] Run migration in Supabase SQL Editor → no error
- [ ] Run verify queries above → counts match
- [ ] Reload iOS app → open Following modal → rows now show real follower counts (Denis, etc.)
- [ ] Tap a Follow button on someone you don't follow → their follower_count increments by 1 (verifiable via the new follower list label on next refetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)