### PR TITLE
fix(content-filter): unblock spicy / crappie / shiitake / damn good lobster

### DIFF
--- a/src/lib/reviewBlocklist.js
+++ b/src/lib/reviewBlocklist.js
@@ -1,98 +1,101 @@
 /**
- * Simple content moderation for reviews.
- * Uses a blocklist approach to catch obvious inappropriate content.
+ * Client-side content moderation for reviews + UGC. Mirrors the server-side
+ * is_offensive() Postgres function (supabase/migrations/20260424... and
+ * 20260517_is_offensive_word_boundaries.sql) so the client catches the
+ * obvious cases before the DB check constraint trips.
  */
 
-// Common profanity, slurs, and spam phrases
-// Based on commonly used profanity lists - includes variations and common misspellings
-const BLOCKED_WORDS = [
-  // Profanity
-  'fuck', 'fucking', 'fucked', 'fucker', 'fck', 'f*ck',
-  'shit', 'shitty', 'bullshit', 'sh*t',
-  'ass', 'asshole', 'a**hole',
-  'bitch', 'b*tch',
-  'damn', 'dammit',
-  'crap',
-  'bastard',
-  'dick', 'd*ck',
-  'piss', 'pissed',
-  'cunt', 'c*nt',
-
-  // Slurs (racial, ethnic, sexual orientation, disability)
-  'nigger', 'nigga', 'n*gger', 'n*gga',
-  'faggot', 'fag', 'f*ggot', 'f*g',
-  'retard', 'retarded', 'r*tard',
-  'spic', 'sp*c',
-  'chink', 'ch*nk',
-  'kike', 'k*ke',
-  'wetback',
-  'beaner',
-  'cracker',
-  'honky',
-  'dyke', 'd*ke',
-  'tranny', 'tr*nny',
-
-  // Hate speech
-  'nazi', 'hitler',
+// Tokens with substring false-positive risk in normal English / food context.
+// Matched with word boundaries — "spicy" / "crappie" / "shiitake" / "Dickens"
+// won't trigger.
+const BLOCKED_WHOLE_WORDS = [
+  // Short profanity / slur abbreviations
+  'ass',
+  'fag', 'f*g',
+  'fggt',
+  'fck',
   'kkk',
+  'nft',
+  'sex', 's*x',
+  'xxx',
+  // 4-letter slurs / profanity with food/English substring risk
+  'spic', 'sp*c',
+  'crap',
+  'piss',
+  'dick', 'd*ck',
+  'dyke', 'd*ke',
+  'kike', 'k*ke',
+  'nazi',
+  'nude',
+  'shit', 'sh*t',
+  'chink', 'ch*nk',
+  'beaner',
+]
 
-  // Spam/scam phrases
+// Tokens safe to substring-match because they're unlikely to appear inside
+// innocent English or food words.
+const BLOCKED_SUBSTRINGS = [
+  // Profanity (longer forms)
+  'fuck', 'fucking', 'fucked', 'fucker', 'f*ck',
+  'shitty', 'bullshit',
+  'asshole', 'a**hole',
+  'bitch', 'b*tch',
+  'bastard',
+  'pissed',
+  'cunt', 'c*nt',
+  // Slurs (longer forms)
+  'nigger', 'nigga', 'n*gger', 'n*gga',
+  'faggot', 'f*ggot',
+  'retard', 'retarded', 'r*tard',
+  'wetback',
+  'honky',
+  'tranny', 'tr*nny',
+  // Hate speech
+  'hitler',
+  // Spam / scam phrases
   'buy now', 'click here', 'free money',
   'make money fast', 'work from home',
-  'bitcoin', 'crypto', 'nft',
+  'bitcoin', 'crypto',
   'www.', 'http://', 'https://',
   '.com', '.net', '.org',
-
   // Sexual content
   'porn', 'p*rn',
-  'sex', 's*x',
-  'nude', 'naked',
-  'xxx',
-];
+]
 
 /**
  * Check if review text contains blocked content.
- * @param {string} text - The review text to check
- * @returns {boolean} - True if blocked content found
+ * @param {string} text
+ * @returns {boolean}
  */
 export function containsBlockedContent(text) {
-  if (!text || typeof text !== 'string') {
-    return false;
+  if (!text || typeof text !== 'string') return false
+  const lower = text.toLowerCase()
+
+  for (const word of BLOCKED_WHOLE_WORDS) {
+    const regex = new RegExp(`\\b${escapeRegex(word)}\\b`, 'i')
+    if (regex.test(lower)) return true
   }
-
-  const lower = text.toLowerCase();
-
-  // Check for exact word matches (with word boundaries to avoid false positives)
-  // e.g., "class" shouldn't match "ass"
-  return BLOCKED_WORDS.some(word => {
-    // For short words (3 chars or less), require word boundaries
-    if (word.length <= 3) {
-      const regex = new RegExp(`\\b${escapeRegex(word)}\\b`, 'i');
-      return regex.test(lower);
-    }
-    // For longer words, simple includes is fine
-    return lower.includes(word);
-  });
+  for (const phrase of BLOCKED_SUBSTRINGS) {
+    if (lower.includes(phrase)) return true
+  }
+  return false
 }
 
 /**
- * Validate any user-generated text for blocked content.
- * Returns an error message string if blocked, or null if clean.
- * @param {string} text - Text to validate
- * @param {string} fieldName - Human-readable field name for error message
- * @returns {string|null} Error message or null
+ * Validate any user-generated text. Returns an error message if blocked,
+ * or null if clean.
+ * @param {string} text
+ * @param {string} fieldName
+ * @returns {string|null}
  */
 export function validateUserContent(text, fieldName = 'Content') {
-  if (!text?.trim()) return null;
+  if (!text?.trim()) return null
   if (containsBlockedContent(text)) {
-    return `${fieldName} contains inappropriate content. Please revise.`;
+    return `${fieldName} contains inappropriate content. Please revise.`
   }
-  return null;
+  return null
 }
 
-/**
- * Escape special regex characters in a string
- */
 function escapeRegex(string) {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }

--- a/supabase/migrations/20260517_is_offensive_word_boundaries.sql
+++ b/supabase/migrations/20260517_is_offensive_word_boundaries.sql
@@ -1,0 +1,136 @@
+-- is_offensive(): fix false-positive substring matches.
+--
+-- The long_terms block uses position(term IN value) which is plain substring,
+-- so short tokens like 'spic' falsely match 'spicy', 'crap' matches 'crappie'
+-- (a real fish), 'piss' matches 'piscine' / 'pissaladière' / 'Pissarro',
+-- 'dick' matches 'Dickens', 'nazi' matches 'nazirite', and so on. This blocks
+-- legitimate food reviews and dish/restaurant names on a Martha's Vineyard
+-- food app where words like "spicy" are common.
+--
+-- Fix: move 4-letter tokens with food/normal-English false-positive risk
+-- from long_terms (substring) into short_terms (word-boundary regex). The
+-- longer tokens (fuck, asshole, etc.) stay in substring mode. 'shit' also
+-- moved (so 'shiitake' passes). Adds 'fggt' (de-voweled faggot bypass).
+--
+-- Also drop 'damn' and 'dammit' entirely — they're mild profanity that
+-- routinely appears in legitimate food reviews ("damn good lobster roll").
+-- Harder swears (fuck, shit, etc.) remain blocked.
+--
+-- After this migration:
+--   - "spicy", "crappie", "pissaladière", "Dickens cake" all pass
+--   - "damn good", "dammit" pass
+--   - "spic", "crap", "piss", "dick", "Moby Dick" (word-boundary match) still flag
+--   - All harder slurs (n-word, f-slur, etc.) unchanged
+
+CREATE OR REPLACE FUNCTION public.is_offensive(p_text TEXT)
+RETURNS BOOLEAN
+LANGUAGE sql
+IMMUTABLE
+SET search_path = public
+AS $$
+  WITH normalized AS (
+    SELECT lower(coalesce(p_text, '')) AS value
+  )
+  SELECT CASE
+    WHEN btrim(coalesce(p_text, '')) = '' THEN FALSE
+    ELSE
+      EXISTS (
+        SELECT 1
+        FROM normalized
+        CROSS JOIN (
+          VALUES
+            -- Original short_terms
+            ('fck'),
+            ('ass'),
+            ('fag'),
+            ('f\*g'),
+            ('kkk'),
+            ('nft'),
+            ('sex'),
+            ('s\*x'),
+            ('xxx'),
+            -- Moved here from long_terms to dodge substring false-positives
+            -- (e.g. 'spic' was matching 'spicy', 'crap' was matching 'crappie').
+            ('spic'),
+            ('sp\*c'),
+            ('crap'),
+            ('piss'),
+            ('dick'),
+            ('d\*ck'),
+            ('dyke'),
+            ('d\*ke'),
+            ('kike'),
+            ('k\*ke'),
+            ('nazi'),
+            ('nude'),
+            ('shit'),
+            ('sh\*t'),
+            ('fggt'),
+            ('chink'),
+            ('ch\*nk'),
+            ('beaner')
+        ) AS short_terms(pattern)
+        WHERE normalized.value ~ ('(^|[^a-z0-9_])' || short_terms.pattern || '($|[^a-z0-9_])')
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM normalized
+        CROSS JOIN (
+          VALUES
+            -- Longer tokens — safe to substring-match because they're
+            -- unlikely to appear as substrings of innocent words.
+            ('fuck'),
+            ('fucking'),
+            ('fucked'),
+            ('fucker'),
+            ('f*ck'),
+            ('shitty'),
+            ('bullshit'),
+            ('asshole'),
+            ('a**hole'),
+            ('bitch'),
+            ('b*tch'),
+            ('bastard'),
+            ('pissed'),
+            ('cunt'),
+            ('c*nt'),
+            ('nigger'),
+            ('nigga'),
+            ('n*gger'),
+            ('n*gga'),
+            ('faggot'),
+            ('f*ggot'),
+            ('retard'),
+            ('retarded'),
+            ('r*tard'),
+            ('wetback'),
+            ('honky'),
+            ('tranny'),
+            ('tr*nny'),
+            ('hitler'),
+            ('buy now'),
+            ('click here'),
+            ('free money'),
+            ('make money fast'),
+            ('work from home'),
+            ('bitcoin'),
+            ('crypto'),
+            ('www.'),
+            ('http://'),
+            ('https://'),
+            ('.com'),
+            ('.net'),
+            ('.org'),
+            ('porn'),
+            ('p*rn')
+        ) AS long_terms(term)
+        WHERE position(long_terms.term IN normalized.value) > 0
+      )
+  END;
+$$;
+
+-- ROLLBACK:
+-- To revert, restore the prior function body from
+-- supabase/migrations/20260424_server_side_content_filter.sql or git history.
+-- The check constraints on votes/dishes/restaurants/profiles do not need to
+-- change — they reference is_offensive() by name.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -839,6 +839,10 @@ $$ LANGUAGE plpgsql IMMUTABLE SET search_path = public;
 -- Server-side UGC content filter. Mirrors src/lib/reviewBlocklist.js exactly:
 -- blocklist entries with length <= 3 use boundary matching; longer entries use
 -- plain case-insensitive substring matching. Asterisks are literal.
+-- 4-letter tokens with substring false-positive risk live in short_terms so
+-- they get word-boundary regex protection (e.g. 'spic' won't match 'spicy',
+-- 'crap' won't match 'crappie', 'dick' won't match 'Dickens'). Longer
+-- tokens stay in long_terms substring mode.
 CREATE OR REPLACE FUNCTION public.is_offensive(p_text TEXT)
 RETURNS BOOLEAN
 LANGUAGE sql
@@ -864,7 +868,25 @@ AS $$
             ('nft'),
             ('sex'),
             ('s\*x'),
-            ('xxx')
+            ('xxx'),
+            ('spic'),
+            ('sp\*c'),
+            ('crap'),
+            ('piss'),
+            ('dick'),
+            ('d\*ck'),
+            ('dyke'),
+            ('d\*ke'),
+            ('kike'),
+            ('k\*ke'),
+            ('nazi'),
+            ('nude'),
+            ('shit'),
+            ('sh\*t'),
+            ('fggt'),
+            ('chink'),
+            ('ch\*nk'),
+            ('beaner')
         ) AS short_terms(pattern)
         WHERE normalized.value ~ ('(^|[^a-z0-9_])' || short_terms.pattern || '($|[^a-z0-9_])')
       )
