### PR TITLE
fix(ui): move dish description into hero card as ingredients drop-down

### DIFF
--- a/src/components/dish/DishDescription.jsx
+++ b/src/components/dish/DishDescription.jsx
@@ -3,30 +3,31 @@ import { DIETARY_TAG_LABELS, DIETARY_DISCLAIMER, ALLOWED_DIETARY_TAGS } from '..
 import { serializeDietParam } from '../../utils/dietUrlParams'
 
 /**
- * DishDescription — the "what's in this?" block on the dish detail page.
+ * DishDescription — the dietary tags + allergen disclaimer block.
  *
- * Renders three optional surfaces, in order:
- *   1. The ingredient/preparation description (terse, ≤80 chars, Sonnet extracted)
- *   2. A row of tappable dietary tag pills (Vegan, Vegetarian, etc.)
- *   3. An allergen disclaimer (only when at least one tag is shown)
+ * The dish description itself now lives inside the hero card (DishHero)
+ * as a tap-to-expand "ingredients" link. This component is the
+ * tag pills + allergen disclaimer surface that sits below the rating
+ * card on the dish detail page.
  *
- * Each surface is null-safe — the whole block returns null when the dish
- * has no description AND no dietary tags, so dishes that haven't been
- * backfilled yet render the page exactly as before.
+ * Renders two optional surfaces, in order:
+ *   1. A row of tappable dietary tag pills (Vegan, Vegetarian, etc.)
+ *   2. An allergen disclaimer (only when at least one tag is shown)
+ *
+ * Returns null when the dish has no dietary tags.
  *
  * Tapping a tag pill navigates to `/?diet=<tag>` so the homepage list
  * filters to that restriction.
  */
