### PR TITLE
feat(menu-refresh): extract coffee + surface coffee/drinks on homepage strip

### DIFF
--- a/src/constants/categories.js
+++ b/src/constants/categories.js
@@ -24,6 +24,8 @@ export const BROWSE_CATEGORIES = [
   { id: 'wings', label: 'Wings', emoji: '🍗' },
   { id: 'chicken', label: 'Chicken', emoji: '🐔' },
   { id: 'pork', label: 'Pork', emoji: '🐷' },
+  { id: 'coffee', label: 'Coffee', emoji: '☕' },
+  { id: 'drinks', label: 'Drinks', emoji: '🍸' },
 ]
 
 // Main categories shown in category picker (singular labels)
@@ -48,6 +50,8 @@ export const MAIN_CATEGORIES = [
   { id: 'wings', label: 'Wings', emoji: '🍗' },
   { id: 'chicken', label: 'Chicken', emoji: '🐔' },
   { id: 'pork', label: 'Pork', emoji: '🐷' },
+  { id: 'coffee', label: 'Coffee', emoji: '☕' },
+  { id: 'drinks', label: 'Drinks', emoji: '🍸' },
 ]
 
 // All categories in the system (including sub-categories)

--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -35,7 +35,7 @@ const VALID_CATEGORIES = [
   'calamari', 'crab', 'curry', 'lobster', 'mussels', 'onion rings',
   'pancakes', 'scallops', 'shrimp', 'waffles', 'wrap',
   'fish-and-chips', 'fish-sandwich', 'eggs-benedict',
-  'oysters', 'pastry',
+  'oysters', 'pastry', 'coffee',
 ]
 
 const MENU_EXTRACTION_PROMPT = `You are extracting a restaurant menu for a food discovery app. Your job is to produce output that mirrors the restaurant's actual menu — a user reading it should feel like they're looking at the real thing.
@@ -109,12 +109,13 @@ Pick the MOST SPECIFIC category that fits. Prefer "lobster roll" over "seafood",
 | pokebowl | Poke bowls |
 | asian | Asian entrees (pad thai, stir-fry) |
 | curry | Curry dishes |
+| coffee | Coffee drinks: drip, americano, espresso, latte, cappuccino, cortado, macchiato, mocha, flat white, cold brew, iced coffee |
 | entree | Catch-all for entrees that don't fit any specific category |
 
 ## Rules
 
 1. **Extract EVERY food dish on the menu** — be thorough, don't skip items
-2. **Skip ALL drinks** — no cocktails, beer, wine, coffee, soda, juice, or any beverages
+2. **Coffee drinks ARE included** — categorize as `coffee`. This covers drip coffee, americano, espresso, latte, cappuccino, cortado, macchiato, mocha, flat white, cold brew, iced coffee, and other coffee preparations. **Skip alcoholic coffee drinks** (Irish coffee, espresso martini, coffee negroni, anything with a liqueur). **Skip all other drinks** — no cocktails, beer, wine, soda, juice, plain water, or non-coffee beverages.
 3. **Skip kids meals**
 4. **Skip condiments** — extra sauce, side of dressing, bread roll
 5. **Skip side dishes** — mashed potatoes, green beans, rice, coleslaw, steamed veggies, etc. NOT rateable.


### PR DESCRIPTION
## Summary

- **Menu-refresh** now extracts coffee drinks (espresso/latte/americano/cappuccino/cold brew/etc.) instead of skipping them. Categorized as `coffee`. Alcoholic coffee drinks (Irish coffee, espresso martini, coffee negroni) still skipped.
- **Homepage strip** now includes `coffee` (☕ takeout cup) and `drinks` (🍸 martini) — the icons we shipped in PR #214 finally show up.
- **Category picker** also includes both for manual classification.

## Deployment

The `menu-refresh` Edge Function changes deploy automatically when you next run `supabase functions deploy menu-refresh` (or however your CI handles Edge Function deploys). **No SQL migration this time.** Categories.js change is a normal Vercel deploy.

## What to expect after deploy

Refreshing a coffee shop (Aalia's, Espresso Love, Lookout, etc.) will now populate the `coffee` category with their drinks menu automatically — no more manual entry.

## Deferred follow-up

`menu-candidates.ts` still downranks `/drinks` and `/beverages` URLs during discovery. Coffee shops whose menus live at those URLs may not be auto-discovered. Different layer (discovery vs extraction), would risk regression on food-menu discovery for full-service restaurants if relaxed. Worth a separate PR with careful testing.

## Review trail

- Codex pass 1: caught missing `coffee` row in the prompt's category table (would silently coerce to `entree`)
- Codex pass 2: caught BROWSE_CATEGORIES + MAIN_CATEGORIES missing coffee/drinks — added
- Codex pass 3: clean

## Test plan

- [ ] Build passes, Vercel deploys
- [ ] Homepage shows ☕ Coffee and 🍸 Drinks pills on the horizontal strip
- [ ] Tap Coffee → opens category view (will be empty until menu-refresh runs)
- [ ] Run menu-refresh on a known coffee shop → coffee dishes appear
- [ ] Run menu-refresh on a full-service restaurant → only food dishes extracted, no beer/wine/cocktails seeping through

🤖 Generated with [Claude Code](https://claude.com/claude-code)