@@ -878,21 +900,13 @@ AS $$
             ('fucked'),
             ('fucker'),
             ('f*ck'),
-            ('shit'),
             ('shitty'),
             ('bullshit'),
-            ('sh*t'),
             ('asshole'),
             ('a**hole'),
             ('bitch'),
             ('b*tch'),
-            ('damn'),
-            ('dammit'),
-            ('crap'),
             ('bastard'),
-            ('dick'),
-            ('d*ck'),
-            ('piss'),
             ('pissed'),
             ('cunt'),
             ('c*nt'),
@@ -905,21 +919,10 @@ AS $$
             ('retard'),
             ('retarded'),
             ('r*tard'),
-            ('spic'),
-            ('sp*c'),
-            ('chink'),
-            ('ch*nk'),
-            ('kike'),
-            ('k*ke'),
             ('wetback'),
-            ('beaner'),
-            ('cracker'),
             ('honky'),
-            ('dyke'),
-            ('d*ke'),
             ('tranny'),
             ('tr*nny'),
-            ('nazi'),
             ('hitler'),
             ('buy now'),
             ('click here'),
@@ -935,9 +938,7 @@ AS $$
             ('.net'),
             ('.org'),
             ('porn'),
-            ('p*rn'),
-            ('nude'),
-            ('naked')
+            ('p*rn')
         ) AS long_terms(term)
         WHERE position(long_terms.term IN normalized.value) > 0
       )

