### PR TITLE
feat(friends-here): taste-match % chip on friend rows + visit header

### DIFF
--- a/src/api/followsApi.js
+++ b/src/api/followsApi.js
@@ -336,6 +336,43 @@ export const followsApi = {
   },
 
   /**
+   * Batch taste compatibility for a list of friends. One RPC for the whole
+   * friends-here surface so the per-friend chip renders without N+1.
+   * @param {string[]} friendIds - Array of user IDs
+   * @returns {Promise<Map<string, { shared_dishes: number, compatibility_pct: number|null }>>}
+   */
+  async getTasteCompatibilityForFriends(friendIds) {
+    if (!Array.isArray(friendIds) || friendIds.length === 0) return new Map()
+    try {
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) return new Map()
+
+      const { data, error } = await supabase
+        .rpc('get_taste_compatibility_for_friends', {
+          p_user_id: user.id,
+          p_friend_ids: friendIds,
+        })
+
+      if (error) {
+        logger.error('Error fetching batch taste compatibility:', error)
+        throw createClassifiedError(error)
+      }
+
+      const map = new Map()
+      ;(data || []).forEach(row => {
+        map.set(row.user_id, {
+          shared_dishes: row.shared_dishes,
+          compatibility_pct: row.compatibility_pct,
+        })
+      })
+      return map
+    } catch (err) {
+      logger.error('Unexpected error in getTasteCompatibilityForFriends:', err)
+      throw err
+    }
+  },
+
+  /**
    * Get friends (people you follow) who voted on dishes at a restaurant
    * @param {string} restaurantId - Restaurant ID
    * @returns {Promise<Array>}

--- a/src/components/restaurants/FriendVisitsModal.jsx
+++ b/src/components/restaurants/FriendVisitsModal.jsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { useFocusTrap } from '../../hooks/useFocusTrap'
-import { getRatingColor } from '../../utils/ranking'
+import { getRatingColor, getMatchColor } from '../../utils/ranking'
 import { getCategoryNeonImage, getDishNameIcon } from '../../constants/categories'
 import { EmptyState } from '../EmptyState'
 
@@ -60,6 +60,7 @@ export function FriendVisitsModal({ friend, votes, restaurantName, onClose }) {
 
   const dishCount = sortedVotes.length
   const expertise = sortedVotes.find(v => v.category_expertise)?.category_expertise
+  const matchPct = Number.isFinite(friend?.compatibility_pct) ? friend.compatibility_pct : null
 
   return (
     <div className="fixed inset-0 z-50" onClick={onClose} role="presentation">
@@ -102,6 +103,14 @@ export function FriendVisitsModal({ friend, votes, restaurantName, onClose }) {
             </h2>
             <p style={{ color: 'var(--color-text-tertiary)', fontSize: '12px', marginTop: '2px' }}>
               {dishCount} {dishCount === 1 ? 'dish' : 'dishes'} at {restaurantName}
+              {matchPct != null && (
+                <>
+                  {' · '}
+                  <span style={{ color: getMatchColor(matchPct), fontWeight: 700 }}>
+                    {matchPct}% taste match
+                  </span>
+                </>
+              )}
               {expertise && (
                 <>
                   {' · '}

--- a/src/components/restaurants/FriendsHereListModal.jsx
+++ b/src/components/restaurants/FriendsHereListModal.jsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { useFocusTrap } from '../../hooks/useFocusTrap'
-import { getRatingColor } from '../../utils/ranking'
+import { getRatingColor, getMatchColor } from '../../utils/ranking'
 import { EmptyState } from '../EmptyState'
 
 function FriendAvatar({ friend, size = 44 }) {
@@ -118,6 +118,7 @@ export function FriendsHereListModal({ friends, restaurantName, onSelectFriend, 
             const ratingDisplay = Number.isFinite(avgRating)
               ? (avgRating % 1 === 0 ? avgRating.toFixed(0) : avgRating.toFixed(1))
               : null
+            const matchPct = Number.isFinite(friend.compatibility_pct) ? friend.compatibility_pct : null
             return (
               <li key={friend.user_id}>
                 <button
@@ -131,12 +132,26 @@ export function FriendsHereListModal({ friends, restaurantName, onSelectFriend, 
                 >
                   <FriendAvatar friend={friend} size={44} />
                   <div className="flex-1 min-w-0">
-                    <p
-                      className="font-bold truncate"
-                      style={{ color: 'var(--color-text-primary)', fontSize: '14px' }}
-                    >
-                      {friend.display_name || 'Friend'}
-                    </p>
+                    <div className="flex items-center gap-2">
+                      <p
+                        className="font-bold truncate flex-1 min-w-0"
+                        style={{ color: 'var(--color-text-primary)', fontSize: '14px' }}
+                      >
+                        {friend.display_name || 'Friend'}
+                      </p>
+                      {matchPct != null && (
+                        <span
+                          className="font-bold flex-shrink-0"
+                          style={{
+                            color: getMatchColor(matchPct),
+                            fontSize: '12px',
+                            letterSpacing: '-0.01em',
+                          }}
+                        >
+                          {matchPct}% match
+                        </span>
+                      )}
+                    </div>
                     <p style={{ color: 'var(--color-text-tertiary)', fontSize: '12px', marginTop: '2px' }}>
                       {friend.dish_count} {friend.dish_count === 1 ? 'dish' : 'dishes'}
                       {ratingDisplay && (

--- a/src/components/restaurants/RestaurantDishes.jsx
+++ b/src/components/restaurants/RestaurantDishes.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { MIN_VOTES_FOR_RANKING } from '../../constants/app'
 import { DishListItem } from '../DishListItem'
 import { SectionHeader } from '../SectionHeader'
@@ -8,10 +8,18 @@ import { FriendsHereListModal } from './FriendsHereListModal'
 const TOP_DISHES_COUNT = 5
 
 // Restaurant dishes component - Job #2: "What should I order?"
-export function RestaurantDishes({ dishes, loading, error, searchQuery = '', friendsVotesByDish = {}, restaurantName = '' }) {
+export function RestaurantDishes({ dishes, loading, error, searchQuery = '', friendsVotesByDish = {}, tasteCompatByFriend = {}, restaurantName = '' }) {
   const [showAllDishes, setShowAllDishes] = useState(false)
   const [friendsListOpen, setFriendsListOpen] = useState(false)
   const [selectedFriend, setSelectedFriend] = useState(null)
+
+  // Close any open friends modals when the restaurant context changes,
+  // so a stale selectedFriend from the previous restaurant can't render
+  // against this restaurant's name.
+  useEffect(() => {
+    setFriendsListOpen(false)
+    setSelectedFriend(null)
+  }, [restaurantName])
 
   // Filter and sort dishes
   const sortedDishes = useMemo(() => {
@@ -79,13 +87,16 @@ export function RestaurantDishes({ dishes, loading, error, searchQuery = '', fri
       const avg = ratings.length
         ? ratings.reduce((s, r) => s + r, 0) / ratings.length
         : null
+      const compat = tasteCompatByFriend[f.user_id] || null
       return {
         ...f,
         dish_count: f.votes.length,
         avg_rating: avg,
+        compatibility_pct: compat?.compatibility_pct ?? null,
+        shared_dishes: compat?.shared_dishes ?? 0,
       }
     })
-  }, [friendsVotesByDish])
+  }, [friendsVotesByDish, tasteCompatByFriend])
 
   const uniqueFriends = friendsHere.length
 

--- a/src/pages/RestaurantDetail.jsx
+++ b/src/pages/RestaurantDetail.jsx
@@ -41,6 +41,7 @@ export function RestaurantDetail() {
   const [dishSearchQuery, setDishSearchQuery] = useState('')
   const [loginModalOpen, setLoginModalOpen] = useState(false)
   const [friendsVotesByDish, setFriendsVotesByDish] = useState({})
+  const [tasteCompatByFriend, setTasteCompatByFriend] = useState({})
   const [expandedReview, setExpandedReview] = useState(null)
 
   // Fetch restaurant by ID
@@ -153,10 +154,13 @@ export function RestaurantDetail() {
 
   // Fetch friend votes
   useEffect(() => {
-    if (!restaurantId || !user) {
-      setFriendsVotesByDish({})
-      return
-    }
+    // Clear synchronously on restaurantId change so the stale
+    // restaurant's friends data doesn't leak into the new view while
+    // the new RPC is in flight.
+    setFriendsVotesByDish({})
+    setTasteCompatByFriend({})
+
+    if (!restaurantId || !user) return
 
     let cancelled = false
 
@@ -165,16 +169,38 @@ export function RestaurantDetail() {
         const votes = await followsApi.getFriendsVotesForRestaurant(restaurantId)
         if (cancelled) return
         const byDish = {}
+        const friendIds = new Set()
         votes.forEach(vote => {
           if (!byDish[vote.dish_id]) {
             byDish[vote.dish_id] = []
           }
           byDish[vote.dish_id].push(vote)
+          friendIds.add(vote.user_id)
         })
         setFriendsVotesByDish(byDish)
+
+        // Fan out compatibility for the same friend set — one batch RPC.
+        // Failure here is non-fatal: chip just hides, votes still render.
+        if (friendIds.size > 0) {
+          try {
+            const compatMap = await followsApi.getTasteCompatibilityForFriends(Array.from(friendIds))
+            if (cancelled) return
+            const obj = {}
+            compatMap.forEach((value, key) => { obj[key] = value })
+            setTasteCompatByFriend(obj)
+          } catch (err) {
+            logger.warn('Failed to fetch taste compatibility for friends:', err)
+            if (!cancelled) setTasteCompatByFriend({})
+          }
+        } else {
+          setTasteCompatByFriend({})
+        }
       } catch (err) {
         logger.error('Failed to fetch friends votes for restaurant:', err)
-        if (!cancelled) setFriendsVotesByDish({})
+        if (!cancelled) {
+          setFriendsVotesByDish({})
+          setTasteCompatByFriend({})
+        }
       }
     }
 
@@ -616,6 +642,7 @@ export function RestaurantDetail() {
           user={user}
           searchQuery={dishSearchQuery}
           friendsVotesByDish={friendsVotesByDish}
+          tasteCompatByFriend={tasteCompatByFriend}
           restaurantName={restaurant?.name || ''}
         />
       ) : (

--- a/src/utils/ranking.js
+++ b/src/utils/ranking.js
@@ -22,6 +22,19 @@ export function getRatingColor(rating) {
 }
 
 /**
+ * Get color for taste-compatibility percentage (0-100). Same warm palette
+ * as getRatingColor, scaled to the percentage domain.
+ * @param {number|null} pct - Compatibility 0-100, or null
+ * @returns {string} CSS color value
+ */
+export function getMatchColor(pct) {
+  if (pct === null || pct === undefined) return 'var(--color-text-tertiary)'
+  if (pct >= 80) return 'var(--color-success)'
+  if (pct >= 60) return 'var(--color-accent-gold)'
+  return 'var(--color-text-tertiary)'
+}
+
+/**
  * Get the left-border accent color used on review cards.
  * Distinct from getRatingColor — uses theme accent tokens, not badge colors.
  * @param {number} rating - Rating on 1-10 scale

--- a/supabase/migrations/20260518_taste_compatibility_for_friends.sql
+++ b/supabase/migrations/20260518_taste_compatibility_for_friends.sql
@@ -1,0 +1,68 @@
+-- Batch version of get_taste_compatibility so the friends-here surfaces can
+-- render a "X% match" chip per friend without N+1 round-trips. Same math as
+-- the single-pair function (avg ABS difference, normalized to 0..100, needs
+-- >=3 shared dishes), but takes an array of friend IDs and returns one row
+-- per friend including those with fewer shared dishes (compatibility_pct is
+-- NULL for those; UI hides the chip).
+--
+-- Block filter respected: blocked friends drop out entirely. Caller guard
+-- mirrors get_taste_compatibility.
+--
+-- New shape, so no DROP required (no existing function with this name).
+
+CREATE OR REPLACE FUNCTION get_taste_compatibility_for_friends(
+  p_user_id UUID,
+  p_friend_ids UUID[]
+)
+RETURNS TABLE (
+  user_id UUID,
+  shared_dishes INT,
+  compatibility_pct INT
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  IF auth.role() <> 'service_role' AND (select auth.uid()) IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'Access denied';
+  END IF;
+
+  RETURN QUERY
+  WITH pairs AS (
+    SELECT
+      f.followed_id AS friend_id,
+      a.rating_10 AS rating_a,
+      b.rating_10 AS rating_b
+    FROM follows f
+    JOIN votes a ON a.user_id = p_user_id
+    JOIN votes b ON b.user_id = f.followed_id AND b.dish_id = a.dish_id
+    WHERE f.follower_id = p_user_id
+      AND f.followed_id = ANY(p_friend_ids)
+      AND NOT is_blocked_pair(p_user_id, f.followed_id)
+      AND a.rating_10 IS NOT NULL
+      AND b.rating_10 IS NOT NULL
+  ),
+  agg AS (
+    SELECT
+      friend_id,
+      COUNT(*)::INT AS shared,
+      AVG(ABS(rating_a - rating_b))::NUMERIC AS avg_diff
+    FROM pairs
+    GROUP BY friend_id
+  )
+  -- Include every requested friend, even those with zero shared rated
+  -- dishes, so callers can iterate the input list without re-zipping.
+  SELECT
+    fid AS user_id,
+    COALESCE(agg.shared, 0) AS shared_dishes,
+    CASE
+      WHEN COALESCE(agg.shared, 0) >= 3
+        THEN ROUND(100 - (agg.avg_diff / 9.0 * 100))::INT
+      ELSE NULL
+    END AS compatibility_pct
+  FROM UNNEST(p_friend_ids) AS fid
+  LEFT JOIN agg ON agg.friend_id = fid
+  WHERE NOT is_blocked_pair(p_user_id, fid);
+END;
+$$;
+
+-- ROLLBACK:
+-- DROP FUNCTION IF EXISTS get_taste_compatibility_for_friends(UUID, UUID[]);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -5344,6 +5344,61 @@ END;
 $$;
 
 
+-- get_taste_compatibility_for_friends — batch version for the friends-here
+-- surfaces. One row per requested friend (NULL compatibility when shared<3).
+CREATE OR REPLACE FUNCTION get_taste_compatibility_for_friends(
+  p_user_id UUID,
+  p_friend_ids UUID[]
+)
+RETURNS TABLE (
+  user_id UUID,
+  shared_dishes INT,
+  compatibility_pct INT
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  IF auth.role() <> 'service_role' AND (select auth.uid()) IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'Access denied';
+  END IF;
+
+  RETURN QUERY
+  WITH pairs AS (
+    SELECT
+      f.followed_id AS friend_id,
+      a.rating_10 AS rating_a,
+      b.rating_10 AS rating_b
+    FROM follows f
+    JOIN votes a ON a.user_id = p_user_id
+    JOIN votes b ON b.user_id = f.followed_id AND b.dish_id = a.dish_id
+    WHERE f.follower_id = p_user_id
+      AND f.followed_id = ANY(p_friend_ids)
+      AND NOT is_blocked_pair(p_user_id, f.followed_id)
+      AND a.rating_10 IS NOT NULL
+      AND b.rating_10 IS NOT NULL
+  ),
+  agg AS (
+    SELECT
+      friend_id,
+      COUNT(*)::INT AS shared,
+      AVG(ABS(rating_a - rating_b))::NUMERIC AS avg_diff
+    FROM pairs
+    GROUP BY friend_id
+  )
+  SELECT
+    fid AS user_id,
+    COALESCE(agg.shared, 0) AS shared_dishes,
+    CASE
+      WHEN COALESCE(agg.shared, 0) >= 3
+        THEN ROUND(100 - (agg.avg_diff / 9.0 * 100))::INT
+      ELSE NULL
+    END AS compatibility_pct
+  FROM UNNEST(p_friend_ids) AS fid
+  LEFT JOIN agg ON agg.friend_id = fid
+  WHERE NOT is_blocked_pair(p_user_id, fid);
+END;
+$$;
+
+
 -- get_similar_taste_users — caller guard + block filter (plpgsql rewrite)
 CREATE OR REPLACE FUNCTION get_similar_taste_users(
   p_user_id UUID,


### PR DESCRIPTION
## Summary
When you tap into "N friends have been here" or a friend's avatar, you now see how aligned your taste is with each friend. Adds even more signal for deciding what to order — Dan's exact ask.

- **Friends-list modal:** "75% match" chip on each row, next to the friend's name. Green ≥80, gold ≥60, muted <60.
- **Per-friend visits modal:** "75% taste match" in the subtitle line next to dish-count and Authority/Specialist badges.
- **Hidden** when shared dishes < 3 (compatibility_pct is NULL) — keeps the surface clean until there's real signal.

## Backend
- New batch RPC `get_taste_compatibility_for_friends(p_user_id, p_friend_ids[])` — one round-trip for the whole list. Caller guard + block filter mirror the single-pair function.
- Migration: `supabase/migrations/20260518_taste_compatibility_for_friends.sql`

## Codex catches (all fixed before push)
1. **Stale data on restaurant switch** — `friendsVotesByDish` / `tasteCompatByFriend` now clear synchronously when `restaurantId` changes
2. **Stale selectedFriend across restaurant changes** — `useEffect` in `RestaurantDishes` closes open modals when `restaurantName` changes
3. **Duplicated `getMatchColor`** — extracted to `src/utils/ranking.js` next to `getRatingColor`

## Test plan
- [ ] Restaurant detail with 1+ friends-here, where you and at least one friend share 3+ rated dishes → chip renders in green/gold per match %.
- [ ] Friend with fewer than 3 shared dishes → no chip (clean row).
- [ ] Navigate from restaurant A → B while a friend modal is open → modal closes; new restaurant shows its own friends with no stale chips.
- [ ] Migration applied to Denis's Supabase before merge — otherwise the RPC 404s and the chip never appears (failure is non-fatal, just hidden).

🤖 Generated with [Claude Code](https://claude.com/claude-code)