### PR TITLE
fix(ui): remove ingredients toggle from dish-list card

### DIFF
--- a/src/components/DishListItem.jsx
+++ b/src/components/DishListItem.jsx
@@ -1,4 +1,4 @@
-import { memo, useState } from 'react'
+import { memo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { MIN_VOTES_FOR_RANKING } from '../constants/app'
 import { getRatingColor } from '../utils/ranking'
@@ -43,9 +43,6 @@ export const DishListItem = memo(function DishListItem({
   hideVotes = false,
 }) {
   const navigate = useNavigate()
-  // Inline "ingredients" expander — local state per card. Closed by default
-  // so the list stays tight; user opts in to see Sonnet's ingredient line.
-  const [showDescription, setShowDescription] = useState(false)
 
   // Normalize data shapes between different sources
   const dishName = dish.dish_name || dish.name
@@ -80,9 +77,9 @@ export const DishListItem = memo(function DishListItem({
   return (
     // Passive container — NOT an ARIA control. Keeps `onClick` for the
     // mouse-anywhere convenience but no `role="button"`/`tabIndex`/`onKeyDown`,
-    // so its interactive children (dish-name button, restaurant link, Order /
-    // Directions / ingredients toggle) are siblings of controls, not nested
-    // inside one. Keyboard activation goes through the dish-name button below.
+    // so its interactive children (dish-name button, restaurant link, Order
+    // Now, Directions) are siblings of controls, not nested inside one.
+    // Keyboard activation goes through the dish-name button below.
     <div
       data-dish-id={dishId}
       onClick={handleClick}
@@ -221,72 +218,10 @@ export const DishListItem = memo(function DishListItem({
         </div>
         {/* Description preview \u2014 terse Sonnet ingredient line. Omitted entirely
             when null/empty so cards render exactly as before backfill. */}
-        {typeof dish.description === 'string' && dish.description.trim() ? (
-          <div style={{ marginTop: '3px' }}>
-            <button
-              type="button"
-              onClick={function (e) {
-                e.stopPropagation()
-                setShowDescription(function (v) { return !v })
-              }}
-              onKeyDown={function (e) {
-                // Parent card handles Enter/Space as its own activation. Without
-                // this guard, keyboard activation of the toggle would bubble up
-                // and navigate to the dish detail page.
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.stopPropagation()
-                }
-              }}
-              aria-expanded={showDescription}
-              aria-controls={'dish-desc-' + dishId}
-              data-testid="dish-description-toggle"
-              style={{
-                background: 'transparent',
-                border: 'none',
-                padding: 0,
-                cursor: 'pointer',
-                fontFamily: 'Outfit, sans-serif',
-                fontSize: isPodium ? '11px' : '10px',
-                fontWeight: 600,
-                color: 'var(--color-text-tertiary)',
-                letterSpacing: '0.04em',
-                textTransform: 'lowercase',
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: '3px',
-              }}
-            >
-              ingredients
-              <span
-                aria-hidden="true"
-                style={{
-                  display: 'inline-block',
-                  transform: showDescription ? 'rotate(180deg)' : 'none',
-                  transition: 'transform 150ms ease',
-                  fontSize: '8px',
-                  lineHeight: 1,
-                }}
-              >
-                ▾
-              </span>
-            </button>
-            {showDescription ? (
-              <div
-                id={'dish-desc-' + dishId}
-                data-testid="dish-description-preview"
-                style={{
-                  marginTop: '4px',
-                  fontFamily: 'Outfit, sans-serif',
-                  fontSize: isPodium ? '12px' : '11px',
-                  color: 'var(--color-text-secondary)',
-                  lineHeight: 1.4,
-                }}
-              >
-                {dish.description.trim()}
-              </div>
-            ) : null}
-          </div>
-        ) : null}
+        {/* Dish description lives on the detail page only (rendered by
+            DishDescription in src/pages/Dish.jsx). Keep the list-item card
+            tight — name, restaurant, rating, and the Order/Directions
+            action buttons below. Users tap into the dish to see ingredients. */}
         {/* Action buttons — Order / Directions */}
         {(toastSlug || sanitizeUrl(orderUrl) || restaurantLat) && (
           <div className="flex items-center gap-2" style={{ marginTop: '4px' }}>

--- a/src/components/DishListItem.test.jsx
+++ b/src/components/DishListItem.test.jsx
@@ -22,91 +22,34 @@ const BASE = {
   total_votes: 12,
 }
 
-describe('DishListItem description toggle', () => {
-  it('shows an "ingredients" toggle when description is non-null', () => {
+describe('DishListItem — description belongs on the detail page, not the card', () => {
+  it('does NOT render any ingredients toggle on the card, even when description is present', () => {
     renderItem({
       ...BASE,
       description: 'Hot lobster meat, drawn butter, split-top bun',
     })
-    expect(screen.getByTestId('dish-description-toggle')).toBeInTheDocument()
-    // Collapsed by default — description body is not rendered yet.
+    expect(screen.queryByTestId('dish-description-toggle')).not.toBeInTheDocument()
     expect(screen.queryByTestId('dish-description-preview')).not.toBeInTheDocument()
   })
 
-  it('tapping the toggle reveals the description inline', () => {
+  it('does NOT render the description text on the card, even when present', () => {
     renderItem({
       ...BASE,
       description: 'Hot lobster meat, drawn butter, split-top bun',
     })
-    fireEvent.click(screen.getByTestId('dish-description-toggle'))
-    expect(screen.getByTestId('dish-description-preview')).toBeInTheDocument()
-    expect(screen.getByText(/hot lobster meat, drawn butter, split-top bun/i)).toBeInTheDocument()
+    expect(screen.queryByText(/hot lobster meat/i)).not.toBeInTheDocument()
   })
 
-  it('tapping the toggle a second time collapses the description', () => {
-    renderItem({
-      ...BASE,
-      description: 'Hot lobster meat, drawn butter',
-    })
-    const toggle = screen.getByTestId('dish-description-toggle')
-    fireEvent.click(toggle)
-    fireEvent.click(toggle)
-    expect(screen.queryByTestId('dish-description-preview')).not.toBeInTheDocument()
-  })
-
-  it('toggle reflects aria-expanded state', () => {
-    renderItem({
-      ...BASE,
-      description: 'Anchovy, lemon, breadcrumb',
-    })
-    const toggle = screen.getByTestId('dish-description-toggle')
-    expect(toggle).toHaveAttribute('aria-expanded', 'false')
-    fireEvent.click(toggle)
-    expect(toggle).toHaveAttribute('aria-expanded', 'true')
-  })
-
-  it('clicking the toggle does NOT navigate to the dish (stopPropagation)', () => {
-    let cardClicks = 0
-    renderItem(
-      { ...BASE, description: 'Some ingredients' },
-      { onClick: () => { cardClicks++ } }
-    )
-    fireEvent.click(screen.getByTestId('dish-description-toggle'))
-    expect(cardClicks).toBe(0)
-  })
-
-  it('keyboard-activating the toggle does NOT bubble Enter/Space to the card', () => {
-    let cardClicks = 0
-    renderItem(
-      { ...BASE, description: 'Some ingredients' },
-      { onClick: () => { cardClicks++ } }
-    )
-    const toggle = screen.getByTestId('dish-description-toggle')
-    fireEvent.keyDown(toggle, { key: 'Enter' })
-    fireEvent.keyDown(toggle, { key: ' ' })
-    expect(cardClicks).toBe(0)
-  })
-
-  it('omits the toggle entirely when description is null', () => {
+  it('renders normally when description is null', () => {
     renderItem({ ...BASE, description: null })
-    expect(screen.queryByTestId('dish-description-toggle')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('dish-description-preview')).not.toBeInTheDocument()
-  })
-
-  it('omits the toggle when description is undefined', () => {
-    renderItem({ ...BASE })
-    expect(screen.queryByTestId('dish-description-toggle')).not.toBeInTheDocument()
-  })
-
-  it('omits the toggle when description is whitespace only', () => {
-    renderItem({ ...BASE, description: '   ' })
+    expect(screen.getByText(BASE.dish_name)).toBeInTheDocument()
     expect(screen.queryByTestId('dish-description-toggle')).not.toBeInTheDocument()
   })
 })
 
 describe('DishListItem accessibility — no nested interactive controls', () => {
   it('outer container is NOT a button (no role="button" or tabIndex)', () => {
-    renderItem({ ...BASE, description: null })
+    renderItem({ ...BASE })
     const outer = document.querySelector('[data-dish-id="' + BASE.dish_id + '"]')
     expect(outer).not.toBeNull()
     expect(outer.getAttribute('role')).toBeNull()
@@ -114,7 +57,7 @@ describe('DishListItem accessibility — no nested interactive controls', () => 
   })
 
   it('dish name is a real <button> for keyboard navigation', () => {
-    renderItem({ ...BASE, description: null })
+    renderItem({ ...BASE })
     const dishNameButton = screen.getByRole('button', { name: BASE.dish_name })
     expect(dishNameButton.tagName).toBe('BUTTON')
   })
@@ -122,7 +65,7 @@ describe('DishListItem accessibility — no nested interactive controls', () => 
   it('clicking the dish name button navigates without double-firing the parent', () => {
     let clicks = 0
     renderItem(
-      { ...BASE, description: null },
+      { ...BASE },
       { onClick: () => { clicks++ } }
     )
     const dishNameButton = screen.getByRole('button', { name: BASE.dish_name })


### PR DESCRIPTION
## Summary
Per design feedback: the **list-item card** should stay tight. The dish description belongs on the **dish detail page** only (already rendered there by `DishDescription` from PR #231).

Reverses the ingredients toggle UX from PR #233 — keeps the a11y root fix that came with it.

## Changes
- **Removes** the inline `ingredients ▾` toggle + collapsible description from `DishListItem` (both ranked and voted variants).
- **Removes** the `useState`/`useState` import that backed the toggle.
- **Keeps** the PR #233 a11y root fix: passive outer `<div>`, real dish-name `<button>` for keyboard nav, voted-variant restaurant-link keyboard parity. None of that was tied to the toggle.
- **Keeps** Order Now and Directions buttons exactly where they were.

## Tests
Rewritten:
- Asserts toggle / preview do **not** render even when description is set.
- Keeps the three a11y assertions (outer is not `role="button"`, dish name is a real `<button>`, single-fire on click).

6/6 pass.

## Codex
Reviewed; no substantive issues. One comment cleanup applied (passive-container comment no longer mentions the removed toggle).

## Test plan
- [ ] Card with description renders without "ingredients" link
- [ ] Card without description renders identically (no regression)
- [ ] Tap the dish → detail page → description block still shows (from PR #231)
- [ ] Order Now / Directions still work
- [ ] Keyboard tab still lands on dish name → Enter navigates

🤖 Generated with [Claude Code](https://claude.com/claude-code)