### PR TITLE
fix(ui): tap-to-expand dish description + root-fix nested interactive controls

### DIFF
--- a/src/components/DishListItem.jsx
+++ b/src/components/DishListItem.jsx
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { memo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { MIN_VOTES_FOR_RANKING } from '../constants/app'
 import { getRatingColor } from '../utils/ranking'
@@ -43,6 +43,9 @@ export const DishListItem = memo(function DishListItem({
   hideVotes = false,
 }) {
   const navigate = useNavigate()
+  // Inline "ingredients" expander — local state per card. Closed by default
+  // so the list stays tight; user opts in to see Sonnet's ingredient line.
+  const [showDescription, setShowDescription] = useState(false)
 
   // Normalize data shapes between different sources
   const dishName = dish.dish_name || dish.name
@@ -200,20 +203,69 @@ export const DishListItem = memo(function DishListItem({
         {/* Description preview \u2014 terse Sonnet ingredient line. Omitted entirely
             when null/empty so cards render exactly as before backfill. */}
         {typeof dish.description === 'string' && dish.description.trim() ? (
-          <div
-            data-testid="dish-description-preview"
-            style={{
-              marginTop: '3px',
-              fontFamily: 'Outfit, sans-serif',
-              fontSize: isPodium ? '12px' : '11px',
-              color: 'var(--color-text-tertiary)',
-              lineHeight: 1.35,
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-            }}
-          >
-            {dish.description.trim()}
+          <div style={{ marginTop: '3px' }}>
+            <button
+              type="button"
+              onClick={function (e) {
+                e.stopPropagation()
+                setShowDescription(function (v) { return !v })
+              }}
+              onKeyDown={function (e) {
+                // Parent card handles Enter/Space as its own activation. Without
+                // this guard, keyboard activation of the toggle would bubble up
+                // and navigate to the dish detail page.
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.stopPropagation()
+                }
+              }}
+              aria-expanded={showDescription}
+              aria-controls={'dish-desc-' + dishId}
+              data-testid="dish-description-toggle"
+              style={{
+                background: 'transparent',
+                border: 'none',
+                padding: 0,
+                cursor: 'pointer',
+                fontFamily: 'Outfit, sans-serif',
+                fontSize: isPodium ? '11px' : '10px',
+                fontWeight: 600,
+                color: 'var(--color-text-tertiary)',
+                letterSpacing: '0.04em',
+                textTransform: 'lowercase',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '3px',
+              }}
+            >
+              ingredients
+              <span
+                aria-hidden="true"
+                style={{
+                  display: 'inline-block',
+                  transform: showDescription ? 'rotate(180deg)' : 'none',
+                  transition: 'transform 150ms ease',
+                  fontSize: '8px',
+                  lineHeight: 1,
+                }}
+              >
+                ▾
+              </span>
+            </button>
+            {showDescription ? (
+              <div
+                id={'dish-desc-' + dishId}
+                data-testid="dish-description-preview"
+                style={{
+                  marginTop: '4px',
+                  fontFamily: 'Outfit, sans-serif',
+                  fontSize: isPodium ? '12px' : '11px',
+                  color: 'var(--color-text-secondary)',
+                  lineHeight: 1.4,
+                }}
+              >
+                {dish.description.trim()}
+              </div>
+            ) : null}
           </div>
         ) : null}
         {/* Action buttons — Order / Directions */}

--- a/src/components/DishListItem.jsx
+++ b/src/components/DishListItem.jsx
@@ -78,12 +78,14 @@ export const DishListItem = memo(function DishListItem({
   var isPodium = rank != null && rank <= 3
 
   return (
+    // Passive container — NOT an ARIA control. Keeps `onClick` for the
+    // mouse-anywhere convenience but no `role="button"`/`tabIndex`/`onKeyDown`,
+    // so its interactive children (dish-name button, restaurant link, Order /
+    // Directions / ingredients toggle) are siblings of controls, not nested
+    // inside one. Keyboard activation goes through the dish-name button below.
     <div
       data-dish-id={dishId}
-      role="button"
-      tabIndex={0}
       onClick={handleClick}
-      onKeyDown={function (e) { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleClick(e) } }}
       className={'w-full text-left active:scale-[0.98]' + (isPodium ? ' rounded-xl' : '')}
       style={{
         background: highlighted
@@ -160,18 +162,35 @@ export const DishListItem = memo(function DishListItem({
 
       {/* Name + restaurant + distance */}
       <div className="flex-1 min-w-0" style={{ marginLeft: showPhoto ? '6px' : (isPodium ? '8px' : '6px') }}>
-        <p
-          className="font-bold line-clamp-2"
+        {/* Dish name is the keyboard-accessible primary navigation control.
+            It's a real <button> so screen readers announce it as an
+            activatable element. Mouse-anywhere navigation still works via
+            the outer container's onClick; this button's onClick stops the
+            click from double-firing the parent. */}
+        <button
+          type="button"
+          onClick={function (e) { e.stopPropagation(); handleClick(e) }}
+          onKeyDown={function (e) {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.stopPropagation()
+            }
+          }}
+          className="font-bold line-clamp-2 text-left w-full block"
           style={{
+            background: 'transparent',
+            border: 'none',
+            padding: 0,
+            cursor: 'pointer',
             fontSize: isPodium ? '15px' : '14px',
             fontWeight: isPodium ? 800 : 700,
             color: 'var(--color-text-primary)',
             lineHeight: 1.3,
             letterSpacing: '-0.01em',
+            fontFamily: 'inherit',
           }}
         >
           {dishName}
-        </p>
+        </button>
         <div className="flex items-center gap-1.5" style={{ marginTop: '2px' }}>
           <p
             className="truncate"
@@ -360,16 +379,21 @@ export const DishListItem = memo(function DishListItem({
     var hasMyRating = myRating !== undefined && myRating !== null && myRatingNum >= 1 && myRatingNum <= 10
     var communityAvg = avgRating ? Number(avgRating) : null
 
-    var CardTag = isOtherProfile ? 'button' : 'div'
+    // Voted card outer is always a passive <div>. When viewing another
+    // user's profile, the card is mouse-clickable via onClick + cursor,
+    // but it's no longer marked as an ARIA control — keyboard activation
+    // routes through the dish-name button inside, so the restaurant link
+    // (role="link") and any future controls aren't nested inside a button.
     var cardProps = isOtherProfile ? { onClick: handleClick } : {}
 
     return (
-      <CardTag
+      <div
         {...cardProps}
         className={'rounded-xl border overflow-hidden' + (isOtherProfile ? ' w-full text-left hover:shadow-md transition-all active:scale-[0.99]' : ' transition-all')}
         style={{
           background: 'var(--color-card)',
           borderColor: 'var(--color-divider)',
+          cursor: isOtherProfile ? 'pointer' : 'default',
         }}
       >
         <div className="flex">
@@ -400,16 +424,46 @@ export const DishListItem = memo(function DishListItem({
                 {restaurantId ? (
                   <span
                     role="link"
+                    tabIndex={0}
                     onClick={function (e) { e.stopPropagation(); navigate('/restaurants/' + restaurantId) }}
-                    style={{ color: 'var(--color-accent-gold)' }}
+                    onKeyDown={function (e) {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault(); e.stopPropagation()
+                        navigate('/restaurants/' + restaurantId)
+                      }
+                    }}
+                    style={{ color: 'var(--color-accent-gold)', cursor: 'pointer' }}
                   >
                     {restaurantName}
                   </span>
                 ) : restaurantName}
               </h3>
-              <p className="text-sm truncate" style={{ color: 'var(--color-text-secondary)' }}>
-                {dishName}
-              </p>
+              {isOtherProfile ? (
+                <button
+                  type="button"
+                  onClick={function (e) { e.stopPropagation(); handleClick(e) }}
+                  onKeyDown={function (e) {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.stopPropagation()
+                    }
+                  }}
+                  className="text-sm truncate text-left w-full block"
+                  style={{
+                    background: 'transparent',
+                    border: 'none',
+                    padding: 0,
+                    cursor: 'pointer',
+                    color: 'var(--color-text-secondary)',
+                    fontFamily: 'inherit',
+                  }}
+                >
+                  {dishName}
+                </button>
+              ) : (
+                <p className="text-sm truncate" style={{ color: 'var(--color-text-secondary)' }}>
+                  {dishName}
+                </p>
+              )}
             </div>
 
             {/* Own Profile Rating */}
@@ -480,7 +534,7 @@ export const DishListItem = memo(function DishListItem({
             </p>
           </div>
         )}
-      </CardTag>
+      </div>
     )
   }
 })

--- a/src/components/DishListItem.test.jsx
+++ b/src/components/DishListItem.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { DishListItem } from './DishListItem'
 
@@ -13,54 +13,93 @@ function renderItem(dish, extra = {}) {
   )
 }
 
-describe('DishListItem description preview', () => {
-  it('renders description line when description is non-null', () => {
+const BASE = {
+  dish_id: 'd1',
+  dish_name: 'Lobster Roll',
+  restaurant_name: 'Coast Cafe',
+  category: 'lobster roll',
+  avg_rating: 8.4,
+  total_votes: 12,
+}
+
+describe('DishListItem description toggle', () => {
+  it('shows an "ingredients" toggle when description is non-null', () => {
     renderItem({
-      dish_id: 'd1',
-      dish_name: 'Lobster Roll',
-      restaurant_name: 'Coast Cafe',
-      category: 'lobster roll',
-      avg_rating: 8.4,
-      total_votes: 12,
+      ...BASE,
       description: 'Hot lobster meat, drawn butter, split-top bun',
     })
-    expect(screen.getByText(/hot lobster meat, drawn butter, split-top bun/i)).toBeInTheDocument()
+    expect(screen.getByTestId('dish-description-toggle')).toBeInTheDocument()
+    // Collapsed by default — description body is not rendered yet.
+    expect(screen.queryByTestId('dish-description-preview')).not.toBeInTheDocument()
+  })
+
+  it('tapping the toggle reveals the description inline', () => {
+    renderItem({
+      ...BASE,
+      description: 'Hot lobster meat, drawn butter, split-top bun',
+    })
+    fireEvent.click(screen.getByTestId('dish-description-toggle'))
     expect(screen.getByTestId('dish-description-preview')).toBeInTheDocument()
+    expect(screen.getByText(/hot lobster meat, drawn butter, split-top bun/i)).toBeInTheDocument()
   })
 
-  it('omits description line when description is null', () => {
+  it('tapping the toggle a second time collapses the description', () => {
     renderItem({
-      dish_id: 'd1',
-      dish_name: 'Lobster Roll',
-      restaurant_name: 'Coast Cafe',
-      category: 'lobster roll',
-      avg_rating: 8.4,
-      total_votes: 12,
-      description: null,
+      ...BASE,
+      description: 'Hot lobster meat, drawn butter',
     })
+    const toggle = screen.getByTestId('dish-description-toggle')
+    fireEvent.click(toggle)
+    fireEvent.click(toggle)
     expect(screen.queryByTestId('dish-description-preview')).not.toBeInTheDocument()
   })
 
-  it('omits description line when description is undefined', () => {
+  it('toggle reflects aria-expanded state', () => {
     renderItem({
-      dish_id: 'd1',
-      dish_name: 'Lobster Roll',
-      restaurant_name: 'Coast Cafe',
-      category: 'lobster roll',
-      avg_rating: 8.4,
-      total_votes: 12,
+      ...BASE,
+      description: 'Anchovy, lemon, breadcrumb',
     })
+    const toggle = screen.getByTestId('dish-description-toggle')
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('clicking the toggle does NOT navigate to the dish (stopPropagation)', () => {
+    let cardClicks = 0
+    renderItem(
+      { ...BASE, description: 'Some ingredients' },
+      { onClick: () => { cardClicks++ } }
+    )
+    fireEvent.click(screen.getByTestId('dish-description-toggle'))
+    expect(cardClicks).toBe(0)
+  })
+
+  it('keyboard-activating the toggle does NOT bubble Enter/Space to the card', () => {
+    let cardClicks = 0
+    renderItem(
+      { ...BASE, description: 'Some ingredients' },
+      { onClick: () => { cardClicks++ } }
+    )
+    const toggle = screen.getByTestId('dish-description-toggle')
+    fireEvent.keyDown(toggle, { key: 'Enter' })
+    fireEvent.keyDown(toggle, { key: ' ' })
+    expect(cardClicks).toBe(0)
+  })
+
+  it('omits the toggle entirely when description is null', () => {
+    renderItem({ ...BASE, description: null })
+    expect(screen.queryByTestId('dish-description-toggle')).not.toBeInTheDocument()
     expect(screen.queryByTestId('dish-description-preview')).not.toBeInTheDocument()
   })
 
-  it('omits description line when description is empty/whitespace string', () => {
-    renderItem({
-      dish_id: 'd1',
-      dish_name: 'Lobster Roll',
-      restaurant_name: 'Coast Cafe',
-      category: 'lobster roll',
-      description: '   ',
-    })
-    expect(screen.queryByTestId('dish-description-preview')).not.toBeInTheDocument()
+  it('omits the toggle when description is undefined', () => {
+    renderItem({ ...BASE })
+    expect(screen.queryByTestId('dish-description-toggle')).not.toBeInTheDocument()
+  })
+
+  it('omits the toggle when description is whitespace only', () => {
+    renderItem({ ...BASE, description: '   ' })
+    expect(screen.queryByTestId('dish-description-toggle')).not.toBeInTheDocument()
   })
 })

--- a/src/components/DishListItem.test.jsx
+++ b/src/components/DishListItem.test.jsx
@@ -103,3 +103,30 @@ describe('DishListItem description toggle', () => {
     expect(screen.queryByTestId('dish-description-toggle')).not.toBeInTheDocument()
   })
 })
+
+describe('DishListItem accessibility — no nested interactive controls', () => {
+  it('outer container is NOT a button (no role="button" or tabIndex)', () => {
+    renderItem({ ...BASE, description: null })
+    const outer = document.querySelector('[data-dish-id="' + BASE.dish_id + '"]')
+    expect(outer).not.toBeNull()
+    expect(outer.getAttribute('role')).toBeNull()
+    expect(outer.getAttribute('tabindex')).toBeNull()
+  })
+
+  it('dish name is a real <button> for keyboard navigation', () => {
+    renderItem({ ...BASE, description: null })
+    const dishNameButton = screen.getByRole('button', { name: BASE.dish_name })
+    expect(dishNameButton.tagName).toBe('BUTTON')
+  })
+
+  it('clicking the dish name button navigates without double-firing the parent', () => {
+    let clicks = 0
+    renderItem(
+      { ...BASE, description: null },
+      { onClick: () => { clicks++ } }
+    )
+    const dishNameButton = screen.getByRole('button', { name: BASE.dish_name })
+    fireEvent.click(dishNameButton)
+    expect(clicks).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
Two changes, intentionally bundled:

1. **UX**: The v1.3 description preview that shipped on dish cards (PR #231) was cramped in the right-column text area. Switched to a small **"ingredients ▾"** toggle that's collapsed by default. Tapping expands the description inline below the row — full width, wraps to multiple lines, no truncation. Closed state keeps the list as tight as before backfill.

2. **A11y root fix**: Codex flagged the entire `DishListItem` card as a *nested interactive controls* anti-pattern — the outer `<div role="button">` had real `<button>` / `<a>` / `<span role="link">` children (Order Now, Directions, restaurant link, and the new toggle). Restructured both the ranked and voted variants so interactive children are *siblings of* an interactive primary control, not descendants of one.

### Ranked variant (home, browse, restaurant detail)
- Outer container is now passive — no `role="button"`, no `tabIndex`, no `onKeyDown`.
- Keeps `onClick` + `cursor: pointer` for mouse-anywhere navigation.
- Dish name is a real `<button>` (primary keyboard navigation), with `stopPropagation` on click + keydown to prevent double-fire.

### Voted variant (profile, "other-profile" mode)
- `CardTag` is no longer conditionally `'button'` / `'div'` — always `'div'`.
- `onClick` added only when `isOtherProfile`, with `cursor: pointer`.
- Dish name becomes a real `<button>` when `isOtherProfile`; plain `<p>` otherwise.
- Restaurant `span role="link"` now has `tabIndex={0}` + `onKeyDown` for keyboard access (matches ranked variant).

### Ingredients toggle behavior
- `<button>` with `aria-expanded` + `aria-controls`.
- `onClick` and `onKeyDown` both `stopPropagation` so toggling never navigates to the dish page.
- Per-card state via `useState` — multiple cards expand independently.
- Renders nothing for null / undefined / empty / whitespace descriptions.

## Tradeoff
Keyboard "tap area" for primary navigation shrinks from "whole card" to "dish name". Conscious design choice for granular, semantically-correct keyboard nav. Codex called this out as a tradeoff, not a defect.

## Review trail
- Per-step Codex review (`gpt-5.3-codex`, medium reasoning). Findings addressed inline:
  - Keyboard bubble bug on toggle → added `onKeyDown` guard + regression test.
  - Voted-variant restaurant link missing keyboard access → matched ranked-variant pattern.
- 12/12 `DishListItem.test.jsx` pass, including three new a11y assertions: outer has no ARIA role, dish name is a real `<button>`, single-fire on click.

## Test plan
- [ ] Dish card shows compact "ingredients ▾" link when description is present
- [ ] Tap toggles open / closed; expanded description wraps and reads naturally
- [ ] Tapping toggle does NOT open the dish detail page
- [ ] Cards without descriptions render exactly as before (no toggle, no extra height)
- [ ] Keyboard tab: dish name receives focus, Enter navigates to dish detail
- [ ] Restaurant name (gold text) tappable / keyboard-activatable separately
- [ ] Order Now / Directions still work without navigating to the dish

🤖 Generated with [Claude Code](https://claude.com/claude-code)