--- a/supabase/tests/content-filter.test.sql
+++ b/supabase/tests/content-filter.test.sql
@@ -2,20 +2,48 @@
 -- migration to confirm the DB-side filter still mirrors src/lib/reviewBlocklist.js.
 WITH cases(input_text, expected, scenario) AS (
   VALUES
+    -- Profanity / hard slurs (must still flag)
     ('fuck this place', TRUE, 'profanity substring'),
-    ('Beach Plum Burger', FALSE, 'clean restaurant name'),
-    ('class act', FALSE, 'ass uses word boundaries'),
     ('ass', TRUE, 'ass exact word'),
-    ('fagioli', FALSE, 'fag does not match inside words'),
     ('fag', TRUE, 'fag exact word'),
-    ('spicier salsa', TRUE, '4-char slur still uses substring semantics'),
     ('n*gga', TRUE, 'literal asterisk slur variant'),
     ('kkk rally', TRUE, 'short slur with word boundaries'),
+    ('s*x', TRUE, 'literal asterisk short sexual-content variant'),
+    -- Spam (must still flag)
     ('Visit example.com', TRUE, 'domain substring spam'),
     ('Buy now and save', TRUE, 'phrase substring spam'),
+    -- Clean baseline
+    ('Beach Plum Burger', FALSE, 'clean restaurant name'),
+    -- Word-boundary protected — these used to falsely flag
+    ('class act', FALSE, 'ass uses word boundaries'),
+    ('fagioli', FALSE, 'fag does not match inside words'),
     ('nftaco', FALSE, 'nft does not match inside a longer token'),
     ('sexiest dish', FALSE, 'sex stays boundary-only because it is 3 chars'),
-    ('s*x', TRUE, 'literal asterisk short sexual-content variant')
+    -- Newly added word-boundary tokens (regressions the 20260517 migration fixes)
+    ('spicier salsa', FALSE, 'spic no longer matches inside spicy'),
+    ('crappie sandwich', FALSE, 'crap no longer matches inside crappie'),
+    ('pissaladière flatbread', FALSE, 'piss no longer matches inside pissaladière'),
+    ('Dickens cake', FALSE, 'dick no longer matches inside Dickens'),
+    ('shiitake mushroom', FALSE, 'shit no longer matches inside shiitake'),
+    ('shitake roll', FALSE, 'shit also passes the alt-spelling shitake'),
+    -- The bare words STILL flag
+    ('spic', TRUE, 'spic still flags as standalone slur'),
+    ('crap on toast', TRUE, 'crap still flags as standalone'),
+    ('that was dick', TRUE, 'dick still flags as standalone'),
+    ('shit was bad', TRUE, 'shit still flags as standalone'),
+    -- damn / dammit now permitted (mild profanity, common in food reviews)
+    ('damn good lobster roll', FALSE, 'damn permitted'),
+    ('dammit this is good', FALSE, 'dammit permitted'),
+    -- fggt (de-voweled slur bypass)
+    ('fggt', TRUE, 'fggt flags as de-voweled slur'),
+    -- Food-domain word-boundary fixes (chink, beaner)
+    ('Chinkiang vinegar', FALSE, 'chink no longer matches inside Chinkiang'),
+    ('Beanery cafe', FALSE, 'beaner no longer matches inside Beanery'),
+    -- Naked / cracker are no longer filter tokens (too common in food context)
+    ('naked burrito', FALSE, 'naked permitted (real menu term)'),
+    ('Naked Pig BBQ', FALSE, 'naked permitted in restaurant names'),
+    ('oyster crackers', FALSE, 'cracker permitted (common food)'),
+    ('try the cracker with cheese', FALSE, 'cracker permitted standalone in food review')
 )
 SELECT
   scenario,
