### PR TITLE
perf(follow-list): pre-emptive trigram index for display_name substring search

### DIFF
--- a/src/api/followsApi.js
+++ b/src/api/followsApi.js
@@ -86,6 +86,9 @@ async function _searchFollows(userId, direction, { query, cursor = null, limit =
     // out before hitting the RPC. Strip escaped LIKE/ILIKE metachars to check.
     const searchable = sanitized.replace(/\\[%_\\]/g, '')
     if (!sanitized || !searchable) return { users: [], hasMore: false }
+    // Min 2 chars (matches searchUsers convention). Single-char queries are
+    // ambiguous and don't benefit from the trigram index — degrade to scan.
+    if (searchable.length < 2) return { users: [], hasMore: false }
 
     const { data, error } = await supabase.rpc('search_user_follows', {
       p_user_id: userId,

--- a/supabase/migrations/20260517_profiles_display_name_trgm.sql
+++ b/supabase/migrations/20260517_profiles_display_name_trgm.sql
@@ -1,0 +1,18 @@
+-- pg_trgm trigram index on profiles.display_name to accelerate the substring
+-- ILIKE search inside search_user_follows (PR #209). At current profile
+-- counts the post-JOIN Seq Scan is fast, but ILIKE '%foo%' has no good
+-- alternative once a single user accumulates ~5K+ follows. Shipping the
+-- index pre-emptively is cheap (one GIN entry per profile) and lets the
+-- planner pick it up automatically as the data grows.
+--
+-- gin_trgm_ops supports ILIKE / LIKE substring matching natively.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS idx_profiles_display_name_trgm
+  ON profiles
+  USING gin (display_name gin_trgm_ops);
+
+-- ROLLBACK:
+-- DROP INDEX IF EXISTS idx_profiles_display_name_trgm;
+-- -- pg_trgm extension can stay; other migrations may depend on it later.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -469,6 +469,12 @@ CREATE INDEX IF NOT EXISTS idx_votes_source_created ON votes(source, created_at 
 
 -- profiles
 CREATE UNIQUE INDEX IF NOT EXISTS profiles_display_name_unique ON profiles(LOWER(display_name)) WHERE display_name IS NOT NULL;
+-- Trigram GIN index accelerates ILIKE '%foo%' substring search used by
+-- search_user_follows (and searchUsers). Becomes load-bearing once any
+-- user accumulates ~5K+ follows; cheap to maintain at smaller scale.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX IF NOT EXISTS idx_profiles_display_name_trgm
+  ON profiles USING gin (display_name gin_trgm_ops);
 
 -- dish_photos
 CREATE INDEX IF NOT EXISTS idx_dish_photos_dish ON dish_photos(dish_id);


### PR DESCRIPTION
## Why

`search_user_follows` (PR #209) uses `ILIKE '%foo%'` against `profiles.display_name`. A btree index can't accelerate `%foo%` substring matching, so the planner falls back to a Seq Scan. At current scale (~2K profiles) that's fine — the scan only runs over rows the JOIN already narrowed.

But it has a known cliff: once a single user accumulates ~5K follows, the post-JOIN scan becomes the bottleneck. Pre-emptive fix is two lines.

## What changed

```sql
CREATE EXTENSION IF NOT EXISTS pg_trgm;
CREATE INDEX IF NOT EXISTS idx_profiles_display_name_trgm
  ON profiles USING gin (display_name gin_trgm_ops);
```

Plus a `min 2 chars` guard in `_searchFollows` (matches the existing `searchUsers` convention) — single-char queries don't benefit from trigram and aren't useful anyway.

## Deployment

⚠️ Run `supabase/migrations/20260517_profiles_display_name_trgm.sql` in Denis's Supabase SQL Editor. `CREATE INDEX` is non-blocking by default with `IF NOT EXISTS` — no downtime concern at current size.

## Review trail

- Codex: clean correctness, flagged short-query weakness → fixed with 2-char min guard.
- Compared `gin_trgm_ops` against existing `LOWER(display_name)` partial unique index — they serve different purposes (uniqueness vs substring search), additive only.

## Test plan

- [ ] Migration runs in <1s (small profiles table)
- [ ] Existing `searchUsers` still works — same `pg_trgm` extension benefits it too
- [ ] Type 1 char in follower search → empty result (intentional 2-char min)
- [ ] Type 2+ chars → results return as before, just faster as user count grows

🤖 Generated with [Claude Code](https://claude.com/claude-code)