### PR TITLE
feat(menu-refresh): description + dietary_tags extraction + iframe + SSRF-hardened fetch

### DIFF
--- a/src/constants/dietaryTags.js
+++ b/src/constants/dietaryTags.js
@@ -1,0 +1,13 @@
+export const ALLOWED_DIETARY_TAGS = ['vegan', 'vegetarian', 'gluten_free', 'dairy_free', 'nut_free']
+
+export const DIETARY_TAG_LABELS = {
+  vegan: 'Vegan',
+  vegetarian: 'Vegetarian',
+  gluten_free: 'Gluten-free',
+  dairy_free: 'Dairy-free',
+  nut_free: 'Nut-free',
+}
+
+export const DIETARY_DISCLAIMER =
+  "These tags come from how the menu labels each dish — we don't verify with the kitchen. " +
+  "If you have an allergy, confirm with the restaurant before ordering."

--- a/src/constants/dietaryTags.test.js
+++ b/src/constants/dietaryTags.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { ALLOWED_DIETARY_TAGS, DIETARY_TAG_LABELS, DIETARY_DISCLAIMER } from './dietaryTags'
+
+describe('dietaryTags constants', () => {
+  it('exports five allowed tags in fixed order', () => {
+    expect(ALLOWED_DIETARY_TAGS).toEqual([
+      'vegan',
+      'vegetarian',
+      'gluten_free',
+      'dairy_free',
+      'nut_free',
+    ])
+  })
+
+  it('has a human label for every allowed tag', () => {
+    for (const tag of ALLOWED_DIETARY_TAGS) {
+      expect(DIETARY_TAG_LABELS[tag]).toBeTruthy()
+      expect(typeof DIETARY_TAG_LABELS[tag]).toBe('string')
+    }
+  })
+
+  it('has no labels for tags outside the allowed list', () => {
+    expect(Object.keys(DIETARY_TAG_LABELS).sort()).toEqual([...ALLOWED_DIETARY_TAGS].sort())
+  })
+
+  it('exports a non-empty disclaimer mentioning allergy/allergens', () => {
+    expect(DIETARY_DISCLAIMER).toMatch(/allerg/i)
+  })
+
+  it('disclaimer tells users to confirm with the restaurant', () => {
+    expect(DIETARY_DISCLAIMER.toLowerCase()).toContain('confirm')
+    expect(DIETARY_DISCLAIMER.toLowerCase()).toContain('restaurant')
+  })
+})

--- a/supabase/functions/menu-refresh/extractors.test.ts
+++ b/supabase/functions/menu-refresh/extractors.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeDescription, sanitizeDietaryTags, sortedArraysEqual, ALLOWED_DIETARY_TAGS } from './extractors.ts'
+
+describe('sanitizeDescription', () => {
+  it('returns null for non-string input', () => {
+    expect(sanitizeDescription(null)).toBe(null)
+    expect(sanitizeDescription(undefined)).toBe(null)
+    expect(sanitizeDescription(42)).toBe(null)
+    expect(sanitizeDescription([])).toBe(null)
+    expect(sanitizeDescription({})).toBe(null)
+  })
+
+  it('returns null for empty / whitespace-only strings', () => {
+    expect(sanitizeDescription('')).toBe(null)
+    expect(sanitizeDescription('   ')).toBe(null)
+    expect(sanitizeDescription('\n\t')).toBe(null)
+  })
+
+  it('trims whitespace before checking emptiness', () => {
+    expect(sanitizeDescription('  Hot lobster, drawn butter  ')).toBe('Hot lobster, drawn butter')
+  })
+
+  it('truncates strings over 80 chars to 80', () => {
+    const long = 'x'.repeat(120)
+    const result = sanitizeDescription(long)
+    expect(result).not.toBeNull()
+    expect(result!.length).toBe(80)
+  })
+
+  it('passes through strings under 80 chars unchanged', () => {
+    const short = 'Pepperoni, mozzarella, San Marzano tomato'
+    expect(sanitizeDescription(short)).toBe(short)
+  })
+
+  it('handles exactly-80-char string without truncation', () => {
+    const exact = 'x'.repeat(80)
+    expect(sanitizeDescription(exact)).toBe(exact)
+  })
+})
+
+describe('sanitizeDietaryTags', () => {
+  it('returns empty array for non-array input', () => {
+    expect(sanitizeDietaryTags(null)).toEqual([])
+    expect(sanitizeDietaryTags(undefined)).toEqual([])
+    expect(sanitizeDietaryTags('vegan')).toEqual([])
+    expect(sanitizeDietaryTags({ vegan: true })).toEqual([])
+    expect(sanitizeDietaryTags(42)).toEqual([])
+  })
+
+  it('returns empty array for empty array input', () => {
+    expect(sanitizeDietaryTags([])).toEqual([])
+  })
+
+  it('drops tags outside the whitelist', () => {
+    expect(sanitizeDietaryTags(['vegan', 'paleo', 'keto', 'gluten_free'])).toEqual(['vegan', 'gluten_free'])
+  })
+
+  it('drops non-string entries', () => {
+    expect(sanitizeDietaryTags(['vegan', 42, null, undefined, 'gluten_free'])).toEqual(['vegan', 'gluten_free'])
+  })
+
+  it('dedupes duplicates while preserving first-seen order', () => {
+    expect(sanitizeDietaryTags(['vegan', 'vegan', 'vegetarian', 'vegan'])).toEqual(['vegan', 'vegetarian'])
+  })
+
+  it('returns empty array when no whitelist tags present', () => {
+    expect(sanitizeDietaryTags(['paleo', 'keto', 'whole30'])).toEqual([])
+  })
+
+  it('accepts all five allowed tags', () => {
+    const all = [...ALLOWED_DIETARY_TAGS]
+    expect(sanitizeDietaryTags(all)).toEqual(all)
+  })
+})
+
+describe('sortedArraysEqual', () => {
+  it('returns true for empty arrays', () => {
+    expect(sortedArraysEqual([], [])).toBe(true)
+  })
+
+  it('returns true for same elements in same order', () => {
+    expect(sortedArraysEqual(['vegan', 'gluten_free'], ['vegan', 'gluten_free'])).toBe(true)
+  })
+
+  it('returns true for same elements in different order', () => {
+    expect(sortedArraysEqual(['vegan', 'gluten_free'], ['gluten_free', 'vegan'])).toBe(true)
+  })
+
+  it('returns false for different lengths', () => {
+    expect(sortedArraysEqual(['vegan'], ['vegan', 'gluten_free'])).toBe(false)
+  })
+
+  it('returns false for same length, different elements', () => {
+    expect(sortedArraysEqual(['vegan'], ['vegetarian'])).toBe(false)
+  })
+
+  it('returns false when one is empty and other is not', () => {
+    expect(sortedArraysEqual([], ['vegan'])).toBe(false)
+    expect(sortedArraysEqual(['vegan'], [])).toBe(false)
+  })
+})