@@ -23,4 +51,5 @@ SELECT
   expected,
   public.is_offensive(input_text) AS actual,
   public.is_offensive(input_text) IS NOT DISTINCT FROM expected AS pass
-FROM cases;
+FROM cases
+ORDER BY pass, scenario;


### PR DESCRIPTION
## Why

Dan tried to write a review with "spicy" and got blocked. `is_offensive()` was substring-matching `spic` against `spicy`. Same class of bug catches `shiitake`, `crappie`, `Dickens cake`, etc.

Photo moderation (Sonnet vision via `photo-moderate` Edge Function) handles the visual side of bad content separately, which is the relevant control for actually-harmful uploads. The text filter just needs to stop blocking normal food vocabulary.

## What changed

**Moved to word-boundary regex** (server `short_terms` / client `BLOCKED_WHOLE_WORDS`):
- `spic`, `sp*c`, `crap`, `piss`, `dick`, `d*ck`, `dyke`, `d*ke`, `kike`, `k*ke`, `nazi`, `nude`, `shit`, `sh*t`, `chink`, `ch*nk`, `beaner`

**Added** (de-voweled slur bypass): `fggt`

**Dropped entirely** (too common in food context, photo moderation handles visual nudity):
- `damn`, `dammit` — "damn good lobster roll" is standard MV review language
- `naked` — "naked burrito", "naked wings", "Naked Pig BBQ"
- `cracker` — oyster crackers, graham crackers, soda crackers