-export function DishDescription({ description, dietaryTags }) {
+export function DishDescription({ dietaryTags }) {
   var navigate = useNavigate()
 
-  var hasDescription = typeof description === 'string' && description.trim().length > 0
   var tags = Array.isArray(dietaryTags)
     ? dietaryTags.filter(function (t) { return ALLOWED_DIETARY_TAGS.indexOf(t) !== -1 })
     : []
   var hasTags = tags.length > 0
 
-  if (!hasDescription && !hasTags) return null
+  if (!hasTags) return null
 
   function handleTagClick(tag) {
     navigate('/?diet=' + serializeDietParam([tag]))
@@ -34,7 +35,7 @@ export function DishDescription({ description, dietaryTags }) {
 
   return (
     <section
-      aria-label="Dish description and dietary tags"
+      aria-label="Dietary tags"
       style={{
         margin: '12px 16px 8px',
         padding: '16px 18px',
@@ -43,22 +44,6 @@ export function DishDescription({ description, dietaryTags }) {
         borderRadius: '14px',
       }}
     >
-      {hasDescription ? (
-        <p
-          style={{
-            margin: 0,
-            fontFamily: 'Outfit, sans-serif',
-            fontSize: '15px',
-            fontWeight: 500,
-            lineHeight: 1.45,
-            color: 'var(--color-text-primary)',
-            letterSpacing: '0.005em',
-          }}
-        >
-          {description.trim()}
-        </p>
-      ) : null}
-
       {hasTags ? (
         <div
           aria-label="Dietary tags"
@@ -67,7 +52,6 @@ export function DishDescription({ description, dietaryTags }) {
             display: 'flex',
             flexWrap: 'wrap',
             gap: '8px',
-            marginTop: hasDescription ? '14px' : 0,
           }}
         >
           {tags.map(function (tag) {

--- a/src/components/dish/DishDescription.test.jsx
+++ b/src/components/dish/DishDescription.test.jsx
@@ -19,7 +19,14 @@ function renderWithRouter(ui, { route = '/dish/abc' } = {}) {
   )
 }
 
-describe('DishDescription', () => {
+describe('DishDescription — dietary tags + disclaimer surface', () => {
+  it('returns null when dietaryTags is empty (description ignored here, rendered by DishHero)', () => {
+    const { container } = renderWithRouter(
+      <DishDescription description="Hot lobster meat, drawn butter, split-top bun" dietaryTags={[]} />
+    )
+    expect(container.querySelector('section')).toBeNull()
+  })
+
   it('returns null when both description and dietaryTags are absent', () => {
     const { container } = renderWithRouter(
       <DishDescription description={null} dietaryTags={[]} />
@@ -27,15 +34,14 @@ describe('DishDescription', () => {
     expect(container.querySelector('section')).toBeNull()
   })
 
-  it('renders description when present, no pill row when tags empty', () => {
+  it('does NOT render the description text (DishHero renders it)', () => {
     renderWithRouter(
       <DishDescription
         description="Hot lobster meat, drawn butter, split-top bun"
-        dietaryTags={[]}
+        dietaryTags={['vegan']}
       />
     )
-    expect(screen.getByText(/hot lobster meat, drawn butter, split-top bun/i)).toBeInTheDocument()
-    expect(screen.queryByTestId('dietary-tag-pills')).not.toBeInTheDocument()
+    expect(screen.queryByText(/hot lobster meat, drawn butter, split-top bun/i)).not.toBeInTheDocument()
   })
 
   it('renders pill row + disclaimer when tags non-empty', () => {
@@ -62,12 +68,5 @@ describe('DishDescription', () => {
     )
     fireEvent.click(screen.getByRole('button', { name: /filter homepage by vegan/i }))
     expect(screen.getByTestId('location').textContent).toBe('/?diet=vegan')
-  })
-
-  it('omits disclaimer when no tags are rendered', () => {
-    renderWithRouter(
-      <DishDescription description="Just ingredients" dietaryTags={[]} />
-    )
-    expect(screen.queryByText(/menu labels/i)).not.toBeInTheDocument()
   })
 })

--- a/src/components/dish/DishHero.jsx
+++ b/src/components/dish/DishHero.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { CategoryIcon } from '../home/CategoryIcons'
 import { TrustBadge } from '../jitter'
@@ -11,6 +12,8 @@ import { getRatingColor, formatScore10 } from '../../utils/ranking'
 export function DishHero({ dish, allPhotos, isVariant, parentDish }) {
   const navigate = useNavigate()
   const isRanked = dish.total_votes >= MIN_VOTES_FOR_RANKING
+  const [showIngredients, setShowIngredients] = useState(false)
+  const hasDescription = typeof dish.description === 'string' && dish.description.trim().length > 0
 
   var heroPhoto = allPhotos.length > 0 ? allPhotos[0].photo_url : (dish.photo_url || null)
 
@@ -109,6 +112,69 @@ export function DishHero({ dish, allPhotos, isVariant, parentDish }) {
             </div>
           </div>
         </div>
+
+        {/* Ingredients drop-down — small "ingredients ▾" link between the
+            title/restaurant block and the rating block. Tap reveals the
+            terse Sonnet-extracted ingredient line; closed by default so
+            the "2-second verdict" stays clean. Hidden entirely when the
+            dish has no description. */}
+        {hasDescription ? (
+          <div style={{ marginTop: '10px' }}>
+            <button
+              type="button"
+              onClick={() => setShowIngredients(v => !v)}
+              aria-expanded={showIngredients}
+              aria-controls={'hero-dish-desc-' + dish.dish_id}
+              data-testid="hero-ingredients-toggle"
+              style={{
+                background: 'transparent',
+                border: 'none',
+                padding: 0,
+                cursor: 'pointer',
+                fontFamily: 'Outfit, sans-serif',
+                fontSize: '12px',
+                fontWeight: 700,
+                color: 'var(--color-primary)',
+                letterSpacing: '0.04em',
+                textTransform: 'lowercase',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '4px',
+              }}
+            >
+              ingredients
+              <span
+                aria-hidden="true"
+                style={{
+                  display: 'inline-block',
+                  transform: showIngredients ? 'rotate(180deg)' : 'none',
+                  transition: 'transform 150ms ease',
+                  fontSize: '9px',
+                  lineHeight: 1,
+                }}
+              >
+                ▾
+              </span>
+            </button>
+            {showIngredients ? (
+              <p
+                id={'hero-dish-desc-' + dish.dish_id}
+                data-testid="hero-dish-description"
+                style={{
+                  margin: '6px 0 0',
+                  fontFamily: 'Outfit, sans-serif',
+                  fontSize: '14px',
+                  fontWeight: 500,
+                  lineHeight: 1.45,
+                  color: 'var(--color-text-primary)',
+                  letterSpacing: '0.005em',
+                }}
+              >
+                {dish.description.trim()}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
 
         {/* Score Block */}
         {isRanked && dish.avg_rating ? (

--- a/src/components/dish/DishHero.test.jsx
+++ b/src/components/dish/DishHero.test.jsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { DishHero } from './DishHero'
+
+afterEach(cleanup)
+
+const BASE_DISH = {
+  dish_id: 'd-1',
+  dish_name: 'Atria’s Crispy Wok Fired Calamari',
+  restaurant_id: 'r-1',
+  restaurant_name: 'Atria',
+  restaurant_town: 'Edgartown',
+  category: 'appetizer',
+  price: 25,
+  avg_rating: 8.7,
+  total_votes: 6,
+}
+
+function renderHero(dish, { allPhotos = [], isVariant = false, parentDish = null } = {}) {
+  return render(
+    <MemoryRouter>
+      <DishHero dish={dish} allPhotos={allPhotos} isVariant={isVariant} parentDish={parentDish} />
+    </MemoryRouter>
+  )
+}
+
+describe('DishHero — ingredients drop-down', () => {
+  it('renders the ingredients toggle when description is present', () => {
+    renderHero({
+      ...BASE_DISH,
+      description: 'Watercress, preserved lemon, sambal aioli, fragrant herbs',
+    })
+    expect(screen.getByTestId('hero-ingredients-toggle')).toBeInTheDocument()
+    expect(screen.queryByTestId('hero-dish-description')).not.toBeInTheDocument()
+  })
+
+  it('tapping the toggle reveals the description inline', () => {
+    renderHero({
+      ...BASE_DISH,
+      description: 'Watercress, preserved lemon, sambal aioli, fragrant herbs',
+    })
+    fireEvent.click(screen.getByTestId('hero-ingredients-toggle'))
+    expect(screen.getByTestId('hero-dish-description')).toBeInTheDocument()
+    expect(
+      screen.getByText(/watercress, preserved lemon, sambal aioli, fragrant herbs/i)
+    ).toBeInTheDocument()
+  })
+
+  it('tapping the toggle a second time collapses the description', () => {
+    renderHero({ ...BASE_DISH, description: 'tomato, basil, mozzarella' })
+    const toggle = screen.getByTestId('hero-ingredients-toggle')
+    fireEvent.click(toggle)
+    fireEvent.click(toggle)
+    expect(screen.queryByTestId('hero-dish-description')).not.toBeInTheDocument()
+  })
+
+  it('toggle reflects aria-expanded state', () => {
+    renderHero({ ...BASE_DISH, description: 'anchovy, lemon, breadcrumb' })
+    const toggle = screen.getByTestId('hero-ingredients-toggle')
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('omits the toggle entirely when description is null', () => {
+    renderHero({ ...BASE_DISH, description: null })
+    expect(screen.queryByTestId('hero-ingredients-toggle')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('hero-dish-description')).not.toBeInTheDocument()
+  })
+
+  it('omits the toggle when description is whitespace only', () => {
+    renderHero({ ...BASE_DISH, description: '   ' })
+    expect(screen.queryByTestId('hero-ingredients-toggle')).not.toBeInTheDocument()
+  })
+})

--- a/src/pages/Dish.jsx
+++ b/src/pages/Dish.jsx
@@ -350,15 +350,11 @@ export function Dish() {
             </div>
           )}
 
-          {/* Description + dietary tags. Self-contained — DishDescription
-              returns null when the dish has neither field, leaving the page
-              layout unchanged for non-backfilled dishes. Spacing lives inside
-              the component so an unconditional wrapper div never adds a
-              ghost gap when the block is empty. */}
-          <DishDescription
-            description={dish.description}
-            dietaryTags={dish.dietary_tags}
-          />
+          {/* Dietary tags + allergen disclaimer. Description itself lives
+              in the hero card now (DishHero's ingredients drop-down).
+              DishDescription returns null when dietary_tags is empty, so
+              the page layout is unchanged for dishes without tags. */}
+          <DishDescription dietaryTags={dish.dietary_tags} />
 
           {/* LAYER 2: THE ACTION — Rate CTA + inline rate flow */}
           <div className="p-4 space-y-3">


### PR DESCRIPTION
## Summary
Per design feedback: the description card sitting below the hero felt detached. Move it INSIDE the hero card, between the title/restaurant/price block and the rating, as a small **"ingredients ▾"** tap-to-expand link.

### Before
- Hero card (title · restaurant · price · rating · Jitter trust)
- Separate description card below
- Rate this dish button

### After
- Hero card (title · restaurant · price · **ingredients ▾** · rating · Jitter trust)
- Rate this dish button (with dietary-tag pills below, only when present)

## Changes
**`DishHero.jsx`**
- New per-card `useState` for the drop-down (collapsed by default).
- "ingredients ▾" link styled in coral primary, small + lowercase.
- Tap reveals the terse Sonnet ingredient line inline below the link.
- Hidden entirely when `dish.description` is null/whitespace.
- `aria-expanded` + `aria-controls` wiring; stable id from `dish_id`.

**`DishDescription.jsx`**
- Refactored to only render dietary tag pills + allergen disclaimer.
- `description` prop removed from signature (caller in `Dish.jsx` updated).
- Returns `null` when `dietary_tags` is empty.

**Tests**
- 6 new `DishHero.test.jsx` cases — toggle open/close, aria-expanded, null/whitespace descriptions.
- `DishDescription.test.jsx` updated — asserts the description text is NOT rendered (DishHero owns it now), tag pill behavior unchanged.

## Codex
Reviewed; no high-severity issues. Applied the suggested cleanup (drop the now-unused `description` prop from `DishDescription`).

## Test plan
- [ ] Atria's Crispy Wok Fired Calamari: hero shows "ingredients ▾" between price/restaurant row and rating
- [ ] Tap "ingredients ▾" → "Watercress, preserved lemon, sambal aioli, fragrant herbs" reveals
- [ ] Tap again → collapses
- [ ] Dish with no description: no toggle, hero looks exactly like before
- [ ] Dish with dietary tags: tag pills + disclaimer still appear below the Rate CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)