--- a/supabase/functions/menu-refresh/extractors.ts
+++ b/supabase/functions/menu-refresh/extractors.ts
@@ -1,0 +1,37 @@
+// Pure sanitization helpers for menu-refresh Sonnet output.
+// No Deno imports here — kept dependency-free so the file is importable by
+// both the Deno edge function and Node/Vitest unit tests.
+// Spec: docs/superpowers/specs/2026-05-18-dish-descriptions-dietary-tags-design.md
+
+export const ALLOWED_DIETARY_TAGS = ['vegan', 'vegetarian', 'gluten_free', 'dairy_free', 'nut_free'] as const
+export type AllowedDietaryTag = typeof ALLOWED_DIETARY_TAGS[number]
+
+export function sanitizeDietaryTags(raw: unknown): AllowedDietaryTag[] {
+  if (!Array.isArray(raw)) return []
+  const seen = new Set<AllowedDietaryTag>()
+  for (const t of raw) {
+    if (typeof t === 'string' && (ALLOWED_DIETARY_TAGS as readonly string[]).includes(t)) {
+      seen.add(t as AllowedDietaryTag)
+    }
+  }
+  return Array.from(seen)
+}
+
+export function sanitizeDescription(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return null
+  return trimmed.length > 80 ? trimmed.slice(0, 80) : trimmed
+}
+
+// Order-insensitive string-array equality for change-detection on dietary_tags.
+// Sanitized tags are already deduped, so this is a clean set-comparison.
+export function sortedArraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false
+  const sa = [...a].sort()
+  const sb = [...b].sort()
+  for (let i = 0; i < sa.length; i++) {
+    if (sa[i] !== sb[i]) return false
+  }
+  return true
+}

--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -3,7 +3,42 @@ import { encode as encodeBase64 } from 'https://deno.land/std@0.177.0/encoding/b
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { detectCms, cmsRequiresRender } from './cms-detect.ts'
 import { fetchRenderedHtml, BrowserlessError } from './browserless.ts'
-import { discoverMenuCandidates, findSubMenuPages, type MenuCandidate } from './menu-candidates.ts'
+import { discoverMenuCandidates, findMenuIframes, findSubMenuPages, isBlockedHostname, isKnownMenuIframeHost, type MenuCandidate } from './menu-candidates.ts'
+
+// v1.3 dietary tag + description sanitizers (kept in sync with
+// ./extractors.ts which exists for Vitest test coverage — Vitest can't
+// import from this file because of the Deno URL imports above).
+// Spec: docs/superpowers/specs/2026-05-18-dish-descriptions-dietary-tags-design.md
+const ALLOWED_DIETARY_TAGS_INLINE = ['vegan', 'vegetarian', 'gluten_free', 'dairy_free', 'nut_free'] as const
+type AllowedDietaryTag = typeof ALLOWED_DIETARY_TAGS_INLINE[number]
+
+function sanitizeDietaryTags(raw: unknown): AllowedDietaryTag[] {
+  if (!Array.isArray(raw)) return []
+  const seen = new Set<AllowedDietaryTag>()
+  for (const t of raw) {
+    if (typeof t === 'string' && (ALLOWED_DIETARY_TAGS_INLINE as readonly string[]).includes(t)) {
+      seen.add(t as AllowedDietaryTag)
+    }
+  }
+  return Array.from(seen)
+}
+
+function sanitizeDescription(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return null
+  return trimmed.length > 80 ? trimmed.slice(0, 80) : trimmed
+}
+
+function sortedArraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false
+  const sa = [...a].sort()
+  const sb = [...b].sort()
+  for (let i = 0; i < sa.length; i++) {
+    if (sa[i] !== sb[i]) return false
+  }
+  return true
+}
 
 /**
  * Menu Refresh Edge Function
@@ -127,6 +162,13 @@ Pick the MOST SPECIFIC category that fits. Prefer "lobster roll" over "seafood",
    - **When in doubt:** if two dishes in the same section have names that a normal human would read as "the same dish at different prices," collapse them. Better to under-count than to duplicate.
 8. **Prices: NEVER INVENT OR GUESS PRICES.** Only set a price if you can see an exact dollar amount next to that specific dish on the source page. If no explicit price is shown for a dish, the price field MUST be \`null\`. Do NOT infer prices from nearby dishes, category averages, or typical market values. Do NOT fill in \`18\` or any default. A null price is always better than a guessed price. If a range is shown (e.g. "$14-18"), use the lower number.
 9. **One category per dish** — pick the most specific match
+10. **Description rule:** Output a terse ingredient/preparation line, 80 chars or fewer, as \`description\`. Format: comma-separated nouns. Examples: "Hot lobster meat, drawn butter, split-top bun" / "Pepperoni, mozzarella, San Marzano tomato" / "Wagyu beef, bacon jam, brioche bun". If the menu has only marketing copy ("OUR SIGNATURE HAND-CRAFTED..."), output \`null\`. Never invent ingredients you don't see in the source.
+11. **Dietary tags rule:** Output a \`dietary_tags\` array. Allowed tags (and only these): \`vegan\`, \`vegetarian\`, \`gluten_free\`, \`dairy_free\`, \`nut_free\`. **Only emit a tag when the menu definitively states the dish IS that diet.** This is an allergen-safety contract — a celiac diner trusts \`gluten_free\` to mean the dish is gluten-free, not "can be modified."
+    - **Emit** when the dish itself is unambiguously labeled: "Vegan Buddha Bowl", "GF Pasta", "Gluten-Free Penne", "Dairy-Free Ice Cream", a definitive "V" or "GF" badge attached directly to the dish.
+    - **Do NOT emit** for "available", "on request", "can be made", "ask your server" qualifiers — those mean modifiable, not the dish as listed. "Gluten-Free Available" → do NOT emit \`gluten_free\`.
+    - **Do NOT emit** when shorthand markers are ambiguous (e.g., "V" could mean vegan or vegetarian and the menu has no legend). When in doubt, emit \`[]\`.
+    - **Do NOT infer from ingredients** — a tofu stir-fry with no animal products does NOT get \`vegan\` unless the menu labels it.
+    - Empty array \`[]\` when nothing is labeled, ambiguous, or only "available". Never invent tags.
 
 ## CRITICAL: Reject placeholder/template content
 
@@ -143,7 +185,14 @@ When in doubt: if dish names don't tell you what the actual dish IS (unique name
 Return ONLY valid JSON (no markdown, no code fences):
 {
   "dishes": [
-    { "name": "Dish Name", "category": "category_id", "menu_section": "Section Name", "price": 18.00 }
+    {
+      "name": "Dish Name",
+      "category": "category_id",
+      "menu_section": "Section Name",
+      "price": 18.00,
+      "description": "ingredient, ingredient, prep",
+      "dietary_tags": ["vegan"]
+    }
   ],
   "menu_section_order": ["Section 1", "Section 2"]
 }`
@@ -153,6 +202,8 @@ interface ExtractedDish {
   category: string
   menu_section: string
   price: number | null
+  description: string | null
+  dietary_tags: string[]
 }
 
 interface MenuExtractionResult {
@@ -344,33 +395,95 @@ const PDF_URL_EXT = /\.pdf(\?|#|$)/i
  * some hosts (and some CDNs that strip mime types) serve PDFs as
  * application/octet-stream.
  */
