### PR TITLE
fix(restaurants): friends-here sheet stuck collapsed (maxHeight bug)

### DIFF
--- a/src/components/restaurants/FriendVisitsModal.jsx
+++ b/src/components/restaurants/FriendVisitsModal.jsx
@@ -73,7 +73,7 @@ export function FriendVisitsModal({ friend, votes, restaurantName, onClose }) {
         className="absolute left-0 right-0 bottom-0 rounded-t-2xl flex flex-col"
         style={{
           background: 'var(--color-surface-elevated)',
-          maxHeight: '85vh',
+          height: '75vh',
           paddingBottom: 'env(safe-area-inset-bottom, 0px)',
         }}
         onClick={(e) => e.stopPropagation()}

--- a/src/components/restaurants/FriendsHereListModal.jsx
+++ b/src/components/restaurants/FriendsHereListModal.jsx
@@ -55,7 +55,7 @@ export function FriendsHereListModal({ friends, restaurantName, onSelectFriend, 
         className="absolute left-0 right-0 bottom-0 rounded-t-2xl flex flex-col"
         style={{
           background: 'var(--color-surface-elevated)',
-          maxHeight: '75vh',
+          height: '65vh',
           paddingBottom: 'env(safe-area-inset-bottom, 0px)',
         }}
         onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
## Summary
Dan reported the friends-here popup feels "stuck to the bottom, can't scroll." Root cause was using `maxHeight` instead of explicit `height` on the bottom-sheet flex container — auto-height parent meant the inner scroll-child had no defined space to overflow into. Switched to `height: 75vh` (visits) / `height: 65vh` (list), matching `FollowListModal`.

## Test plan
- [ ] Restaurant detail with friends-here banner. Tap avatar → visits modal opens at ~75vh, scrolls smoothly even with one dish.
- [ ] Tap the rest of the banner → list modal at ~65vh, scrolls.
- [ ] Backdrop tap + close button + Escape still dismiss correctly.

Memory written: `feedback_bottom_sheet_explicit_height.md` so this anti-pattern doesn't get re-introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)