### PR TITLE
feat(schema): dish description + dietary_tags columns + RPC signatures

### DIFF
--- a/supabase/migrations/2026-05-18-dish-descriptions-and-dietary-tags.sql
+++ b/supabase/migrations/2026-05-18-dish-descriptions-and-dietary-tags.sql
@@ -1,0 +1,407 @@
+-- 2026-05-18: Dish descriptions + dietary tags (v1.3)
+-- Spec: docs/superpowers/specs/2026-05-18-dish-descriptions-dietary-tags-design.md
+-- Pure additive — no SQL rollback needed (drop columns + indexes if absolutely needed).
+--
+-- Runs as a single paste in Supabase SQL Editor (which wraps the script in
+-- one outer transaction):
+--   1. ALTER TABLE — fast, additive
+--   2. BEGIN/COMMIT-wrapped function changes — atomic so RPC callers block-and-wait
+--      instead of seeing "function does not exist" during the DROP→CREATE window
+--   3. CREATE INDEX (plain, not CONCURRENTLY) — CONCURRENTLY can't run inside a
+--      transaction block and SQL Editor doesn't allow disabling that. Plain index
+--      build is sub-second at 6,380 rows; blocks writes but not reads during build.
+
+-- =============================================================================
+-- 1. Columns (additive — autocommit)
+-- =============================================================================
+
+ALTER TABLE dishes
+  ADD COLUMN IF NOT EXISTS description TEXT,
+  ADD COLUMN IF NOT EXISTS dietary_tags TEXT[] NOT NULL DEFAULT '{}';
+
+-- =============================================================================
+-- 2. RPC signature updates (wrapped in transaction for atomicity)
+--
+-- All three updated RPCs change RETURNS TABLE. Postgres' CREATE OR REPLACE
+-- does NOT allow changing the return type — we must DROP first.
+-- For get_ranked_dishes, the param list also changed (5 → 6 args), so the
+-- old 5-arg signature would otherwise remain as a stale overload.
+-- =============================================================================
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS get_ranked_dishes(DECIMAL, DECIMAL, INT, TEXT, TEXT);
+DROP FUNCTION IF EXISTS get_ranked_dishes(DECIMAL, DECIMAL, INT, TEXT, TEXT, TEXT[]);
+DROP FUNCTION IF EXISTS get_restaurant_dishes(UUID);
+DROP FUNCTION IF EXISTS get_dish_variants(UUID);
+
+-- -----------------------------------------------------------------------------
+-- 2a. get_ranked_dishes — main feed RPC
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION get_ranked_dishes(
+  user_lat DECIMAL,
+  user_lng DECIMAL,
+  radius_miles INT DEFAULT 50,
+  filter_category TEXT DEFAULT NULL,
+  filter_town TEXT DEFAULT NULL,
+  filter_dietary_tags TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+  dish_id UUID,
+  dish_name TEXT,
+  restaurant_id UUID,
+  restaurant_name TEXT,
+  restaurant_town TEXT,
+  category TEXT,
+  tags TEXT[],
+  cuisine TEXT,
+  price DECIMAL,
+  photo_url TEXT,
+  total_votes BIGINT,
+  avg_rating DECIMAL,
+  distance_miles DECIMAL,
+  has_variants BOOLEAN,
+  variant_count INT,
+  best_variant_name TEXT,
+  best_variant_rating DECIMAL,
+  value_score DECIMAL,
+  value_percentile DECIMAL,
+  search_score DECIMAL,
+  featured_photo_url TEXT,
+  restaurant_lat DECIMAL,
+  restaurant_lng DECIMAL,
+  restaurant_address TEXT,
+  restaurant_phone TEXT,
+  restaurant_website_url TEXT,
+  toast_slug TEXT,
+  order_url TEXT,
+  description TEXT,
+  dietary_tags TEXT[]
+) AS $$
+DECLARE
+  lat_delta DECIMAL := radius_miles / 69.0;
+  lng_delta DECIMAL := radius_miles / (69.0 * COS(RADIANS(user_lat)));
+BEGIN
+  RETURN QUERY
+  WITH global_stats AS (
+    SELECT COALESCE(AVG(dishes.avg_rating), 7.0) AS global_mean
+    FROM dishes
+    WHERE dishes.total_votes > 0 AND dishes.avg_rating IS NOT NULL
+  ),
+  nearby_restaurants AS (
+    SELECT r.id, r.name, r.town, r.lat, r.lng, r.cuisine,
+           r.address, r.phone, r.website_url, r.toast_slug, r.order_url
+    FROM restaurants r
+    WHERE r.is_open = true
+      AND r.lat BETWEEN (user_lat - lat_delta) AND (user_lat + lat_delta)
+      AND r.lng BETWEEN (user_lng - lng_delta) AND (user_lng + lng_delta)
+      AND (filter_town IS NULL OR r.town = filter_town)
+  ),
+  restaurants_with_distance AS (
+    SELECT
+      nr.id, nr.name, nr.town, nr.lat, nr.lng, nr.cuisine,
+      nr.address, nr.phone, nr.website_url, nr.toast_slug, nr.order_url,
+      ROUND((
+        3959 * ACOS(
+          LEAST(1.0, GREATEST(-1.0,
+            COS(RADIANS(user_lat)) * COS(RADIANS(nr.lat)) *
+            COS(RADIANS(nr.lng) - RADIANS(user_lng)) +
+            SIN(RADIANS(user_lat)) * SIN(RADIANS(nr.lat))
+          ))
+        )
+      )::NUMERIC, 2) AS distance
+    FROM nearby_restaurants nr
+  ),
+  filtered_restaurants AS (
+    SELECT * FROM restaurants_with_distance WHERE distance <= radius_miles
+  ),
+  variant_stats AS (
+    SELECT
+      d.parent_dish_id,
+      COUNT(DISTINCT d.id)::INT AS child_count,
+      SUM(COALESCE(ds.vote_count, 0))::NUMERIC AS total_child_votes
+    FROM dishes d
+    LEFT JOIN (
+      SELECT v.dish_id,
+        SUM(CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END)::NUMERIC AS vote_count
+      FROM votes v GROUP BY v.dish_id
+    ) ds ON ds.dish_id = d.id
+    WHERE d.parent_dish_id IS NOT NULL
+    GROUP BY d.parent_dish_id
+  ),
+  best_variants AS (
+    SELECT DISTINCT ON (d.parent_dish_id)
+      d.parent_dish_id,
+      d.name AS best_name,
+      ROUND(AVG(v.rating_10)::NUMERIC, 1) AS best_rating
+    FROM dishes d
+    LEFT JOIN votes v ON v.dish_id = d.id
+    WHERE d.parent_dish_id IS NOT NULL
+    GROUP BY d.parent_dish_id, d.id, d.name
+    HAVING COUNT(v.id) >= 1
+    ORDER BY d.parent_dish_id, AVG(v.rating_10) DESC NULLS LAST, COUNT(v.id) DESC
+  ),
+  recent_vote_counts AS (
+    SELECT votes.dish_id, COUNT(*)::INT AS recent_votes
+    FROM votes
+    WHERE votes.created_at > NOW() - INTERVAL '14 days'
+    GROUP BY votes.dish_id
+  ),
+  best_photos AS (
+    -- H3: exclude photos authored by users the viewer has blocked.
+    SELECT DISTINCT ON (dp.dish_id)
+      dp.dish_id,
+      dp.photo_url
+    FROM dish_photos dp
+    INNER JOIN dishes d2 ON dp.dish_id = d2.id
+    INNER JOIN filtered_restaurants fr2 ON d2.restaurant_id = fr2.id
+    WHERE dp.status IN ('featured', 'community')
+      AND d2.parent_dish_id IS NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM user_blocks ub
+        WHERE (ub.blocker_id = (select auth.uid()) AND ub.blocked_id = dp.user_id)
+           OR (ub.blocker_id = dp.user_id AND ub.blocked_id = (select auth.uid()))
+      )
+    ORDER BY dp.dish_id,
+      CASE dp.source_type WHEN 'restaurant' THEN 0 ELSE 1 END,
+      CASE dp.status WHEN 'featured' THEN 0 ELSE 1 END,
+      dp.quality_score DESC NULLS LAST,
+      dp.created_at DESC
+  )
+  SELECT
+    d.id AS dish_id,
+    d.name AS dish_name,
+    fr.id AS restaurant_id,
+    fr.name AS restaurant_name,
+    fr.town AS restaurant_town,
+    d.category,
+    d.tags,
+    fr.cuisine,
+    d.price,
+    d.photo_url,
+    COALESCE(vs.total_child_votes,
+      SUM(CASE WHEN v.source = 'user' THEN 1.0 WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END)
+    )::BIGINT AS total_votes,
+    COALESCE(ROUND(
+      (SUM(CASE WHEN v.source = 'user' THEN v.rating_10
+                WHEN v.source = 'ai_estimated' THEN v.rating_10 * 0.5
+                ELSE 0 END) /
+       NULLIF(SUM(CASE WHEN v.source = 'user' THEN 1.0
+                       WHEN v.source = 'ai_estimated' THEN 0.5
+                       ELSE 0 END), 0)
+      )::NUMERIC, 1), 0) AS avg_rating,
+    fr.distance AS distance_miles,
+    (vs.child_count IS NOT NULL AND vs.child_count > 0) AS has_variants,
+    COALESCE(vs.child_count, 0)::INT AS variant_count,
+    bv.best_name AS best_variant_name,
+    bv.best_rating AS best_variant_rating,
+    d.value_score,
+    d.value_percentile,
+    dish_search_score(
+      COALESCE(ROUND(
+        (SUM(CASE WHEN v.source = 'user' THEN v.rating_10
+                  WHEN v.source = 'ai_estimated' THEN v.rating_10 * 0.5
+                  ELSE 0 END) /
+         NULLIF(SUM(CASE WHEN v.source = 'user' THEN 1.0
+                         WHEN v.source = 'ai_estimated' THEN 0.5
+                         ELSE 0 END), 0)
+        )::NUMERIC, 1), 0),
+      COALESCE(vs.total_child_votes,
+        SUM(CASE WHEN v.source = 'user' THEN 1.0 WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END))::NUMERIC,
+      fr.distance,
+      COALESCE(rvc.recent_votes, 0),
+      (SELECT global_mean FROM global_stats)
+    ) AS search_score,
+    bp.photo_url AS featured_photo_url,
+    fr.lat AS restaurant_lat,
+    fr.lng AS restaurant_lng,
+    fr.address AS restaurant_address,
+    fr.phone AS restaurant_phone,
+    fr.website_url AS restaurant_website_url,
+    fr.toast_slug,
+    fr.order_url,
+    d.description,
+    d.dietary_tags
+  FROM dishes d
+  INNER JOIN filtered_restaurants fr ON d.restaurant_id = fr.id
+  LEFT JOIN votes v ON d.id = v.dish_id
+  LEFT JOIN variant_stats vs ON vs.parent_dish_id = d.id
+  LEFT JOIN best_variants bv ON bv.parent_dish_id = d.id
+  LEFT JOIN recent_vote_counts rvc ON rvc.dish_id = d.id
+  LEFT JOIN best_photos bp ON bp.dish_id = d.id
+  WHERE (filter_category IS NULL OR d.category = filter_category)
+    AND d.parent_dish_id IS NULL
+    AND (
+      filter_dietary_tags IS NULL
+      OR array_length(filter_dietary_tags, 1) IS NULL
+      OR d.dietary_tags @> filter_dietary_tags
+    )
+  GROUP BY d.id, d.name, fr.id, fr.name, fr.town, d.category, d.tags, fr.cuisine,
+           d.price, d.photo_url, fr.distance, fr.lat, fr.lng,
+           fr.address, fr.phone, fr.website_url, fr.toast_slug, fr.order_url,
+           vs.total_child_votes, vs.child_count,
+           bv.best_name, bv.best_rating,
+           d.value_score, d.value_percentile,
+           rvc.recent_votes,
+           bp.photo_url,
+           d.description, d.dietary_tags
+  ORDER BY search_score DESC NULLS LAST, total_votes DESC;
+END;
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public;
+
+GRANT EXECUTE ON FUNCTION get_ranked_dishes(DECIMAL, DECIMAL, INT, TEXT, TEXT, TEXT[]) TO anon, authenticated;
+
+-- -----------------------------------------------------------------------------
+-- 2b. get_restaurant_dishes — restaurant detail RPC
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION get_restaurant_dishes(
+  p_restaurant_id UUID
+)
+RETURNS TABLE (
+  dish_id UUID,
+  dish_name TEXT,
+  restaurant_id UUID,
+  restaurant_name TEXT,
+  category TEXT,
+  menu_section TEXT,
+  price DECIMAL,
+  photo_url TEXT,
+  total_votes BIGINT,
+  avg_rating DECIMAL,
+  has_variants BOOLEAN,
+  variant_count INT,
+  best_variant_id UUID,
+  best_variant_name TEXT,
+  best_variant_rating DECIMAL,
+  tags TEXT[],
+  description TEXT,
+  dietary_tags TEXT[]
+) AS $$
+BEGIN
+  RETURN QUERY
+  WITH variant_stats AS (
+    SELECT
+      d.parent_dish_id,
+      COUNT(DISTINCT d.id)::INT AS child_count,
+      SUM(COALESCE(ds.vote_count, 0))::NUMERIC AS total_child_votes,
+      CASE
+        WHEN SUM(COALESCE(ds.vote_count, 0)) > 0
+        THEN ROUND((SUM(COALESCE(ds.rating_sum, 0)) / NULLIF(SUM(COALESCE(ds.vote_count, 0)), 0))::NUMERIC, 1)
+        ELSE NULL
+      END AS combined_avg_rating
+    FROM dishes d
+    LEFT JOIN (
+      SELECT v.dish_id,
+        SUM(CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END)::NUMERIC AS vote_count,
+        SUM(COALESCE(v.rating_10, 0) * (CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END))::DECIMAL AS rating_sum
+      FROM votes v GROUP BY v.dish_id
+    ) ds ON ds.dish_id = d.id
+    WHERE d.parent_dish_id IS NOT NULL
+    GROUP BY d.parent_dish_id
+  ),
+  best_variants AS (
+    SELECT DISTINCT ON (d.parent_dish_id)
+      d.parent_dish_id, d.id AS best_id, d.name AS best_name,
+      ROUND(AVG(v.rating_10)::NUMERIC, 1) AS best_rating
+    FROM dishes d
+    LEFT JOIN votes v ON v.dish_id = d.id
+    WHERE d.parent_dish_id IS NOT NULL
+    GROUP BY d.parent_dish_id, d.id, d.name
+    HAVING COUNT(v.id) >= 1
+    ORDER BY d.parent_dish_id, AVG(v.rating_10) DESC NULLS LAST, COUNT(v.id) DESC
+  ),
+  dish_vote_stats AS (
+    SELECT d.id AS dish_id, COUNT(v.id)::BIGINT AS direct_votes,
+      ROUND(AVG(v.rating_10)::NUMERIC, 1) AS direct_avg
+    FROM dishes d LEFT JOIN votes v ON v.dish_id = d.id
+    WHERE d.parent_dish_id IS NULL
+    GROUP BY d.id
+  )
+  SELECT
+    d.id AS dish_id, d.name AS dish_name, r.id AS restaurant_id, r.name AS restaurant_name,
+    d.category, d.menu_section, d.price, d.photo_url,
+    COALESCE(vs.total_child_votes, dvs.direct_votes, 0)::BIGINT AS total_votes,
+    COALESCE(vs.combined_avg_rating, dvs.direct_avg) AS avg_rating,
+    (vs.child_count IS NOT NULL AND vs.child_count > 0) AS has_variants,
+    COALESCE(vs.child_count, 0)::INT AS variant_count,
+    bv.best_id AS best_variant_id, bv.best_name AS best_variant_name, bv.best_rating AS best_variant_rating,
+    d.tags,
+    d.description,
+    d.dietary_tags
+  FROM dishes d
+  INNER JOIN restaurants r ON d.restaurant_id = r.id
+  LEFT JOIN variant_stats vs ON vs.parent_dish_id = d.id
+  LEFT JOIN best_variants bv ON bv.parent_dish_id = d.id
+  LEFT JOIN dish_vote_stats dvs ON dvs.dish_id = d.id
+  WHERE d.restaurant_id = p_restaurant_id
+    AND r.is_open = true
+    AND d.parent_dish_id IS NULL
+  GROUP BY d.id, d.name, r.id, r.name, d.category, d.menu_section, d.price, d.photo_url, d.tags,
+           vs.total_child_votes, vs.combined_avg_rating, vs.child_count,
+           dvs.direct_votes, dvs.direct_avg,
+           bv.best_id, bv.best_name, bv.best_rating,
+           d.description, d.dietary_tags
+  ORDER BY
+    CASE WHEN COALESCE(vs.total_child_votes, dvs.direct_votes, 0) >= 5 THEN 0 ELSE 1 END,
+    COALESCE(vs.combined_avg_rating, dvs.direct_avg) DESC NULLS LAST,
+    COALESCE(vs.total_child_votes, dvs.direct_votes, 0) DESC;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+GRANT EXECUTE ON FUNCTION get_restaurant_dishes(UUID) TO anon, authenticated;
+
+-- -----------------------------------------------------------------------------
+-- 2c. get_dish_variants — variant rows for a parent dish
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION get_dish_variants(
+  p_parent_dish_id UUID
+)
+RETURNS TABLE (
+  dish_id UUID,
+  dish_name TEXT,
+  price DECIMAL,
+  photo_url TEXT,
+  display_order INT,
+  total_votes BIGINT,
+  avg_rating DECIMAL,
+  description TEXT,
+  dietary_tags TEXT[]
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    d.id AS dish_id, d.name AS dish_name, d.price, d.photo_url, d.display_order,
+    COUNT(v.id)::BIGINT AS total_votes,
+    ROUND(AVG(v.rating_10)::NUMERIC, 1) AS avg_rating,
+    d.description,
+    d.dietary_tags
+  FROM dishes d
+  LEFT JOIN votes v ON d.id = v.dish_id
+  WHERE d.parent_dish_id = p_parent_dish_id
+  GROUP BY d.id, d.name, d.price, d.photo_url, d.display_order, d.description, d.dietary_tags
+  ORDER BY d.display_order, d.name;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+GRANT EXECUTE ON FUNCTION get_dish_variants(UUID) TO anon, authenticated;
+
+COMMIT;
+
+-- =============================================================================
+-- 3. Indexes
+--
+-- Plain CREATE INDEX (not CONCURRENTLY) because Supabase SQL Editor wraps
+-- the entire pasted script in a single transaction, and CONCURRENTLY can't
+-- run inside a transaction. At 6,380 rows on the dishes table, GIN index
+-- build is sub-second. Plain build takes a SHARE lock — blocks writes but
+-- not reads during the brief build window.
+-- =============================================================================
+
+CREATE INDEX IF NOT EXISTS dishes_dietary_tags_idx
+  ON dishes USING GIN (dietary_tags);
+
+CREATE INDEX IF NOT EXISTS dishes_description_trgm_idx
+  ON dishes USING GIN (description gin_trgm_ops);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -71,6 +71,8 @@ CREATE TABLE IF NOT EXISTS dishes (
   value_score DECIMAL(6, 2),
   value_percentile DECIMAL(5, 2),
   category_median_price DECIMAL(6, 2),
+  description TEXT,
+  dietary_tags TEXT[] NOT NULL DEFAULT '{}',
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
@@ -451,6 +453,8 @@ CREATE INDEX IF NOT EXISTS idx_dishes_restaurant_category ON dishes(restaurant_i
 CREATE INDEX IF NOT EXISTS idx_dishes_created_by ON dishes(created_by);
 CREATE INDEX IF NOT EXISTS idx_dishes_restaurant_toplevel ON dishes(restaurant_id) WHERE parent_dish_id IS NULL;
 CREATE INDEX IF NOT EXISTS idx_dishes_consensus_eligible ON dishes(id) WHERE total_votes >= 5 AND avg_rating IS NOT NULL;
+CREATE INDEX IF NOT EXISTS dishes_dietary_tags_idx ON dishes USING GIN (dietary_tags);
+CREATE INDEX IF NOT EXISTS dishes_description_trgm_idx ON dishes USING GIN (description gin_trgm_ops);
 
 -- votes
 CREATE INDEX IF NOT EXISTS idx_votes_dish ON votes(dish_id);
@@ -1069,7 +1073,8 @@ CREATE OR REPLACE FUNCTION get_ranked_dishes(
   user_lng DECIMAL,
   radius_miles INT DEFAULT 50,
   filter_category TEXT DEFAULT NULL,
-  filter_town TEXT DEFAULT NULL
+  filter_town TEXT DEFAULT NULL,
+  filter_dietary_tags TEXT[] DEFAULT NULL
 )
 RETURNS TABLE (
   dish_id UUID,
@@ -1099,7 +1104,9 @@ RETURNS TABLE (
   restaurant_phone TEXT,
   restaurant_website_url TEXT,
   toast_slug TEXT,
-  order_url TEXT
+  order_url TEXT,
+  description TEXT,
+  dietary_tags TEXT[]
 ) AS $$
 DECLARE
   lat_delta DECIMAL := radius_miles / 69.0;
@@ -1244,7 +1251,9 @@ BEGIN
     fr.phone AS restaurant_phone,
     fr.website_url AS restaurant_website_url,
     fr.toast_slug,
-    fr.order_url
+    fr.order_url,
+    d.description,
+    d.dietary_tags
   FROM dishes d
   INNER JOIN filtered_restaurants fr ON d.restaurant_id = fr.id
   LEFT JOIN votes v ON d.id = v.dish_id
@@ -1254,6 +1263,11 @@ BEGIN
   LEFT JOIN best_photos bp ON bp.dish_id = d.id
   WHERE (filter_category IS NULL OR d.category = filter_category)
     AND d.parent_dish_id IS NULL
+    AND (
+      filter_dietary_tags IS NULL
+      OR array_length(filter_dietary_tags, 1) IS NULL
+      OR d.dietary_tags @> filter_dietary_tags
+    )
   GROUP BY d.id, d.name, fr.id, fr.name, fr.town, d.category, d.tags, fr.cuisine,
            d.price, d.photo_url, fr.distance, fr.lat, fr.lng,
            fr.address, fr.phone, fr.website_url, fr.toast_slug, fr.order_url,
@@ -1261,7 +1275,8 @@ BEGIN
            bv.best_name, bv.best_rating,
            d.value_score, d.value_percentile,
            rvc.recent_votes,
-           bp.photo_url
+           bp.photo_url,
+           d.description, d.dietary_tags
   ORDER BY search_score DESC NULLS LAST, total_votes DESC;
 END;
 $$ LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public;
@@ -1286,7 +1301,9 @@ RETURNS TABLE (
   best_variant_id UUID,
   best_variant_name TEXT,
   best_variant_rating DECIMAL,
-  tags TEXT[]
+  tags TEXT[],
+  description TEXT,
+  dietary_tags TEXT[]
 ) AS $$
 BEGIN
   RETURN QUERY
@@ -1336,7 +1353,9 @@ BEGIN
     (vs.child_count IS NOT NULL AND vs.child_count > 0) AS has_variants,
     COALESCE(vs.child_count, 0)::INT AS variant_count,
     bv.best_id AS best_variant_id, bv.best_name AS best_variant_name, bv.best_rating AS best_variant_rating,
-    d.tags
+    d.tags,
+    d.description,
+    d.dietary_tags
   FROM dishes d
   INNER JOIN restaurants r ON d.restaurant_id = r.id
   LEFT JOIN variant_stats vs ON vs.parent_dish_id = d.id
@@ -1348,7 +1367,8 @@ BEGIN
   GROUP BY d.id, d.name, r.id, r.name, d.category, d.menu_section, d.price, d.photo_url, d.tags,
            vs.total_child_votes, vs.combined_avg_rating, vs.child_count,
            dvs.direct_votes, dvs.direct_avg,
-           bv.best_id, bv.best_name, bv.best_rating
+           bv.best_id, bv.best_name, bv.best_rating,
+           d.description, d.dietary_tags
   ORDER BY
     CASE WHEN COALESCE(vs.total_child_votes, dvs.direct_votes, 0) >= 5 THEN 0 ELSE 1 END,
     COALESCE(vs.combined_avg_rating, dvs.direct_avg) DESC NULLS LAST,
@@ -1367,18 +1387,22 @@ RETURNS TABLE (
   photo_url TEXT,
   display_order INT,
   total_votes BIGINT,
-  avg_rating DECIMAL
+  avg_rating DECIMAL,
+  description TEXT,
+  dietary_tags TEXT[]
 ) AS $$
 BEGIN
   RETURN QUERY
   SELECT
     d.id AS dish_id, d.name AS dish_name, d.price, d.photo_url, d.display_order,
     COUNT(v.id)::BIGINT AS total_votes,
-    ROUND(AVG(v.rating_10)::NUMERIC, 1) AS avg_rating
+    ROUND(AVG(v.rating_10)::NUMERIC, 1) AS avg_rating,
+    d.description,
+    d.dietary_tags
   FROM dishes d
   LEFT JOIN votes v ON d.id = v.dish_id
   WHERE d.parent_dish_id = p_parent_dish_id
-  GROUP BY d.id, d.name, d.price, d.photo_url, d.display_order
+  GROUP BY d.id, d.name, d.price, d.photo_url, d.display_order, d.description, d.dietary_tags
   ORDER BY d.display_order, d.name;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
@@ -3657,6 +3681,9 @@ GRANT EXECUTE ON FUNCTION find_nearby_restaurants TO authenticated;
 GRANT EXECUTE ON FUNCTION find_nearby_restaurants TO anon;
 GRANT EXECUTE ON FUNCTION get_restaurants_within_radius(DECIMAL, DECIMAL, INT) TO authenticated;
 GRANT EXECUTE ON FUNCTION get_restaurants_within_radius(DECIMAL, DECIMAL, INT) TO anon;
+GRANT EXECUTE ON FUNCTION get_ranked_dishes(DECIMAL, DECIMAL, INT, TEXT, TEXT, TEXT[]) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION get_restaurant_dishes(UUID) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION get_dish_variants(UUID) TO anon, authenticated;
 
 
 -- =============================================


### PR DESCRIPTION
## Summary

PR 1 of 3 for v1.3 dish descriptions + dietary tags. Schema-only change.

**Production DB already updated via SQL Editor;** this PR catches main up to deployed state so PR 2 (extractor) and PR 3 (UI) can build on it. Migration script lives in \`supabase/migrations/\` for the record.

### Schema changes
- \`dishes\` table: +\`description TEXT\`, +\`dietary_tags TEXT[] NOT NULL DEFAULT '{}'\`
- \`get_ranked_dishes\`: new \`filter_dietary_tags TEXT[]\` param (contains-all AND semantics), description + dietary_tags in RETURNS TABLE
- \`get_restaurant_dishes\` + \`get_dish_variants\`: description + dietary_tags in RETURNS TABLE
- Two new GIN indexes
- \`GRANT EXECUTE\` for the three RPCs (DROP cleared them, re-granted to anon, authenticated)

### Review trail
Codex (gpt-5.3-codex / medium) reviewed every step:
- Task 1.2 (columns) — flagged NOT NULL on dietary_tags, applied
- Task 1.3 (get_ranked_dishes) — confirmed signature/filter/GROUP BY correctness, flagged DROP FUNCTION need for migration
- Task 1.4 (other RPCs) — flagged local-picks RPCs as out-of-scope (different card shape, deferred to v1.4)
- Task 1.5 (migration) — flagged DROP→CREATE outage window (wrapped in BEGIN/COMMIT) and write-lock risk on CONCURRENTLY
- Task 1.6 (apply) — flagged Supabase SQL Editor transaction wrap incompatible with CONCURRENTLY, switched to plain CREATE INDEX (sub-second at 6,380 rows)
- Task 1.7 (final) — caught missing GIN index + GRANT EXECUTE drift between schema.sql and migration, patched

### Deployment status
**Already applied to production** (\`vpioftosgdkyiwvhxewy\`). Verified:
- Columns present with correct types/defaults
- Both indexes built and valid
- \`get_ranked_dishes\` spot-call returns 3 rows with \`description=null\`, \`dietary_tags={}\`

### Test plan
- [ ] After merge, \`npm run build\` still passes (no client breakage — RPC returns extra columns; clients ignore them)
- [ ] Existing homepage list still renders identically (no description data yet — PR 2 lands first)
- [ ] No regressions on existing dish detail pages or category filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)