### PR TITLE
fix(menu-refresh): extractor fingerprint + Path B failure-path rotation

### DIFF
--- a/docs/superpowers/plans/2026-05-19-menu-refresh-backfill-loop-fix.md
+++ b/docs/superpowers/plans/2026-05-19-menu-refresh-backfill-loop-fix.md
@@ -1,0 +1,183 @@
+# Menu-Refresh Backfill — Fix Infinite Loop on Failure Paths
+
+**Date:** 2026-05-19 (planned)
+**Origin:** Issue surfaced during v1.3 dish descriptions backfill on 2026-05-18 (see `project_menu_refresh_backfill_infinite_loop.md` memory)
+**Estimated time:** ~45-60 min total (edit + codex + deploy + re-run backfill)
+
+---
+
+## Goal
+
+Fix the `menu-refresh` Edge Function so the `force_all=true` batch backfill cycles through restaurants correctly instead of infinite-looping on the same unextractable ones. After fix, re-run the v1.3 description backfill cleanly across all ~177 restaurants.
+
+## Problem statement
+
+On 2026-05-18 during the v1.3 description backfill, the script (`scripts/backfill-menu-descriptions.sh`) hit an infinite loop:
+
+- Iterations 1, 2, 3, ... all processed the **exact same 8 restaurants** (Rocco's Pizzeria, Highlands General, The Port Hunter, Katama General Store, S&S Kitchenette, Bobby B's Restaurant & Bakery, Catboat, Le Grenier French Restaurant, Mikado Asian Bistro)
+- All 8 had legitimate skip/error reasons (DNS-broken URLs, HTTP 404, page too short, no dishes found, hash match, JSON parse errors on huge HTML)
+- `total_inserted: 0, total_updated: 0` on every iteration — zero new dishes populated
+- After SQL-marking the 9 stuck IDs manually, iteration 2 picked a *different* 8 — but the same loop pattern repeated with the new 8
+
+Backfill terminated at iteration ~8 with only the original 8 restaurants (from the very first pre-bug run) actually backfilled. **~169 restaurants still need descriptions.**
+
+## Root cause
+
+Two compounding issues in `supabase/functions/menu-refresh/index.ts`:
+
+1. **No `ORDER BY` on the batch query.** The `force_all=true` branch (`serve(req)` handler, around line 1593) selects restaurants without any ordering. Postgres returns rows in implementation-defined order (typically insertion order), so the query keeps returning the same restaurants on every call.
+
+2. **`menu_last_checked` only updates on success.** The success path (around line 1500-1505) updates `restaurants.menu_last_checked = now()`. All failure paths (no-dishes, page-too-short, fetch errors, hash_unchanged short-circuit) leave `menu_last_checked` unchanged. So failed restaurants stay "fresh" by the staleness check forever.
+
+Either fix alone solves the loop; both together is the robust answer.
+
+## Specific changes
+
+### File: `supabase/functions/menu-refresh/index.ts`
+
+**Change 1: Add ORDER BY to the batch query**
+
+Around line 1593 (after `let restaurants: Array<...>`), in the batch fallback block. Find:
+
+```ts
+let query = supabase
+  .from('restaurants')
+  .select('id, name, menu_url, menu_content_hash')
+  .not('menu_url', 'is', null)
+  .eq('is_open', true)
+```
+
+Add an ORDER BY clause before the `.or(...)` / `.limit(...)`:
+
+```ts
+let query = supabase
+  .from('restaurants')
+  .select('id, name, menu_url, menu_content_hash')
+  .not('menu_url', 'is', null)
+  .eq('is_open', true)
+  .order('menu_last_checked', { ascending: true, nullsFirst: true })
+```
+
+Rationale: cycles through least-recently-checked restaurants first. Combined with change 2 below, every processed restaurant gets pushed to the back of the queue.
+
+**Change 2: Update `menu_last_checked` on EVERY job outcome**
+
+There are 4-5 places in `serve(req)` where a job terminates without setting `menu_last_checked`. Find them by searching for `menu_import_jobs` updates that don't have a paired `restaurants` update.
+
+Specific paths (line numbers from current `main`, may drift slightly):
+
+| Path | Where | Action |
+|---|---|---|
+| Success (already correct) | ~line 1500-1505 | ✅ keep as is |
+| `hash_unchanged` short-circuit | ~line 1193 (search for `reason: 'hash_unchanged'`) | Add `await supabase.from('restaurants').update({ menu_last_checked: new Date().toISOString() }).eq('id', restaurant.id)` before the early continue |
+| `page_too_short` | ~line 1303 (search for `'page_too_short'`) | Same update before the `continue` |
+| `no_dishes` after all strategies failed | ~line 1463-1466 (search for `attempts.find(a => a.dishes_found > 0)?.strategy ?? 'html'` — the negative branch leads here) | Same update |
+| Catch block / job failure | ~line 1640 (the `catch (err)` after the job-processing try) | Same update |
+
+Pattern for each:
+
+```ts
+await supabase.from('restaurants').update({
+  menu_last_checked: new Date().toISOString(),
+}).eq('id', restaurant.id)
+```
+
+Do NOT update `menu_content_hash` on failure paths — leave it null/unchanged so a future successful extraction can still detect "no change since last successful pull."
+
+### File: `supabase/functions/menu-refresh/index.test.ts` (likely doesn't exist yet)
+
+This is integration territory and we don't currently have orchestration tests for the function — the existing 132 tests cover the pure helpers (`extractors.ts`, `menu-candidates.ts`, etc.).
+
+Skip writing a new test file for this fix. Verify manually instead (see "Verification" below).
+
+## Test plan
+
+1. **Local sanity** — `npm run test -- --run` should still pass (132 menu-refresh tests, expected). No tests should fail since we're not changing tested code.
+
+2. **Codex review** — `/codex-cli` skill, default `gpt-5.3-codex` + `medium`. Prompt should ask for: (a) any missed failure path that still doesn't update `menu_last_checked`, (b) whether `nullsFirst: true` is correct Supabase query syntax (it is — verify it generates `NULLS FIRST` SQL), (c) any race condition between the success-path update and the failure-path update.
+
+3. **Deploy** to production via Supabase Dashboard. Only `index.ts` changes (menu-candidates.ts unchanged from current `main`).
+
+## Verification
+
+After deploy:
+
+1. **Reset the test bed** — mark the previously-stuck restaurants back to null so we can verify the new ordering works:
+
+```sql
+-- Restaurants we marked manually on 2026-05-18 + the new 8 from iterations 1+2
+UPDATE restaurants SET menu_last_checked = NULL
+WHERE id IN (
+  'fa030eb4-55b8-4bc6-a6d2-50fafa14f782',  -- Rocco's
+  '312cdf8c-0bf2-4894-b43e-d49a0c6fc5b3',  -- Highlands General
+  '5d1b8666-4fe6-400f-9282-f4b97c9a3b6e',  -- The Port Hunter
+  '9851c285-6ba6-4f78-bff0-ff7ba692acdd',  -- Katama General
+  '845710b2-b07c-4429-8c08-cf2de679ccef',  -- S&S Kitchenette
+  '6c10a076-f420-4592-9def-97d0bf655098',  -- Bobby B's
+  '7531d345-d6ba-435c-b6cf-f1c10a1d040f',  -- Catboat
+  'fb6cde5d-379b-4b3f-a350-a02b816c47ef',  -- Le Grenier
+  '97bb644c-9d42-47ff-b7e7-8e2c843f5369',  -- Mikado
+  'c93aa88b-9cc5-4ef9-b78e-59d6671729b6',  -- Vineyard Grocer
+  '01245424-1548-4560-9c0f-3e23c97dd4b0',  -- Edgartown Pizza
+  '246def84-2763-49bb-a946-9d124b0f49a8',  -- Tony's Market
+  '6741a3e3-d5b5-4d70-8910-3a29d6e2b29c',  -- Vineyard Caribbean
+  '169fae98-5974-402a-94e7-6cf8eac1ed69',  -- El Barco
+  '0e1e8ba2-0da6-4318-a649-33ca9aed76bb'   -- Edgartown Meat & Fish
+);
+```
+
+(Not strictly necessary — the new ordering will work on any state — but it lets us prove the fix on the same failure set.)
+
+2. **Single-iteration test** — POST one batch and confirm:
+
+```bash
+curl -X POST "https://vpioftosgdkyiwvhxewy.supabase.co/functions/v1/menu-refresh?force_all=true&limit=8" \
+  -H "Authorization: Bearer $CRON_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+Expected: response shows 8 restaurants. Run it again — second call should show **8 DIFFERENT restaurants** (not the same set). If still the same set, change 1 didn't take. If a different set, but some duplicates linger, change 2 missed a failure path.
+
+3. **Re-launch full backfill** — same script as before:
+
+```bash
+export SUPABASE_URL="https://vpioftosgdkyiwvhxewy.supabase.co"
+export CRON_SECRET="<from Supabase function secrets>"
+./scripts/backfill-menu-descriptions.sh
+```
+
+Expected:
+- ~22 iterations total (177 ÷ 8)
+- Each iteration shows DIFFERENT restaurants from the previous
+- `total_inserted` + `total_updated` should grow each iteration for restaurants that DO extract
+- Script terminates with `✓ Done. Total restaurants backfilled: ~170`
+- Wall time: ~25-45 min
+
+4. **Final DB check:**
+
+```sql
+SELECT
+  COUNT(DISTINCT d.restaurant_id) FILTER (WHERE d.description IS NOT NULL) AS restaurants_done,
+  COUNT(*) FILTER (WHERE d.description IS NOT NULL) AS dishes_with_descriptions,
+  COUNT(*) FILTER (WHERE d.dietary_tags <> '{}') AS dishes_with_dietary_tags,
+  (SELECT COUNT(*) FROM restaurants WHERE menu_url IS NOT NULL AND is_open) AS total_eligible
+FROM dishes d;
+```
+
+Expected: `restaurants_done` should be at least 80-100 (every restaurant whose menu can actually be extracted). `dishes_with_descriptions` should be 1000-3000+. `dishes_with_dietary_tags` will reveal whether any MV menus actually use explicit V/GF labels — first real data point on that question.
+
+## Commit + PR
+
+Follow the same pattern as PR #229 (Phase 2 extractor):
+
+- Branch: `fix/menu-refresh-backfill-cycle`
+- Title: `fix(menu-refresh): cycle through restaurants by menu_last_checked, update on failure paths`
+- Body: link to this plan + the project memory + a one-line summary of changes
+- Codex before commit (per standing rule)
+- Admin-merge after CI greens
+
+## Out of scope
+
+- **Data quality of broken menu URLs.** Several MV restaurants have menus we just can't extract: DNS-broken URLs (Rocco's, Le Grenier), HTTP 404 (El Barco), JSON parse errors on huge HTML (Edgartown Pizza), JS-rendered iframes our Browserless config doesn't render (State Road / checkle.menu). Those are individual data-quality follow-ups — file separately as needed.
+- **Dedupe pass for zombie dishes.** Some restaurants have leftover seed entries that don't match current menu names (e.g. Atria's `Beet Salad`, Alchemy's `Tuna Tartare*` with asterisk). Tomorrow's backfill will populate descriptions for the matched ones; the zombies will persist with null descriptions. Follow the existing dedupe-migration pattern (`chore(data): Back Door Donuts dedupe migration`, `chore(data): mass dedupe sweep`) as a separate effort.

--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -214,6 +214,21 @@ interface MenuExtractionResult {
 const MAX_RESTAURANTS_PER_RUN = 10
 const STALE_DAYS = 14
 
+// Identifies the extractor pipeline that produced the dishes currently stored
+// for a restaurant. The hash short-circuit skips Sonnet only when BOTH
+// restaurants.menu_content_hash matches the freshly-fetched HTML hash AND
+// restaurants.extractor_fingerprint matches this constant. Bump the
+// appropriate segment whenever something changes that affects what gets
+// stored:
+//   - model         : the Sonnet model identifier (current: sonnet-4-6)
+//   - prompt        : the Sonnet system/user prompt revision
+//   - pipeline      : extractors.ts sanitization, candidate scoring, strategy
+//                     ordering (html/pdf/image/render), iframe-following
+//   - features      : output-schema features (e.g. desc+dietary tags from PR #229)
+// Format is intentionally human-readable so the stored value alone tells you
+// which extractor produced a row — easier to debug than a bare integer.
+const CURRENT_EXTRACTOR_FINGERPRINT = 'sonnet-4-6|prompt-v2|pipeline-v1|desc+dietary'
+
 // Signals that a restaurant is closed (check before wasting Claude API call)
 const CLOSED_SIGNALS = [
   /closed\s+(for\s+the\s+)?season/i,
@@ -1063,7 +1078,7 @@ serve(async (req) => {
         try {
           const { data: restaurant, error: restErr } = await supabase
             .from('restaurants')
-            .select('id, name, address, menu_url, website_url, google_place_id, menu_content_hash')
+            .select('id, name, address, menu_url, website_url, google_place_id, menu_content_hash, extractor_fingerprint')
             .eq('id', job.restaurant_id)
             .single()
 
@@ -1174,8 +1189,14 @@ serve(async (req) => {
 
             if (pdfExtracted.dishes.length > 0) {
               const stats = await upsertDishes(supabase, restaurant.id, pdfExtracted)
+              // Note: we deliberately do not store menu_content_hash here —
+              // PDFs route through a different fetch path with no equivalent
+              // raw-HTML shell to fingerprint. The extractor_fingerprint is
+              // still written so a future extractor bump invalidates the
+              // cache for PDF-backed restaurants too.
               await supabase.from('restaurants').update({
                 menu_last_checked: new Date().toISOString(),
+                extractor_fingerprint: CURRENT_EXTRACTOR_FINGERPRINT,
               }).eq('id', restaurant.id)
               await supabase.from('menu_import_jobs').update({
                 status: 'completed',
@@ -1245,12 +1266,19 @@ serve(async (req) => {
           const triedUrls = new Set<string>()
 
           // Fast path: compute raw hash BEFORE any Sonnet/render call.
-          // If the raw HTML shell hasn't changed since last successful run, skip everything.
-          // This costs some freshness on JS-rendered sites (Wix shell may not change even when
-          // the menu does), but avoids paying Sonnet and Browserless on every cron cycle.
-          // The 14-day refresh cron will eventually catch menu updates.
+          // Skip Sonnet only when BOTH the raw HTML shell AND the extractor
+          // fingerprint match what's stored. The fingerprint check ensures
+          // that prompt/schema upgrades (e.g. PR #229 added description +
+          // dietary_tags) invalidate the cache automatically — every restaurant
+          // with a stored fingerprint from an older extractor re-extracts.
+          // The 14-day refresh cron still catches actual menu updates between
+          // extractor versions.
           const rawHash = await hashContent(rawText)
-          if (restaurant.menu_content_hash && restaurant.menu_content_hash === rawHash) {
+          if (
+            restaurant.menu_content_hash &&
+            restaurant.menu_content_hash === rawHash &&
+            restaurant.extractor_fingerprint === CURRENT_EXTRACTOR_FINGERPRINT
+          ) {
             await supabase.from('restaurants').update({ menu_last_checked: new Date().toISOString() }).eq('id', restaurant.id)
             await supabase.from('menu_import_jobs').update({
               status: 'completed',
@@ -1600,6 +1628,7 @@ serve(async (req) => {
           await supabase.from('restaurants').update({
             menu_last_checked: new Date().toISOString(),
             menu_content_hash: rawHash,
+            extractor_fingerprint: CURRENT_EXTRACTOR_FINGERPRINT,
           }).eq('id', restaurant.id)
 
           const winningStrategy = attempts.find(a => a.dishes_found > 0)?.strategy ?? 'html'
@@ -1689,14 +1718,27 @@ serve(async (req) => {
     }
 
     // === Batch fallback mode: find stale menus (or all if force_all=true) ===
-    let restaurants: Array<{ id: string; name: string; menu_url: string; menu_content_hash: string | null }>
+    let restaurants: Array<{
+      id: string;
+      name: string;
+      menu_url: string;
+      menu_content_hash: string | null;
+      extractor_fingerprint: string | null;
+    }>
 
     {
+      // ORDER BY menu_last_checked (NULLS FIRST) so a backfill that runs the
+      // same edge function in a loop cycles through the inventory instead of
+      // grabbing the same physical-heap-order rows every call. Tiebreak by id
+      // so batch boundaries are deterministic when many rows share the same
+      // (or NULL) timestamp.
       let query = supabase
         .from('restaurants')
-        .select('id, name, menu_url, menu_content_hash')
+        .select('id, name, menu_url, menu_content_hash, extractor_fingerprint')
         .not('menu_url', 'is', null)
         .eq('is_open', true)
+        .order('menu_last_checked', { ascending: true, nullsFirst: true })
+        .order('id', { ascending: true })
 
       if (!forceAll) {
         // Default cron mode: only stale (or never-checked) menus
@@ -1736,6 +1778,20 @@ serve(async (req) => {
       total_dishes?: number
     }> = []
 
+    // Stamp menu_last_checked = now on EVERY processed restaurant, regardless
+    // of outcome. The column doubles as the rotation key for ORDER BY above:
+    // if failure paths leave it stale, the same broken-URL rows get re-picked
+    // every call and the backfill loops forever on a bad cluster (this is the
+    // bug that motivated this whole change). The cost is that the 14-day
+    // staleness cron sees failed rows as "fresh" for ~14 days — acceptable
+    // because Path A's queue retry/backoff handles short-term retries.
+    const stampChecked = async (restaurantId: string) => {
+      await supabase
+        .from('restaurants')
+        .update({ menu_last_checked: new Date().toISOString() })
+        .eq('id', restaurantId)
+    }
+
     for (const restaurant of restaurants) {
       try {
         console.log(`Processing menu for: ${restaurant.name}`)
@@ -1743,18 +1799,23 @@ serve(async (req) => {
         // Fetch menu content
         const content = await fetchMenuContent(restaurant.menu_url)
         if (content.length < 50) {
+          await stampChecked(restaurant.id)
           results.push({ restaurant_id: restaurant.id, name: restaurant.name, status: 'skipped: page too short' })
           continue
         }
 
-        // Content hash — skip Claude if page hasn't changed
+        // Content hash — skip Claude only when BOTH the page hash and the
+        // stored extractor fingerprint match. Fingerprint mismatch means we've
+        // upgraded the extractor since last extraction (new prompt, new
+        // schema, etc.) — re-run Sonnet so the upgrade actually takes effect.
         const contentHash = await hashContent(content)
-        if (restaurant.menu_content_hash && restaurant.menu_content_hash === contentHash) {
-          console.log(`${restaurant.name}: content unchanged, skipping`)
-          await supabase
-            .from('restaurants')
-            .update({ menu_last_checked: new Date().toISOString() })
-            .eq('id', restaurant.id)
+        if (
+          restaurant.menu_content_hash &&
+          restaurant.menu_content_hash === contentHash &&
+          restaurant.extractor_fingerprint === CURRENT_EXTRACTOR_FINGERPRINT
+        ) {
+          console.log(`${restaurant.name}: content + extractor unchanged, skipping`)
+          await stampChecked(restaurant.id)
           results.push({ restaurant_id: restaurant.id, name: restaurant.name, status: 'unchanged (hash match)' })
           continue
         }
@@ -1778,6 +1839,7 @@ serve(async (req) => {
         // Extract dishes with Claude
         const extracted = await extractMenuWithClaude(content, restaurant.name)
         if (extracted.dishes.length === 0) {
+          await stampChecked(restaurant.id)
           results.push({ restaurant_id: restaurant.id, name: restaurant.name, status: 'skipped: no dishes found' })
           continue
         }
@@ -1785,12 +1847,13 @@ serve(async (req) => {
         // Upsert dishes
         const stats = await upsertDishes(supabase, restaurant.id, extracted)
 
-        // Mark menu as checked + save content hash
+        // Mark menu as checked + save content hash + extractor fingerprint
         await supabase
           .from('restaurants')
           .update({
             menu_last_checked: new Date().toISOString(),
             menu_content_hash: contentHash,
+            extractor_fingerprint: CURRENT_EXTRACTOR_FINGERPRINT,
           })
           .eq('id', restaurant.id)
 
@@ -1804,6 +1867,7 @@ serve(async (req) => {
           total_dishes: extracted.dishes.length,
         })
       } catch (err) {
+        await stampChecked(restaurant.id)
         console.error(`Error processing ${restaurant.name}:`, err)
         results.push({
           restaurant_id: restaurant.id,

--- a/supabase/migrations/2026-05-19-extractor-fingerprint.sql
+++ b/supabase/migrations/2026-05-19-extractor-fingerprint.sql
@@ -1,0 +1,56 @@
+-- 2026-05-19: Extractor fingerprint for menu-refresh short-circuit gating
+--
+-- Adds restaurants.extractor_fingerprint (TEXT). The menu-refresh edge function
+-- already short-circuits Sonnet when restaurants.menu_content_hash matches the
+-- freshly-fetched HTML hash. That's correct when the EXTRACTOR is the same —
+-- but when we upgrade the extractor (e.g. PR #229 taught it to pull
+-- description + dietary_tags), every previously-extracted restaurant short-
+-- circuits and never gets the new fields. The fingerprint closes that gap:
+-- skip only when both the content hash AND the extractor fingerprint match
+-- what's stored.
+--
+-- Pure additive — no SQL rollback needed. Drop column to revert:
+--   ALTER TABLE restaurants DROP COLUMN extractor_fingerprint;
+--   (and revert protect_restaurant_fields below).
+
+-- =============================================================================
+-- 1. Column (additive — autocommit)
+-- =============================================================================
+
+ALTER TABLE restaurants
+  ADD COLUMN IF NOT EXISTS extractor_fingerprint TEXT;
+
+-- =============================================================================
+-- 2. Field-protection trigger update
+--
+-- Managers' UPDATE statements bypass identity/geo/menu-bookkeeping columns.
+-- The new fingerprint joins menu_last_checked + menu_content_hash in the
+-- frozen set so a manager can't clear it via the restaurant edit form
+-- (which would silently force a re-extract every cron cycle).
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION protect_restaurant_fields()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF current_user IN ('postgres', 'service_role', 'supabase_admin') THEN
+    RETURN NEW;
+  END IF;
+  IF is_admin() THEN
+    RETURN NEW;
+  END IF;
+  NEW.id := OLD.id;
+  NEW.name := OLD.name;
+  NEW.address := OLD.address;
+  NEW.lat := OLD.lat;
+  NEW.lng := OLD.lng;
+  NEW.region := OLD.region;
+  NEW.town := OLD.town;
+  NEW.google_place_id := OLD.google_place_id;
+  NEW.created_by := OLD.created_by;
+  NEW.created_at := OLD.created_at;
+  NEW.menu_last_checked := OLD.menu_last_checked;
+  NEW.menu_content_hash := OLD.menu_content_hash;
+  NEW.extractor_fingerprint := OLD.extractor_fingerprint;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -41,6 +41,16 @@ CREATE TABLE IF NOT EXISTS restaurants (
   menu_url TEXT,
   menu_last_checked TIMESTAMPTZ,
   menu_content_hash TEXT,
+  -- Fingerprint of the extractor pipeline (model + prompt + pipeline + features)
+  -- that produced the dishes currently stored. The menu-refresh short-circuit
+  -- skips Sonnet only when menu_content_hash AND extractor_fingerprint both
+  -- match the current versions — so prompt/schema upgrades naturally invalidate
+  -- the cache without manual hash-wipes. Stored as TEXT (e.g.
+  -- 'sonnet-4-6|prompt-v2|pipeline-v1|desc+dietary') instead of an integer so
+  -- the stored value describes WHICH extractor produced it, not just an opaque
+  -- generation counter. Source of truth for the constant is
+  -- CURRENT_EXTRACTOR_FINGERPRINT in supabase/functions/menu-refresh/index.ts.
+  extractor_fingerprint TEXT,
   menu_section_order TEXT[] DEFAULT '{}',
   toast_slug TEXT,
   order_url TEXT,
@@ -2670,8 +2680,9 @@ BEGIN
     RETURN NEW;
   END IF;
   -- Managers can only change contact/social/menu/order fields. Identity + geo frozen.
-  -- menu_last_checked + menu_content_hash are menu-refresh bookkeeping — frozen
-  -- so managers can't force or skip auto-scrapes.
+  -- menu_last_checked + menu_content_hash + extractor_fingerprint are
+  -- menu-refresh bookkeeping — frozen so managers can't force or skip
+  -- auto-scrapes (and can't trick the cache by clearing the fingerprint).
   NEW.id := OLD.id;
   NEW.name := OLD.name;
   NEW.address := OLD.address;
@@ -2684,6 +2695,7 @@ BEGIN
   NEW.created_at := OLD.created_at;
   NEW.menu_last_checked := OLD.menu_last_checked;
   NEW.menu_content_hash := OLD.menu_content_hash;
+  NEW.extractor_fingerprint := OLD.extractor_fingerprint;
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary

Fixes the v1.3 description backfill that populated only 8 of 177 restaurants last night. Two compounding root causes:

1. **Path B (force_all=true) failure paths never updated `menu_last_checked`**, so the same physically-first 8 restaurants with broken menu URLs got re-picked every call.
2. **Hash short-circuit had no extractor-version gate.** PR #229 taught the extractor to pull `description` + `dietary_tags`, but every previously-extracted restaurant hash-matched against pre-PR-#229 content and skipped Sonnet entirely — so the new fields never got backfilled. **This is THE reason 169 of 177 didn't populate.**

## What changed

- **New column** `restaurants.extractor_fingerprint TEXT` — frozen by `protect_restaurant_fields` trigger so managers can't tamper with it.
- **New constant** `CURRENT_EXTRACTOR_FINGERPRINT = 'sonnet-4-6|prompt-v2|pipeline-v1|desc+dietary'` in `menu-refresh/index.ts`. Format encodes model + prompt + pipeline + features so any of those changes can invalidate the cache.
- **Hash short-circuit** now requires BOTH `menu_content_hash` match AND `extractor_fingerprint === CURRENT_EXTRACTOR_FINGERPRINT`. Applied at Path A (queue mode, line ~1267) and Path B (batch fallback, line ~1787).
- **Path B SELECT** now includes `extractor_fingerprint` + adds `.order('id')` tiebreaker for deterministic batch boundaries when many rows share NULL `menu_last_checked`.
- **Path B failure paths** (page-too-short, no-dishes, catch block) now call `stampChecked()` to update `menu_last_checked = now()` so failed rows rotate out of the queue.
- **Success paths** (Path A queue success, Path A PDF-direct shortcut, Path B success) write `extractor_fingerprint` alongside the existing hash + last-checked updates.

## Design decisions

**Codex review (gpt-5.3-codex, high) caught and we fixed:**
1. ✅ PDF-direct success path was missing the fingerprint write (added at line ~1196).
2. ✅ Fingerprint format underspecified relative to its documentation — added explicit `pipeline-v1` segment so sanitizer/strategy changes have a designated bump point.
3. ✅ Schema comment example didn't match the actual constant — synced.

**Intentionally NOT done (deferred to post-launch):**
- **Path A failure paths don't stamp `menu_last_checked`.** Queue mode has its own retry/backoff via `menu_import_jobs`, so the cron-staleness concern doesn't apply there. Bundling a Path A change would expand scope unnecessarily.
- **No timestamp split** (`menu_last_attempted_at` vs `menu_last_succeeded_at`). Codex flagged that updating `menu_last_checked` on failure overloads the column's "freshness" semantics — Path B non-force_all cron now treats failed broken URLs as "fresh" for 14 days. That's arguably the right behavior (don't burn Sonnet on DNS-dead URLs every cron cycle), and the alternative (column rename in a multi-RPC codebase 6 days from Memorial Day launch) is medium risk. Filed for post-launch as `menu_last_attempted_at` split.
- **Path B → Path A consolidation.** The architectural fix (kill Path B, route force_all through the queue) is the truly root-cause solution but ~400 lines of change. Filed for post-launch.

## Deploy steps (manual)

1. Paste `supabase/migrations/2026-05-19-extractor-fingerprint.sql` into Supabase SQL Editor at `vpioftosgdkyiwvhxewy` and run.
2. Deploy `supabase/functions/menu-refresh/index.ts` via Supabase Dashboard → Edge Functions → menu-refresh → Edit → paste → Deploy.

## Verification after deploy

```bash
# 1. Single-iteration smoke test — should return 8 restaurants
curl -X POST "https://vpioftosgdkyiwvhxewy.supabase.co/functions/v1/menu-refresh?force_all=true&limit=8" \
  -H "Authorization: Bearer $CRON_SECRET" -H "Content-Type: application/json" -d '{}'

# 2. Second call should return 8 DIFFERENT restaurants (proves rotation works)
# 3. Re-run full backfill
./scripts/backfill-menu-descriptions.sh
```

Expected after full backfill:
- ~22 iterations
- Final SQL check: `SELECT COUNT(DISTINCT restaurant_id) FILTER (WHERE description IS NOT NULL) FROM dishes` should be ~100-130 (the curated-menu tier we never reached before).
- `dishes` rows with descriptions: 1000-3000+
- First real data point on dietary-tag prevalence in MV menus

## Test plan

- [x] `npm run test -- --run` — 598/599 pass, 1 pre-existing failure unrelated to menu-refresh (`src/lib/nativeAuth.test.js`, Google plugin subcode mismatch from PR #157)
- [x] Codex review at gpt-5.3-codex high effort — all medium issues addressed
- [ ] Deploy migration + edge function via Supabase Dashboard
- [ ] Single-iteration smoke test returns 8 restaurants
- [ ] Second iteration returns 8 *different* restaurants
- [ ] Full backfill terminates cleanly, `restaurants_done` ≥ 80
- [ ] Dietary tag prevalence query returns real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)