### PR TITLE
chore(ci): split AASA validation — shape on PR, live on daily cron

### DIFF
--- a/.github/workflows/aasa-check.yml
+++ b/.github/workflows/aasa-check.yml
@@ -1,17 +1,35 @@
 name: AASA validation
 
 on:
-  push:
-    branches: [main]
+  pull_request:
+    paths:
+      - 'public/.well-known/apple-app-site-association'
+      - 'vercel.json'
+  schedule:
+    - cron: '17 13 * * *'
+  workflow_dispatch:
 
 jobs:
-  aasa:
+  shape:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate AASA shape in repo
+        run: |
+          FILE="public/.well-known/apple-app-site-association"
+          jq -e '.applinks.details[0].appIDs | length >= 1' "$FILE" > /dev/null
+          jq -e '.applinks.details[0].paths    | length >= 1' "$FILE" > /dev/null
+          echo "AASA shape OK"
+
+  live:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Fetch AASA from production
         run: |
           URL="https://wghapp.com/.well-known/apple-app-site-association"
-          HTTP_CODE=$(curl -o aasa.json -w "%{http_code}" -sL --max-redirs 0 "$URL")
+          HTTP_CODE=$(curl -o aasa.json -w "%{http_code}" -s --max-redirs 0 "$URL")
           if [ "$HTTP_CODE" != "200" ]; then
             echo "::error::AASA returned $HTTP_CODE (expected 200, no redirects)"
             exit 1
@@ -21,7 +39,6 @@ jobs:
             echo "::error::AASA Content-Type is '$CONTENT_TYPE', expected application/json"
             exit 1
           fi
-          # Schema check
           jq -e '.applinks.details[0].appIDs | length >= 1' aasa.json > /dev/null
-          jq -e '.applinks.details[0].paths | length >= 1' aasa.json > /dev/null
-          echo "AASA OK"
+          jq -e '.applinks.details[0].paths    | length >= 1' aasa.json > /dev/null
+          echo "AASA live OK"


### PR DESCRIPTION
## Summary

The on-push AASA validation has been failing on nearly every merge (#221, #222, #223, etc) because it races Vercel's deploy: the check fires immediately after merge, hits production before the new deploy settles, sees an empty Content-Type, and emits a red X. That trains the team to ignore red Xs — worse than no check at all.

Live curl just now confirmed AASA is serving correctly in production. The check is wrong, not the file.

## What changed

Split into two jobs based on what each can actually catch:

- **shape** (PR-time, only when AASA file or vercel.json change): jq schema check on the file in \`public/.well-known/apple-app-site-association\`. Fast, deterministic, catches real PR-introduced bugs.
- **live** (daily cron + workflow_dispatch): same end-to-end HTTP check as before. Doesn't race deploys. Catches infra drift, CDN regressions, domain expiry.

## Review trail

- Codex (gpt-5.3-codex / medium) flagged a required-check deadlock risk if AASA were a required status check on main — verified via \`gh api branches/main/protection\`: no required checks on main, only PR approval. Risk doesn't apply.
- Cleanup: removed stray \`-L\` flag from \`curl\` (Codex finding).

## Test plan

- [ ] This PR's own status checks: only \`AASA validation / shape\` runs (because this PR doesn't touch AASA or vercel.json — wait, it touches the workflow itself, so neither job runs)
- [ ] After merge: no AASA red X on subsequent unrelated PRs
- [ ] Manually trigger via Actions → AASA validation → Run workflow → confirms live check still passes
- [ ] Tomorrow 13:17 UTC: daily cron fires and reports green

🤖 Generated with [Claude Code](https://claude.com/claude-code)