+// Maximum redirect hops we'll follow manually. Each hop is validated against
+// isBlockedHostname before fetching, which is the SSRF defense that
+// `redirect: 'follow'` doesn't give us.
+const MAX_REDIRECT_HOPS = 5
+
 async function fetchRawHtml(url: string): Promise<MenuFetchResult> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), 20000)
 
   try {
-    const response = await fetch(url, {
-      signal: controller.signal,
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (compatible; WhatsGoodHere-MenuBot/1.0)',
-        'Accept': 'text/html,application/xhtml+xml,application/pdf',
-      },
-    })
+    let currentUrl = url
+    let response: Response | null = null
 
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`)
+    // Manual redirect loop: validate each hop's hostname BEFORE issuing the
+    // fetch, so a public iframe URL that 302s to a private/loopback/metadata
+    // host never actually reaches that host. The default `redirect: 'follow'`
+    // does the redirect internally before we can inspect it — too late.
+    for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
+      let parsed: URL
+      try {
+        parsed = new URL(currentUrl)
+      } catch {
+        throw new Error('invalid_url')
+      }
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        throw new Error(`bad_scheme:${parsed.protocol}`)
+      }
+      if (isBlockedHostname(parsed.hostname)) {
+        throw new Error(`blocked_host:${parsed.hostname}`)
+      }
+
+      response = await fetch(currentUrl, {
+        signal: controller.signal,
+        redirect: 'manual',
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (compatible; WhatsGoodHere-MenuBot/1.0)',
+          'Accept': 'text/html,application/xhtml+xml,application/pdf',
+        },
+      })
+
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get('location')
+        await response.body?.cancel()
+        if (!location) throw new Error(`redirect_no_location:${response.status}`)
+        try {
+          currentUrl = new URL(location, currentUrl).href
+        } catch {
+          throw new Error('invalid_redirect_location')
+        }
+        continue
+      }
+      break
+    }
+    if (!response) throw new Error('no_response')
+    if (response.status >= 300 && response.status < 400) {
+      throw new Error('too_many_redirects')
     }
 
-    const finalUrl = response.url || url
+    const finalUrl = response.url || currentUrl
     const contentType = (response.headers.get('content-type') || '').toLowerCase()
     const looksLikePdf = contentType.includes('application/pdf') || PDF_URL_EXT.test(finalUrl)
     if (looksLikePdf) {
-      // Discard the body — we'll pass the URL itself to Sonnet's PDF tool.
+      // PDF: the URL itself is what gets passed to Sonnet's PDF tool, so a
+      // non-2xx response means Sonnet would also fail to fetch it. Strict.
+      if (!response.ok) {
+        await response.body?.cancel()
+        throw new Error(`HTTP ${response.status}`)
+      }
       await response.body?.cancel()
       return { type: 'pdf', pdfUrl: finalUrl }
     }
 
-    return { type: 'html', html: await response.text() }
+    // HTML: tolerate non-2xx if the response actually looks like HTML AND has
+    // real body content. Some third-party menu hosts (e.g. checkle.menu) return
+    // 500 status with full menu HTML in the body — a framework fluke, not an
+    // actual server error. The content-type / sniff gate prevents us from
+    // accepting long JSON error payloads or branded error pages as menu HTML.
+    const html = await response.text()
+    if (!response.ok) {
+      const isHtmlContentType = contentType.includes('text/html') || contentType.includes('application/xhtml')
+      const sniffsAsHtml = !contentType && /^\s*(<!doctype|<html)/i.test(html.slice(0, 200))
+      if (!isHtmlContentType && !sniffsAsHtml) {
+        throw new Error(`HTTP ${response.status}`)
+      }
+      if (html.length < 200) {
+        throw new Error(`HTTP ${response.status}`)
+      }
+    }
+    return { type: 'html', html }
   } finally {
     clearTimeout(timeout)
   }
@@ -435,18 +548,19 @@ async function fetchMenuContent(url: string): Promise<string> {
 }
 
 interface ExtractionAttempt {
-  strategy: 'image' | 'pdf' | 'html' | 'sub-page'
+  strategy: 'image' | 'pdf' | 'html' | 'sub-page' | 'iframe'
   url_count: number
   top_score?: number
   dishes_found: number
   error?: string
-  url?: string  // for sub-page attempts, which sub-URL was tried
+  url?: string  // for sub-page / iframe attempts, which URL was tried
 }
 
 // Caps per strategy. Vision is per-pixel-token expensive — keep image batches small.
 const MAX_IMAGE_CANDIDATES = 3
 const MAX_PDF_CANDIDATES = 6
 const MAX_SUB_PAGES = 4
+const MAX_MENU_IFRAMES = 2
 // Render fallback #2 fires more broadly than fallback #1: even on plain HTML
 // sites without a CMS signature, if everything else returned 0 dishes the page
 // might just be a JS-loaded shell. One Browserless call per failed job is cheap
@@ -538,6 +652,8 @@ async function extractMenuWithClaude(content: string, restaurantName: string): P
     .map((d: ExtractedDish) => ({
       ...d,
       category: VALID_CATEGORIES.includes(d.category) ? d.category : 'entree',
+      description: sanitizeDescription(d.description),
+      dietary_tags: sanitizeDietaryTags(d.dietary_tags),
     }))
 
   return {
@@ -674,6 +790,8 @@ async function extractMenuFromImagesWithClaude(
     .map((d: ExtractedDish) => ({
       ...d,
       category: VALID_CATEGORIES.includes(d.category) ? d.category : 'entree',
+      description: sanitizeDescription(d.description),
+      dietary_tags: sanitizeDietaryTags(d.dietary_tags),
     }))
 
   return {
@@ -744,6 +862,8 @@ async function extractMenuFromPdfsWithClaude(
     .map((d: ExtractedDish) => ({
       ...d,
       category: VALID_CATEGORIES.includes(d.category) ? d.category : 'entree',
+      description: sanitizeDescription(d.description),
+      dietary_tags: sanitizeDietaryTags(d.dietary_tags),
     }))
 
   return {
@@ -763,7 +883,7 @@ async function upsertDishes(
   // Get existing dishes
   const { data: existingDishes, error: fetchErr } = await supabase
     .from('dishes')
-    .select('id, name, category, menu_section, price, photo_url')
+    .select('id, name, category, menu_section, price, photo_url, description, dietary_tags')
     .eq('restaurant_id', restaurantId)
 
   if (fetchErr) {
@@ -787,12 +907,16 @@ async function upsertDishes(
       const priceChanged = dish.price !== null && dish.price !== existing.price
       const categoryChanged = dish.category !== existing.category
       const sectionChanged = dish.menu_section !== existing.menu_section
+      const descriptionChanged = (dish.description ?? null) !== (existing.description ?? null)
+      const tagsChanged = !sortedArraysEqual(dish.dietary_tags || [], existing.dietary_tags || [])
 
-      if (priceChanged || categoryChanged || sectionChanged) {
+      if (priceChanged || categoryChanged || sectionChanged || descriptionChanged || tagsChanged) {
         const updates: Record<string, unknown> = {}
         if (categoryChanged) updates.category = dish.category
         if (sectionChanged) updates.menu_section = dish.menu_section
         if (priceChanged) updates.price = dish.price
+        if (descriptionChanged) updates.description = dish.description
+        if (tagsChanged) updates.dietary_tags = dish.dietary_tags
 
         const { error } = await supabase
           .from('dishes')
@@ -813,6 +937,8 @@ async function upsertDishes(
           category: dish.category,
           menu_section: dish.menu_section || null,
           price: dish.price || null,
+          description: dish.description ?? null,
+          dietary_tags: dish.dietary_tags || [],
         })
 
       if (!error) inserted++
@@ -865,6 +991,15 @@ serve(async (req) => {
     const supabaseUrl = Deno.env.get('SUPABASE_URL')!
     const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
     const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+    // v1.3 backfill flag: ?force_all=true bypasses the STALE_DAYS filter so
+    // a backfill operator can sweep every open restaurant with a menu_url in
+    // a few batched invocations. ?limit=N caps per-invocation work (default
+    // MAX_RESTAURANTS_PER_RUN, hard ceiling 50 to stay under edge timeout).
+    const reqUrl = new URL(req.url)
+    const forceAll = reqUrl.searchParams.get('force_all') === 'true'
+    const forceLimitRaw = parseInt(reqUrl.searchParams.get('limit') || `${MAX_RESTAURANTS_PER_RUN}`, 10)
+    const forceLimit = Math.min(50, Math.max(1, isNaN(forceLimitRaw) ? MAX_RESTAURANTS_PER_RUN : forceLimitRaw))
 
     // Check if single restaurant mode
     let body: Record<string, unknown> = {}
@@ -1263,10 +1398,20 @@ serve(async (req) => {
           // linking to /brunch /lunch /dinner /breakfast (Webflow / WordPress /
           // multi-service restaurants split the menu across pages). Fetch each
           // sub-page, run extraction on each, merge results.
+          //
+          // Iframe fallback runs alongside: some restaurants embed their menu
+          // in a cross-origin iframe (checkle.menu, popmenu, singleplatform,
+          // Toast). findMenuIframes pulls those URLs so the same loop fetches
+          // and extracts them.
           if (extracted.dishes.length === 0) {
             const subPages = findSubMenuPages(rawHtml, menuUrl, MAX_SUB_PAGES)
-            if (subPages.length > 0) {
-              console.log(`${restaurant.name}: trying ${subPages.length} sub-menu pages`)
+            const menuIframes = findMenuIframes(rawHtml, MAX_MENU_IFRAMES)
+            const subUrls: Array<{ url: string; strategy: 'sub-page' | 'iframe' }> = [
+              ...subPages.map(url => ({ url, strategy: 'sub-page' as const })),
+              ...menuIframes.map(url => ({ url, strategy: 'iframe' as const })),
+            ]
+            if (subUrls.length > 0) {
+              console.log(`${restaurant.name}: trying ${subPages.length} sub-pages + ${menuIframes.length} menu iframes`)
               // Dedupe across sub-pages by (lowercased name, lowercased section).
               // Many restaurants list the same dish on /lunch and /dinner; without
               // deduping we'd report inflated dishes_found, and even though
@@ -1276,7 +1421,7 @@ serve(async (req) => {
               const seenDishes = new Set<string>()
               const mergedDishes: typeof extracted.dishes = []
               const mergedSections: string[] = []
-              for (const subUrl of subPages) {
+              for (const { url: subUrl, strategy } of subUrls) {
                 try {
                   const subFetch = await fetchRawHtml(subUrl)
                   // Sub-page itself served a PDF (e.g. /lunch redirects to lunch.pdf).
@@ -1284,7 +1429,7 @@ serve(async (req) => {
                   // merged sub-page output below.
                   if (subFetch.type === 'pdf') {
                     const subPdfResult = await extractMenuFromPdfsWithClaude([subFetch.pdfUrl], restaurant.name)
-                    attempts.push({ strategy: 'sub-page', url_count: 1, dishes_found: subPdfResult.dishes.length, url: subUrl })
+                    attempts.push({ strategy, url_count: 1, dishes_found: subPdfResult.dishes.length, url: subUrl })
                     for (const dish of subPdfResult.dishes) {
                       const key = `${dish.name.toLowerCase()}|${(dish.menu_section || '').toLowerCase()}`
                       if (seenDishes.has(key)) continue
@@ -1296,13 +1441,49 @@ serve(async (req) => {
                     }
                     continue
                   }
-                  const subText = extractMenuTextFromHtml(subFetch.html)
+                  let subText = extractMenuTextFromHtml(subFetch.html)
+                  let subRendered = false
+                  // Iframe URLs frequently point at Next.js / React menu services
+                  // (checkle.menu, popmenu, etc.) where the static HTML is just a
+                  // shell — actual menu content lives in JS state. Always render
+                  // iframes from known menu-service hosts; cost is bounded
+                  // because the allowlist limits which hosts qualify.
+                  //
+                  // Known-host gate also bounds the SSRF surface: Browserless
+                  // follows redirects internally, so sending it an attacker-
+                  // controlled URL would reopen the redirect-SSRF gap we closed
+                  // for raw fetch.
+                  if (strategy === 'iframe') {
+                    let iframeHost = ''
+                    try {
+                      iframeHost = new URL(subUrl).hostname
+                    } catch {
+                      iframeHost = ''
+                    }
+                    const knownHost = iframeHost ? isKnownMenuIframeHost(iframeHost) : false
+                    if (knownHost) {
+                      try {
+                        const renderedIframeHtml = await fetchRenderedHtml(subUrl, {
+                          gotoTimeout: 45000,
+                          waitForTimeoutMs: 12000,
+                        })
+                        const renderedIframeText = extractMenuTextFromHtml(renderedIframeHtml)
+                        if (renderedIframeText.length > subText.length) {
+                          subText = renderedIframeText
+                          subRendered = true
+                        }
+                      } catch (renderErr) {
+                        const msg = renderErr instanceof Error ? renderErr.message : String(renderErr)
+                        console.error(`${restaurant.name}: iframe render failed for ${subUrl}:`, msg)
+                      }
+                    }
+                  }
                   if (subText.length < 50) {
-                    attempts.push({ strategy: 'sub-page', url_count: 1, dishes_found: 0, url: subUrl, error: 'page_too_short' })
+                    attempts.push({ strategy, url_count: 1, dishes_found: 0, url: subUrl, error: subRendered ? 'rendered_but_short' : 'page_too_short' })
                     continue
                   }
                   const subResult = await extractMenuWithClaude(subText, restaurant.name)
-                  attempts.push({ strategy: 'sub-page', url_count: 1, dishes_found: subResult.dishes.length, url: subUrl })
+                  attempts.push({ strategy, url_count: 1, dishes_found: subResult.dishes.length, url: subUrl })
                   for (const dish of subResult.dishes) {
                     const key = `${dish.name.toLowerCase()}|${(dish.menu_section || '').toLowerCase()}`
                     if (seenDishes.has(key)) continue
@@ -1314,8 +1495,8 @@ serve(async (req) => {
                   }
                 } catch (err) {
                   const message = err instanceof Error ? err.message : String(err)
-                  console.error(`${restaurant.name}: sub-page ${subUrl} failed:`, message)
-                  attempts.push({ strategy: 'sub-page', url_count: 1, dishes_found: 0, url: subUrl, error: message })
+                  console.error(`${restaurant.name}: ${strategy} ${subUrl} failed:`, message)
+                  attempts.push({ strategy, url_count: 1, dishes_found: 0, url: subUrl, error: message })
                 }
               }
               if (mergedDishes.length > 0) {
@@ -1507,21 +1688,24 @@ serve(async (req) => {
       })
     }
 
-    // === Batch fallback mode: find stale menus ===
+    // === Batch fallback mode: find stale menus (or all if force_all=true) ===
     let restaurants: Array<{ id: string; name: string; menu_url: string; menu_content_hash: string | null }>
 
     {
-      // Batch mode: find stale menus
-      const staleDate = new Date()
-      staleDate.setDate(staleDate.getDate() - STALE_DAYS)
-
-      const { data, error } = await supabase
+      let query = supabase
         .from('restaurants')
         .select('id, name, menu_url, menu_content_hash')
         .not('menu_url', 'is', null)
         .eq('is_open', true)
-        .or(`menu_last_checked.is.null,menu_last_checked.lt.${staleDate.toISOString()}`)
-        .limit(MAX_RESTAURANTS_PER_RUN)
+
+      if (!forceAll) {
+        // Default cron mode: only stale (or never-checked) menus
+        const staleDate = new Date()
+        staleDate.setDate(staleDate.getDate() - STALE_DAYS)
+        query = query.or(`menu_last_checked.is.null,menu_last_checked.lt.${staleDate.toISOString()}`)
+      }
+
+      const { data, error } = await query.limit(forceAll ? forceLimit : MAX_RESTAURANTS_PER_RUN)
 
       if (error) {
         return new Response(JSON.stringify({ error: 'Failed to fetch restaurants' }), {
@@ -1530,6 +1714,10 @@ serve(async (req) => {
         })
       }
       restaurants = data || []
+
+      if (forceAll) {
+        console.log(`menu-refresh: force_all=true, limit=${forceLimit}, found ${restaurants.length} restaurants to refresh`)
+      }
     }
 
     if (restaurants.length === 0) {

--- a/supabase/functions/menu-refresh/menu-candidates.test.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { discoverMenuCandidates, findSubMenuPages, scoreCandidate } from './menu-candidates.ts'
+import { discoverMenuCandidates, findMenuIframes, findSubMenuPages, isBlockedHostname, isKnownMenuIframeHost, scoreCandidate } from './menu-candidates.ts'
 
 describe('scoreCandidate', () => {
   it('positive: menu in URL', () => {
@@ -410,5 +410,299 @@ describe('findSubMenuPages', () => {
     const html = '<a href="/drinks-menu">Drinks Menu</a>'
     const out = findSubMenuPages(html, 'https://x.com/')
     expect(out).toEqual([])
+  })
+})
+
+describe('findMenuIframes', () => {
+  it('catches the State Road / checkle.menu pattern (protocol-relative)', () => {
+    const html = '<iframe id="menuFrame" src="//checkle.menu/stateroadrestaurant?embed=true"></iframe>'
+    expect(findMenuIframes(html)).toEqual([
+      'https://checkle.menu/stateroadrestaurant?embed=true',
+    ])
+  })
+
+  it('catches iframes by known menu-service host (popmenu, singleplatform, toast)', () => {
+    const html = `
+      <iframe src="https://popmenu.com/restaurants/foo/menu"></iframe>
+      <iframe src="https://www.singleplatform.com/bar/menu"></iframe>
+      <iframe src="https://order.toasttab.com/online/baz"></iframe>
+    `
+    const out = findMenuIframes(html, 5)
+    expect(out).toContain('https://popmenu.com/restaurants/foo/menu')
+    expect(out).toContain('https://www.singleplatform.com/bar/menu')
+    expect(out).toContain('https://order.toasttab.com/online/baz')
+  })
+
+  it('catches iframes by "menu" keyword in src even when host is unknown', () => {
+    const html = '<iframe src="https://unknown-cms.example/restaurant/menu"></iframe>'
+    expect(findMenuIframes(html)).toEqual(['https://unknown-cms.example/restaurant/menu'])
+  })
+
+  it('skips iframes that are clearly not menus (ads, maps, video)', () => {
+    const html = `
+      <iframe src="https://www.google.com/maps/embed?q=foo"></iframe>
+      <iframe src="https://www.youtube.com/embed/abc"></iframe>
+      <iframe src="https://googletagmanager.com/ns.html?id=GTM-XYZ"></iframe>
+    `
+    expect(findMenuIframes(html)).toEqual([])
+  })
+
+  it('caps results at max', () => {
+    const html = `
+      <iframe src="https://a.com/menu"></iframe>
+      <iframe src="https://b.com/menu"></iframe>
+      <iframe src="https://c.com/menu"></iframe>
+    `
+    expect(findMenuIframes(html, 2).length).toBe(2)
+  })
+
+  it('dedupes identical iframe srcs', () => {
+    const html = `
+      <iframe src="https://checkle.menu/foo"></iframe>
+      <iframe src="https://checkle.menu/foo"></iframe>
+    `
+    expect(findMenuIframes(html)).toEqual(['https://checkle.menu/foo'])
+  })
+
+  it('ignores javascript: and other non-http schemes', () => {
+    const html = `
+      <iframe src="javascript:void(0)"></iframe>
+      <iframe src="about:blank"></iframe>
+      <iframe src="data:text/html,foo"></iframe>
+    `
+    expect(findMenuIframes(html)).toEqual([])
+  })
+
+  it('returns empty when there are no iframes at all', () => {
+    expect(findMenuIframes('<p>no iframes here</p>')).toEqual([])
+  })
+
+  it('ignores iframe-shaped strings inside <script> tags (no smuggling)', () => {
+    const html = `
+      <script>
+        const trap = '<iframe src="http://169.254.169.254/menu"></iframe>';
+      </script>
+      <p>nothing else</p>
+    `
+    expect(findMenuIframes(html)).toEqual([])
+  })
+
+  it('ignores iframe-shaped strings inside HTML comments', () => {
+    const html = `<!-- <iframe src="https://checkle.menu/foo"></iframe> -->`
+    expect(findMenuIframes(html)).toEqual([])
+  })
+
+  it('ignores iframe-shaped strings inside <style> and <noscript>', () => {
+    const html = `
+      <style>/* <iframe src="https://checkle.menu/foo"></iframe> */</style>
+      <noscript><iframe src="https://popmenu.com/menu"></iframe></noscript>
+    `
+    expect(findMenuIframes(html)).toEqual([])
+  })
+
+  it('blocks SSRF: loopback (127.0.0.1, localhost, ::1)', () => {
+    const html = `
+      <iframe src="http://127.0.0.1/menu"></iframe>
+      <iframe src="http://localhost/menu"></iframe>
+      <iframe src="http://[::1]/menu"></iframe>
+    `
+    expect(findMenuIframes(html)).toEqual([])
+  })
+
+  it('blocks SSRF: cloud metadata (169.254.169.254)', () => {
+    const html = '<iframe src="http://169.254.169.254/menu"></iframe>'
+    expect(findMenuIframes(html)).toEqual([])
+  })
+
+  it('blocks SSRF: RFC1918 private ranges', () => {
+    const html = `
+      <iframe src="http://10.0.0.5/menu"></iframe>
+      <iframe src="http://172.16.0.1/menu"></iframe>
+      <iframe src="http://172.31.255.254/menu"></iframe>
+      <iframe src="http://192.168.1.1/menu"></iframe>
+    `
+    expect(findMenuIframes(html)).toEqual([])
+  })
+
+  it('blocks SSRF: .local / .internal hostnames', () => {
+    const html = `
+      <iframe src="http://service.local/menu"></iframe>
+      <iframe src="http://api.internal/menu"></iframe>
+    `
+    expect(findMenuIframes(html)).toEqual([])
+  })
+
+  it('keyword fallback matches pathname only — not query string', () => {
+    const html = '<iframe src="https://cdn.example.com/siteimage.png?menu=footer"></iframe>'
+    expect(findMenuIframes(html)).toEqual([])
+  })
+
+  it('keyword fallback matches pathname only — not asset extensions', () => {
+    // No "menu" substring at a word boundary in the pathname here, so this
+    // should be rejected (path = /assets/footer.png, no menu word).
+    const html = '<iframe src="https://cdn.example.com/assets/footer.png"></iframe>'
+    expect(findMenuIframes(html)).toEqual([])
+  })
+
+  it('still catches legitimate /menu in pathname', () => {
+    const html = '<iframe src="https://unknown-cms.example/restaurant/menu/index.html"></iframe>'
+    expect(findMenuIframes(html)).toEqual(['https://unknown-cms.example/restaurant/menu/index.html'])
+  })
+
+  it('blocks SSRF: IPv4-mapped IPv6 (::ffff:127.0.0.1 and dotted/hex variants)', () => {
+    const html = `
+      <iframe src="http://[::ffff:127.0.0.1]/menu"></iframe>
+      <iframe src="http://[::ffff:10.0.0.1]/menu"></iframe>
+      <iframe src="http://[::127.0.0.1]/menu"></iframe>
+    `
+    expect(findMenuIframes(html)).toEqual([])
+  })
+
+  it('blocks SSRF: ::ffff: hex form (no dots)', () => {
+    // ::ffff:7f00:0001 is the hex IPv4-mapping of 127.0.0.1. Any ::ffff:
+    // prefix is rejected since it's exclusively IPv4-mapping.
+    const html = '<iframe src="http://[::ffff:7f00:0001]/menu"></iframe>'
+    expect(findMenuIframes(html)).toEqual([])
+  })
+
+  it('ignores iframe-shaped strings inside <template> elements', () => {
+    const html = `
+      <template id="menuTpl">
+        <iframe src="https://checkle.menu/foo"></iframe>
+      </template>
+    `
+    expect(findMenuIframes(html)).toEqual([])
+  })
+
+  it('ignores iframe-shaped strings inside <textarea> elements', () => {
+    const html = `
+      <textarea name="example">
+        <iframe src="https://checkle.menu/foo"></iframe>
+      </textarea>
+    `
+    expect(findMenuIframes(html)).toEqual([])
+  })
+})
+
+describe('isBlockedHostname', () => {
+  it('blocks localhost and 0.0.0.0', () => {
+    expect(isBlockedHostname('localhost')).toBe(true)
+    expect(isBlockedHostname('0.0.0.0')).toBe(true)
+  })
+
+  it('blocks loopback (127/8)', () => {
+    expect(isBlockedHostname('127.0.0.1')).toBe(true)
+    expect(isBlockedHostname('127.255.255.254')).toBe(true)
+  })
+
+  it('blocks RFC1918 private ranges', () => {
+    expect(isBlockedHostname('10.0.0.1')).toBe(true)
+    expect(isBlockedHostname('172.16.0.1')).toBe(true)
+    expect(isBlockedHostname('172.31.255.254')).toBe(true)
+    expect(isBlockedHostname('192.168.1.1')).toBe(true)
+  })
+
+  it('does NOT block 172.32+ (outside RFC1918)', () => {
+    expect(isBlockedHostname('172.32.0.1')).toBe(false)
+    expect(isBlockedHostname('172.15.0.1')).toBe(false)
+  })
+
+  it('blocks link-local + cloud metadata (169.254/16)', () => {
+    expect(isBlockedHostname('169.254.169.254')).toBe(true)
+    expect(isBlockedHostname('169.254.0.1')).toBe(true)
+  })
+
+  it('blocks IPv6 loopback and unspecified', () => {
+    expect(isBlockedHostname('::1')).toBe(true)
+    expect(isBlockedHostname('::')).toBe(true)
+  })
+
+  it('blocks IPv6 with embedded IPv4 (::ffff:x.x.x.x and ::x.x.x.x)', () => {
+    expect(isBlockedHostname('::ffff:127.0.0.1')).toBe(true)
+    expect(isBlockedHostname('::ffff:10.0.0.1')).toBe(true)
+    expect(isBlockedHostname('::127.0.0.1')).toBe(true)
+  })
+
+  it('blocks ::ffff: hex prefix (covers ::ffff:7f00:0001 form)', () => {
+    expect(isBlockedHostname('::ffff:7f00:0001')).toBe(true)
+  })
+
+  it('blocks IPv6 unique-local and link-local ranges', () => {
+    expect(isBlockedHostname('fc00:0:0:0:0:0:0:1')).toBe(true)
+    expect(isBlockedHostname('fd00:0:0:0:0:0:0:1')).toBe(true)
+    expect(isBlockedHostname('fe80:0:0:0:0:0:0:1')).toBe(true)
+  })
+
+  it('blocks .local / .internal / .localhost suffixes', () => {
+    expect(isBlockedHostname('service.local')).toBe(true)
+    expect(isBlockedHostname('api.internal')).toBe(true)
+    expect(isBlockedHostname('foo.localhost')).toBe(true)
+  })
+
+  it('strips IPv6 brackets (URL hostname may include them)', () => {
+    expect(isBlockedHostname('[::1]')).toBe(true)
+  })
+
+  it('allows legitimate public hostnames', () => {
+    expect(isBlockedHostname('checkle.menu')).toBe(false)
+    expect(isBlockedHostname('www.example.com')).toBe(false)
+    expect(isBlockedHostname('8.8.8.8')).toBe(false)
+  })
+
+  it('blocks trailing-dot variants (DNS-equivalent FQDN forms)', () => {
+    // WHATWG URL preserves trailing dots in hostname. Without normalization,
+    // 'localhost.' and 'service.local.' would slip past the blocklist.
+    expect(isBlockedHostname('localhost.')).toBe(true)
+    expect(isBlockedHostname('service.local.')).toBe(true)
+    expect(isBlockedHostname('api.internal.')).toBe(true)
+    expect(isBlockedHostname('foo.localhost.')).toBe(true)
+  })
+
+  it('does NOT block public hostnames that happen to end in a dot', () => {
+    expect(isBlockedHostname('checkle.menu.')).toBe(false)
+    expect(isBlockedHostname('example.com.')).toBe(false)
+  })
+})
+
+describe('isKnownMenuIframeHost', () => {
+  it('matches the menu-service whitelist', () => {
+    expect(isKnownMenuIframeHost('checkle.menu')).toBe(true)
+    expect(isKnownMenuIframeHost('www.popmenu.com')).toBe(true)
+    expect(isKnownMenuIframeHost('singleplatform.com')).toBe(true)
+    expect(isKnownMenuIframeHost('order.toasttab.com')).toBe(true)
+    expect(isKnownMenuIframeHost('menustar.com')).toBe(true)
+  })
+
+  it('rejects hosts not on the whitelist', () => {
+    expect(isKnownMenuIframeHost('attacker.com')).toBe(false)
+    expect(isKnownMenuIframeHost('localhost')).toBe(false)
+    expect(isKnownMenuIframeHost('example.com')).toBe(false)
+    expect(isKnownMenuIframeHost('googletagmanager.com')).toBe(false)
+  })
+
+  it('rejects superdomain bypass (attacker-controlled hostname containing trusted apex)', () => {
+    // The substring/regex form of this check would match these — the
+    // exact-or-subdomain check must reject them.
+    expect(isKnownMenuIframeHost('popmenu.com.evil')).toBe(false)
+    expect(isKnownMenuIframeHost('foo.popmenu.com.evil')).toBe(false)
+    expect(isKnownMenuIframeHost('toasttab.com.attacker.io')).toBe(false)
+    expect(isKnownMenuIframeHost('checkle.menu.attacker.io')).toBe(false)
+  })
+
+  it('rejects prefix-match imposters (e.g. xpopmenu.com)', () => {
+    expect(isKnownMenuIframeHost('xpopmenu.com')).toBe(false)
+    expect(isKnownMenuIframeHost('not-popmenu.com')).toBe(false)
+    expect(isKnownMenuIframeHost('checkle.menus')).toBe(false)
+  })
+
+  it('matches exact apex and proper subdomains', () => {
+    expect(isKnownMenuIframeHost('popmenu.com')).toBe(true)
+    expect(isKnownMenuIframeHost('order.popmenu.com')).toBe(true)
+    expect(isKnownMenuIframeHost('any.deep.subdomain.popmenu.com')).toBe(true)
+  })
+
+  it('normalizes trailing dot (DNS-equivalent FQDN forms)', () => {
+    expect(isKnownMenuIframeHost('popmenu.com.')).toBe(true)
+    expect(isKnownMenuIframeHost('order.popmenu.com.')).toBe(true)
   })
 })

--- a/supabase/functions/menu-refresh/menu-candidates.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.ts
@@ -380,3 +380,140 @@ export function discoverMenuCandidates(html: string, baseUrl: string): MenuCandi
   candidates.sort((a, b) => b.score - a.score)
   return candidates
 }
+
+/**
+ * Find iframes that look like embedded third-party menu services.
+ *
+ * Some restaurants (e.g. State Road via checkle.menu, others via PopMenu /
+ * SinglePlatform / Toast) embed their menu in a cross-origin iframe. The
+ * parent page has almost no text content; the iframe URL serves the actual
+ * menu HTML. findSubMenuPages skips iframes (it scans anchor tags) and
+ * filters cross-origin, so those menus never get extracted.
+ *
+ * Match strategy: iframe src matches a known menu-service host OR contains
+ * "menu" in its URL pathname. Cross-origin allowed — iframes intentionally
+ * embed third-party content. Protocol-relative srcs (`//host/path`) are
+ * upgraded to https.
+ *
+ * Security: SSRF-resilient. Scripts/comments are stripped before scanning
+ * so injected iframe strings inside <script> or <!-- --> can't smuggle a URL.
+ * Hostnames matching loopback / private CIDRs / link-local / cloud metadata
+ * are rejected to prevent server-side request forgery via fetchRawHtml.
+ *
+ * Capped at `max` to keep cost bounded.
+ */
+// Exact apex hosts. Matching is exact-equality OR proper-subdomain (host
+// ends with `.<apex>`). Substring matching would let attacker-controlled
+// hostnames like `popmenu.com.evil` slip through as "trusted".
+const KNOWN_MENU_IFRAME_HOSTS: string[] = [
+  'checkle.menu',
+  'popmenu.com',
+  'singleplatform.com',
+  'toasttab.com',
+  'getbento.com',     // BentoBox's customer-site domain
+  'menustar.com',
+]
+
+/**
+ * Used by the iframe-render gate in index.ts: we only spend Browserless
+ * cycles re-fetching iframe URLs that point at known menu-service hosts.
+ * This both bounds spend and limits the SSRF surface — an attacker-controlled
+ * iframe pointing at a public URL that 302s to internal infra can't trick
+ * us into having Browserless render it.
+ *
+ * Matches exact apex OR proper subdomain only. `popmenu.com` → true,
+ * `order.popmenu.com` → true, `popmenu.com.evil` → false, `xpopmenu.com` →
+ * false. Hostname is normalized (lowercase, trailing-dot stripped) to match
+ * isBlockedHostname's normalization.
+ */
+export function isKnownMenuIframeHost(hostname: string): boolean {
+  const lower = hostname.toLowerCase().replace(/\.+$/, '')
+  return KNOWN_MENU_IFRAME_HOSTS.some(apex => lower === apex || lower.endsWith('.' + apex))
+}
+
+// Block hostnames that fetchRawHtml could otherwise be coaxed into reaching:
+// loopback, RFC1918 private space, link-local (incl. AWS/GCP metadata at
+// 169.254.169.254), and the *.local / *.internal suffixes used by service
+// discovery on private networks. A legitimate restaurant menu iframe never
+// points here.
+//
+// Exported so fetchRawHtml can re-check `response.url` after redirects —
+// a public iframe URL can 302 to an internal one, so per-hop validation
+// is required, not just initial-URL validation.
+export function isBlockedHostname(hostname: string): boolean {
+  // Normalize: strip IPv6 brackets, trailing FQDN dot, lowercase.
+  // Trailing-dot variants ('localhost.', 'service.local.') would otherwise
+  // sneak past the suffix and equality checks — DNS treats them as equivalent.
+  const lower = hostname.toLowerCase().replace(/^\[|\]$/g, '').replace(/\.+$/, '')
+  if (lower === 'localhost' || lower === '0.0.0.0' || lower === '') return true
+  if (lower.endsWith('.localhost') || lower.endsWith('.local') || lower.endsWith('.internal')) return true
+  // IPv4 numeric
+  if (/^(\d{1,3}\.){3}\d{1,3}$/.test(lower)) {
+    const parts = lower.split('.').map(Number)
+    if (parts[0] === 0) return true                                            // 0/8
+    if (parts[0] === 127) return true                                          // 127/8 loopback
+    if (parts[0] === 10) return true                                           // 10/8 private
+    if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true      // 172.16/12 private
+    if (parts[0] === 192 && parts[1] === 168) return true                      // 192.168/16 private
+    if (parts[0] === 169 && parts[1] === 254) return true                      // link-local + cloud metadata
+    return false
+  }
+  // Any IPv6 starting with `::` is unreachable on the public internet: those
+  // are the unspecified/loopback/IPv4-compatible/IPv4-mapped compatibility
+  // forms (::1, ::, ::1.2.3.4, ::ffff:1.2.3.4, parser-normalized variants
+  // like ::7f00:1). Real public IPv6 services live in 2000::/3 — none of
+  // them start with `::`. Block the whole class so we don't have to enumerate
+  // every parser-normalization quirk.
+  if (lower.startsWith('::')) return true
+  // IPv6 unique-local + link-local
+  if (/^fc[0-9a-f]{2}:/i.test(lower) || /^fd[0-9a-f]{2}:/i.test(lower)) return true  // fc00::/7 ULA
+  if (/^fe80:/i.test(lower)) return true                                              // fe80::/10 link-local
+  return false
+}
+
+// Strip content the regex shouldn't peek into: HTML comments, script/style
+// bodies, noscript, and inert text containers (<template>, <textarea>) that
+// hold literal HTML text the browser never instantiates. Without this, an
+// iframe-shaped string inside any of these would match the regex.
+function stripNonRenderedContent(html: string): string {
+  return html
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, '')
+    .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi, '')
+    .replace(/<template\b[^>]*>[\s\S]*?<\/template>/gi, '')
+    .replace(/<textarea\b[^>]*>[\s\S]*?<\/textarea>/gi, '')
+}
+
+export function findMenuIframes(html: string, max = 2): string[] {
+  const out: string[] = []
+  const seen = new Set<string>()
+  const sanitized = stripNonRenderedContent(html)
+  const iframeRegex = /<iframe\b[^>]*\ssrc=["']([^"']+)["'][^>]*>/gi
+  let m
+  while ((m = iframeRegex.exec(sanitized)) !== null) {
+    let src = m[1].trim()
+    if (src.startsWith('//')) src = 'https:' + src
+    if (!/^https?:\/\//i.test(src)) continue
+    if (seen.has(src)) continue
+
+    let parsed: URL
+    try {
+      parsed = new URL(src)
+    } catch {
+      continue
+    }
+    if (isBlockedHostname(parsed.hostname)) continue
+
+    // Reuse the same exact-or-subdomain logic via isKnownMenuIframeHost so
+    // discovery and the Browserless render gate stay in sync.
+    const isKnown = isKnownMenuIframeHost(parsed.hostname)
+    const hasMenuKeyword = /\bmenus?\b/i.test(parsed.pathname)
+    if (!isKnown && !hasMenuKeyword) continue
+
+    seen.add(src)
+    out.push(src)
+    if (out.length >= max) break
+  }
+  return out
+}


### PR DESCRIPTION
## Summary
PR 2 of 3 for v1.3 dish descriptions + dietary tags. Extends the Sonnet extractor + upsert pipeline. Adds force_all backfill mechanism. Bonus: significant scraper hardening (iframe following, SSRF defenses, redirect handling) that came out of debugging State Road specifically — applies broadly across the 177-restaurant backfill.

## What's in this PR

**Phase 2 (core spec):**
- Sonnet prompt rules 10 + 11 (description + dietary_tags), output shape extended
- `sanitizeDescription` + `sanitizeDietaryTags` validators with whitelist + 80-char cap + null coercion
- `upsertDishes` change-detection + insert paths for both new fields
- `force_all=true&limit=N` query handling for eager backfill
- `src/constants/dietaryTags.js` (ALLOWED_DIETARY_TAGS, DIETARY_TAG_LABELS, hardened DIETARY_DISCLAIMER)

**Scraper improvements (bonus):**
- `findMenuIframes()` — discovers menu-service iframes (checkle.menu, popmenu.com, singleplatform.com, toasttab.com, getbento.com, menustar.com)
- `isKnownMenuIframeHost()` — exact-apex/subdomain match (no substring bypass)
- `isBlockedHostname()` — SSRF blocklist (loopback, RFC1918, link-local, cloud metadata, IPv6 :: forms, .local/.internal, trailing dots)
- `fetchRawHtml()` rewritten with manual redirect handling (per-hop hostname/scheme check), tolerates non-2xx HTML when sniffs as HTML + body >=200 chars
- Sub-page/iframe loop unified with strategy-tagged URLs; known-host iframes get Browserless rendering with graceful degradation

## Review trail
- Codex (gpt-5.3-codex / medium) reviewed across multiple rounds — final pass returned no blocking findings
- Codex caught and fixed: redirect SSRF, IPv4-mapped IPv6 bypass, trailing-dot bypass, content-type leniency, superdomain bypass
- Verified end-to-end on Atria production restaurant: 15 of 21 dishes extracted with proper ingredient descriptions

## Deployment status
Edge Function deployed to production. This PR brings main in sync with deployed state.

## Test plan
- [x] 132 menu-refresh unit tests passing (incl. 14 SSRF + 4 superdomain-bypass + 8 smuggling tests)
- [x] 546/547 overall (`nativeAuth.test.js` pre-existing failure unrelated)
- [x] `npm run build` succeeds
- [x] Live verification on Atria — descriptions populated, dietary_tags correctly empty (Atria menu doesn't label)
- [x] Live verification on Alchemy (earlier in session) — descriptions populated
- [ ] Run backfill across 177 restaurants after merge

## Known limitation (filed as follow-up)
checkle.menu returns HTTP 500 with body, which Browserless can't render. Graceful degradation works (clean `no_dishes` outcome), but ~1-3 checkle-hosted restaurants on MV won't extract until Browserless config is tuned. Not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)