## What still flags
- `spic`, `dick`, `shit` standalone (word-boundary still catches)
- Every harder slur (n-word, f-slur, etc.) unchanged
- All spam/scam phrases (`buy now`, `.com`, `bitcoin`, etc.) unchanged

## Deployment

⚠️ **Migration not deployed.** Run `supabase/migrations/20260517_is_offensive_word_boundaries.sql` in Denis's Supabase SQL Editor. Verify with `supabase/tests/content-filter.test.sql` (all rows should show `pass = true`).

## Review trail

- Codex pass 1: caught client-side blocklist parity bug + stale test file + `shiitake` false positive
- Codex pass 2: caught `chink/Chinkiang vinegar`, `naked/naked burrito`, `cracker/crackers`, `beaner/Beanery` — Dan called drop on naked + cracker, word-boundary on chink + beaner
- Codex pass 3: clean. Known leftover risks (NOT in scope here): `cunt/Scunthorpe`, `bitch/Bitchin' Sauce`, `honky/Honky Tonk`. Fix if reported.

## Test plan

- [ ] Migration runs without error
- [ ] `content-filter.test.sql` all 30+ rows show `pass = true`
- [ ] Try writing review "this is **damn** good and so **spicy**" — passes client + server
- [ ] Try writing "**shiitake** mushroom" — passes
- [ ] Try writing "you **fggt**" — blocked (de-voweled slur catches)
- [ ] Try writing "**dick**" alone — blocked (slur catches at word-boundary)
- [ ] Try writing "**Dickens** cake" — passes (substring no longer catches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)