### PR TITLE
feat(ui): dish description preview + detail block + Diet filter sheet

### DIFF
--- a/docs/superpowers/plans/2026-05-18-dish-descriptions-dietary-tags-plan.md
+++ b/docs/superpowers/plans/2026-05-18-dish-descriptions-dietary-tags-plan.md
@@ -1,0 +1,1541 @@
+# Dish Descriptions + Dietary Tags Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a terse one-line `description` and a strict-label `dietary_tags[]` array to every dish, extracted by the existing menu-refresh Sonnet pipeline. Render description on the card and detail page; add a multi-select "Diet" bottom sheet filter on the homepage.
+
+**Architecture:** Three load-bearing PRs in order — (1) schema migration + RPC signature updates (must deploy first or RPC calls fail), (2) extractor + upsert + force_all backfill flag, (3) UI (card line + detail block + Diet sheet + URL reactivity fix + client-side search extension). Followed by a manual eager backfill of all 177 production restaurants. Spec is at `docs/superpowers/specs/2026-05-18-dish-descriptions-dietary-tags-design.md` — refer to it for locked decisions; do not re-litigate.
+
+**Tech Stack:** React 19, Vite 7, Supabase Postgres + Edge Functions (Deno), Claude Sonnet 4.6 for menu extraction, Vitest for unit tests, React Router v7.
+
+**Standing rules per Dan:**
+- Every PR through `codex-cli` before commit (per `feedback_run_each_fix_through_codex` memory)
+- UI work routes through the `frontend-design` skill
+- Schema changes follow schema.sql-first-then-SQL-Editor pattern per CLAUDE.md
+- No direct Supabase calls from components — all data access through `src/api/`
+- Logger only (`src/utils/logger.js`), never `console.*` in `src/`
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `supabase/schema.sql` | Modify | Source of truth — add columns to `dishes`, extend RPC signatures + bodies |
+| `supabase/migrations/2026-05-18-dish-descriptions-and-dietary-tags.sql` | Create | Runnable migration — ALTER TABLE + indexes + CREATE OR REPLACE FUNCTION blocks |
+| `src/constants/dietaryTags.js` | Create | `ALLOWED_DIETARY_TAGS`, `DIETARY_TAG_LABELS`, `DIETARY_DISCLAIMER` |
+| `src/constants/dietaryTags.test.js` | Create | Sanity checks on the constants |
+| `supabase/functions/menu-refresh/index.ts` | Modify | Extend `ExtractedDish` interface, prompt rules, `parseExtraction` validator, `upsertDishes` to persist new fields, add `force_all` query handling |
+| `supabase/functions/menu-refresh/cms-detect.test.ts` | Modify | Add tests for output validator (description truncation, tag whitelist, null coercion) |
+| `src/api/dishesApi.js` | Modify | `getRankedDishes` passes `filter_dietary_tags`; `getAllSearchable` selects `description` + `dietary_tags` |
+| `src/api/dishesApi.test.js` | Modify | Tests for new param passing + new fields in result shape |
+| `src/utils/dishSearch.js` | Modify | `searchDishes` matches against `description` in addition to name |
+| `src/utils/dishSearch.test.js` | Modify | Tests for description-based match |
+| `src/utils/dietUrlParams.js` | Create | Sanitization helper for `?diet=...` URL state |
+| `src/utils/dietUrlParams.test.js` | Create | Tests for invalid/duplicate/empty handling |
+| `src/pages/Map.jsx` | Modify | Replace one-shot mount-time URL read with reactive `useSearchParams` for `diet` param |
+| `src/components/DishListItem.jsx` | Modify | Add 1-line description preview under restaurant/distance, null-safe |
+| `src/components/DishListItem.test.jsx` | Create or modify | Test description line renders when present, omits when null |
+| `src/pages/Dish.jsx` | Modify | Add description block + tag pills + disclaimer above vote slider, null-safe |
+| `src/components/DietButton.jsx` | Create | Pill button next to search showing filter state (`Diet · Off` / `Diet · Vegan` / `Diet · 2 selected`) |
+| `src/components/DietSheet.jsx` | Create | Modal overlay with multi-select chips, Reset + Apply buttons, disclaimer copy |
+| `src/components/DietSheet.test.jsx` | Create | Test multi-select state, Reset behavior, Apply emits selection |
+| `scripts/backfill-menu-descriptions.sh` | Create | Bash loop that POSTs to menu-refresh with force_all until processed:0 |
+
+---
+
+## PR 1 — Schema migration + RPC signature updates
+
+### Task 1.1: Branch off main
+
+- [ ] **Step 1:** Verify on main and clean
+
+```bash
+cd /Users/danielwalsh/.local/bin/whats-good-here
+git checkout main
+git pull --ff-only
+git status --short
+```
+
+Expected: no modified files other than known untracked drift (.tmp/, deno.lock, ios swiftpm).
+
+- [ ] **Step 2:** Create the feature branch
+
+```bash
+git checkout -b feat/dish-descriptions-schema
+git branch --show-current
+```
+
+Expected output: `feat/dish-descriptions-schema`
+
+### Task 1.2: Update `supabase/schema.sql` — `dishes` table
+
+**Files:**
+- Modify: `supabase/schema.sql` (around line 51, the `CREATE TABLE dishes` block)
+
+- [ ] **Step 1:** Open the file and find the `dishes` table definition (line 51). Find the `created_at` line (currently the last column).
+
+- [ ] **Step 2:** Insert two new column lines BEFORE `created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()`:
+
+```sql
+  description TEXT,
+  dietary_tags TEXT[] DEFAULT '{}',
+```
+
+The block should now end with:
+```sql
+  ...
+  category_median_price DECIMAL(6, 2),
+  description TEXT,
+  dietary_tags TEXT[] DEFAULT '{}',
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+```
+
+- [ ] **Step 3:** No commit yet — `schema.sql` and the migration are committed together at Task 1.7.
+
+### Task 1.3: Update `supabase/schema.sql` — `get_ranked_dishes` RPC
+
+**Files:**
+- Modify: `supabase/schema.sql` (around line 1067, `CREATE OR REPLACE FUNCTION get_ranked_dishes`)
+
+- [ ] **Step 1:** In the signature, change the last param line from:
+
+```sql
+  filter_town TEXT DEFAULT NULL
+)
+```
+
+To:
+
+```sql
+  filter_town TEXT DEFAULT NULL,
+  filter_dietary_tags TEXT[] DEFAULT NULL
+)
+```
+
+- [ ] **Step 2:** In the `RETURNS TABLE` block (immediately below), append two columns BEFORE the closing `)`:
+
+```sql
+  description TEXT,
+  dietary_tags TEXT[],
+```
+
+The block ends with `order_url TEXT, description TEXT, dietary_tags TEXT[]) AS $$`.
+
+- [ ] **Step 3:** In the `SELECT` statement inside the function body, append `, d.description, d.dietary_tags` to the column list (preserving existing column order). The dish table alias is `d` (or whatever the function uses — confirm by reading the body).
+
+- [ ] **Step 4:** In the `WHERE` clause inside the function body, after the existing `filter_town` clause, add:
+
+```sql
+  AND (
+    filter_dietary_tags IS NULL
+    OR array_length(filter_dietary_tags, 1) IS NULL
+    OR d.dietary_tags @> filter_dietary_tags
+  )
+```
+
+### Task 1.4: Audit + extend other dish-feed RPCs
+
+- [ ] **Step 1:** Find every dish-feed RPC that powers a UI list:
+
+```bash
+grep -n "RETURNS TABLE" supabase/schema.sql
+```
+
+- [ ] **Step 2:** For each RPC consumed by `DishListItem` or the dish detail page, perform the same surgery as Task 1.3 — add `description TEXT, dietary_tags TEXT[]` to `RETURNS TABLE` and `d.description, d.dietary_tags` to the `SELECT`. Known candidates: `get_restaurant_dishes`, `get_dish_variants`.
+
+For `get_dish_variants` and `get_restaurant_dishes`, do NOT add the `filter_dietary_tags` param — only the new return columns. The dietary filter only applies to the main feed.
+
+- [ ] **Step 3:** No commit yet.
+
+### Task 1.5: Create the migration file
+
+**Files:**
+- Create: `supabase/migrations/2026-05-18-dish-descriptions-and-dietary-tags.sql`
+
+- [ ] **Step 1:** Write the migration with the ALTER TABLE + indexes block:
+
+```sql
+-- 2026-05-18: dish descriptions + dietary tags
+-- Spec: docs/superpowers/specs/2026-05-18-dish-descriptions-dietary-tags-design.md
+-- Additive only. No SQL rollback needed.
+
+ALTER TABLE dishes
+  ADD COLUMN IF NOT EXISTS description TEXT,
+  ADD COLUMN IF NOT EXISTS dietary_tags TEXT[] DEFAULT '{}';
+
+CREATE INDEX IF NOT EXISTS dishes_dietary_tags_idx
+  ON dishes USING GIN (dietary_tags);
+
+CREATE INDEX IF NOT EXISTS dishes_description_trgm_idx
+  ON dishes USING GIN (description gin_trgm_ops);
+```
+
+- [ ] **Step 2:** Below the ALTER TABLE block, copy the COMPLETE `CREATE OR REPLACE FUNCTION get_ranked_dishes` body from `supabase/schema.sql` (the one you edited in Task 1.3). Same for `get_restaurant_dishes`, `get_dish_variants`, and any other RPC you edited in Task 1.4.
+
+These blocks must be the full `CREATE OR REPLACE FUNCTION ... AS $$ ... $$ LANGUAGE plpgsql;` form so they can be pasted directly into the SQL Editor.
+
+### Task 1.6: Apply migration to production database
+
+- [ ] **Step 1:** Open Supabase Dashboard for Denis's project (`vpioftosgdkyiwvhxewy`) → SQL Editor.
+
+- [ ] **Step 2:** Paste the contents of `supabase/migrations/2026-05-18-dish-descriptions-and-dietary-tags.sql` into a new SQL Editor query.
+
+- [ ] **Step 3:** Run it. Expected: `Success. No rows returned.` for each block.
+
+- [ ] **Step 4:** Verify columns exist:
+
+```sql
+SELECT column_name, data_type, column_default
+FROM information_schema.columns
+WHERE table_name = 'dishes'
+  AND column_name IN ('description', 'dietary_tags');
+```
+
+Expected: two rows — `description TEXT NULL`, `dietary_tags ARRAY '{}'::text[]`.
+
+- [ ] **Step 5:** Verify indexes:
+
+```sql
+SELECT indexname FROM pg_indexes
+WHERE tablename = 'dishes'
+  AND indexname IN ('dishes_dietary_tags_idx', 'dishes_description_trgm_idx');
+```
+
+Expected: both index names returned.
+
+- [ ] **Step 6:** Spot-call `get_ranked_dishes` with default args + a sample lat/lng:
+
+```sql
+SELECT dish_id, dish_name, description, dietary_tags
+FROM get_ranked_dishes(41.4540, -70.5660, 50)
+LIMIT 3;
+```
+
+Expected: three rows, `description` is `NULL`, `dietary_tags` is `{}`.
+
+### Task 1.7: Codex review + commit + push + PR + admin-merge
+
+- [ ] **Step 1:** Run codex on the schema diff. Pass model gpt-5.3-codex, medium reasoning:
+
+```bash
+git diff main -- supabase/schema.sql supabase/migrations/2026-05-18-dish-descriptions-and-dietary-tags.sql | \
+  head -500 > /tmp/pr1-diff.txt
+
+echo "Review the v1.3 dish descriptions + dietary tags schema migration. Diff at /tmp/pr1-diff.txt. Check for: (1) any RPC body that selects columns by index vs name (positional return mismatch risk), (2) trigger or view dependencies on the dishes table that might break with added columns, (3) WHERE clause logic for filter_dietary_tags handles NULL and empty array correctly, (4) any other dish-feed RPC the migration missed." | \
+  npx @openai/codex exec --skip-git-repo-check -m gpt-5.3-codex --config model_reasoning_effort="medium" --sandbox read-only 2>/dev/null
+```
+
+- [ ] **Step 2:** Apply any real codex findings inline (re-run SQL Editor for any RPC changes).
+
+- [ ] **Step 3:** Stage and commit:
+
+```bash
+git add supabase/schema.sql supabase/migrations/2026-05-18-dish-descriptions-and-dietary-tags.sql
+git diff --cached --stat
+
+git commit -m "$(cat <<'EOF'
+feat(schema): add dish description + dietary_tags columns and RPC signatures
+
+Additive migration for v1.3 dish descriptions + dietary tags feature.
+Schema source of truth + runnable migration with ALTER TABLE, GIN indexes
+for dietary tag filtering and description trigram search, and updated
+RETURNS TABLE on get_ranked_dishes (plus filter_dietary_tags param),
+get_restaurant_dishes, get_dish_variants.
+
+Migration already applied to production via SQL Editor — columns and
+indexes verified present, RPC spot-calls return new columns as expected.
+This PR exists for source-of-truth alignment; main branch must catch up
+to deployed state before PR 2 (extractor) lands.
+
+Per spec docs/superpowers/specs/2026-05-18-dish-descriptions-dietary-tags-design.md.
+
+Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 4:** Push + open PR + admin-merge:
+
+```bash
+git push -u origin feat/dish-descriptions-schema
+
+gh pr create --base main --title "feat(schema): dish description + dietary_tags columns + RPC signatures" --body "$(cat <<'EOF'
+## Summary
+PR 1 of 3 for v1.3 dish descriptions + dietary tags. Schema-only change. Production DB already updated via SQL Editor; this PR catches main up to deployed state so PR 2 (extractor) and PR 3 (UI) can build on it.
+
+## Review trail
+- Codex (gpt-5.3-codex / medium) review on the diff before commit.
+- Additive only: dishes table gains `description TEXT` + `dietary_tags TEXT[]`. RPC signatures extended additively.
+
+## Deployment status
+Already applied to production. Verified: columns exist, indexes exist, RPC spot-call returns new columns as NULL/empty.
+
+## Test plan
+- [ ] After merge, `npm run build` still passes (no client breakage from RPC return shape changes — clients ignore extra columns)
+- [ ] Existing dish lists still render — pizza/burger card on homepage looks identical
+- [ ] `get_ranked_dishes(...)` SQL Editor call returns `description` + `dietary_tags`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+
+# Wait for Vercel preview check to pass, then admin-merge:
+PR_NUM=$(gh pr view --json number -q .number)
+gh pr checks $PR_NUM
+gh pr merge $PR_NUM --admin --squash --delete-branch
+```
+
+- [ ] **Step 5:** Sync local main:
+
+```bash
+git checkout main
+git pull --ff-only
+git log --oneline -1
+```
+
+Expected: top commit is the merged PR.
+
+---
+
+## PR 2 — Extractor + upsert + backfill flag
+
+### Task 2.1: Branch off main
+
+- [ ] **Step 1:**
+
+```bash
+cd /Users/danielwalsh/.local/bin/whats-good-here
+git checkout main
+git pull --ff-only
+git checkout -b feat/dish-descriptions-extractor
+git branch --show-current
+```
+
+Expected: `feat/dish-descriptions-extractor`
+
+### Task 2.2: Create `src/constants/dietaryTags.js` (TDD)
+
+**Files:**
+- Create: `src/constants/dietaryTags.js`
+- Create: `src/constants/dietaryTags.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/constants/dietaryTags.test.js`:
+
+```js
+import { describe, it, expect } from 'vitest'
+import { ALLOWED_DIETARY_TAGS, DIETARY_TAG_LABELS, DIETARY_DISCLAIMER } from './dietaryTags'
+
+describe('dietaryTags constants', () => {
+  it('exports five allowed tags in fixed order', () => {
+    expect(ALLOWED_DIETARY_TAGS).toEqual([
+      'vegan',
+      'vegetarian',
+      'gluten_free',
+      'dairy_free',
+      'nut_free',
+    ])
+  })
+
+  it('has a human label for every allowed tag', () => {
+    for (const tag of ALLOWED_DIETARY_TAGS) {
+      expect(DIETARY_TAG_LABELS[tag]).toBeTruthy()
+      expect(typeof DIETARY_TAG_LABELS[tag]).toBe('string')
+    }
+  })
+
+  it('has no labels for tags outside the allowed list', () => {
+    expect(Object.keys(DIETARY_TAG_LABELS).sort()).toEqual([...ALLOWED_DIETARY_TAGS].sort())
+  })
+
+  it('exports a non-empty disclaimer mentioning allergens', () => {
+    expect(DIETARY_DISCLAIMER).toContain('allergen')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```bash
+npm run test -- --run src/constants/dietaryTags.test.js
+```
+
+Expected: FAIL — `dietaryTags` module not found.
+
+- [ ] **Step 3: Write the constants**
+
+Create `src/constants/dietaryTags.js`:
+
+```js
+export const ALLOWED_DIETARY_TAGS = ['vegan', 'vegetarian', 'gluten_free', 'dairy_free', 'nut_free']
+
+export const DIETARY_TAG_LABELS = {
+  vegan: 'Vegan',
+  vegetarian: 'Vegetarian',
+  gluten_free: 'Gluten-free',
+  dairy_free: 'Dairy-free',
+  nut_free: 'Nut-free',
+}
+
+export const DIETARY_DISCLAIMER = 'Tags reflect menu labels. Always confirm with the restaurant for allergens.'
+```
+
+- [ ] **Step 4: Run test to confirm it passes**
+
+```bash
+npm run test -- --run src/constants/dietaryTags.test.js
+```
+
+Expected: PASS, 4 tests.
+
+### Task 2.3: Update `menu-refresh` interfaces
+
+**Files:**
+- Modify: `supabase/functions/menu-refresh/index.ts` (line 151 — `ExtractedDish` interface)
+
+- [ ] **Step 1:** Find the `ExtractedDish` interface (currently lines 151-156):
+
+```ts
+interface ExtractedDish {
+  name: string
+  category: string
+  menu_section: string
+  price: number | null
+}
+```
+
+Replace with:
+
+```ts
+interface ExtractedDish {
+  name: string
+  category: string
+  menu_section: string
+  price: number | null
+  description: string | null
+  dietary_tags: string[]
+}
+```
+
+- [ ] **Step 2:** No test yet — interface change has no runtime effect alone. Tests follow in Task 2.4.
+
+### Task 2.4: Add output validator + tests
+
+**Files:**
+- Modify: `supabase/functions/menu-refresh/index.ts` (the `parseExtraction` function, around line 740)
+- Modify: `supabase/functions/menu-refresh/cms-detect.test.ts` (add new describe block)
+
+- [ ] **Step 1:** Read the current `parseExtraction` function body (around line 740) and identify the `.map((d: ExtractedDish) => ({ ...d, category: ... }))` step.
+
+- [ ] **Step 2:** Add a constant near the top of `menu-refresh/index.ts` (after `VALID_CATEGORIES`):
+
+```ts
+const ALLOWED_DIETARY_TAGS = ['vegan', 'vegetarian', 'gluten_free', 'dairy_free', 'nut_free'] as const
+type AllowedDietaryTag = typeof ALLOWED_DIETARY_TAGS[number]
+
+function sanitizeDietaryTags(raw: unknown): AllowedDietaryTag[] {
+  if (!Array.isArray(raw)) return []
+  const seen = new Set<AllowedDietaryTag>()
+  for (const t of raw) {
+    if (typeof t === 'string' && (ALLOWED_DIETARY_TAGS as readonly string[]).includes(t)) {
+      seen.add(t as AllowedDietaryTag)
+    }
+  }
+  return Array.from(seen)
+}
+
+function sanitizeDescription(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return null
+  return trimmed.length > 80 ? trimmed.slice(0, 80) : trimmed
+}
+```
+
+- [ ] **Step 3:** In `parseExtraction`, extend the `.map` to apply the new sanitizers:
+
+Find:
+```ts
+.map((d: ExtractedDish) => ({
+  ...d,
+  category: VALID_CATEGORIES.includes(d.category) ? d.category : 'entree',
+}))
+```
+
+Replace with:
+```ts
+.map((d: ExtractedDish) => ({
+  ...d,
+  category: VALID_CATEGORIES.includes(d.category) ? d.category : 'entree',
+  description: sanitizeDescription(d.description),
+  dietary_tags: sanitizeDietaryTags(d.dietary_tags),
+}))
+```
+
+- [ ] **Step 4: Write the failing tests**
+
+Add to `supabase/functions/menu-refresh/cms-detect.test.ts` (or create a sibling test file `extractors.test.ts` if cms-detect doesn't make sense — check existing file structure first). New describe block:
+
+```ts
+import { describe, it, expect } from 'vitest'
+// If the helpers are not exported today, export them from index.ts for testability,
+// or replicate them in a new module like supabase/functions/menu-refresh/extractors.ts
+// and import from there.
+
+describe('sanitizeDescription', () => {
+  it('returns null for non-string input', () => {
+    expect(sanitizeDescription(null)).toBe(null)
+    expect(sanitizeDescription(undefined)).toBe(null)
+    expect(sanitizeDescription(42)).toBe(null)
+  })
+
+  it('returns null for empty/whitespace strings', () => {
+    expect(sanitizeDescription('')).toBe(null)
+    expect(sanitizeDescription('   ')).toBe(null)
+  })
+
+  it('truncates strings over 80 chars', () => {
+    const long = 'x'.repeat(120)
+    expect(sanitizeDescription(long)?.length).toBe(80)
+  })
+
+  it('passes through short trimmed strings', () => {
+    expect(sanitizeDescription('  Hot lobster, drawn butter  ')).toBe('Hot lobster, drawn butter')
+  })
+})
+
+describe('sanitizeDietaryTags', () => {
+  it('returns empty array for non-array input', () => {
+    expect(sanitizeDietaryTags(null)).toEqual([])
+    expect(sanitizeDietaryTags('vegan')).toEqual([])
+  })
+
+  it('drops tags outside the whitelist', () => {
+    expect(sanitizeDietaryTags(['vegan', 'paleo', 'keto', 'gluten_free']))
+      .toEqual(['vegan', 'gluten_free'])
+  })
+
+  it('dedupes duplicates', () => {
+    expect(sanitizeDietaryTags(['vegan', 'vegan', 'vegetarian']))
+      .toEqual(['vegan', 'vegetarian'])
+  })
+
+  it('drops non-string entries', () => {
+    expect(sanitizeDietaryTags(['vegan', 42, null, 'gluten_free']))
+      .toEqual(['vegan', 'gluten_free'])
+  })
+})
+```
+
+- [ ] **Step 5:** If the helpers aren't exported from `index.ts`, export them:
+
+At the bottom of `menu-refresh/index.ts`, add:
+
+```ts
+export { sanitizeDescription, sanitizeDietaryTags, ALLOWED_DIETARY_TAGS }
+```
+
+- [ ] **Step 6: Run tests to confirm they pass**
+
+```bash
+npm run test -- --run supabase/functions/menu-refresh/
+```
+
+Expected: all new tests PASS.
+
+### Task 2.5: Update Sonnet prompt rules
+
+**Files:**
+- Modify: `supabase/functions/menu-refresh/index.ts` (the prompt string, around the rules block ~line 115)
+
+- [ ] **Step 1:** Find rule 9 in the prompt (`9. **One category per dish**`).
+
+- [ ] **Step 2:** Insert new rules 10 and 11 after rule 9:
+
+```text
+10. **Description rule:** Output a terse ingredient/preparation line under 80 chars as `description`. Format: comma-separated nouns. Examples: "Hot lobster meat, drawn butter, split-top bun" / "Pepperoni, mozzarella, San Marzano tomato" / "Wagyu beef, bacon jam, brioche bun". If the menu has only marketing copy ("OUR SIGNATURE HAND-CRAFTED..."), output `null`. Never invent ingredients you don't see in the source.
+
+11. **Dietary tags rule:** Output a `dietary_tags` array. Only emit a tag when the menu explicitly labels it. Allowed tags (and only these): `vegan`, `vegetarian`, `gluten_free`, `dairy_free`, `nut_free`. Triggers: explicit labels like "Vegan", "V", "GF", "Gluten-Free Available", "Dairy-Free", "Nut-Free" on the dish itself. **Inferring from ingredients is NOT allowed** — a tofu stir-fry with no animal products does NOT get `vegan` unless the menu labels it. Empty array `[]` when nothing is labeled. Never invent tags.
+```
+
+- [ ] **Step 3:** Update the example output JSON shape in the prompt (search for the `"dishes":` example near `## Output Format`):
+
+```json
+{
+  "dishes": [
+    {
+      "name": "Dish Name",
+      "category": "category_id",
+      "menu_section": "Section Name",
+      "price": 18.00,
+      "description": "ingredient, ingredient, prep",
+      "dietary_tags": ["vegan"]
+    }
+  ],
+  "menu_section_order": ["Section 1", "Section 2"]
+}
+```
+
+### Task 2.6: Extend `upsertDishes` to persist new fields
+
+**Files:**
+- Modify: `supabase/functions/menu-refresh/index.ts` (around line 758)
+
+- [ ] **Step 1:** Find the existing `SELECT` of existing dishes (around line 766) and extend it:
+
+Change:
+```ts
+.select('id, name, category, menu_section, price, photo_url')
+```
+
+To:
+```ts
+.select('id, name, category, menu_section, price, photo_url, description, dietary_tags')
+```
+
+- [ ] **Step 2:** Find the change-detection block (around line 786):
+
+```ts
+const priceChanged = dish.price !== null && dish.price !== existing.price
+const categoryChanged = dish.category !== existing.category
+const sectionChanged = dish.menu_section !== existing.menu_section
+```
+
+Extend with two new detectors:
+
+```ts
+const descriptionChanged = (dish.description ?? null) !== (existing.description ?? null)
+const tagsChanged = !arraysEqual(dish.dietary_tags || [], existing.dietary_tags || [])
+```
+
+- [ ] **Step 3:** Add the `arraysEqual` helper near the top of the file (after imports):
+
+```ts
+function arraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false
+  const sa = [...a].sort()
+  const sb = [...b].sort()
+  for (let i = 0; i < sa.length; i++) if (sa[i] !== sb[i]) return false
+  return true
+}
+```
+
+- [ ] **Step 4:** Extend the `if (priceChanged || categoryChanged || sectionChanged)` condition + updates object:
+
+Change:
+```ts
+if (priceChanged || categoryChanged || sectionChanged) {
+  const updates: Record<string, unknown> = {}
+  if (categoryChanged) updates.category = dish.category
+  if (sectionChanged) updates.menu_section = dish.menu_section
+  if (priceChanged) updates.price = dish.price
+```
+
+To:
+```ts
+if (priceChanged || categoryChanged || sectionChanged || descriptionChanged || tagsChanged) {
+  const updates: Record<string, unknown> = {}
+  if (categoryChanged) updates.category = dish.category
+  if (sectionChanged) updates.menu_section = dish.menu_section
+  if (priceChanged) updates.price = dish.price
+  if (descriptionChanged) updates.description = dish.description
+  if (tagsChanged) updates.dietary_tags = dish.dietary_tags
+```
+
+- [ ] **Step 5:** Extend the INSERT (around line 808):
+
+Change:
+```ts
+.insert({
+  restaurant_id: restaurantId,
+  name: dish.name,
+  category: dish.category,
+  menu_section: dish.menu_section || null,
+  price: dish.price || null,
+})
+```
+
+To:
+```ts
+.insert({
+  restaurant_id: restaurantId,
+  name: dish.name,
+  category: dish.category,
+  menu_section: dish.menu_section || null,
+  price: dish.price || null,
+  description: dish.description ?? null,
+  dietary_tags: dish.dietary_tags || [],
+})
+```
+
+- [ ] **Step 6:** No new unit test for upsertDishes itself (it's a Supabase-coupled function) — the verification in Task 2.9 (manual test against one restaurant) covers this end-to-end.
+
+### Task 2.7: Add `force_all` + `limit` query handling
+
+**Files:**
+- Modify: `supabase/functions/menu-refresh/index.ts` (the batch fallback section around line 1510)
+
+- [ ] **Step 1:** At the top of the handler (where query params are parsed), add force flag extraction. Find the request URL parsing (look for `new URL(req.url)`); if it doesn't exist, add it after the auth check:
+
+```ts
+const url = new URL(req.url)
+const forceAll = url.searchParams.get('force_all') === 'true'
+const forceLimit = Math.min(50, Math.max(1, parseInt(url.searchParams.get('limit') || '10', 10)))
+```
+
+- [ ] **Step 2:** In the batch fallback block (around line 1513-1524), branch on `forceAll`:
+
+Change:
+```ts
+const staleDate = new Date()
+staleDate.setDate(staleDate.getDate() - STALE_DAYS)
+
+const { data, error } = await supabase
+  .from('restaurants')
+  .select('id, name, menu_url, menu_content_hash')
+  .not('menu_url', 'is', null)
+  .eq('is_open', true)
+  .or(`menu_last_checked.is.null,menu_last_checked.lt.${staleDate.toISOString()}`)
+  .limit(MAX_RESTAURANTS_PER_RUN)
+```
+
+To:
+```ts
+let query = supabase
+  .from('restaurants')
+  .select('id, name, menu_url, menu_content_hash')
+  .not('menu_url', 'is', null)
+  .eq('is_open', true)
+
+if (!forceAll) {
+  const staleDate = new Date()
+  staleDate.setDate(staleDate.getDate() - STALE_DAYS)
+  query = query.or(`menu_last_checked.is.null,menu_last_checked.lt.${staleDate.toISOString()}`)
+}
+
+const { data, error } = await query.limit(forceAll ? forceLimit : MAX_RESTAURANTS_PER_RUN)
+```
+
+- [ ] **Step 3:** Add a log line so backfill operators can see what's happening:
+
+After the query, before the error check:
+```ts
+if (forceAll) {
+  console.log(`menu-refresh: force_all=true, limit=${forceLimit}, found ${data?.length || 0} restaurants`)
+}
+```
+
+### Task 2.8: Deploy Edge Function to production
+
+- [ ] **Step 1:** Open Supabase Dashboard for Denis's project (`vpioftosgdkyiwvhxewy`) → Edge Functions → `menu-refresh` → Edit.
+
+- [ ] **Step 2:** Paste the full updated `supabase/functions/menu-refresh/index.ts` into the editor and Deploy.
+
+- [ ] **Step 3:** Wait for deploy to complete (~30s).
+
+### Task 2.9: Verify on one test restaurant
+
+- [ ] **Step 1:** Pick a known-good restaurant with a scrapable menu. Get its UUID:
+
+```bash
+URL="https://vpioftosgdkyiwvhxewy.supabase.co"
+KEY="<production anon key from .env>"
+curl -s "$URL/rest/v1/restaurants?select=id,name,menu_url&menu_url=not.is.null&limit=1" \
+  -H "apikey: $KEY"
+```
+
+- [ ] **Step 2:** Trigger menu-refresh for that one restaurant (use the existing single-restaurant payload pattern — read `menu-refresh/index.ts` for the exact body shape; pass `{ restaurant_id: "<uuid>" }` typically):
+
+```bash
+CRON_SECRET="<from supabase function secrets>"
+curl -X POST "$URL/functions/v1/menu-refresh" \
+  -H "Authorization: Bearer $CRON_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"restaurant_id": "<uuid>"}'
+```
+
+- [ ] **Step 3:** Query the dishes table for that restaurant and inspect the new fields:
+
+```bash
+curl -s "$URL/rest/v1/dishes?restaurant_id=eq.<uuid>&select=name,description,dietary_tags&limit=5" \
+  -H "apikey: $KEY"
+```
+
+Expected: at least some dishes have a non-null `description` under 80 chars. If the menu had labels like "Vegan" or "GF", those dishes should have populated `dietary_tags`. If no menu items were labeled, `dietary_tags` is `[]` everywhere — that's correct behavior, not a bug.
+
+- [ ] **Step 4:** If description quality is bad (marketing fluff slipping through), tune the prompt and redeploy before continuing.
+
+### Task 2.10: Codex review + commit + push + PR + admin-merge
+
+- [ ] **Step 1:** Codex review on the extractor diff:
+
+```bash
+git diff main -- supabase/functions/menu-refresh/index.ts src/constants/dietaryTags.js | \
+  head -800 > /tmp/pr2-diff.txt
+
+echo "Review the v1.3 menu-refresh extractor changes. Diff at /tmp/pr2-diff.txt. Check for: (1) upsertDishes change-detection covers all six fields correctly including null/undefined edge cases, (2) force_all + limit handling has no auth bypass (CRON_SECRET still required), (3) prompt rule changes are unambiguous to Sonnet, (4) output validator correctly handles malformed Sonnet output (string instead of array, etc), (5) any regression to the existing single-restaurant POST path." | \
+  npx @openai/codex exec --skip-git-repo-check -m gpt-5.3-codex --config model_reasoning_effort="medium" --sandbox read-only 2>/dev/null
+```
+
+- [ ] **Step 2:** Apply real codex findings inline. Re-deploy Edge Function if any file changes.
+
+- [ ] **Step 3:** Run all tests:
+
+```bash
+npm run test -- --run
+```
+
+Expected: all pass (pre-existing nativeAuth.test.js may fail — that's unrelated, ignore).
+
+- [ ] **Step 4:** Stage, commit, push, PR:
+
+```bash
+git add supabase/functions/menu-refresh/index.ts \
+        supabase/functions/menu-refresh/cms-detect.test.ts \
+        src/constants/dietaryTags.js \
+        src/constants/dietaryTags.test.js
+
+git commit -m "$(cat <<'EOF'
+feat(menu-refresh): extract description + dietary_tags, add force_all backfill flag
+
+PR 2 of 3 for v1.3 dish descriptions + dietary tags. Sonnet prompt now
+asks for a terse <80 char description and a strict-label dietary_tags
+array (vegan, vegetarian, gluten_free, dairy_free, nut_free). Output
+validator drops out-of-whitelist tags, truncates oversize descriptions,
+coerces empty strings to null. upsertDishes extended to persist both
+new fields with change-detection (idempotent on no-op refreshes).
+
+Added force_all=true&limit=N query handling to bypass STALE_DAYS for
+the eager backfill of all 177 production restaurants. CRON_SECRET still
+required.
+
+Edge Function already deployed to production. Verified on one test
+restaurant: description quality good, tags only present where menu
+explicitly labels.
+
+Per spec docs/superpowers/specs/2026-05-18-dish-descriptions-dietary-tags-design.md.
+
+Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+
+git push -u origin feat/dish-descriptions-extractor
+
+gh pr create --base main --title "feat(menu-refresh): description + dietary_tags extraction + force_all flag" --body "$(cat <<'EOF'
+## Summary
+PR 2 of 3 for v1.3 dish descriptions + dietary tags. Extends the Sonnet extractor and upsert pipeline; adds force_all backfill mechanism for the eager 177-restaurant refresh.
+
+## Review trail
+- Codex (gpt-5.3-codex / medium) review on the diff before commit.
+- Verified end-to-end on one production restaurant.
+
+## Deployment status
+Edge Function already deployed via Supabase Dashboard. The 14-day cron now naturally populates new fields. Backfill (separate from this PR) runs after merge.
+
+## Test plan
+- [ ] Trigger menu-refresh on a known-labeled menu (one with "Vegan"/"GF" markers) — verify both fields populate correctly
+- [ ] Trigger menu-refresh on a menu with marketing fluff only — verify description is null, no tags
+- [ ] Confirm force_all=true bypasses STALE_DAYS but still requires CRON_SECRET
+- [ ] Existing 14-day cron continues to work unchanged
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+
+PR_NUM=$(gh pr view --json number -q .number)
+gh pr merge $PR_NUM --admin --squash --delete-branch
+git checkout main && git pull --ff-only
+```
+
+---
+
+## PR 3 — UI: card preview, detail block, Diet sheet, URL state, search
+
+### Task 3.1: Branch off main
+
+- [ ] **Step 1:**
+
+```bash
+cd /Users/danielwalsh/.local/bin/whats-good-here
+git checkout main
+git pull --ff-only
+git checkout -b feat/dish-descriptions-ui
+git branch --show-current
+```
+
+Expected: `feat/dish-descriptions-ui`
+
+### Task 3.2: Extend `dishesApi.getRankedDishes` (TDD)
+
+**Files:**
+- Modify: `src/api/dishesApi.js` (line 24, `getRankedDishes` signature + RPC call)
+- Modify: `src/api/dishesApi.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/api/dishesApi.test.js`, add to the `describe('getRankedDishes', ...)` block:
+
+```js
+it('passes filter_dietary_tags to the RPC when provided', async () => {
+  const mockRpc = vi.fn().mockResolvedValue({ data: [], error: null })
+  supabase.rpc = mockRpc
+
+  await dishesApi.getRankedDishes({
+    lat: 41.45,
+    lng: -70.56,
+    radiusMiles: 25,
+    dietaryTags: ['vegan', 'gluten_free'],
+  })
+
+  expect(mockRpc).toHaveBeenCalledWith('get_ranked_dishes', expect.objectContaining({
+    filter_dietary_tags: ['vegan', 'gluten_free'],
+  }))
+})
+
+it('omits filter_dietary_tags when dietaryTags is empty or undefined', async () => {
+  const mockRpc = vi.fn().mockResolvedValue({ data: [], error: null })
+  supabase.rpc = mockRpc
+
+  await dishesApi.getRankedDishes({ lat: 41.45, lng: -70.56, radiusMiles: 25 })
+
+  const callArg = mockRpc.mock.calls[0][1]
+  expect(callArg.filter_dietary_tags ?? null).toBe(null)
+})
+```
+
+(Verify the mock pattern matches existing tests in the file — adjust if `supabase` is imported differently.)
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```bash
+npm run test -- --run src/api/dishesApi.test.js
+```
+
+Expected: FAIL — RPC isn't passing `filter_dietary_tags`.
+
+- [ ] **Step 3: Implement**
+
+In `src/api/dishesApi.js` around line 24, change:
+
+```js
+async getRankedDishes({ lat, lng, radiusMiles, category = null }) {
+```
+
+To:
+
+```js
+async getRankedDishes({ lat, lng, radiusMiles, category = null, dietaryTags = null }) {
+```
+
+In the `.rpc('get_ranked_dishes', { ... })` call inside the function body, add to the args object:
+
+```js
+filter_dietary_tags: (dietaryTags && dietaryTags.length > 0) ? dietaryTags : null,
+```
+
+- [ ] **Step 4: Run test to confirm it passes**
+
+```bash
+npm run test -- --run src/api/dishesApi.test.js
+```
+
+Expected: PASS.
+
+### Task 3.3: Extend `dishesApi.getAllSearchable` (TDD)
+
+**Files:**
+- Modify: `src/api/dishesApi.js` (around line 276 — `getAllSearchable`)
+- Modify: `src/api/dishesApi.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/api/dishesApi.test.js`:
+
+```js
+describe('getAllSearchable', () => {
+  it('includes description and dietary_tags in selectFields', async () => {
+    const mockFrom = vi.fn().mockReturnThis()
+    const mockSelect = vi.fn().mockReturnThis()
+    const mockNot = vi.fn().mockResolvedValue({ data: [], error: null })
+
+    supabase.from = mockFrom
+    mockFrom.mockReturnValue({ select: mockSelect })
+    mockSelect.mockReturnValue({ not: mockNot })
+
+    await dishesApi.getAllSearchable()
+
+    const selectArg = mockSelect.mock.calls[0][0]
+    expect(selectArg).toContain('description')
+    expect(selectArg).toContain('dietary_tags')
+  })
+})
+```
+
+- [ ] **Step 2: Run test, confirm fail**
+
+```bash
+npm run test -- --run src/api/dishesApi.test.js
+```
+
+- [ ] **Step 3:** In `dishesApi.js` line ~280, find the `selectFields` template literal in `getAllSearchable` and add `description` and `dietary_tags` to it. Also include them in the `.map()` transform that produces the output row shape.
+
+- [ ] **Step 4: Run test, confirm pass**
+
+### Task 3.4: Extend client-side search to match description (TDD)
+
+**Files:**
+- Modify: `src/utils/dishSearch.js`
+- Modify: `src/utils/dishSearch.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/utils/dishSearch.test.js`, add:
+
+```js
+describe('searchDishes — description matching', () => {
+  it('matches dishes by description ingredient', () => {
+    const dishes = [
+      { id: '1', name: 'Pad Thai', description: 'rice noodle, peanut, lime, tamarind', avg_rating: 8 },
+      { id: '2', name: 'Spaghetti', description: 'tomato, basil', avg_rating: 7 },
+    ]
+    const results = searchDishes(dishes, 'peanut', { limit: 5 })
+    expect(results.map(r => r.id)).toEqual(['1'])
+  })
+
+  it('returns no match when description is null', () => {
+    const dishes = [{ id: '1', name: 'Mystery Dish', description: null, avg_rating: 8 }]
+    const results = searchDishes(dishes, 'peanut', { limit: 5 })
+    expect(results).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: Run test, confirm fail**
+
+- [ ] **Step 3:** In `dishSearch.js`, find `scoreDish` (read the existing implementation first to match style). Add a description-match path: when description is non-null, tokenize it and score matches at a weight below the name match weight (so name matches still win). Suggested weight: half the weight of a restaurant_name match.
+
+- [ ] **Step 4: Run test, confirm pass + ensure existing tests still pass**
+
+```bash
+npm run test -- --run src/utils/dishSearch.test.js
+```
+
+### Task 3.5: Create URL param helper (TDD)
+
+**Files:**
+- Create: `src/utils/dietUrlParams.js`
+- Create: `src/utils/dietUrlParams.test.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+```js
+import { describe, it, expect } from 'vitest'
+import { parseDietParam, serializeDietParam } from './dietUrlParams'
+
+describe('parseDietParam', () => {
+  it('returns empty array for null/undefined/empty', () => {
+    expect(parseDietParam(null)).toEqual([])
+    expect(parseDietParam(undefined)).toEqual([])
+    expect(parseDietParam('')).toEqual([])
+    expect(parseDietParam(',,,')).toEqual([])
+  })
+
+  it('parses a single valid tag', () => {
+    expect(parseDietParam('vegan')).toEqual(['vegan'])
+  })
+
+  it('parses multiple comma-separated valid tags', () => {
+    expect(parseDietParam('vegan,gluten_free')).toEqual(['vegan', 'gluten_free'])
+  })
+
+  it('drops invalid tag values', () => {
+    expect(parseDietParam('vegan,paleo,gluten_free')).toEqual(['vegan', 'gluten_free'])
+  })
+
+  it('dedupes repeats', () => {
+    expect(parseDietParam('vegan,vegan,gluten_free')).toEqual(['vegan', 'gluten_free'])
+  })
+
+  it('trims whitespace', () => {
+    expect(parseDietParam('vegan , gluten_free')).toEqual(['vegan', 'gluten_free'])
+  })
+})
+
+describe('serializeDietParam', () => {
+  it('returns empty string for empty array', () => {
+    expect(serializeDietParam([])).toBe('')
+  })
+
+  it('joins with commas', () => {
+    expect(serializeDietParam(['vegan', 'gluten_free'])).toBe('vegan,gluten_free')
+  })
+})
+```
+
+- [ ] **Step 2: Run, fail.**
+
+- [ ] **Step 3:** Implement:
+
+```js
+import { ALLOWED_DIETARY_TAGS } from '../constants/dietaryTags'
+
+export function parseDietParam(raw) {
+  if (typeof raw !== 'string' || raw.length === 0) return []
+  const seen = new Set()
+  for (const part of raw.split(',')) {
+    const trimmed = part.trim()
+    if (ALLOWED_DIETARY_TAGS.includes(trimmed)) {
+      seen.add(trimmed)
+    }
+  }
+  return Array.from(seen)
+}
+
+export function serializeDietParam(tags) {
+  if (!Array.isArray(tags) || tags.length === 0) return ''
+  return tags.filter(t => ALLOWED_DIETARY_TAGS.includes(t)).join(',')
+}
+```
+
+- [ ] **Step 4: Run, pass.**
+
+### Task 3.6: Fix `Map.jsx` URL reactivity for `diet` param
+
+**Files:**
+- Modify: `src/pages/Map.jsx`
+
+- [ ] **Step 1:** Read `Map.jsx` lines 27-50 to understand the current pattern. The file uses `useSearchParams` to seed `initialCategory` and `initialQuery` once at mount.
+
+- [ ] **Step 2:** Add a new piece of state for dietary filter:
+
+```js
+import { parseDietParam, serializeDietParam } from '../utils/dietUrlParams'
+// ...
+var initialDiet = parseDietParam(searchParams.get('diet'))
+var [dietaryTags, setDietaryTags] = useState(initialDiet)
+```
+
+- [ ] **Step 3:** Critical fix: add a `useEffect` that syncs state when URL changes:
+
+```js
+useEffect(() => {
+  const fromUrl = parseDietParam(searchParams.get('diet'))
+  // shallow array equality
+  if (fromUrl.length !== dietaryTags.length ||
+      fromUrl.some((t, i) => t !== dietaryTags[i])) {
+    setDietaryTags(fromUrl)
+  }
+}, [searchParams])
+```
+
+This is the fix for the codex-flagged bug: navigation to `/?diet=vegan` from the detail page now re-applies the filter on return.
+
+- [ ] **Step 4:** Wire `dietaryTags` into the dish-fetching hook (likely `useDishes` or wherever `getRankedDishes` is consumed):
+
+```js
+// example shape — match the actual hook signature in Map.jsx
+const { dishes } = useDishes({ lat, lng, radiusMiles: radius, dietaryTags })
+```
+
+- [ ] **Step 5:** When the user updates filter via Diet sheet (built in Task 3.7), update the URL via `setSearchParams`, NOT just local state. The `useEffect` above will sync state back.
+
+- [ ] **Step 6:** Run dev server, manually verify navigating to `/?diet=vegan` from address bar applies the filter to the list.
+
+```bash
+npm run dev
+# Visit http://localhost:5173/?diet=vegan in browser
+```
+
+### Task 3.7: Build DietButton + DietSheet (frontend-design skill)
+
+**Files:**
+- Create: `src/components/DietButton.jsx`
+- Create: `src/components/DietSheet.jsx`
+- Create: `src/components/DietSheet.test.jsx`
+
+- [ ] **Step 1:** Invoke the `frontend-design` skill to design and implement the DietButton + DietSheet components. Pass these requirements:
+
+> Build two React components for the v1.3 dietary filter:
+>
+> 1. **DietButton** — Small pill button placed next to the homepage search bar. Shows current filter state: "Diet · Off" / "Diet · Vegan" / "Diet · 2 selected". Tap opens DietSheet. Visual language must match existing buttons (search bar, ModeFAB) — Outfit font, warm color palette, var(--color-*) tokens.
+>
+> 2. **DietSheet** — Modal overlay (or fullscreen bottom sheet) with:
+>    - Header "Dietary preferences" in Amatic SC display font
+>    - Multi-select chip row: Vegan, Vegetarian, Gluten-free, Dairy-free, Nut-free (use `DIETARY_TAG_LABELS` from `src/constants/dietaryTags.js`)
+>    - Disclaimer line at bottom (use `DIETARY_DISCLAIMER` constant) with info icon prefix, in `var(--color-text-tertiary)` small text
+>    - Helper copy under the chips: "All selected restrictions must apply"
+>    - Reset button (clears selection) + Apply button (closes sheet, emits selection)
+>    - Native keyboard + escape-key dismissal
+>
+> Wire DietButton onClick to open DietSheet. DietSheet's Apply callback receives the selected tag array. Parent component (Map.jsx) handles URL update via setSearchParams.
+>
+> Constraints: light theme only, no Tailwind color classes, brand colors via var(--color-*), Outfit body + Amatic SC display, no console.* (use logger if needed).
+
+- [ ] **Step 2:** Review the frontend-design output for taste + match to existing components (DishListItem, CategoryIcons). Iterate if needed.
+
+- [ ] **Step 3:** Add unit tests for DietSheet state in `DietSheet.test.jsx`:
+
+```jsx
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DietSheet } from './DietSheet'
+
+describe('DietSheet', () => {
+  it('starts with provided initial selection', () => {
+    render(<DietSheet open initial={['vegan']} onApply={() => {}} onClose={() => {}} />)
+    expect(screen.getByRole('checkbox', { name: /vegan/i })).toBeChecked()
+  })
+
+  it('Reset clears all selections', () => {
+    render(<DietSheet open initial={['vegan', 'gluten_free']} onApply={() => {}} onClose={() => {}} />)
+    fireEvent.click(screen.getByRole('button', { name: /reset/i }))
+    expect(screen.getByRole('checkbox', { name: /vegan/i })).not.toBeChecked()
+  })
+
+  it('Apply emits the current selection and closes', () => {
+    const onApply = vi.fn()
+    const onClose = vi.fn()
+    render(<DietSheet open initial={[]} onApply={onApply} onClose={onClose} />)
+    fireEvent.click(screen.getByRole('checkbox', { name: /vegan/i }))
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }))
+    expect(onApply).toHaveBeenCalledWith(['vegan'])
+    expect(onClose).toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 4:** Mount DietButton in `Map.jsx` near the search bar. Wire the Apply callback to update `setSearchParams({ diet: serializeDietParam(tags) })` (or remove the param when array is empty).
+
+### Task 3.8: Card preview line in `DishListItem.jsx` (TDD)
+
+**Files:**
+- Modify: `src/components/DishListItem.jsx`
+- Create: `src/components/DishListItem.test.jsx` (if it doesn't exist; if it does, extend it)
+
+- [ ] **Step 1: Write the failing test**
+
+```jsx
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import { DishListItem } from './DishListItem'
+
+const renderWithRouter = (ui) => render(<BrowserRouter>{ui}</BrowserRouter>)
+
+describe('DishListItem description preview', () => {
+  it('renders description line when description is non-null', () => {
+    renderWithRouter(
+      <DishListItem dish={{
+        dish_id: '1',
+        dish_name: 'Lobster Roll',
+        restaurant_name: 'Coast Cafe',
+        category: 'lobster roll',
+        description: 'Hot lobster meat, drawn butter, split-top bun',
+        avg_rating: 8.4,
+      }} />
+    )
+    expect(screen.getByText(/hot lobster meat, drawn butter/i)).toBeInTheDocument()
+  })
+
+  it('omits description line when description is null', () => {
+    renderWithRouter(
+      <DishListItem dish={{
+        dish_id: '1',
+        dish_name: 'Lobster Roll',
+        restaurant_name: 'Coast Cafe',
+        category: 'lobster roll',
+        description: null,
+        avg_rating: 8.4,
+      }} />
+    )
+    // No element should match a description selector — assert via test id or class
+    expect(screen.queryByTestId('dish-description-preview')).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run, fail.**
+
+- [ ] **Step 3:** In `DishListItem.jsx`, find the "Name + restaurant + distance" block (around line 158). Below the restaurant/distance line, add (rendered conditionally):
+
+```jsx
+{dish.description ? (
+  <div
+    data-testid="dish-description-preview"
+    style={{
+      fontFamily: 'Outfit, sans-serif',
+      fontSize: '13px',
+      color: 'var(--color-text-tertiary)',
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      marginTop: '2px',
+    }}
+  >
+    {dish.description}
+  </div>
+) : null}
+```
+
+- [ ] **Step 4: Run, pass + verify all other card tests still pass.**
+
+### Task 3.9: Detail page description block + tag pills + disclaimer (frontend-design skill)
+
+**Files:**
+- Modify: `src/pages/Dish.jsx`
+
+- [ ] **Step 1:** Invoke `frontend-design` with:
+
+> Add a description block to `src/pages/Dish.jsx` between the restaurant header and the vote slider. Layout:
+>
+> ```
+> [restaurant header / hero]
+>
+> <description text>            ← Outfit body, var(--color-text-primary)
+>
+> ○ Vegan  ○ Vegetarian  ○ GF   ← tag pills (rounded chips, secondary surface)
+> ℹ️ Tags reflect menu labels.   ← disclaimer (small, tertiary text)
+>    Confirm with restaurant
+>    for allergens.
+>
+> [vote slider]
+> ```
+>
+> Conditional rendering:
+> - Description block hidden when `dish.description` is null
+> - Tag pill row + disclaimer hidden when `dish.dietary_tags` is empty
+> - Use `DIETARY_TAG_LABELS` and `DIETARY_DISCLAIMER` from `src/constants/dietaryTags.js`
+>
+> Tag pills are clickable — clicking a pill navigates to `/?diet=<tag>` (use `useNavigate`).
+>
+> Constraints: brand colors via var(--color-*), no Tailwind color classes, no console.*.
+
+- [ ] **Step 2:** Review output and iterate.
+
+### Task 3.10: Manual smoke test end-to-end
+
+- [ ] **Step 1:** Run dev server, sign in, verify:
+
+```bash
+npm run dev
+```
+
+- [ ] **Step 2:** Test each surface:
+  - [ ] Homepage list shows description lines on cards that have descriptions (after PR 2 backfill or for newly-refreshed restaurants)
+  - [ ] Homepage list cards WITHOUT a description render identically to today (no extra space, no placeholder)
+  - [ ] Search "anchovy" or another ingredient returns dishes with that ingredient in description
+  - [ ] Tap dish card → detail page renders description + tag pills + disclaimer correctly
+  - [ ] Tap a tag pill → returns to homepage with that filter applied (URL shows `?diet=<tag>`)
+  - [ ] Diet button shows current state, opens sheet
+  - [ ] Sheet multi-select + Apply updates URL and filters list (AND semantics: vegan + gluten_free = both)
+  - [ ] Reset clears selection
+  - [ ] Back button restores prior filter state
+
+### Task 3.11: Codex review + commit + push + PR + admin-merge
+
+- [ ] **Step 1:** Codex review:
+
+```bash
+git diff main -- src/ > /tmp/pr3-diff.txt
+
+echo "Review the v1.3 dish descriptions UI PR. Diff at /tmp/pr3-diff.txt. Check for: (1) Map.jsx URL reactivity actually works for late navigations (not just initial mount), (2) DishListItem description rendering is null-safe and doesn't break existing card layouts, (3) URL sanitization handles tampered ?diet= values safely, (4) tag pill tap navigation preserves other URL state (category, query) instead of clobbering it, (5) test coverage gaps for edge cases, (6) any direct console.* usage that should be logger." | \
+  npx @openai/codex exec --skip-git-repo-check -m gpt-5.3-codex --config model_reasoning_effort="medium" --sandbox read-only 2>/dev/null
+```
+
+- [ ] **Step 2:** Apply codex findings inline.
+
+- [ ] **Step 3:** Run lint + tests + build in parallel:
+
+```bash
+npm run lint &
+npm run test -- --run &
+npm run build &
+wait
+```
+
+Expected: all green (pre-existing `nativeAuth.test.js` may fail — ignore).
+
+- [ ] **Step 4:** Stage, commit, push, PR, merge:
+
+```bash
+git add src/
+git diff --cached --stat
+
+git commit -m "$(cat <<'EOF'
+feat(ui): dish description preview, detail block, Diet filter sheet
+
+PR 3 of 3 for v1.3 dish descriptions + dietary tags. UI surfaces:
+
+- Card preview: 1-line description under restaurant/distance, null-safe
+- Dish detail page: full description + tag pills + allergen disclaimer
+- Tag pill tap → /?diet=<tag> applies homepage filter
+- Diet button + multi-select bottom sheet (built via frontend-design skill)
+- Map.jsx URL reactivity fix — late navigations to /?diet=... now apply
+- Client-side search indexes description (search "anchovy" finds it)
+- dishesApi.getRankedDishes passes filter_dietary_tags to the RPC
+
+Renders nothing when fields are null/empty — safe to ship before backfill.
+
+Per spec docs/superpowers/specs/2026-05-18-dish-descriptions-dietary-tags-design.md.
+
+Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+
+git push -u origin feat/dish-descriptions-ui
+
+gh pr create --base main --title "feat(ui): dish description preview + detail block + Diet filter sheet" --body "$(cat <<'EOF'
+## Summary
+PR 3 of 3 for v1.3 dish descriptions + dietary tags. All UI surfaces — card preview, detail page block + pills + disclaimer, Diet button + multi-select sheet, URL state with Map.jsx reactivity fix, client-side description search, RPC param passthrough.
+
+## Review trail
+- Codex (gpt-5.3-codex / medium) review on the diff before commit.
+- UI components built via frontend-design skill.
+- Manual smoke test of all surfaces.
+
+## Test plan
+- [ ] Homepage cards show description line when populated, omit cleanly when null
+- [ ] Search "anchovy" / "truffle" / "maple" surfaces dishes with those ingredients
+- [ ] Detail page description block + tag pills + disclaimer render correctly
+- [ ] Tag pill tap navigates to homepage with filter applied
+- [ ] Diet button → sheet → multi-select → Apply updates list and URL
+- [ ] Browser back/forward preserves filter state
+- [ ] AND semantics: vegan + gluten-free returns only dishes with BOTH tags
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+
+PR_NUM=$(gh pr view --json number -q .number)
+gh pr merge $PR_NUM --admin --squash --delete-branch
+git checkout main && git pull --ff-only
+```
+
+---
+
+## Backfill
+
+### Task B.1: Create backfill script
+
+**Files:**
+- Create: `scripts/backfill-menu-descriptions.sh`
+
+- [ ] **Step 1:** Create the script:
+
+```bash
+#!/usr/bin/env bash
+# scripts/backfill-menu-descriptions.sh
+# Eager backfill for v1.3 dish descriptions + dietary tags.
+# Requires: SUPABASE_URL, CRON_SECRET env vars.
+set -euo pipefail
+
+: "${SUPABASE_URL:?must set SUPABASE_URL}"
+: "${CRON_SECRET:?must set CRON_SECRET}"
+
+ENDPOINT="$SUPABASE_URL/functions/v1/menu-refresh?force_all=true&limit=50"
+TOTAL=0
+
+while true; do
+  echo "→ POST $ENDPOINT"
+  RESPONSE=$(curl -s -X POST "$ENDPOINT" \
+    -H "Authorization: Bearer $CRON_SECRET" \
+    -H "Content-Type: application/json")
+  echo "  response: $RESPONSE"
+
+  PROCESSED=$(echo "$RESPONSE" | grep -oE '"processed":[0-9]+' | grep -oE '[0-9]+' || echo "0")
+  TOTAL=$((TOTAL + PROCESSED))
+  echo "  processed: $PROCESSED (running total: $TOTAL)"
+
+  if [ "$PROCESSED" -eq 0 ]; then
+    echo "✓ Done. Total restaurants backfilled: $TOTAL"
+    break
+  fi
+
+  sleep 5
+done
+```
+
+- [ ] **Step 2:** Make executable:
+
+```bash
+chmod +x scripts/backfill-menu-descriptions.sh
+```
+
+### Task B.2: Run backfill
+
+- [ ] **Step 1:** Source env vars (production):
+
+```bash
+export SUPABASE_URL="https://vpioftosgdkyiwvhxewy.supabase.co"
+export CRON_SECRET="<from Supabase function secrets dashboard>"
+```
+
+- [ ] **Step 2:** Run:
+
+```bash
+./scripts/backfill-menu-descriptions.sh
+```
+
+Expected: 4 invocations (~50 restaurants each), final "Total restaurants backfilled: 177" (or close to it; some may be skipped if `menu_url` is null or `is_open=false`).
+
+Total elapsed: ~30-60 min.
+
+### Task B.3: Validation pass
+
+- [ ] **Step 1:** Spot-check 10 random restaurants via Supabase Dashboard SQL Editor:
+
+```sql
+SELECT
+  r.name AS restaurant,
+  d.name AS dish,
+  d.description,
+  d.dietary_tags
+FROM dishes d
+JOIN restaurants r ON r.id = d.restaurant_id
+ORDER BY random()
+LIMIT 30;
+```
+
+- [ ] **Step 2:** Check:
+  - Are descriptions terse and ingredient-focused (not marketing fluff)?
+  - Are they under 80 chars?
+  - Are dietary tags only present when menus literally label?
+  - Any tag values outside `vegan, vegetarian, gluten_free, dairy_free, nut_free`? (Should be impossible — validator drops these.)
+
+- [ ] **Step 3:** If description quality is poor, tune the prompt in `menu-refresh/index.ts`, redeploy via Dashboard, and re-run the backfill script. Cost per iteration: ~$5.
+
+- [ ] **Step 4:** Commit the backfill script (no new PR needed if already on main):
+
+```bash
+git checkout main
+git pull --ff-only
+git checkout -b chore/backfill-script
+git add scripts/backfill-menu-descriptions.sh
+git commit -m "chore(scripts): add backfill-menu-descriptions for v1.3
+
+One-time eager backfill helper for the dish descriptions + dietary tags
+feature. Loops POSTs to menu-refresh with force_all=true until processed:0.
+
+Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push -u origin chore/backfill-script
+gh pr create --base main --title "chore(scripts): add menu description backfill script" --body "Helper script used for the one-time eager backfill during v1.3 launch. Lives in scripts/ for future use if we need to re-run extraction."
+PR_NUM=$(gh pr view --json number -q .number)
+gh pr merge $PR_NUM --admin --squash --delete-branch
+```
+
+---
+
+## Done check
+
+After all PRs merged + backfill complete, verify the user-visible feature:
+
+- [ ] Homepage: descriptions render on cards that have them
+- [ ] Search "anchovy" or another ingredient: results appear
+- [ ] Dish detail page: description + tag pills + disclaimer render
+- [ ] Diet button: opens sheet, multi-select works, Apply filters list
+- [ ] URL state survives: refresh `/?diet=vegan,gluten_free` preserves filter
+- [ ] Browser back/forward: filter state restored correctly
+- [ ] No regressions: existing card layout, vote slider, photos all still work

--- a/docs/superpowers/specs/2026-05-18-dish-descriptions-dietary-tags-design.md
+++ b/docs/superpowers/specs/2026-05-18-dish-descriptions-dietary-tags-design.md
@@ -1,0 +1,339 @@
+# Dish Descriptions + Dietary Tags — v1.3 Design Spec
+
+**Date:** 2026-05-18
+**Target release:** v1.3
+**Status:** Approved by Dan; pending implementation plan
+
+---
+
+## Summary
+
+Add two new fields to every dish: a terse one-line **description** and an array of **dietary tags**. Both are extracted by the existing `menu-refresh` Sonnet pipeline from the source content it already reads. Card preview gets a one-line description under the restaurant name (clean, no chips). Dish detail page gets the full description plus dietary tag pills and a disclaimer. Homepage gains a "Diet" button next to search that opens a multi-select bottom sheet for filtering.
+
+**Goal:** Answer the "what's in it?" question every user has, and let dietary-restricted users filter the discovery feed without paging through every detail page.
+
+---
+
+## Locked decisions (from brainstorm 2026-05-18)
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | **Placement:** 1-line preview on card + full block on detail page | Card stays readable, detail page becomes the information hub |
+| 2 | **Description style:** terse ingredient list, <80 chars, null on marketing fluff | Signal density. Fits one card line. Never invent. |
+| 3 | **Backfill:** eager one-time mass refresh of all 177 restaurants on release | Launch feels complete; ~$5-6 one-time cost |
+| 4 | **Search:** index descriptions alongside dish name | "Anchovy", "maple", "truffle" surface dishes that contain them |
+| 5 | **Dietary tags:** ship in v1.3 alongside descriptions | Same model call, marginal cost, unlocks vegan/veg/GF/DF/NF filtering |
+| 6 | **Safety:** strict — only emit tag when menu explicitly labels it | Allergen liability. Never infer from ingredients. |
+| 7 | **Tag set:** `vegan`, `vegetarian`, `gluten_free`, `dairy_free`, `nut_free` | The five most-labeled tags. Skip halal/kosher (certification territory). |
+| 8 | **Card UI:** no dietary chips on card. Tags on detail page only. | Card clutter rejected by Dan; filter row already shows dietary state at list level |
+| 9 | **Homepage filter:** "Diet" button → multi-select bottom sheet | Saves vertical space vs always-visible chip row |
+| 10 | **Null handling:** card renders normally when description is null (no placeholder) | Never force empty UI |
+
+---
+
+## Section 1 — Data layer
+
+### Schema migration
+
+One additive migration. New file: `supabase/migrations/2026-05-18-dish-descriptions-and-dietary-tags.sql` (matches the date-prefixed naming pattern used by all migrations since April 2026).
+
+```sql
+ALTER TABLE dishes
+  ADD COLUMN IF NOT EXISTS description TEXT,
+  ADD COLUMN IF NOT EXISTS dietary_tags TEXT[] DEFAULT '{}';
+
+-- GIN index for fast tag filtering ("show me vegan dishes")
+CREATE INDEX IF NOT EXISTS dishes_dietary_tags_idx
+  ON dishes USING GIN (dietary_tags);
+
+-- Trigram index for description search (matches the pattern from PR #213)
+CREATE INDEX IF NOT EXISTS dishes_description_trgm_idx
+  ON dishes USING GIN (description gin_trgm_ops);
+
+-- No SQL rollback needed (pure additive change).
+```
+
+`schema.sql` must be updated first per CLAUDE.md ("source of truth"), then the migration runs in the Supabase SQL Editor.
+
+### Allowed dietary tag values
+
+Constrained at the application layer (no DB CHECK constraint — keeps flexibility to add future tags without a migration):
+
+```ts
+const ALLOWED_DIETARY_TAGS = [
+  'vegan',
+  'vegetarian',
+  'gluten_free',
+  'dairy_free',
+  'nut_free',
+] as const
+```
+
+Lives in `src/constants/dietaryTags.js` alongside display labels (`{ vegan: 'Vegan', gluten_free: 'Gluten-free', ... }`).
+
+### Extractor changes — `supabase/functions/menu-refresh/index.ts`
+
+Output schema grows from 4 fields to 6:
+
+```ts
+interface ExtractedDish {
+  name: string
+  category: string
+  menu_section: string
+  price: number | null
+  description: string | null   // NEW
+  dietary_tags: string[]       // NEW
+}
+```
+
+**Prompt additions** (added to the existing rules block, after the price rule):
+
+> **Description rule:** Output a terse ingredient/preparation line under 80 chars. Format: comma-separated nouns. Examples: "Hot lobster meat, drawn butter, split-top bun" / "Pepperoni, mozzarella, San Marzano tomato" / "Wagyu beef, bacon jam, brioche bun". If the menu has only marketing copy ("OUR SIGNATURE HAND-CRAFTED..."), output `null`. Never invent ingredients you don't see in the source.
+>
+> **Dietary tags rule:** Only emit a tag when the menu explicitly labels it. Allowed tags (and only these): `vegan`, `vegetarian`, `gluten_free`, `dairy_free`, `nut_free`. Triggers: explicit labels like "Vegan", "V", "GF", "Gluten-Free Available", "Dairy-Free", "Nut-Free" on the dish itself. **Inferring from ingredients is NOT allowed** — a tofu stir-fry with no animal products does NOT get `vegan` unless the menu labels it. Empty array `[]` when nothing is labeled. Never invent tags.
+
+**Output validator** (in `parseExtraction` / equivalent):
+- Drop any `dietary_tags` value not in `ALLOWED_DIETARY_TAGS`
+- Truncate `description` to 80 chars if Sonnet exceeds (defensive — prompt should already enforce)
+- Coerce empty string `""` → `null` for description
+
+---
+
+## Section 2 — UI
+
+### Dish card (`src/components/DishListItem.jsx`)
+
+Add one line under restaurant/distance, rendered only when `dish.description != null`:
+
+```
+[icon]  Lobster Roll                    8.4 ★
+        Coast Cafe · 0.3 mi
+        Hot lobster meat, drawn butter…
+```
+
+- Font: same family as restaurant line (Outfit), smaller size, `var(--color-text-tertiary)`
+- Single line with CSS `text-overflow: ellipsis` (defensive — most descriptions will fit at <80 chars)
+- No dietary chips. Card stays clean.
+- When `description == null`, render the card exactly as today (no placeholder, no extra space).
+
+Implement via the `frontend-design` skill to match the existing visual language.
+
+### Dish detail page (`src/pages/Dish.jsx`)
+
+Add a description block under the restaurant name, above the vote slider, rendered only when `description != null`:
+
+```
+Lobster Roll                            8.4 ★
+Coast Cafe · Oak Bluffs
+
+Hot lobster meat, drawn butter, split-top bun.
+
+○ Vegan   ○ Vegetarian   ○ Dairy-free
+ℹ️ Tags reflect menu labels. Confirm with restaurant for allergens.
+
+[vote slider, photos, reviews…]
+```
+
+- Description: Outfit body weight, `var(--color-text-primary)`
+- Tag pills: rounded chips, secondary surface color, body text. **Tappable** — tapping a tag navigates to `/?diet=<tag>` (homepage with that filter pre-applied)
+- Disclaimer: small text, `var(--color-text-tertiary)`, info icon prefix
+- When `dietary_tags` is empty, no pill row and no disclaimer renders
+
+Implement via the `frontend-design` skill.
+
+### Homepage Diet button + bottom sheet
+
+**Button placement:** near the existing search bar on the homepage. Shows current state:
+- `Diet · Off` when no filter active
+- `Diet · Vegan` when one tag
+- `Diet · 2 selected` when multi-select
+
+**Bottom sheet** (uses the existing `BottomSheet` component from Denis's gesture-based work, per memory):
+
+```
+Dietary preferences
+
+○ Vegan       ○ Vegetarian    ○ Gluten-free
+○ Dairy-free  ○ Nut-free
+
+ℹ️ Tags reflect menu labels. Always confirm
+   with the restaurant for allergens.
+
+         [ Reset ]   [ Apply ]
+```
+
+- Multi-select chips
+- Reset clears all selections
+- Apply closes sheet and updates URL: `/?diet=vegan,gluten_free`
+- URL state round-trips so filters are shareable and survive back-button
+
+Implement via the `frontend-design` skill.
+
+### Constants & display
+
+`src/constants/dietaryTags.js`:
+
+```js
+export const ALLOWED_DIETARY_TAGS = ['vegan', 'vegetarian', 'gluten_free', 'dairy_free', 'nut_free']
+
+export const DIETARY_TAG_LABELS = {
+  vegan: 'Vegan',
+  vegetarian: 'Vegetarian',
+  gluten_free: 'Gluten-free',
+  dairy_free: 'Dairy-free',
+  nut_free: 'Nut-free',
+}
+
+export const DIETARY_DISCLAIMER = 'Tags reflect menu labels. Always confirm with the restaurant for allergens.'
+```
+
+---
+
+## Section 3 — Search + RPC changes
+
+### Search (client-side, not server-side)
+
+Homepage search is **client-side** today via `getAllSearchable()` → `useDishSearch()` hook, not a server-side `dishesApi.search()`. To make descriptions searchable:
+
+- Extend `dishesApi.getAllSearchable()` to include `description` in the returned row shape
+- Extend the `useDishSearch` client-side filter to match the search term against `name`, `restaurant_name`, **and `description`**
+- The trigram index from the migration earns its keep for the RPC-side dietary filter and future server-side description search; not used by the client-side path
+
+### RPC changes — `get_ranked_dishes` (and equivalent feed RPCs)
+
+Current `get_ranked_dishes` (`schema.sql:1067`) returns 28 columns but NOT `description` or `dietary_tags`. The card preview needs both. Extend signature + return:
+
+**Add param** (new, with default for backwards-compatibility):
+```sql
+filter_dietary_tags TEXT[] DEFAULT NULL
+```
+
+**Add to RETURNS TABLE**:
+```sql
+description TEXT,
+dietary_tags TEXT[],
+```
+
+**Filter logic** in body:
+```sql
+AND (
+  filter_dietary_tags IS NULL
+  OR array_length(filter_dietary_tags, 1) IS NULL
+  OR dishes.dietary_tags @> filter_dietary_tags
+)
+```
+
+**Semantics:** `@>` is **contains-all** (AND). Multi-select `[Vegan, Gluten-free]` returns dishes tagged BOTH. Helper copy under the bottom sheet chips: "All selected restrictions must apply".
+
+**Other RPCs to audit** at implementation time — run `grep -n "RETURNS TABLE" supabase/schema.sql` and add description + dietary_tags to any RPC that powers a dish list/card. Known candidates: `get_restaurant_dishes`, `get_dish_variants`. Any RPC consumed by `DishListItem` needs the new return columns.
+
+### URL state
+
+`?diet=vegan,gluten_free` parsed by the homepage. Required handling:
+
+- **Sanitize:** drop any tag not in `ALLOWED_DIETARY_TAGS` (defends against tampered URLs)
+- **Dedupe:** Set-coerce after split
+- **Empty/malformed:** treat `?diet=`, `?diet=,,`, or any unparseable form as no filter
+- **Critical reactivity bug fix:** `src/pages/Map.jsx` currently seeds URL params into local state once at mount and does NOT react to later URL changes. Implementation must add `useSearchParams` reactivity so the dish-detail-tap-tag → `/?diet=vegan` flow actually re-applies the filter on return to homepage.
+
+---
+
+## Section 4 — Backfill + rollout
+
+### PR sequence (each through `codex-cli` before commit)
+
+**Ordering is load-bearing:** SQL function signature changes must deploy in production BEFORE the UI ships, or RPC calls from the new UI will fail with "function does not exist" because the live function won't accept the new `filter_dietary_tags` param.
+
+1. **PR 1 — Schema migration + RPC signature updates**
+   - Update `supabase/schema.sql`: new columns on `dishes` + extended RPC signatures (`get_ranked_dishes`, `get_restaurant_dishes`, `get_dish_variants`, plus any other RPC feeding the dish UI — audit at impl time)
+   - Create migration file with `ALTER TABLE` + indexes + `CREATE OR REPLACE FUNCTION` for each touched RPC
+   - Run BOTH the ALTER TABLE and all CREATE OR REPLACE FUNCTION blocks in Supabase SQL Editor
+   - Verify: `\d dishes` shows new columns; spot-call each RPC with default args, confirm new columns return NULL/empty
+   - Additive only → safe to ship before extractor or UI
+
+2. **PR 2 — Extractor + upsert + backfill flag**
+   - Update `menu-refresh/index.ts` interfaces, prompt rules, output validator (drop tag values not in `ALLOWED_DIETARY_TAGS`, truncate description to 80 chars, coerce empty-string description to null)
+   - **Critical: extend `upsertDishes()` to persist `description` and `dietary_tags`.** Today it only compares/writes `category, menu_section, price`. Without this change new fields never reach the DB. Overwrite policy: replace existing values on every refresh (Sonnet is source of truth).
+   - Add `?force_all=true&limit=N` query support that bypasses the `STALE_DAYS` filter and processes up to `N` restaurants per invocation (cap at 50 to stay under Edge Function timeout). Absent flag = unchanged behavior.
+   - Add `src/constants/dietaryTags.js` with `ALLOWED_DIETARY_TAGS`, `DIETARY_TAG_LABELS`, `DIETARY_DISCLAIMER`
+   - Backfill mechanics (used by step 4):
+     - Endpoint: **POST** (existing handler is POST-only)
+     - Auth header: `Authorization: Bearer <CRON_SECRET>` — required for any manual invocation
+     - Convention for `force_all` + `limit`: pick body OR query string in the implementation and document it inline so step 4 invocations match
+   - Deploy Edge Function via Supabase Dashboard "Edit" UI (per `reference_supabase_mcp_limitation`)
+   - Verify on ONE test restaurant before bulk run
+
+3. **PR 3 — UI**
+   - Card preview line in `DishListItem.jsx`
+   - Detail page description block + tag pills + disclaimer in `Dish.jsx`
+   - Tag pill tap → navigate to `/?diet=<tag>`
+   - Diet button + multi-select bottom sheet on homepage (routes through `frontend-design` skill)
+   - URL parameter parsing + sanitization + **reactivity fix** in `Map.jsx` (replace one-shot mount-time read with `useSearchParams` reactivity)
+   - Extend `dishesApi.getAllSearchable` to include `description`
+   - Extend `useDishSearch` client-side filter to match against description
+   - `dishesApi.getRankedDishes` (and equivalent feed-RPC callers) updated to pass `filter_dietary_tags`
+   - All UI renders nothing when fields are null/empty → safe to ship before backfill completes
+
+4. **Backfill run** (after PR 2 deployed; can be before or after PR 3 — UI handles empty fields gracefully)
+   - POST to `menu-refresh` with `force_all=true` + `limit=50`, `Authorization: Bearer $CRON_SECRET`
+   - Invoke 4 times in sequence (4 × 50 = 200 covers all 177), or run a bash loop until response is `{ processed: 0 }`
+   - Total time: ~30-60 min depending on per-restaurant Sonnet latency
+   - Total cost: ~$5-6
+   - **Mid-flight prompt change risk:** if PR 2's prompt is tuned between batches (e.g., validation pass finds tags are too aggressive), restart the backfill — already-extracted restaurants get re-extracted with the new prompt. Sonnet output is the source of truth; overwrites are safe.
+
+5. **Validation pass**
+   - Spot-check 10 random restaurants in Supabase Dashboard:
+     - Description: terse? <80 chars? No marketing fluff?
+     - Dietary tags: only present when menu literally labels?
+   - If quality off: tune prompt, re-run backfill (~$5 per iteration)
+
+### Rollback plan
+
+| Failure mode | Recovery |
+|---|---|
+| Migration breaks something (additive — unlikely) | Drop columns + indexes |
+| Extractor produces garbage | Revert PR 2; new dishes get no description until prompt fixed; existing populated data harmless |
+| UI breaks | Revert PR 3; data stays in columns, just not rendered |
+| Backfill cost surprise | Stop the batch; the partial-populated state is fine (mixed cards render correctly because of null-safe UI) |
+
+---
+
+## Testing
+
+Each PR must add or extend tests for the surfaces it touches:
+
+**PR 1 (Schema + RPC):**
+- No JS tests; verification via SQL Editor spot calls on each RPC after deploy
+
+**PR 2 (Extractor + upsert + backfill flag):**
+- `supabase/functions/menu-refresh/cms-detect.test.ts` — existing test file; add unit tests for the output validator: tags outside `ALLOWED_DIETARY_TAGS` are dropped; description >80 chars is truncated; empty-string description becomes null
+- New tests covering `upsertDishes` persisting description + dietary_tags
+- New tests for `force_all` query behavior: with flag = bypass staleness filter; without = unchanged behavior
+
+**PR 3 (UI):**
+- `src/api/dishesApi.test.js` — extend tests for `getRankedDishes` passing the new `filter_dietary_tags` param through; `getAllSearchable` returning description
+- New tests for URL sanitization in `Map.jsx` (or its query-param helper): invalid tag values dropped, deduped, empty/malformed handled
+- New tests for `useDishSearch` matching against description
+- Component test: `DishListItem` renders description line when present, omits when null
+- Component test: dish detail page renders tag pills when array non-empty, omits disclaimer when array empty
+
+---
+
+## Out of scope (v1.3)
+
+- **`AddDishModal` description/tags input** — User-added dishes will land with `description = null` and `dietary_tags = []`. Card behavior is null-safe so they render fine. Adding optional inputs is a future enhancement, decided in design but explicitly punted from v1.3 scope to keep the PR set tight.
+- **Halal / kosher / pescatarian tags** — Certification territory + rarely labeled. Out for v1.3.
+- **Nut-free is in but rarely labeled** — Expect low coverage on cards. Acceptable for v1.3 — the data is correct (we only mark what's labeled); coverage grows as restaurants update menus.
+- **Tag-based analytics on user behavior** — How many users filter by vegan? Out of v1.3, deferred to PostHog instrumentation post-launch.
+- **Description editing UI for restaurant managers** — Managers can't override the Sonnet-extracted description in v1.3. If a restaurant manager complains, that's a real signal but not a v1.3 blocker.
+
+---
+
+## Implementation notes
+
+- **UI work routes through the `frontend-design` skill** per Dan's direction (`Diet` button, bottom sheet, detail page block, disclaimer styling).
+- **Every PR goes through `codex-cli` before commit** per Dan's standing rule (`feedback_run_each_fix_through_codex`).
+- **Migration source of truth:** update `supabase/schema.sql` first, then run in Supabase SQL Editor per CLAUDE.md ("Never modify schema.sql without running the change in SQL Editor").
+- **Edge Function deploy:** prefer Supabase Dashboard "Edit" UI per `reference_supabase_mcp_limitation` (Dan's MCP only sees the old project; Edge Functions live on Denis's project).
+- **No direct Supabase calls from components:** all data access through `src/api/dishesApi.js` + React Query hooks per CLAUDE.md §1.4.
+- **Logger only, never `console.*`:** per CLAUDE.md §1.7.

--- a/scripts/backfill-menu-descriptions.sh
+++ b/scripts/backfill-menu-descriptions.sh
@@ -28,12 +28,16 @@ set -euo pipefail
 : "${SUPABASE_URL:?must set SUPABASE_URL}"
 : "${CRON_SECRET:?must set CRON_SECRET}"
 
-ENDPOINT="$SUPABASE_URL/functions/v1/menu-refresh?force_all=true&limit=50"
+# Batch size of 8 keeps each invocation under Supabase's 150s edge-function
+# timeout. Each restaurant takes ~3-15s (HTML fetch + optional Browserless
+# render + Sonnet extraction + upsert). 8 × 15s worst case = 120s, leaving
+# headroom under the 150s limit.
+LIMIT=8
+ENDPOINT="$SUPABASE_URL/functions/v1/menu-refresh?force_all=true&limit=$LIMIT"
 
 # Safety cap so a buggy "processed > 0 forever" loop can't run unbounded.
-# 20 iterations × 50 restaurants = 1000 restaurants ceiling; well above the
-# current ~177 inventory.
-MAX_ITERATIONS=20
+# 30 iterations × 8 restaurants = 240 ceiling; well above the ~177 inventory.
+MAX_ITERATIONS=30
 TOTAL=0
 
 for ((i=1; i<=MAX_ITERATIONS; i++)); do
@@ -43,7 +47,23 @@ for ((i=1; i<=MAX_ITERATIONS; i++)); do
     -H "Content-Type: application/json")
   echo "  response: $RESPONSE"
 
-  PROCESSED=$(echo "$RESPONSE" | grep -oE '"processed":[0-9]+' | grep -oE '[0-9]+' || echo "0")
+  # Detect timeout / explicit error responses — these have no "processed" field
+  # and previously caused the script to falsely exit "done" with 0 work done.
+  if echo "$RESPONSE" | grep -qE '"code":"IDLE_TIMEOUT"|"error":'; then
+    echo "✗ Edge function returned an error response. Backfill aborted."
+    echo "  Total restaurants successfully processed before error: $TOTAL"
+    echo "  Re-run the script — already-backfilled restaurants are hash-skipped fast."
+    exit 1
+  fi
+
+  # Successful response must contain "processed". Strict check — if missing, error.
+  if ! echo "$RESPONSE" | grep -qE '"processed":'; then
+    echo "✗ Unexpected response shape (no 'processed' field). Aborting."
+    echo "  Total restaurants successfully processed before error: $TOTAL"
+    exit 1
+  fi
+
+  PROCESSED=$(echo "$RESPONSE" | grep -oE '"processed":[0-9]+' | grep -oE '[0-9]+')
   TOTAL=$((TOTAL + PROCESSED))
   echo "  processed this iteration: $PROCESSED (running total: $TOTAL)"
 

--- a/scripts/backfill-menu-descriptions.sh
+++ b/scripts/backfill-menu-descriptions.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# scripts/backfill-menu-descriptions.sh
+#
+# One-time eager backfill for v1.3 dish descriptions + dietary tags.
+# Loops POSTs to the menu-refresh Edge Function with force_all=true&limit=50
+# until the response reports processed:0. Each invocation extracts up to 50
+# restaurants in a single edge-function run (bounded by the limit param).
+#
+# Requirements:
+#   SUPABASE_URL    https://<project-ref>.supabase.co (no trailing slash)
+#   CRON_SECRET     the menu-refresh function's authorization secret
+#
+# Usage:
+#   export SUPABASE_URL="https://vpioftosgdkyiwvhxewy.supabase.co"
+#   export CRON_SECRET="<from Supabase function secrets dashboard>"
+#   ./scripts/backfill-menu-descriptions.sh
+#
+# Expected wall time: ~30-60 min for ~177 restaurants (the function does most
+# of the work serially per invocation; budget ~2-5s per restaurant for fetch
+# + Sonnet extraction + upsert).
+#
+# Safe to re-run: hash-skip means previously-extracted restaurants are
+# either re-processed (if their menu changed) or short-circuit with
+# 'hash_unchanged' status.
+
+set -euo pipefail
+
+: "${SUPABASE_URL:?must set SUPABASE_URL}"
+: "${CRON_SECRET:?must set CRON_SECRET}"
+
+ENDPOINT="$SUPABASE_URL/functions/v1/menu-refresh?force_all=true&limit=50"
+
+# Safety cap so a buggy "processed > 0 forever" loop can't run unbounded.
+# 20 iterations × 50 restaurants = 1000 restaurants ceiling; well above the
+# current ~177 inventory.
+MAX_ITERATIONS=20
+TOTAL=0
+
+for ((i=1; i<=MAX_ITERATIONS; i++)); do
+  echo "→ Iteration $i: POST $ENDPOINT"
+  RESPONSE=$(curl -s -X POST "$ENDPOINT" \
+    -H "Authorization: Bearer $CRON_SECRET" \
+    -H "Content-Type: application/json")
+  echo "  response: $RESPONSE"
+
+  PROCESSED=$(echo "$RESPONSE" | grep -oE '"processed":[0-9]+' | grep -oE '[0-9]+' || echo "0")
+  TOTAL=$((TOTAL + PROCESSED))
+  echo "  processed this iteration: $PROCESSED (running total: $TOTAL)"
+
+  if [ "$PROCESSED" -eq 0 ]; then
+    echo "✓ Done. Total restaurants backfilled: $TOTAL"
+    exit 0
+  fi
+
+  echo "  sleeping 5s before next batch..."
+  sleep 5
+done
+
+echo "⚠ Reached MAX_ITERATIONS ($MAX_ITERATIONS) without seeing processed:0."
+echo "  Total restaurants processed so far: $TOTAL"
+echo "  Re-run the script to continue if needed."
+exit 1

--- a/src/api/dishesApi.js
+++ b/src/api/dishesApi.js
@@ -18,10 +18,11 @@ export const dishesApi = {
    * @param {number} params.lng - User longitude
    * @param {number} params.radiusMiles - Search radius in miles
    * @param {string|null} params.category - Optional category filter
+   * @param {string[]|null} params.dietaryTags - Optional dietary tag filter (AND semantics)
    * @returns {Promise<Array>} Array of ranked dishes
    * @throws {Error} With classified error type
    */
-  async getRankedDishes({ lat, lng, radiusMiles, category = null }) {
+  async getRankedDishes({ lat, lng, radiusMiles, category = null, dietaryTags = null }) {
     try {
       const { data, error } = await supabase.rpc('get_ranked_dishes', {
         user_lat: lat,
@@ -29,6 +30,8 @@ export const dishesApi = {
         radius_miles: radiusMiles === 0 ? 25000 : radiusMiles,
         filter_category: category,
         filter_town: null,
+        filter_dietary_tags:
+          Array.isArray(dietaryTags) && dietaryTags.length > 0 ? dietaryTags : null,
       })
 
       if (error) {
@@ -280,6 +283,7 @@ export const dishesApi = {
     const selectFields = `
       id, name, category, tags, photo_url, price,
       avg_rating, total_votes, value_score, value_percentile,
+      description, dietary_tags,
       restaurants!inner (
         id, name, is_open, cuisine, town, lat, lng,
         address, phone, website_url, toast_slug, order_url
@@ -318,6 +322,8 @@ export const dishesApi = {
           total_votes: d.total_votes || 0,
           value_score: d.value_score,
           value_percentile: d.value_percentile,
+          description: d.description ?? null,
+          dietary_tags: Array.isArray(d.dietary_tags) ? d.dietary_tags : [],
           restaurant_id: d.restaurants.id,
           restaurant_name: d.restaurants.name,
           restaurant_is_open: d.restaurants.is_open,

--- a/src/api/dishesApi.test.js
+++ b/src/api/dishesApi.test.js
@@ -51,6 +51,7 @@ describe('dishesApi', () => {
         radius_miles: 10,
         filter_category: 'seafood',
         filter_town: null,
+        filter_dietary_tags: null,
       })
       expect(result).toEqual(mockData)
     })
@@ -70,7 +71,53 @@ describe('dishesApi', () => {
         radius_miles: 10,
         filter_category: null,
         filter_town: null,
+        filter_dietary_tags: null,
       })
+    })
+
+    it('passes filter_dietary_tags to the RPC when provided', async () => {
+      supabase.rpc.mockResolvedValueOnce({ data: [], error: null })
+
+      await dishesApi.getRankedDishes({
+        lat: 41.45,
+        lng: -70.56,
+        radiusMiles: 25,
+        dietaryTags: ['vegan', 'gluten_free'],
+      })
+
+      expect(supabase.rpc).toHaveBeenCalledWith(
+        'get_ranked_dishes',
+        expect.objectContaining({
+          filter_dietary_tags: ['vegan', 'gluten_free'],
+        })
+      )
+    })
+
+    it('sends filter_dietary_tags as null when dietaryTags is empty array', async () => {
+      supabase.rpc.mockResolvedValueOnce({ data: [], error: null })
+
+      await dishesApi.getRankedDishes({
+        lat: 41.45,
+        lng: -70.56,
+        radiusMiles: 25,
+        dietaryTags: [],
+      })
+
+      const callArg = supabase.rpc.mock.calls[0][1]
+      expect(callArg.filter_dietary_tags).toBeNull()
+    })
+
+    it('sends filter_dietary_tags as null when dietaryTags is undefined', async () => {
+      supabase.rpc.mockResolvedValueOnce({ data: [], error: null })
+
+      await dishesApi.getRankedDishes({
+        lat: 41.45,
+        lng: -70.56,
+        radiusMiles: 25,
+      })
+
+      const callArg = supabase.rpc.mock.calls[0][1]
+      expect(callArg.filter_dietary_tags).toBeNull()
     })
 
     it('should return empty array when data is null', async () => {
@@ -109,6 +156,104 @@ describe('dishesApi', () => {
       } catch (error) {
         expect(error.type).toBeDefined()
       }
+    })
+  })
+
+  describe('getAllSearchable', () => {
+    function mockDishesPage(rows) {
+      const rangeMock = vi.fn().mockResolvedValue({ data: rows, error: null })
+      const orderMock = vi.fn().mockReturnValue({ range: rangeMock })
+      const selectMock = vi.fn().mockReturnValue({ order: orderMock })
+      supabase.from.mockReturnValue({ select: selectMock })
+      return { selectMock, rangeMock }
+    }
+
+    it('selects description and dietary_tags in the query', async () => {
+      const { selectMock } = mockDishesPage([])
+      await dishesApi.getAllSearchable()
+
+      const selectArg = selectMock.mock.calls[0][0]
+      expect(selectArg).toContain('description')
+      expect(selectArg).toContain('dietary_tags')
+    })
+
+    it('maps description and dietary_tags onto the result rows', async () => {
+      mockDishesPage([
+        {
+          id: 'd1',
+          name: 'Lobster Roll',
+          category: 'lobster roll',
+          tags: ['classic'],
+          photo_url: null,
+          price: 28,
+          avg_rating: 8.4,
+          total_votes: 12,
+          value_score: null,
+          value_percentile: null,
+          description: 'Hot lobster meat, drawn butter, split-top bun',
+          dietary_tags: ['dairy_free'],
+          restaurants: {
+            id: 'r1',
+            name: 'Coast Cafe',
+            is_open: true,
+            cuisine: 'Seafood',
+            town: 'Oak Bluffs',
+            lat: 41.45,
+            lng: -70.56,
+            address: '1 Circuit Ave',
+            phone: null,
+            website_url: null,
+            toast_slug: null,
+            order_url: null,
+          },
+        },
+      ])
+
+      const result = await dishesApi.getAllSearchable()
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({
+        id: 'd1',
+        description: 'Hot lobster meat, drawn butter, split-top bun',
+        dietary_tags: ['dairy_free'],
+      })
+    })
+
+    it('defaults dietary_tags to empty array and description to null when DB returns nullish', async () => {
+      mockDishesPage([
+        {
+          id: 'd2',
+          name: 'Mystery Dish',
+          category: 'entree',
+          tags: null,
+          photo_url: null,
+          price: null,
+          avg_rating: null,
+          total_votes: null,
+          value_score: null,
+          value_percentile: null,
+          description: null,
+          dietary_tags: null,
+          restaurants: {
+            id: 'r2',
+            name: 'Test Restaurant',
+            is_open: true,
+            cuisine: null,
+            town: null,
+            lat: 0,
+            lng: 0,
+            address: null,
+            phone: null,
+            website_url: null,
+            toast_slug: null,
+            order_url: null,
+          },
+        },
+      ])
+
+      const result = await dishesApi.getAllSearchable()
+      expect(result[0].description).toBeNull()
+      expect(result[0].dietary_tags).toEqual([])
     })
   })
 

--- a/src/components/DietButton.jsx
+++ b/src/components/DietButton.jsx
@@ -1,0 +1,96 @@
+/**
+ * DietButton — homepage dietary-filter trigger.
+ *
+ * Sibling of the homepage search bar. Renders one of three states based on
+ * the `selected` array length so a user can see at a glance whether the
+ * feed is filtered:
+ *
+ *   []                   → "Diet · Off"        (tertiary text, neutral pill)
+ *   ['vegan']            → "Diet · Vegan"      (primary text, coral wash)
+ *   ['vegan', 'gluten_free'] → "Diet · 2 selected" (primary text, coral wash)
+ *
+ * Tap → calls `onOpen()` so the parent can mount DietSheet.
+ */
+
+function leafIcon(active) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={active ? 'var(--color-primary)' : 'var(--color-text-tertiary)'}
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M5 21c.5-6 4.5-13 16-15-1 11-7.5 14-13 14" />
+      <path d="M5 21c5-3 8-6 11-9" />
+    </svg>
+  )
+}
+
+export function DietButton({ selected, labels, onOpen }) {
+  var count = Array.isArray(selected) ? selected.length : 0
+  var active = count > 0
+
+  var trailing
+  if (count === 0) {
+    trailing = 'Off'
+  } else if (count === 1) {
+    trailing = (labels && labels[selected[0]]) || selected[0]
+  } else {
+    trailing = count + ' selected'
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      aria-label={active ? 'Edit dietary filter, ' + count + ' selected' : 'Open dietary filter'}
+      className="inline-flex items-center gap-2 px-4 transition-colors duration-150"
+      style={{
+        height: '48px',
+        borderRadius: '14px',
+        background: active ? 'var(--color-primary-muted)' : 'var(--color-surface-elevated)',
+        border: active
+          ? '1.5px solid var(--color-primary)'
+          : '1.5px solid var(--color-divider)',
+        color: active ? 'var(--color-primary)' : 'var(--color-text-secondary)',
+        fontFamily: 'Outfit, sans-serif',
+        fontWeight: 600,
+        fontSize: '14px',
+        letterSpacing: '0.01em',
+        whiteSpace: 'nowrap',
+        cursor: 'pointer',
+        flexShrink: 0,
+      }}
+    >
+      {leafIcon(active)}
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
+        <span style={{ color: active ? 'var(--color-primary)' : 'var(--color-text-tertiary)' }}>
+          Diet
+        </span>
+        <span
+          aria-hidden="true"
+          style={{
+            color: 'var(--color-text-tertiary)',
+            fontWeight: 400,
+            fontSize: '13px',
+          }}
+        >
+          ·
+        </span>
+        <span
+          style={{
+            color: active ? 'var(--color-primary)' : 'var(--color-text-tertiary)',
+            fontWeight: active ? 700 : 600,
+          }}
+        >
+          {trailing}
+        </span>
+      </span>
+    </button>
+  )
+}

--- a/src/components/DietSheet.jsx
+++ b/src/components/DietSheet.jsx
@@ -1,0 +1,355 @@
+import { useEffect, useState } from 'react'
+import { useFocusTrap } from '../hooks/useFocusTrap'
+
+/**
+ * DietSheet — bottom-sheet multi-select for dietary preferences.
+ *
+ * Editorial-leaning preferences screen, not a filter dropdown:
+ *   - Amatic SC header "Dietary preferences" with thin coral hairline
+ *   - 2-column tile grid; selected = coral border + faint coral wash
+ *   - Inline "All selected restrictions must apply" helper (italic, AND-semantics cue)
+ *   - Disclaimer block at the bottom: info-icon prefix + tertiary text
+ *   - Sticky footer with Reset (ghost) + Apply (coral)
+ *
+ * Selection state is local to the sheet — `Apply` commits the current set
+ * via `onApply` then closes. `Reset` clears local state but does not
+ * commit until Apply. Backdrop tap, Escape key, and Close button all
+ * dismiss without committing (parent state unchanged).
+ */
+export function DietSheet({
+  open,
+  initial = [],
+  allowed = [],
+  labels = {},
+  disclaimer = '',
+  onApply,
+  onClose,
+}) {
+  var [selected, setSelected] = useState(initial)
+
+  // Resync local selection whenever the sheet opens or initial prop changes
+  // — without this, a re-open after URL-change keeps stale local state.
+  useEffect(function () {
+    if (open) setSelected(initial)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, JSON.stringify(initial)])
+
+  var containerRef = useFocusTrap(open, onClose)
+
+  if (!open) return null
+
+  function toggle(tag) {
+    setSelected(function (prev) {
+      return prev.indexOf(tag) === -1 ? prev.concat([tag]) : prev.filter(function (t) { return t !== tag })
+    })
+  }
+
+  function handleReset() {
+    setSelected([])
+  }
+
+  function handleApply() {
+    if (typeof onApply === 'function') onApply(selected)
+    if (typeof onClose === 'function') onClose()
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[60]"
+      style={{ background: 'rgba(0,0,0,0.5)' }}
+      onClick={function (e) { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div
+        ref={containerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Dietary preferences"
+        className="absolute left-0 right-0 bottom-0 flex flex-col"
+        style={{
+          background: 'var(--color-surface-elevated)',
+          borderTopLeftRadius: '20px',
+          borderTopRightRadius: '20px',
+          maxHeight: '85vh',
+          paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+          boxShadow: '0 -8px 32px rgba(0,0,0,0.18)',
+        }}
+      >
+        {/* Grabber */}
+        <div
+          aria-hidden="true"
+          style={{
+            width: 40,
+            height: 4,
+            background: 'var(--color-divider)',
+            borderRadius: 2,
+            margin: '8px auto 16px',
+            flex: '0 0 auto',
+          }}
+        />
+
+        {/* Header */}
+        <div
+          style={{
+            padding: '0 24px 16px',
+            flex: '0 0 auto',
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            gap: '12px',
+          }}
+        >
+          <div>
+            <h2
+              style={{
+                fontFamily: "'Amatic SC', cursive",
+                fontWeight: 700,
+                fontSize: '38px',
+                lineHeight: 1,
+                color: 'var(--color-text-primary)',
+                margin: 0,
+                letterSpacing: '0.01em',
+              }}
+            >
+              Dietary preferences
+            </h2>
+            <div
+              aria-hidden="true"
+              style={{
+                width: 44,
+                height: 2,
+                background: 'var(--color-primary)',
+                marginTop: 10,
+                borderRadius: 1,
+              }}
+            />
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close dietary preferences"
+            style={{
+              flex: '0 0 auto',
+              width: 32,
+              height: 32,
+              borderRadius: '50%',
+              background: 'var(--color-surface)',
+              border: '1px solid var(--color-divider)',
+              color: 'var(--color-text-secondary)',
+              cursor: 'pointer',
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              padding: 0,
+              marginTop: '2px',
+            }}
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M6 6l12 12M6 18L18 6" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body — scrolls if tile grid grows */}
+        <div
+          style={{
+            flex: '1 1 auto',
+            minHeight: 0,
+            overflowY: 'auto',
+            WebkitOverflowScrolling: 'touch',
+            padding: '4px 24px 20px',
+          }}
+        >
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(2, 1fr)',
+              gap: '10px',
+            }}
+          >
+            {allowed.map(function (tag) {
+              var isOn = selected.indexOf(tag) !== -1
+              var label = labels[tag] || tag
+              return (
+                <button
+                  key={tag}
+                  type="button"
+                  role="checkbox"
+                  aria-checked={isOn}
+                  aria-label={label}
+                  onClick={function () { toggle(tag) }}
+                  style={{
+                    appearance: 'none',
+                    position: 'relative',
+                    padding: '16px 18px',
+                    minHeight: '56px',
+                    textAlign: 'left',
+                    background: isOn ? 'var(--color-primary-muted)' : 'var(--color-surface-elevated)',
+                    border: isOn
+                      ? '1.5px solid var(--color-primary)'
+                      : '1.5px solid var(--color-divider)',
+                    borderRadius: '12px',
+                    color: isOn ? 'var(--color-primary)' : 'var(--color-text-primary)',
+                    fontFamily: 'Outfit, sans-serif',
+                    fontWeight: isOn ? 700 : 600,
+                    fontSize: '15px',
+                    letterSpacing: '0.01em',
+                    cursor: 'pointer',
+                    transition: 'background 150ms, border-color 150ms, color 150ms',
+                  }}
+                >
+                  {label}
+                  {isOn && (
+                    <span
+                      aria-hidden="true"
+                      style={{
+                        position: 'absolute',
+                        top: '10px',
+                        right: '12px',
+                        width: 18,
+                        height: 18,
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        borderRadius: '50%',
+                        background: 'var(--color-primary)',
+                        color: '#FFFFFF',
+                        fontSize: '11px',
+                        fontWeight: 700,
+                        lineHeight: 1,
+                      }}
+                    >
+                      ✓
+                    </span>
+                  )}
+                </button>
+              )
+            })}
+          </div>
+
+          {/* AND-semantics helper */}
+          <p
+            style={{
+              marginTop: '14px',
+              marginBottom: 0,
+              fontFamily: 'Outfit, sans-serif',
+              fontStyle: 'italic',
+              fontSize: '13px',
+              color: 'var(--color-text-secondary)',
+              lineHeight: 1.4,
+            }}
+          >
+            All selected restrictions must apply.
+          </p>
+
+          {/* Disclaimer */}
+          {disclaimer ? (
+            <div
+              style={{
+                marginTop: '18px',
+                padding: '12px 14px',
+                background: 'var(--color-bg)',
+                border: '1px solid var(--color-divider)',
+                borderRadius: '10px',
+                display: 'flex',
+                gap: '10px',
+                alignItems: 'flex-start',
+              }}
+            >
+              <span
+                aria-hidden="true"
+                style={{
+                  flex: '0 0 auto',
+                  width: 18,
+                  height: 18,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  borderRadius: '50%',
+                  border: '1.5px solid var(--color-text-tertiary)',
+                  color: 'var(--color-text-tertiary)',
+                  fontSize: '11px',
+                  fontWeight: 700,
+                  fontFamily: 'Outfit, sans-serif',
+                  lineHeight: 1,
+                  marginTop: '1px',
+                }}
+              >
+                i
+              </span>
+              <p
+                style={{
+                  margin: 0,
+                  fontFamily: 'Outfit, sans-serif',
+                  fontSize: '12px',
+                  lineHeight: 1.45,
+                  color: 'var(--color-text-tertiary)',
+                }}
+              >
+                {disclaimer}
+              </p>
+            </div>
+          ) : null}
+        </div>
+
+        {/* Footer — Reset (ghost) + Apply (primary) */}
+        <div
+          style={{
+            flex: '0 0 auto',
+            padding: '14px 24px 20px',
+            borderTop: '1px solid var(--color-divider)',
+            display: 'flex',
+            gap: '12px',
+            background: 'var(--color-surface-elevated)',
+          }}
+        >
+          <button
+            type="button"
+            onClick={handleReset}
+            style={{
+              flex: '1 1 auto',
+              minHeight: '48px',
+              background: 'transparent',
+              border: '1.5px solid var(--color-divider)',
+              borderRadius: '12px',
+              color: 'var(--color-text-secondary)',
+              fontFamily: 'Outfit, sans-serif',
+              fontWeight: 700,
+              fontSize: '15px',
+              cursor: 'pointer',
+            }}
+          >
+            Reset
+          </button>
+          <button
+            type="button"
+            onClick={handleApply}
+            style={{
+              flex: '2 1 auto',
+              minHeight: '48px',
+              background: 'var(--color-primary)',
+              border: '1.5px solid var(--color-primary)',
+              borderRadius: '12px',
+              color: '#FFFFFF',
+              fontFamily: 'Outfit, sans-serif',
+              fontWeight: 700,
+              fontSize: '15px',
+              cursor: 'pointer',
+            }}
+          >
+            Apply
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/DietSheet.test.jsx
+++ b/src/components/DietSheet.test.jsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { DietSheet } from './DietSheet'
+
+const labels = {
+  vegan: 'Vegan',
+  vegetarian: 'Vegetarian',
+  gluten_free: 'Gluten-free',
+  dairy_free: 'Dairy-free',
+  nut_free: 'Nut-free',
+}
+const allowed = ['vegan', 'vegetarian', 'gluten_free', 'dairy_free', 'nut_free']
+
+afterEach(cleanup)
+
+describe('DietSheet', () => {
+  it('renders nothing when open=false', () => {
+    const { container } = render(
+      <DietSheet open={false} allowed={allowed} labels={labels} onApply={() => {}} onClose={() => {}} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('starts with provided initial selection', () => {
+    render(
+      <DietSheet open initial={['vegan']} allowed={allowed} labels={labels} onApply={() => {}} onClose={() => {}} />
+    )
+    expect(screen.getByRole('checkbox', { name: /vegan/i })).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByRole('checkbox', { name: /vegetarian/i })).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('Reset clears all selections without committing', () => {
+    const onApply = vi.fn()
+    render(
+      <DietSheet
+        open
+        initial={['vegan', 'gluten_free']}
+        allowed={allowed}
+        labels={labels}
+        onApply={onApply}
+        onClose={() => {}}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /reset/i }))
+    expect(screen.getByRole('checkbox', { name: /vegan/i })).toHaveAttribute('aria-checked', 'false')
+    expect(screen.getByRole('checkbox', { name: /gluten-free/i })).toHaveAttribute('aria-checked', 'false')
+    // Reset does not commit — Apply must be tapped to emit
+    expect(onApply).not.toHaveBeenCalled()
+  })
+
+  it('Apply emits the current selection and closes', () => {
+    const onApply = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <DietSheet
+        open
+        initial={[]}
+        allowed={allowed}
+        labels={labels}
+        onApply={onApply}
+        onClose={onClose}
+      />
+    )
+    fireEvent.click(screen.getByRole('checkbox', { name: /vegan/i }))
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }))
+    expect(onApply).toHaveBeenCalledWith(['vegan'])
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('toggles a tile off when tapped twice', () => {
+    render(
+      <DietSheet open initial={['vegan']} allowed={allowed} labels={labels} onApply={() => {}} onClose={() => {}} />
+    )
+    fireEvent.click(screen.getByRole('checkbox', { name: /vegan/i }))
+    expect(screen.getByRole('checkbox', { name: /vegan/i })).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('renders the disclaimer when provided', () => {
+    render(
+      <DietSheet
+        open
+        allowed={allowed}
+        labels={labels}
+        disclaimer="Always confirm with the restaurant."
+        onApply={() => {}}
+        onClose={() => {}}
+      />
+    )
+    expect(screen.getByText(/always confirm with the restaurant\./i)).toBeInTheDocument()
+  })
+
+  it('Close button calls onClose without committing', () => {
+    const onApply = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <DietSheet
+        open
+        initial={['vegan']}
+        allowed={allowed}
+        labels={labels}
+        onApply={onApply}
+        onClose={onClose}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /close dietary preferences/i }))
+    expect(onClose).toHaveBeenCalled()
+    expect(onApply).not.toHaveBeenCalled()
+  })
+
+  it('omits the disclaimer block when prop is empty', () => {
+    render(
+      <DietSheet
+        open
+        allowed={allowed}
+        labels={labels}
+        disclaimer=""
+        onApply={() => {}}
+        onClose={() => {}}
+      />
+    )
+    expect(screen.queryByText(/allergen/i)).not.toBeInTheDocument()
+  })
+})

--- a/src/components/DishListItem.jsx
+++ b/src/components/DishListItem.jsx
@@ -197,6 +197,25 @@ export const DishListItem = memo(function DishListItem({
             {showDistance && distanceMiles != null && ' \u00b7 ' + Number(distanceMiles).toFixed(1) + ' mi'}
           </p>
         </div>
+        {/* Description preview \u2014 terse Sonnet ingredient line. Omitted entirely
+            when null/empty so cards render exactly as before backfill. */}
+        {typeof dish.description === 'string' && dish.description.trim() ? (
+          <div
+            data-testid="dish-description-preview"
+            style={{
+              marginTop: '3px',
+              fontFamily: 'Outfit, sans-serif',
+              fontSize: isPodium ? '12px' : '11px',
+              color: 'var(--color-text-tertiary)',
+              lineHeight: 1.35,
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {dish.description.trim()}
+          </div>
+        ) : null}
         {/* Action buttons — Order / Directions */}
         {(toastSlug || sanitizeUrl(orderUrl) || restaurantLat) && (
           <div className="flex items-center gap-2" style={{ marginTop: '4px' }}>

--- a/src/components/DishListItem.test.jsx
+++ b/src/components/DishListItem.test.jsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { DishListItem } from './DishListItem'
+
+afterEach(cleanup)
+
+function renderItem(dish, extra = {}) {
+  return render(
+    <MemoryRouter>
+      <DishListItem dish={dish} {...extra} />
+    </MemoryRouter>
+  )
+}
+
+describe('DishListItem description preview', () => {
+  it('renders description line when description is non-null', () => {
+    renderItem({
+      dish_id: 'd1',
+      dish_name: 'Lobster Roll',
+      restaurant_name: 'Coast Cafe',
+      category: 'lobster roll',
+      avg_rating: 8.4,
+      total_votes: 12,
+      description: 'Hot lobster meat, drawn butter, split-top bun',
+    })
+    expect(screen.getByText(/hot lobster meat, drawn butter, split-top bun/i)).toBeInTheDocument()
+    expect(screen.getByTestId('dish-description-preview')).toBeInTheDocument()
+  })
+
+  it('omits description line when description is null', () => {
+    renderItem({
+      dish_id: 'd1',
+      dish_name: 'Lobster Roll',
+      restaurant_name: 'Coast Cafe',
+      category: 'lobster roll',
+      avg_rating: 8.4,
+      total_votes: 12,
+      description: null,
+    })
+    expect(screen.queryByTestId('dish-description-preview')).not.toBeInTheDocument()
+  })
+
+  it('omits description line when description is undefined', () => {
+    renderItem({
+      dish_id: 'd1',
+      dish_name: 'Lobster Roll',
+      restaurant_name: 'Coast Cafe',
+      category: 'lobster roll',
+      avg_rating: 8.4,
+      total_votes: 12,
+    })
+    expect(screen.queryByTestId('dish-description-preview')).not.toBeInTheDocument()
+  })
+
+  it('omits description line when description is empty/whitespace string', () => {
+    renderItem({
+      dish_id: 'd1',
+      dish_name: 'Lobster Roll',
+      restaurant_name: 'Coast Cafe',
+      category: 'lobster roll',
+      description: '   ',
+    })
+    expect(screen.queryByTestId('dish-description-preview')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/dish/DishDescription.jsx
+++ b/src/components/dish/DishDescription.jsx
@@ -1,0 +1,146 @@
+import { useNavigate } from 'react-router-dom'
+import { DIETARY_TAG_LABELS, DIETARY_DISCLAIMER, ALLOWED_DIETARY_TAGS } from '../../constants/dietaryTags'
+import { serializeDietParam } from '../../utils/dietUrlParams'
+
+/**
+ * DishDescription — the "what's in this?" block on the dish detail page.
+ *
+ * Renders three optional surfaces, in order:
+ *   1. The ingredient/preparation description (terse, ≤80 chars, Sonnet extracted)
+ *   2. A row of tappable dietary tag pills (Vegan, Vegetarian, etc.)
+ *   3. An allergen disclaimer (only when at least one tag is shown)
+ *
+ * Each surface is null-safe — the whole block returns null when the dish
+ * has no description AND no dietary tags, so dishes that haven't been
+ * backfilled yet render the page exactly as before.
+ *
+ * Tapping a tag pill navigates to `/?diet=<tag>` so the homepage list
+ * filters to that restriction.
+ */
+export function DishDescription({ description, dietaryTags }) {
+  var navigate = useNavigate()
+
+  var hasDescription = typeof description === 'string' && description.trim().length > 0
+  var tags = Array.isArray(dietaryTags)
+    ? dietaryTags.filter(function (t) { return ALLOWED_DIETARY_TAGS.indexOf(t) !== -1 })
+    : []
+  var hasTags = tags.length > 0
+
+  if (!hasDescription && !hasTags) return null
+
+  function handleTagClick(tag) {
+    navigate('/?diet=' + serializeDietParam([tag]))
+  }
+
+  return (
+    <section
+      aria-label="Dish description and dietary tags"
+      style={{
+        margin: '12px 16px 8px',
+        padding: '16px 18px',
+        background: 'var(--color-surface-elevated)',
+        border: '1px solid var(--color-divider)',
+        borderRadius: '14px',
+      }}
+    >
+      {hasDescription ? (
+        <p
+          style={{
+            margin: 0,
+            fontFamily: 'Outfit, sans-serif',
+            fontSize: '15px',
+            fontWeight: 500,
+            lineHeight: 1.45,
+            color: 'var(--color-text-primary)',
+            letterSpacing: '0.005em',
+          }}
+        >
+          {description.trim()}
+        </p>
+      ) : null}
+
+      {hasTags ? (
+        <div
+          aria-label="Dietary tags"
+          data-testid="dietary-tag-pills"
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '8px',
+            marginTop: hasDescription ? '14px' : 0,
+          }}
+        >
+          {tags.map(function (tag) {
+            var label = DIETARY_TAG_LABELS[tag] || tag
+            return (
+              <button
+                key={tag}
+                type="button"
+                onClick={function () { handleTagClick(tag) }}
+                aria-label={'Filter homepage by ' + label}
+                style={{
+                  padding: '6px 12px',
+                  background: 'var(--color-primary-muted)',
+                  border: '1.5px solid var(--color-primary)',
+                  borderRadius: '999px',
+                  color: 'var(--color-primary)',
+                  fontFamily: 'Outfit, sans-serif',
+                  fontWeight: 700,
+                  fontSize: '12px',
+                  letterSpacing: '0.02em',
+                  cursor: 'pointer',
+                }}
+              >
+                {label}
+              </button>
+            )
+          })}
+        </div>
+      ) : null}
+
+      {hasTags ? (
+        <div
+          style={{
+            marginTop: '12px',
+            display: 'flex',
+            gap: '8px',
+            alignItems: 'flex-start',
+          }}
+        >
+          <span
+            aria-hidden="true"
+            style={{
+              flex: '0 0 auto',
+              width: 16,
+              height: 16,
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRadius: '50%',
+              border: '1.5px solid var(--color-text-tertiary)',
+              color: 'var(--color-text-tertiary)',
+              fontSize: '10px',
+              fontWeight: 700,
+              fontFamily: 'Outfit, sans-serif',
+              lineHeight: 1,
+              marginTop: '1px',
+            }}
+          >
+            i
+          </span>
+          <p
+            style={{
+              margin: 0,
+              fontFamily: 'Outfit, sans-serif',
+              fontSize: '11px',
+              lineHeight: 1.45,
+              color: 'var(--color-text-tertiary)',
+            }}
+          >
+            {DIETARY_DISCLAIMER}
+          </p>
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/src/components/dish/DishDescription.test.jsx
+++ b/src/components/dish/DishDescription.test.jsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+import { DishDescription } from './DishDescription'
+
+afterEach(cleanup)
+
+function renderWithRouter(ui, { route = '/dish/abc' } = {}) {
+  function LocationProbe() {
+    var loc = useLocation()
+    return <div data-testid="location">{loc.pathname + loc.search}</div>
+  }
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <Routes>
+        <Route path="*" element={<><div>{ui}</div><LocationProbe /></>} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('DishDescription', () => {
+  it('returns null when both description and dietaryTags are absent', () => {
+    const { container } = renderWithRouter(
+      <DishDescription description={null} dietaryTags={[]} />
+    )
+    expect(container.querySelector('section')).toBeNull()
+  })
+
+  it('renders description when present, no pill row when tags empty', () => {
+    renderWithRouter(
+      <DishDescription
+        description="Hot lobster meat, drawn butter, split-top bun"
+        dietaryTags={[]}
+      />
+    )
+    expect(screen.getByText(/hot lobster meat, drawn butter, split-top bun/i)).toBeInTheDocument()
+    expect(screen.queryByTestId('dietary-tag-pills')).not.toBeInTheDocument()
+  })
+
+  it('renders pill row + disclaimer when tags non-empty', () => {
+    renderWithRouter(
+      <DishDescription description={null} dietaryTags={['vegan', 'gluten_free']} />
+    )
+    expect(screen.getByRole('button', { name: /filter homepage by vegan/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /filter homepage by gluten-free/i })).toBeInTheDocument()
+    expect(screen.getByText(/menu labels/i)).toBeInTheDocument()
+  })
+
+  it('drops tags outside the allowed list', () => {
+    renderWithRouter(
+      <DishDescription description={null} dietaryTags={['vegan', 'paleo', 'keto']} />
+    )
+    expect(screen.getByRole('button', { name: /filter homepage by vegan/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /paleo/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /keto/i })).not.toBeInTheDocument()
+  })
+
+  it('tag pill click navigates to /?diet=<tag>', () => {
+    renderWithRouter(
+      <DishDescription description={null} dietaryTags={['vegan']} />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /filter homepage by vegan/i }))
+    expect(screen.getByTestId('location').textContent).toBe('/?diet=vegan')
+  })
+
+  it('omits disclaimer when no tags are rendered', () => {
+    renderWithRouter(
+      <DishDescription description="Just ingredients" dietaryTags={[]} />
+    )
+    expect(screen.queryByText(/menu labels/i)).not.toBeInTheDocument()
+  })
+})

--- a/src/components/dish/index.js
+++ b/src/components/dish/index.js
@@ -1,2 +1,3 @@
 export { DishHero } from './DishHero'
 export { DishEvidence } from './DishEvidence'
+export { DishDescription } from './DishDescription'

--- a/src/components/home/HomeListMode.jsx
+++ b/src/components/home/HomeListMode.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { BROWSE_CATEGORIES } from '../../constants/categories'
 import { DishSearch } from '../DishSearch'
 import { DishListItem } from '../DishListItem'
+import { DietButton } from '../DietButton'
 import { EmptyState } from '../EmptyState'
 import { DataLoadError } from '../DataLoadError'
 import { LocationBanner } from '../LocationBanner'
@@ -29,6 +30,9 @@ export const HomeListMode = memo(function HomeListMode({
   onExpandedCategoryChange,
   onCategoryChange,
   onLocalListExpanded,
+  dietaryTags,
+  dietaryLabels,
+  onDietOpen,
 }) {
   var navigate = useNavigate()
   var carouselRef = useRef(null)
@@ -114,6 +118,19 @@ export const HomeListMode = memo(function HomeListMode({
             />
           </div>
         </div>
+
+        {/* Dietary filter trigger — sits just under the search row, right-aligned
+            so it doesn't compete with the search bar visually. Only render when a
+            handler is wired in (keeps the test/storybook surfaces simple). */}
+        {onDietOpen ? (
+          <div className="px-5 pt-1 pb-1 flex justify-end">
+            <DietButton
+              selected={dietaryTags}
+              labels={dietaryLabels}
+              onOpen={onDietOpen}
+            />
+          </div>
+        ) : null}
 
         {/* Location banner */}
         <div className="px-4">

--- a/src/hooks/useDishes.js
+++ b/src/hooks/useDishes.js
@@ -8,10 +8,17 @@ import { logger } from '../utils/logger'
  * Fetch and cache dishes using React Query
  * Supports both location-based ranked dishes and restaurant-specific dishes
  */
-export function useDishes(location, radius, category = null, restaurantId = null) {
+export function useDishes(location, radius, category = null, restaurantId = null, dietaryTags = null) {
+  // Normalize for stable query keys: ignore order so ['vegan','gluten_free']
+  // and ['gluten_free','vegan'] share a cache. Empty/non-array → null (no filter).
+  const normalizedTags = Array.isArray(dietaryTags) && dietaryTags.length > 0
+    ? [...dietaryTags].sort()
+    : null
+  const tagsKey = normalizedTags ? normalizedTags.join(',') : null
+
   const queryKey = restaurantId
     ? ['dishes', 'restaurant', restaurantId, category]
-    : ['dishes', 'ranked', location?.lat, location?.lng, radius, category]
+    : ['dishes', 'ranked', location?.lat, location?.lng, radius, category, tagsKey]
 
   const enabled = restaurantId ? !!restaurantId : !!location
 
@@ -26,6 +33,7 @@ export function useDishes(location, radius, category = null, restaurantId = null
         lng: location.lng,
         radiusMiles: radius,
         category,
+        dietaryTags: normalizedTags,
       })
     },
     enabled,

--- a/src/pages/Dish.jsx
+++ b/src/pages/Dish.jsx
@@ -12,7 +12,7 @@ import { useMyLocalList } from '../hooks/useMyLocalList'
 import { ReviewFlow } from '../components/ReviewFlow'
 import { PhotoUploadConfirmation } from '../components/PhotoUploadConfirmation'
 import { LoginModal } from '../components/Auth/LoginModal'
-import { DishHero, DishEvidence } from '../components/dish'
+import { DishHero, DishEvidence, DishDescription } from '../components/dish'
 import { AddToPlaylistSheet } from '../components/playlists/AddToPlaylistSheet'
 import { ReportModal } from '../components/ReportModal'
 import { MIN_VOTES_FOR_RANKING } from '../constants/app'
@@ -349,6 +349,16 @@ export function Dish() {
               </span>
             </div>
           )}
+
+          {/* Description + dietary tags. Self-contained — DishDescription
+              returns null when the dish has neither field, leaving the page
+              layout unchanged for non-backfilled dishes. Spacing lives inside
+              the component so an unconditional wrapper div never adds a
+              ghost gap when the block is empty. */}
+          <DishDescription
+            description={dish.description}
+            dietaryTags={dish.dietary_tags}
+          />
 
           {/* LAYER 2: THE ACTION — Rate CTA + inline rate flow */}
           <div className="p-4 space-y-3">

--- a/src/pages/Map.jsx
+++ b/src/pages/Map.jsx
@@ -12,6 +12,10 @@ import { ModeFAB } from '../components/ModeFAB'
 import { HomeListMode, MapCategoryBar } from '../components/home'
 import { getSessionItem, setSessionItem } from '../lib/storage'
 import { logger } from '../utils/logger'
+import { parseDietParam, serializeDietParam } from '../utils/dietUrlParams'
+import { ALLOWED_DIETARY_TAGS, DIETARY_TAG_LABELS, DIETARY_DISCLAIMER } from '../constants/dietaryTags'
+import { DietButton } from '../components/DietButton'
+import { DietSheet } from '../components/DietSheet'
 
 var RestaurantMap = lazy(function () {
   return import('../components/restaurants/RestaurantMap').then(function (m) {
@@ -24,13 +28,14 @@ export function Map() {
 
   var navigate = useNavigate()
   var routeLocation = useLocation()
-  var [searchParams] = useSearchParams()
+  var [searchParams, setSearchParams] = useSearchParams()
   var { location, radius, setRadius, permissionState, requestLocation } = useLocationContext()
 
   // Seed filters from URL on first render. Used when arriving via search/category
   // links from elsewhere in the app (DishSearch) or from a legacy /browse bookmark.
   var initialCategory = searchParams.get('category')
   var initialQuery = searchParams.get('q')
+  var initialDiet = parseDietParam(searchParams.get('diet'))
 
   var [mode, setMode] = useState(function () {
     return getSessionItem('wgh_home_mode') || 'list'
@@ -38,6 +43,8 @@ export function Map() {
   var [selectedCategory, setSelectedCategory] = useState(initialCategory)
   var [radiusSheetOpen, setRadiusSheetOpen] = useState(false)
   var [searchQuery, setSearchQuery] = useState(initialQuery || '')
+  var [dietaryTags, setDietaryTags] = useState(initialDiet)
+  var [dietSheetOpen, setDietSheetOpen] = useState(false)
   var [searchLimit, setSearchLimit] = useState(10)
   var [focusDishId, setFocusDishId] = useState(null)
   var [highlightedDishId, setHighlightedDishId] = useState(null)
@@ -52,6 +59,31 @@ export function Map() {
   var listScrollRef = useRef(null)
   var scrollPositionRef = useRef(0)
   var highlightTimerRef = useRef(null)
+
+  // Reactive sync for ?diet= — picks up navigations that change the URL after
+  // mount (e.g. tapping a tag pill on a dish detail page jumps back to /?diet=vegan).
+  // Without this, the param is read once at mount and the filter never re-applies.
+  useEffect(function () {
+    var fromUrl = parseDietParam(searchParams.get('diet'))
+    var changed =
+      fromUrl.length !== dietaryTags.length ||
+      fromUrl.some(function (t, i) { return t !== dietaryTags[i] })
+    if (changed) setDietaryTags(fromUrl)
+    // dietaryTags intentionally omitted — this effect mirrors URL → state only.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams])
+
+  // Helper: update both state and URL together. Empty selection drops the param.
+  var updateDietaryTags = useCallback(function (tags) {
+    var serialized = serializeDietParam(tags)
+    var next = new URLSearchParams(searchParams)
+    if (serialized) {
+      next.set('diet', serialized)
+    } else {
+      next.delete('diet')
+    }
+    setSearchParams(next, { replace: false })
+  }, [searchParams, setSearchParams])
 
   // Route state: "See on map" from dish detail
   var focusDishFromRoute = routeLocation.state?.focusDish || null
@@ -133,8 +165,10 @@ export function Map() {
   var searchLoading = searchData.loading
 
   // Ranked dishes — single source of truth for both modes
-  // Always fetch ALL dishes — carousel does client-side category filtering
-  var rankedData = useDishes(location, radius, null, null, null)
+  // Always fetch ALL dishes — carousel does client-side category filtering.
+  // dietaryTags is passed server-side so AND-semantics filtering happens in
+  // the RPC (d.dietary_tags @> filter_dietary_tags).
+  var rankedData = useDishes(location, radius, null, null, dietaryTags)
   var rankedDishes = rankedData.dishes
   var rankedLoading = rankedData.loading || rankedData.isFetching
   var rankedError = rankedData.error
@@ -344,6 +378,9 @@ export function Map() {
           onExpandedCategoryChange={setExpandedCategory}
           onCategoryChange={setSelectedCategory}
           onLocalListExpanded={handleLocalListExpanded}
+          dietaryTags={dietaryTags}
+          dietaryLabels={DIETARY_TAG_LABELS}
+          onDietOpen={function () { setDietSheetOpen(true) }}
         />
       )}
 
@@ -435,6 +472,18 @@ export function Map() {
               </div>
             </div>
 
+            {/* Diet filter trigger — keeps the active dietary state visible while in map mode. */}
+            <div
+              className="mt-2 flex justify-end"
+              style={{ pointerEvents: (pinSelected && location) ? 'none' : 'auto' }}
+            >
+              <DietButton
+                selected={dietaryTags}
+                labels={DIETARY_TAG_LABELS}
+                onOpen={function () { setDietSheetOpen(true) }}
+              />
+            </div>
+
             {/* Floating category bar */}
             <div className="mt-2" style={{ pointerEvents: (pinSelected && location) ? 'none' : 'auto' }}>
               <MapCategoryBar activeCategory={mapCategory} onCategoryChange={setMapCategory} />
@@ -489,6 +538,16 @@ export function Map() {
         onClose={function () { setRadiusSheetOpen(false) }}
         radius={radius}
         onRadiusChange={setRadius}
+      />
+
+      <DietSheet
+        open={dietSheetOpen}
+        initial={dietaryTags}
+        allowed={ALLOWED_DIETARY_TAGS}
+        labels={DIETARY_TAG_LABELS}
+        disclaimer={DIETARY_DISCLAIMER}
+        onApply={updateDietaryTags}
+        onClose={function () { setDietSheetOpen(false) }}
       />
 
     </main>

--- a/src/utils/dietUrlParams.js
+++ b/src/utils/dietUrlParams.js
@@ -1,0 +1,55 @@
+import { ALLOWED_DIETARY_TAGS } from '../constants/dietaryTags'
+
+const ALLOWED = new Set(ALLOWED_DIETARY_TAGS)
+
+/**
+ * Parse a ?diet=... URL search-param value into a sanitized array of
+ * dietary tags. Drops anything not in ALLOWED_DIETARY_TAGS, dedupes,
+ * preserves first-seen order, trims surrounding whitespace.
+ *
+ * Strict case: input is not lowercased before allowlist check. Mixed-case
+ * tokens (e.g. `Vegan`, `GLUTEN_FREE`) are dropped individually — valid
+ * lowercase tokens in the same param are still returned. That prevents
+ * URL aliasing where multiple cases map to the same canonical filter
+ * while still degrading gracefully when tampered URLs include both
+ * valid and invalid tokens.
+ *
+ * @param {unknown} raw - The raw search-param value (typeof string expected)
+ * @returns {string[]} Sanitized list of allowed tag ids
+ */
+export function parseDietParam(raw) {
+  if (typeof raw !== 'string' || raw.length === 0) return []
+  const seen = new Set()
+  const out = []
+  for (const part of raw.split(',')) {
+    const trimmed = part.trim()
+    if (trimmed && ALLOWED.has(trimmed) && !seen.has(trimmed)) {
+      seen.add(trimmed)
+      out.push(trimmed)
+    }
+  }
+  return out
+}
+
+/**
+ * Serialize an array of dietary tags to the ?diet= URL search-param
+ * value. Empty array → empty string (caller should omit the param).
+ * Invalid tags are dropped silently, duplicates are collapsed, and
+ * first-seen order of valid tags is preserved — guarantees a true
+ * round-trip with parseDietParam.
+ *
+ * @param {unknown} tags - Expected string[] of tag ids
+ * @returns {string} Canonical comma-joined value, or '' when empty
+ */
+export function serializeDietParam(tags) {
+  if (!Array.isArray(tags) || tags.length === 0) return ''
+  const seen = new Set()
+  const out = []
+  for (const t of tags) {
+    if (typeof t === 'string' && ALLOWED.has(t) && !seen.has(t)) {
+      seen.add(t)
+      out.push(t)
+    }
+  }
+  return out.join(',')
+}

--- a/src/utils/dietUrlParams.test.js
+++ b/src/utils/dietUrlParams.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { parseDietParam, serializeDietParam } from './dietUrlParams'
+
+describe('parseDietParam', () => {
+  it('returns empty array for null', () => {
+    expect(parseDietParam(null)).toEqual([])
+  })
+
+  it('returns empty array for undefined', () => {
+    expect(parseDietParam(undefined)).toEqual([])
+  })
+
+  it('returns empty array for empty string', () => {
+    expect(parseDietParam('')).toEqual([])
+  })
+
+  it('returns empty array for non-string input', () => {
+    expect(parseDietParam(42)).toEqual([])
+    expect(parseDietParam([])).toEqual([])
+    expect(parseDietParam({})).toEqual([])
+  })
+
+  it('returns empty array when string is only commas/whitespace', () => {
+    expect(parseDietParam(',,,')).toEqual([])
+    expect(parseDietParam('  ,  ,  ')).toEqual([])
+  })
+
+  it('parses a single valid tag', () => {
+    expect(parseDietParam('vegan')).toEqual(['vegan'])
+  })
+
+  it('parses multiple comma-separated valid tags preserving order', () => {
+    expect(parseDietParam('vegan,gluten_free')).toEqual(['vegan', 'gluten_free'])
+  })
+
+  it('drops invalid tag values', () => {
+    expect(parseDietParam('vegan,paleo,gluten_free,keto')).toEqual(['vegan', 'gluten_free'])
+  })
+
+  it('dedupes repeats', () => {
+    expect(parseDietParam('vegan,vegan,gluten_free,vegan')).toEqual(['vegan', 'gluten_free'])
+  })
+
+  it('trims whitespace around tags', () => {
+    expect(parseDietParam('vegan , gluten_free')).toEqual(['vegan', 'gluten_free'])
+    expect(parseDietParam('  vegan  ,  gluten_free  ')).toEqual(['vegan', 'gluten_free'])
+  })
+
+  it('rejects mixed-case tokens but keeps valid lowercase ones', () => {
+    expect(parseDietParam('Vegan,GLUTEN_FREE')).toEqual([])
+    expect(parseDietParam('vegan,GLUTEN_FREE')).toEqual(['vegan'])
+    expect(parseDietParam('VEGAN,gluten_free,Vegetarian')).toEqual(['gluten_free'])
+  })
+})
+
+describe('serializeDietParam', () => {
+  it('returns empty string for empty array', () => {
+    expect(serializeDietParam([])).toBe('')
+  })
+
+  it('returns empty string for non-array input', () => {
+    expect(serializeDietParam(null)).toBe('')
+    expect(serializeDietParam(undefined)).toBe('')
+    expect(serializeDietParam('vegan')).toBe('')
+  })
+
+  it('joins valid tags with commas', () => {
+    expect(serializeDietParam(['vegan', 'gluten_free'])).toBe('vegan,gluten_free')
+  })
+
+  it('drops invalid tags when serializing', () => {
+    expect(serializeDietParam(['vegan', 'paleo', 'gluten_free'])).toBe('vegan,gluten_free')
+  })
+
+  it('preserves order of allowed tags', () => {
+    expect(serializeDietParam(['gluten_free', 'vegan'])).toBe('gluten_free,vegan')
+  })
+
+  it('dedupes repeated tags', () => {
+    expect(serializeDietParam(['vegan', 'vegan', 'gluten_free'])).toBe('vegan,gluten_free')
+  })
+})
+
+describe('round-trip', () => {
+  it('serialize then parse is identity for valid tags', () => {
+    const input = ['vegan', 'gluten_free', 'dairy_free']
+    expect(parseDietParam(serializeDietParam(input))).toEqual(input)
+  })
+
+  it('parse then serialize is identity for canonical strings', () => {
+    expect(serializeDietParam(parseDietParam('vegan,gluten_free'))).toBe('vegan,gluten_free')
+  })
+})

--- a/src/utils/dishSearch.js
+++ b/src/utils/dishSearch.js
@@ -67,6 +67,7 @@ function scoreDish(dish, tokens, normalizedPhrase, expandedTags) {
   const dishCategory = (dish.category || '').toLowerCase()
   const dishCuisine = (dish.restaurant_cuisine || '').toLowerCase()
   const dishRestaurant = (dish.restaurant_name || '').toLowerCase()
+  const dishDescription = (dish.description || '').toLowerCase()
   const dishTags = dish.tags || []
 
   // Exact phrase in name: 100
@@ -98,6 +99,19 @@ function scoreDish(dish, tokens, normalizedPhrase, expandedTags) {
   // All tokens match restaurant cuisine: 50
   if (dishCuisine && tokens.every(t => dishCuisine.includes(t)) && tokens.length > 0) {
     return 50
+  }
+
+  // Description match (ingredient): 45
+  // Single token → substring contains. Multi-token → require the joined
+  // phrase as a substring so "fried chicken" doesn't match a description
+  // like "fried tofu, chicken broth" where both tokens appear but unrelated.
+  // Ranked below name+category (60) so direct identifiers win, above
+  // tag-synonym (40) since ingredient matches are a more specific signal.
+  if (dishDescription && tokens.length > 0) {
+    const phraseHit = tokens.length === 1
+      ? dishDescription.includes(tokens[0])
+      : dishDescription.includes(normalizedPhrase)
+    if (phraseHit) return 45
   }
 
   // Tag overlap with synonym expansion: 40

--- a/src/utils/dishSearch.test.js
+++ b/src/utils/dishSearch.test.js
@@ -6,6 +6,7 @@ const makeDish = (overrides = {}) => ({
   name: overrides.name || 'Lobster Roll',
   category: overrides.category || 'lobster roll',
   tags: overrides.tags || [],
+  description: 'description' in overrides ? overrides.description : null,
   avg_rating: overrides.avg_rating ?? 8.5,
   total_votes: overrides.total_votes ?? 10,
   price: overrides.price ?? 18,
@@ -340,6 +341,81 @@ describe('searchDishes', () => {
       expect(result.avg_rating).toBe(9.2)
       expect(result.total_votes).toBe(45)
       expect(result.restaurant_name).toBe("Nancy's")
+    })
+  })
+
+  describe('description matching', () => {
+    const DISHES_WITH_DESC = [
+      makeDish({
+        id: 'd-anchovy',
+        name: 'House Salad',
+        category: 'salad',
+        tags: [],
+        description: 'Romaine, anchovy, lemon vinaigrette',
+        avg_rating: 8.0,
+        restaurant_name: 'Coast Cafe',
+      }),
+      makeDish({
+        id: 'd-plain',
+        name: 'Mystery Plate',
+        category: 'entree',
+        tags: [],
+        description: null,
+        avg_rating: 8.0,
+        restaurant_name: 'Other Place',
+      }),
+    ]
+
+    it('matches dishes by description ingredient', () => {
+      const results = searchDishes(DISHES_WITH_DESC, 'anchovy')
+      expect(results.map(r => r.dish_id)).toEqual(['d-anchovy'])
+    })
+
+    it('returns no match for query that only appears in a null description', () => {
+      const results = searchDishes(
+        [makeDish({ id: 'd-null', name: 'No Desc', description: null })],
+        'anchovy'
+      )
+      expect(results).toEqual([])
+    })
+
+    it('does not crash on undefined description', () => {
+      const dishes = [makeDish({ id: 'd-undef', name: 'Stew', description: undefined })]
+      expect(() => searchDishes(dishes, 'anchovy')).not.toThrow()
+    })
+
+    it('multi-token query does not match unrelated tokens in same description', () => {
+      const dishes = [
+        makeDish({
+          id: 'd-falsepos',
+          name: 'Tofu Stir Fry',
+          description: 'fried tofu, chicken broth, scallion',
+          avg_rating: 8.0,
+        }),
+      ]
+      const results = searchDishes(dishes, 'fried chicken')
+      // "fried" and "chicken" both appear but as parts of separate ingredients;
+      // word-boundary matching should reject this for the multi-token query
+      expect(results).toEqual([])
+    })
+
+    it('description match does not outrank dish name match', () => {
+      const dishes = [
+        makeDish({
+          id: 'd-named',
+          name: 'Truffle Pasta',
+          description: null,
+          avg_rating: 7.0,
+        }),
+        makeDish({
+          id: 'd-desc',
+          name: 'Tagliatelle',
+          description: 'house-made pasta, truffle, parmesan',
+          avg_rating: 9.5,
+        }),
+      ]
+      const results = searchDishes(dishes, 'truffle')
+      expect(results[0].dish_id).toBe('d-named')
     })
   })
 


### PR DESCRIPTION
## Summary
PR 3 of 3 for v1.3 dish descriptions + dietary tags. UI surfaces only — Phase 1 (schema #228) and Phase 2 (extractor #229) are already shipped to production.

- **Card preview**: 1-line description under the restaurant/distance row on `DishListItem`. Null-safe — cards render identically to today when description is empty.
- **Detail page block**: full description + tappable dietary tag pills + allergen disclaimer on `Dish.jsx`. Self-contained component that renders nothing when both fields are absent (no ghost margin).
- **Tag pill tap → `/?diet=<tag>`**: jumps to the homepage with that filter pre-applied.
- **Diet button + multi-select bottom sheet**: `DietButton` next to homepage search + map-mode controls; `DietSheet` is a Jobs-styled preferences sheet (Amatic SC header, coral-bordered tiles, AND-semantics helper, allergen disclaimer, Reset + Apply). Built via the `frontend-design` skill, not hand-rolled.
- **Map.jsx URL reactivity fix**: replaces one-shot mount-time read with `useSearchParams` reactivity so `/?diet=vegan` navigations from the dish-detail tag pill re-apply the filter on return.
- **Client-side search indexes description**: searching "anchovy" or "truffle" now surfaces dishes that contain those words in their description. Single-token = substring; multi-token = phrase match (avoids false positives like "fried chicken" matching "fried tofu, chicken broth").
- **`dishesApi.getRankedDishes` passes `filter_dietary_tags`** through to the Phase 1 RPC (AND semantics via `@>`).

Plan + spec docs (previously on `spec/dish-descriptions-dietary-tags`) ride along so main carries the source of truth.

## Review trail
- Per-task Codex review via `codex-cli` (`gpt-5.3-codex`, medium reasoning). Findings addressed inline:
  - 3.4: switched description match to phrase-match for multi-token queries (false-positive fix).
  - 3.5: tightened JSDoc + added dedupe to `serializeDietParam` for true round-trip.
  - 3.7: added explicit `×` close button to `DietSheet` for the dismiss-affordance gap; normalized `'white'` → `'#FFFFFF'`.
  - 3.9: removed the unconditional wrapper `<div>` ghost gap in `Dish.jsx`; replaced conflicting `role="list"` + `role="listitem"` on the pills with plain `<button>` + aria-label.
- UI components routed through the `frontend-design` skill.
- Full lint/test/build clean on the new files (598/599 unit tests pass — the one failure is pre-existing `nativeAuth.test.js`, per the plan).

## Test plan
- [ ] Homepage cards show description line when populated (e.g. Alchemy or Atria after Phase 2 backfill), omit cleanly when null
- [ ] Search "anchovy", "truffle", "maple" surfaces dishes containing those ingredients
- [ ] Dish detail page renders description + tag pills + disclaimer correctly when both fields populated
- [ ] Tag pill tap navigates to homepage with the filter applied
- [ ] Diet button → sheet → multi-select → Apply updates list AND URL (`/?diet=vegan,gluten_free`)
- [ ] Reset clears selection without committing; Apply commits + closes
- [ ] Browser back/forward preserves filter state
- [ ] AND semantics: `vegan + gluten_free` returns only dishes with both tags
- [ ] Backfill (Dan's parallel terminal) — verify post-completion that real dishes show real descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)