### PR TITLE
feat(restaurant): tappable friends-here + chalkboard/icon polish

### DIFF
--- a/src/components/DishListItem.jsx
+++ b/src/components/DishListItem.jsx
@@ -141,7 +141,7 @@ export const DishListItem = memo(function DishListItem({
       {showPhoto && photoUrl && (
         <div
           className="flex-shrink-0 rounded-lg overflow-hidden"
-          style={{ width: '48px', height: '48px', marginLeft: '6px', background: 'var(--color-surface)' }}
+          style={{ width: '56px', height: '56px', marginLeft: '6px', background: 'var(--color-surface)' }}
         >
           <img src={photoUrl} alt={dishName} loading="lazy" className="w-full h-full object-cover" />
         </div>
@@ -149,9 +149,9 @@ export const DishListItem = memo(function DishListItem({
       {showPhoto && !photoUrl && (
         <div
           className="flex-shrink-0 rounded-lg overflow-hidden relative"
-          style={{ width: '48px', height: '48px', marginLeft: '6px' }}
+          style={{ width: '56px', height: '56px', marginLeft: '6px' }}
         >
-          <RestaurantAvatar name={restaurantName} town={restaurantTown} dishCategory={category} fill />
+          <RestaurantAvatar name={restaurantName} town={restaurantTown} dishCategory={category} size={56} fill />
         </div>
       )}
 

--- a/src/components/home/HomeListMode.jsx
+++ b/src/components/home/HomeListMode.jsx
@@ -237,7 +237,7 @@ function ChalkboardCard({ tag, title, titleSize, sub, stat, cta, onClick, icon, 
             {icon && <img src={icon} alt="" style={BOARD_ICON_STYLE} />}
             <span>{tag}</span>
           </p>
-          <p style={Object.assign({}, CHALK_BIG, { fontSize: titleSize || '30px', fontWeight: 700, lineHeight: 0.95, margin: '2px 0 0' })}>{title}</p>
+          <p style={Object.assign({}, CHALK_BIG, { fontSize: titleSize || '36px', fontWeight: 700, lineHeight: 0.95, margin: '2px 0 0' })}>{title}</p>
           {sub && <p style={Object.assign({}, CHALK_MED, { fontSize: '15px', margin: 0 })}>{sub}</p>}
           <div style={CHALK_LINE} />
           {stat && <p style={Object.assign({}, CHALK_BRIGHT, { fontSize: '16px', margin: 0 })}>{stat}</p>}
@@ -311,7 +311,7 @@ function ChalkboardSection({ topRestaurant, mostVotedDish, bestValueMeal, bestIc
           icon="/categories/icons/speech-bubble.png"
           tag={'most talked about'}
           title={mostVotedDish.dish_name || mostVotedDish.name}
-          titleSize="28px"
+          titleSize="32px"
           sub={mostVotedDish.restaurant_name}
           stat={(mostVotedDish.total_votes || 0) + ' votes'}
           cta={'see why \u2192'}
@@ -325,7 +325,7 @@ function ChalkboardSection({ topRestaurant, mostVotedDish, bestValueMeal, bestIc
           icon="/categories/icons/money-bag.png"
           tag={'best value'}
           title={bestValueMeal.dish_name || bestValueMeal.name}
-          titleSize="28px"
+          titleSize="32px"
           sub={bestValueMeal.restaurant_name}
           stat={'$' + Number(bestValueMeal.price).toFixed(0) + ' \u00B7 rated ' + Number(bestValueMeal.avg_rating || 0).toFixed(1)}
           cta={'best meal under $15 \u2192'}
@@ -339,7 +339,7 @@ function ChalkboardSection({ topRestaurant, mostVotedDish, bestValueMeal, bestIc
           icon="/categories/icons/ice-cream-clean.png"
           tag={'island scoops'}
           title={bestIceCream.dish_name || bestIceCream.name}
-          titleSize="28px"
+          titleSize="32px"
           sub={bestIceCream.restaurant_name}
           stat={(bestIceCream.total_votes || 0) + ' votes \u00B7 rated ' + Number(bestIceCream.avg_rating || 0).toFixed(1)}
           cta={'best ice cream \u2192'}

--- a/src/components/restaurants/FriendVisitsModal.jsx
+++ b/src/components/restaurants/FriendVisitsModal.jsx
@@ -1,0 +1,268 @@
+import { useMemo } from 'react'
+import { Link } from 'react-router-dom'
+import { useFocusTrap } from '../../hooks/useFocusTrap'
+import { getRatingColor } from '../../utils/ranking'
+import { getCategoryNeonImage, getDishNameIcon } from '../../constants/categories'
+import { EmptyState } from '../EmptyState'
+
+function FriendAvatar({ friend, size = 48 }) {
+  if (friend.avatar_url) {
+    return (
+      <img
+        src={friend.avatar_url}
+        alt=""
+        className="rounded-full object-cover flex-shrink-0"
+        style={{ width: size, height: size }}
+        draggable={false}
+      />
+    )
+  }
+  return (
+    <div
+      className="rounded-full flex items-center justify-center flex-shrink-0 font-bold"
+      style={{
+        width: size,
+        height: size,
+        background: 'var(--color-primary)',
+        color: 'var(--color-text-on-primary, white)',
+        fontSize: size * 0.4,
+      }}
+    >
+      {(friend.display_name || '?').charAt(0).toUpperCase()}
+    </div>
+  )
+}
+
+function formatDate(iso) {
+  if (!iso) return ''
+  const d = new Date(iso)
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+function expertiseLabel(level) {
+  if (level === 'authority') return 'Authority'
+  if (level === 'specialist') return 'Specialist'
+  return null
+}
+
+export function FriendVisitsModal({ friend, votes, restaurantName, onClose }) {
+  const modalRef = useFocusTrap(true, onClose)
+
+  // votes = array of vote rows for this friend at this restaurant
+  // Sort newest-first so most recent visit is on top
+  const sortedVotes = useMemo(() => {
+    return (votes || []).slice().sort((a, b) => {
+      const aDate = a.voted_at ? new Date(a.voted_at).getTime() : 0
+      const bDate = b.voted_at ? new Date(b.voted_at).getTime() : 0
+      return bDate - aDate
+    })
+  }, [votes])
+
+  const dishCount = sortedVotes.length
+  const expertise = sortedVotes.find(v => v.category_expertise)?.category_expertise
+
+  return (
+    <div className="fixed inset-0 z-50" onClick={onClose} role="presentation">
+      <div className="absolute inset-0" style={{ background: 'rgba(0,0,0,0.6)' }} aria-hidden="true" />
+
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="friend-visits-title"
+        className="absolute left-0 right-0 bottom-0 rounded-t-2xl flex flex-col"
+        style={{
+          background: 'var(--color-surface-elevated)',
+          maxHeight: '85vh',
+          paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Grabber */}
+        <div style={{ padding: '8px 0 4px' }}>
+          <div
+            style={{ width: 40, height: 4, background: 'var(--color-divider)', borderRadius: 2, margin: '0 auto' }}
+            aria-hidden="true"
+          />
+        </div>
+
+        {/* Header */}
+        <div
+          className="flex items-center gap-3 px-4 py-3 border-b"
+          style={{ borderColor: 'var(--color-divider)', flex: '0 0 auto' }}
+        >
+          <FriendAvatar friend={friend} size={44} />
+          <div className="flex-1 min-w-0">
+            <h2
+              id="friend-visits-title"
+              className="font-bold truncate"
+              style={{ color: 'var(--color-text-primary)', fontSize: '16px' }}
+            >
+              {friend.display_name || 'Friend'}
+            </h2>
+            <p style={{ color: 'var(--color-text-tertiary)', fontSize: '12px', marginTop: '2px' }}>
+              {dishCount} {dishCount === 1 ? 'dish' : 'dishes'} at {restaurantName}
+              {expertise && (
+                <>
+                  {' · '}
+                  <span style={{ color: 'var(--color-accent-gold)', fontWeight: 600 }}>
+                    {expertiseLabel(expertise)}
+                  </span>
+                </>
+              )}
+            </p>
+          </div>
+          <Link
+            to={`/user/${friend.user_id}`}
+            onClick={onClose}
+            className="font-bold flex-shrink-0"
+            style={{ color: 'var(--color-primary)', fontSize: '13px' }}
+          >
+            Profile
+          </Link>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-2 -mr-2 rounded-full flex-shrink-0"
+            style={{ color: 'var(--color-text-secondary)' }}
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Visits list */}
+        <div
+          style={{
+            flex: '1 1 auto',
+            minHeight: 0,
+            overflowY: 'auto',
+            WebkitOverflowScrolling: 'touch',
+            overscrollBehavior: 'contain',
+          }}
+        >
+          {sortedVotes.length === 0 ? (
+            <div className="px-4 py-8">
+              <EmptyState emoji="🍽️" title="No dishes rated here yet" />
+            </div>
+          ) : (
+            <ul className="px-4 py-3" style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              {sortedVotes.map(vote => (
+                <FriendVisitRow key={vote.dish_id} vote={vote} onNavigate={onClose} />
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function FriendVisitRow({ vote, onNavigate }) {
+  const rating = Number(vote.rating_10)
+  const ratingDisplay = Number.isFinite(rating)
+    ? (rating % 1 === 0 ? rating.toFixed(0) : rating.toFixed(1))
+    : null
+  const iconSrc = getDishNameIcon(vote.dish_name) || getCategoryNeonImage(vote.category)
+
+  return (
+    <li
+      className="rounded-xl"
+      style={{
+        background: 'var(--color-card)',
+        border: '1px solid var(--color-divider)',
+        overflow: 'hidden',
+      }}
+    >
+      <Link
+        to={`/dish/${vote.dish_id}`}
+        onClick={onNavigate}
+        className="flex gap-3 p-3 active:scale-[0.99]"
+        style={{ transition: 'transform 0.1s ease' }}
+      >
+        {/* Photo or icon */}
+        <div
+          className="rounded-lg flex items-center justify-center flex-shrink-0 overflow-hidden"
+          style={{
+            width: 64,
+            height: 64,
+            background: 'var(--color-surface)',
+          }}
+        >
+          {vote.photo_url ? (
+            <img
+              src={vote.photo_url}
+              alt=""
+              className="w-full h-full object-cover"
+              loading="lazy"
+              draggable={false}
+            />
+          ) : iconSrc ? (
+            <img
+              src={iconSrc}
+              alt=""
+              style={{ width: 44, height: 44, objectFit: 'contain' }}
+              loading="lazy"
+            />
+          ) : (
+            <span style={{ fontSize: '24px' }} aria-hidden="true">🍽️</span>
+          )}
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-start gap-2">
+            <p
+              className="font-bold flex-1 min-w-0"
+              style={{
+                color: 'var(--color-text-primary)',
+                fontSize: '14px',
+                lineHeight: 1.3,
+              }}
+            >
+              {vote.dish_name}
+            </p>
+            {ratingDisplay && (
+              <span
+                className="font-bold flex-shrink-0"
+                style={{
+                  fontSize: '18px',
+                  fontWeight: 800,
+                  letterSpacing: '-0.02em',
+                  color: getRatingColor(rating),
+                  lineHeight: 1,
+                }}
+              >
+                {ratingDisplay}
+              </span>
+            )}
+          </div>
+          <p
+            style={{
+              color: 'var(--color-text-tertiary)',
+              fontSize: '11px',
+              marginTop: '2px',
+            }}
+          >
+            {formatDate(vote.voted_at)}
+          </p>
+          {vote.review_text && (
+            <p
+              className="italic"
+              style={{
+                color: 'var(--color-text-secondary)',
+                fontSize: '13px',
+                lineHeight: 1.5,
+                marginTop: '6px',
+              }}
+            >
+              &ldquo;{vote.review_text}&rdquo;
+            </p>
+          )}
+        </div>
+      </Link>
+    </li>
+  )
+}

--- a/src/components/restaurants/FriendsHereListModal.jsx
+++ b/src/components/restaurants/FriendsHereListModal.jsx
@@ -1,0 +1,171 @@
+import { useMemo } from 'react'
+import { useFocusTrap } from '../../hooks/useFocusTrap'
+import { getRatingColor } from '../../utils/ranking'
+import { EmptyState } from '../EmptyState'
+
+function FriendAvatar({ friend, size = 44 }) {
+  if (friend.avatar_url) {
+    return (
+      <img
+        src={friend.avatar_url}
+        alt=""
+        className="rounded-full object-cover flex-shrink-0"
+        style={{ width: size, height: size }}
+        draggable={false}
+      />
+    )
+  }
+  return (
+    <div
+      className="rounded-full flex items-center justify-center flex-shrink-0 font-bold"
+      style={{
+        width: size,
+        height: size,
+        background: 'var(--color-primary)',
+        color: 'var(--color-text-on-primary, white)',
+        fontSize: size * 0.4,
+      }}
+    >
+      {(friend.display_name || '?').charAt(0).toUpperCase()}
+    </div>
+  )
+}
+
+export function FriendsHereListModal({ friends, restaurantName, onSelectFriend, onClose }) {
+  const modalRef = useFocusTrap(true, onClose)
+
+  const sortedFriends = useMemo(() => {
+    return (friends || []).slice().sort((a, b) => {
+      if (b.dish_count !== a.dish_count) return b.dish_count - a.dish_count
+      return (a.display_name || '').localeCompare(b.display_name || '')
+    })
+  }, [friends])
+
+  const total = sortedFriends.length
+
+  return (
+    <div className="fixed inset-0 z-50" onClick={onClose} role="presentation">
+      <div className="absolute inset-0" style={{ background: 'rgba(0,0,0,0.6)' }} aria-hidden="true" />
+
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="friends-here-title"
+        className="absolute left-0 right-0 bottom-0 rounded-t-2xl flex flex-col"
+        style={{
+          background: 'var(--color-surface-elevated)',
+          maxHeight: '75vh',
+          paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Grabber */}
+        <div style={{ padding: '8px 0 4px' }}>
+          <div
+            style={{ width: 40, height: 4, background: 'var(--color-divider)', borderRadius: 2, margin: '0 auto' }}
+            aria-hidden="true"
+          />
+        </div>
+
+        {/* Header */}
+        <div
+          className="flex items-center justify-between px-4 py-3 border-b"
+          style={{ borderColor: 'var(--color-divider)', flex: '0 0 auto' }}
+        >
+          <div className="min-w-0">
+            <h2
+              id="friends-here-title"
+              className="font-bold truncate"
+              style={{ color: 'var(--color-text-primary)', fontSize: '16px' }}
+            >
+              {total} {total === 1 ? 'friend has' : 'friends have'} been here
+            </h2>
+            <p style={{ color: 'var(--color-text-tertiary)', fontSize: '12px', marginTop: '2px' }}>
+              {restaurantName}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-2 -mr-2 rounded-full flex-shrink-0"
+            style={{ color: 'var(--color-text-secondary)' }}
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Friends list */}
+        {sortedFriends.length === 0 ? (
+          <div className="px-4 py-8">
+            <EmptyState emoji="👥" title="No friends here yet" />
+          </div>
+        ) : (
+        <ul
+          style={{
+            flex: '1 1 auto',
+            minHeight: 0,
+            overflowY: 'auto',
+            WebkitOverflowScrolling: 'touch',
+            overscrollBehavior: 'contain',
+          }}
+        >
+          {sortedFriends.map(friend => {
+            const avgRating = friend.avg_rating
+            const ratingDisplay = Number.isFinite(avgRating)
+              ? (avgRating % 1 === 0 ? avgRating.toFixed(0) : avgRating.toFixed(1))
+              : null
+            return (
+              <li key={friend.user_id}>
+                <button
+                  type="button"
+                  onClick={() => onSelectFriend(friend)}
+                  className="w-full flex items-center gap-3 px-4 py-3 text-left active:scale-[0.99]"
+                  style={{
+                    borderBottom: '1px solid var(--color-divider)',
+                    transition: 'transform 0.1s ease',
+                  }}
+                >
+                  <FriendAvatar friend={friend} size={44} />
+                  <div className="flex-1 min-w-0">
+                    <p
+                      className="font-bold truncate"
+                      style={{ color: 'var(--color-text-primary)', fontSize: '14px' }}
+                    >
+                      {friend.display_name || 'Friend'}
+                    </p>
+                    <p style={{ color: 'var(--color-text-tertiary)', fontSize: '12px', marginTop: '2px' }}>
+                      {friend.dish_count} {friend.dish_count === 1 ? 'dish' : 'dishes'}
+                      {ratingDisplay && (
+                        <>
+                          {' · avg '}
+                          <span style={{ color: getRatingColor(avgRating), fontWeight: 700 }}>
+                            {ratingDisplay}
+                          </span>
+                        </>
+                      )}
+                    </p>
+                  </div>
+                  <svg
+                    className="w-5 h-5 flex-shrink-0"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="var(--color-text-tertiary)"
+                    strokeWidth={2}
+                    aria-hidden="true"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                  </svg>
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/restaurants/RestaurantDishes.jsx
+++ b/src/components/restaurants/RestaurantDishes.jsx
@@ -1,14 +1,17 @@
 import { useState, useMemo } from 'react'
-import { Link } from 'react-router-dom'
 import { MIN_VOTES_FOR_RANKING } from '../../constants/app'
 import { DishListItem } from '../DishListItem'
 import { SectionHeader } from '../SectionHeader'
+import { FriendVisitsModal } from './FriendVisitsModal'
+import { FriendsHereListModal } from './FriendsHereListModal'
 
 const TOP_DISHES_COUNT = 5
 
 // Restaurant dishes component - Job #2: "What should I order?"
-export function RestaurantDishes({ dishes, loading, error, searchQuery = '', friendsVotesByDish = {} }) {
+export function RestaurantDishes({ dishes, loading, error, searchQuery = '', friendsVotesByDish = {}, restaurantName = '' }) {
   const [showAllDishes, setShowAllDishes] = useState(false)
+  const [friendsListOpen, setFriendsListOpen] = useState(false)
+  const [selectedFriend, setSelectedFriend] = useState(null)
 
   // Filter and sort dishes
   const sortedDishes = useMemo(() => {
@@ -50,14 +53,50 @@ export function RestaurantDishes({ dishes, loading, error, searchQuery = '', fri
 
   const rankedCount = dishes?.filter(d => (d.total_votes || 0) >= MIN_VOTES_FOR_RANKING).length || 0
 
-  // Count unique friends who rated dishes here
-  const uniqueFriends = useMemo(() => {
-    const friendIds = new Set()
+  // Aggregate friends-here data: one row per friend with their full visit list.
+  // dish_count + avg_rating power the list view; votes power the per-friend popup.
+  const friendsHere = useMemo(() => {
+    const byFriend = new Map()
     Object.values(friendsVotesByDish).forEach(votes => {
-      votes.forEach(v => friendIds.add(v.user_id))
+      votes.forEach(v => {
+        let entry = byFriend.get(v.user_id)
+        if (!entry) {
+          entry = {
+            user_id: v.user_id,
+            display_name: v.display_name,
+            avatar_url: v.avatar_url,
+            votes: [],
+          }
+          byFriend.set(v.user_id, entry)
+        }
+        entry.votes.push(v)
+      })
     })
-    return friendIds.size
+    return Array.from(byFriend.values()).map(f => {
+      const ratings = f.votes
+        .map(v => Number(v.rating_10))
+        .filter(r => Number.isFinite(r))
+      const avg = ratings.length
+        ? ratings.reduce((s, r) => s + r, 0) / ratings.length
+        : null
+      return {
+        ...f,
+        dish_count: f.votes.length,
+        avg_rating: avg,
+      }
+    })
   }, [friendsVotesByDish])
+
+  const uniqueFriends = friendsHere.length
+
+  const handleSelectFriend = (friend) => {
+    setFriendsListOpen(false)
+    setSelectedFriend(friend)
+  }
+
+  const handleCloseVisits = () => setSelectedFriend(null)
+  const handleCloseList = () => setFriendsListOpen(false)
+  const handleOpenList = () => setFriendsListOpen(true)
 
   if (loading) {
     return (
@@ -105,52 +144,63 @@ export function RestaurantDishes({ dishes, loading, error, searchQuery = '', fri
         />
       </div>
 
-      {/* Friends banner */}
+      {/* Friends banner — tap avatar = open that friend's visits popup;
+          tap the rest of the row = open the full friends-here list. */}
       {uniqueFriends > 0 && (
         <div
-          className="mb-4 px-3.5 py-3 rounded-xl flex items-center gap-3"
+          className="mb-4 rounded-xl flex items-center"
           style={{
             background: 'var(--color-surface-elevated)',
             border: '1.5px solid var(--color-primary)',
           }}
         >
-          {/* Stacked avatars */}
-          <div className="flex -space-x-2 flex-shrink-0">
-            {(() => {
-              const seen = new Set()
-              const friendList = []
-              Object.values(friendsVotesByDish).forEach(votes => {
-                votes.forEach(v => {
-                  if (!seen.has(v.user_id)) {
-                    seen.add(v.user_id)
-                    friendList.push(v)
-                  }
-                })
-              })
-              return friendList.slice(0, 3).map((friend, i) => (
-                <Link
-                  key={friend.user_id}
-                  to={`/user/${friend.user_id}`}
-                  className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold ring-2 overflow-hidden"
-                  style={{
-                    background: 'var(--color-primary)',
-                    color: 'var(--color-text-on-primary)',
-                    ringColor: 'var(--color-surface-elevated)',
-                    zIndex: 3 - i,
-                  }}
-                >
-                  {friend.avatar_url ? (
-                    <img src={friend.avatar_url} alt="" className="w-full h-full object-cover" draggable={false} />
-                  ) : (
-                    <span>{friend.display_name?.charAt(0).toUpperCase() || '?'}</span>
-                  )}
-                </Link>
-              ))
-            })()}
+          {/* Stacked avatars (tappable per-friend) */}
+          <div className="flex -space-x-2 flex-shrink-0 pl-3.5 py-3">
+            {friendsHere.slice(0, 3).map((friend, i) => (
+              <button
+                type="button"
+                key={friend.user_id}
+                onClick={() => setSelectedFriend(friend)}
+                aria-label={`See what ${friend.display_name || 'friend'} ordered`}
+                className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold overflow-hidden active:scale-95 transition-transform"
+                style={{
+                  background: 'var(--color-primary)',
+                  color: 'var(--color-text-on-primary, white)',
+                  boxShadow: '0 0 0 2px var(--color-surface-elevated)',
+                  zIndex: 3 - i,
+                  position: 'relative',
+                  cursor: 'pointer',
+                }}
+              >
+                {friend.avatar_url ? (
+                  <img src={friend.avatar_url} alt="" className="w-full h-full object-cover" draggable={false} />
+                ) : (
+                  <span>{friend.display_name?.charAt(0).toUpperCase() || '?'}</span>
+                )}
+              </button>
+            ))}
           </div>
-          <p className="text-sm font-bold" style={{ color: 'var(--color-text-primary)' }}>
-            {uniqueFriends} {uniqueFriends === 1 ? 'friend has' : 'friends have'} been here
-          </p>
+          {/* Rest of row (tappable → opens friends list) */}
+          <button
+            type="button"
+            onClick={handleOpenList}
+            className="flex-1 flex items-center justify-between gap-2 pl-3 pr-3.5 py-3 text-left active:bg-black/5"
+            style={{ cursor: 'pointer', background: 'transparent', border: 'none' }}
+          >
+            <p className="text-sm font-bold" style={{ color: 'var(--color-text-primary)' }}>
+              {uniqueFriends} {uniqueFriends === 1 ? 'friend has' : 'friends have'} been here
+            </p>
+            <svg
+              className="w-4 h-4 flex-shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="var(--color-text-tertiary)"
+              strokeWidth={2}
+              aria-hidden="true"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
         </div>
       )}
 
@@ -232,6 +282,24 @@ export function RestaurantDishes({ dishes, loading, error, searchQuery = '', fri
             </div>
           )}
         </div>
+      )}
+
+      {friendsListOpen && (
+        <FriendsHereListModal
+          friends={friendsHere}
+          restaurantName={restaurantName}
+          onSelectFriend={handleSelectFriend}
+          onClose={handleCloseList}
+        />
+      )}
+
+      {selectedFriend && (
+        <FriendVisitsModal
+          friend={selectedFriend}
+          votes={selectedFriend.votes}
+          restaurantName={restaurantName}
+          onClose={handleCloseVisits}
+        />
       )}
     </div>
   )

--- a/src/pages/RestaurantDetail.jsx
+++ b/src/pages/RestaurantDetail.jsx
@@ -616,6 +616,7 @@ export function RestaurantDetail() {
           user={user}
           searchQuery={dishSearchQuery}
           friendsVotesByDish={friendsVotesByDish}
+          restaurantName={restaurant?.name || ''}
         />
       ) : (
         <RestaurantMenu

--- a/supabase/migrations/20260518_friends_votes_for_restaurant_review_photo.sql
+++ b/supabase/migrations/20260518_friends_votes_for_restaurant_review_photo.sql
@@ -1,0 +1,60 @@
+-- Extend get_friends_votes_for_restaurant to include review_text and photo_url
+-- so the new per-friend "what they ordered here" popup can render each visit
+-- in full (rating + written review + their uploaded photo) without an extra
+-- round-trip.
+--
+-- review_text comes from votes.review_text (already exists, 200-char cap).
+-- photo_url comes from dish_photos via LEFT JOIN on (dish_id, user_id) —
+-- dish_photos has UNIQUE(dish_id, user_id), so at most one row per pair.
+-- We restrict to status IN ('featured', 'community') so hidden/rejected
+-- moderation states don't leak through.
+--
+-- CREATE OR REPLACE cannot widen the RETURNS TABLE shape, so DROP first
+-- (matching 20260516_friends_votes_rpcs_avatar_url.sql's pattern).
+
+DROP FUNCTION IF EXISTS get_friends_votes_for_restaurant(UUID, UUID);
+
+CREATE OR REPLACE FUNCTION get_friends_votes_for_restaurant(
+  p_user_id UUID,
+  p_restaurant_id UUID
+)
+RETURNS TABLE (
+  user_id UUID, display_name TEXT, avatar_url TEXT, dish_id UUID, dish_name TEXT,
+  rating_10 DECIMAL(3, 1), voted_at TIMESTAMPTZ, category_expertise TEXT,
+  review_text TEXT, photo_url TEXT
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  IF auth.role() <> 'service_role' AND (select auth.uid()) IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'Access denied';
+  END IF;
+
+  RETURN QUERY
+  SELECT p.id, p.display_name, p.avatar_url, d.id, d.name, v.rating_10, v.created_at,
+    CASE
+      WHEN EXISTS (SELECT 1 FROM user_badges ub WHERE ub.user_id = p.id
+                   AND ub.badge_key = 'authority_' || REPLACE(d.category, ' ', '_')) THEN 'authority'
+      WHEN EXISTS (SELECT 1 FROM user_badges ub WHERE ub.user_id = p.id
+                   AND ub.badge_key = 'specialist_' || REPLACE(d.category, ' ', '_')) THEN 'specialist'
+      ELSE NULL
+    END,
+    v.review_text,
+    dp.photo_url
+  FROM follows f
+  JOIN profiles p ON p.id = f.followed_id
+  JOIN votes v ON v.user_id = f.followed_id
+  JOIN dishes d ON d.id = v.dish_id AND d.restaurant_id = p_restaurant_id
+  LEFT JOIN dish_photos dp ON dp.dish_id = d.id
+    AND dp.user_id = f.followed_id
+    AND dp.status IN ('featured', 'community')
+  WHERE f.follower_id = p_user_id
+    AND NOT is_blocked_pair(p_user_id, f.followed_id)
+  ORDER BY d.name, v.created_at DESC;
+END;
+$$;
+
+-- ROLLBACK: drop this and re-run the prior signature from
+-- supabase/migrations/20260516_friends_votes_rpcs_avatar_url.sql (the
+-- 8-column version with avatar_url but no review_text / photo_url).
+-- DROP FUNCTION IF EXISTS get_friends_votes_for_restaurant(UUID, UUID);
+-- Then paste the get_friends_votes_for_restaurant block from that migration.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1530,7 +1530,9 @@ LANGUAGE SQL STABLE SET search_path = public AS $$
   ORDER BY v.created_at DESC;
 $$;
 
--- Get friends' votes for a restaurant (with category expertise)
+-- Get friends' votes for a restaurant (with category expertise, review, photo)
+-- Authoritative shape lives in the SECURITY DEFINER variant lower in this file
+-- (around line 5263). Kept in sync; the lower copy is what callers hit.
 CREATE OR REPLACE FUNCTION get_friends_votes_for_restaurant(
   p_user_id UUID,
   p_restaurant_id UUID
@@ -1538,25 +1540,34 @@ CREATE OR REPLACE FUNCTION get_friends_votes_for_restaurant(
 RETURNS TABLE (
   user_id UUID,
   display_name TEXT,
+  avatar_url TEXT,
   dish_id UUID,
   dish_name TEXT,
   rating_10 DECIMAL(3, 1),
   voted_at TIMESTAMPTZ,
-  category_expertise TEXT
+  category_expertise TEXT,
+  review_text TEXT,
+  photo_url TEXT
 )
 LANGUAGE SQL STABLE SET search_path = public AS $$
   SELECT
-    p.id AS user_id, p.display_name, d.id AS dish_id, d.name AS dish_name,
+    p.id AS user_id, p.display_name, p.avatar_url,
+    d.id AS dish_id, d.name AS dish_name,
     v.rating_10, v.created_at AS voted_at,
     CASE
       WHEN EXISTS (SELECT 1 FROM user_badges ub WHERE ub.user_id = p.id AND ub.badge_key = 'authority_' || REPLACE(d.category, ' ', '_')) THEN 'authority'
       WHEN EXISTS (SELECT 1 FROM user_badges ub WHERE ub.user_id = p.id AND ub.badge_key = 'specialist_' || REPLACE(d.category, ' ', '_')) THEN 'specialist'
       ELSE NULL
-    END AS category_expertise
+    END AS category_expertise,
+    v.review_text,
+    dp.photo_url
   FROM follows f
   JOIN profiles p ON p.id = f.followed_id
   JOIN votes v ON v.user_id = f.followed_id
   JOIN dishes d ON d.id = v.dish_id AND d.restaurant_id = p_restaurant_id
+  LEFT JOIN dish_photos dp ON dp.dish_id = d.id
+    AND dp.user_id = f.followed_id
+    AND dp.status IN ('featured', 'community')
   WHERE f.follower_id = p_user_id
   ORDER BY d.name, v.created_at DESC;
 $$;
@@ -5259,14 +5270,15 @@ END;
 $$;
 
 
--- get_friends_votes_for_restaurant — caller guard + block filter
+-- get_friends_votes_for_restaurant — caller guard + block filter + review/photo
 CREATE OR REPLACE FUNCTION get_friends_votes_for_restaurant(
   p_user_id UUID,
   p_restaurant_id UUID
 )
 RETURNS TABLE (
-  user_id UUID, display_name TEXT, dish_id UUID, dish_name TEXT,
-  rating_10 DECIMAL(3, 1), voted_at TIMESTAMPTZ, category_expertise TEXT
+  user_id UUID, display_name TEXT, avatar_url TEXT, dish_id UUID, dish_name TEXT,
+  rating_10 DECIMAL(3, 1), voted_at TIMESTAMPTZ, category_expertise TEXT,
+  review_text TEXT, photo_url TEXT
 )
 LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public AS $$
 BEGIN
@@ -5275,18 +5287,23 @@ BEGIN
   END IF;
 
   RETURN QUERY
-  SELECT p.id, p.display_name, d.id, d.name, v.rating_10, v.created_at,
+  SELECT p.id, p.display_name, p.avatar_url, d.id, d.name, v.rating_10, v.created_at,
     CASE
       WHEN EXISTS (SELECT 1 FROM user_badges ub WHERE ub.user_id = p.id
                    AND ub.badge_key = 'authority_' || REPLACE(d.category, ' ', '_')) THEN 'authority'
       WHEN EXISTS (SELECT 1 FROM user_badges ub WHERE ub.user_id = p.id
                    AND ub.badge_key = 'specialist_' || REPLACE(d.category, ' ', '_')) THEN 'specialist'
       ELSE NULL
-    END
+    END,
+    v.review_text,
+    dp.photo_url
   FROM follows f
   JOIN profiles p ON p.id = f.followed_id
   JOIN votes v ON v.user_id = f.followed_id
   JOIN dishes d ON d.id = v.dish_id AND d.restaurant_id = p_restaurant_id
+  LEFT JOIN dish_photos dp ON dp.dish_id = d.id
+    AND dp.user_id = f.followed_id
+    AND dp.status IN ('featured', 'community')
   WHERE f.follower_id = p_user_id
     AND NOT is_blocked_pair(p_user_id, f.followed_id)
   ORDER BY d.name, v.created_at DESC;


### PR DESCRIPTION
## Summary

Bundled v1.2 web fixes from Dan's screenshots:

- **Chalkboard headers** — bumped 30→36px (default) / 28→32px (dish-name variants) on the homepage strip so each card announces what it is.
- **Restaurant-detail dish-list icons** — bumped 48→56px container + matched `RestaurantAvatar` `size` so the inner icon scales with it. The icons read as the visual anchor of each row now, not an afterthought.
- **"N friends have been here" is finally interactive.** Tap an avatar → `FriendVisitsModal` (that friend's dishes/ratings/reviews/photos at this restaurant, drillable to /dish/:id). Tap the rest of the row → `FriendsHereListModal` (all friends, tap a row to drill into the same per-friend popup).

Backend: extended `get_friends_votes_for_restaurant` RPC with `review_text` and `photo_url` (LEFT JOIN `dish_photos` on featured/community status). Both `schema.sql` copies synced. Migration drops + recreates since `RETURNS TABLE` shape changes.

## Test plan
- [ ] Homepage: open the chalkboard strip. PIZZA / The Covington / Chowder / Most Talked About / Best Value / Island Scoops all readable at the new sizes without overflow.
- [ ] Restaurant detail (e.g. El Barco, Red Cat Kitchen): dish icons on the dish list feel like the visual anchor of the row, not too small.
- [ ] Restaurant detail with friends-here banner: tap avatar → per-friend popup opens with their dishes, ratings, any reviews, any photos. "Profile" link routes to /user/:id.
- [ ] Same banner: tap the text/chevron → friends list popup, tap a row → per-friend popup opens (list closes underneath).
- [ ] Escape key closes both modals; backdrop tap closes; focus traps.
- [ ] Migration applied to Denis's Supabase before merge — otherwise the popup renders but `review_text`/`photo_url` come through undefined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)