### PR TITLE
fix(ui): show curator avatars on the homepage Locals' Picks banner

### DIFF
--- a/src/components/home/LocalsPicksBanner.jsx
+++ b/src/components/home/LocalsPicksBanner.jsx
@@ -2,6 +2,110 @@ import { useNavigate } from 'react-router-dom'
 import { useLocalPicksCurators } from '../../hooks/useLocalPicksCurators'
 import { Seal } from '../Seal'
 
+// Avatar stack — overlapping circles showing up to MAX_VISIBLE curators
+// so users can see WHO the locals are at a glance. Falls back to a coral
+// initial chip when a curator hasn't uploaded a profile photo.
+var MAX_VISIBLE_AVATARS = 4
+var AVATAR_SIZE = 36
+var AVATAR_OVERLAP = 12
+
+function CuratorAvatar({ curator, size }) {
+  var borderWidth = 2
+  var ringStyle = {
+    width: size,
+    height: size,
+    borderRadius: '50%',
+    border: borderWidth + 'px solid var(--color-paper-cream-light)',
+    flexShrink: 0,
+    overflow: 'hidden',
+    background: 'var(--color-primary)',
+    color: '#FFFFFF',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontFamily: 'Outfit, sans-serif',
+    fontWeight: 700,
+    fontSize: size * 0.42,
+    letterSpacing: '0.01em',
+    lineHeight: 1,
+    boxShadow: '0 1px 2px rgba(0,0,0,0.12)',
+  }
+  if (curator && curator.avatar_url) {
+    return (
+      <div style={ringStyle} aria-hidden="true">
+        <img
+          src={curator.avatar_url}
+          alt=""
+          style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+          draggable={false}
+        />
+      </div>
+    )
+  }
+  var initial = (curator && curator.display_name ? curator.display_name.charAt(0) : '?').toUpperCase()
+  return (
+    <div style={ringStyle} aria-hidden="true">
+      {initial}
+    </div>
+  )
+}
+
+function CuratorAvatarStack({ curators }) {
+  var visible = curators.slice(0, MAX_VISIBLE_AVATARS)
+  var extra = Math.max(0, curators.length - MAX_VISIBLE_AVATARS)
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        position: 'relative',
+        zIndex: 2,
+        flexShrink: 0,
+        paddingRight: extra > 0 ? '6px' : 0,
+      }}
+      aria-label={curators.length + ' islanders'}
+    >
+      {visible.map(function (c, i) {
+        return (
+          <div
+            key={c.user_id || i}
+            style={{
+              marginLeft: i === 0 ? 0 : -AVATAR_OVERLAP,
+              zIndex: visible.length - i,
+            }}
+          >
+            <CuratorAvatar curator={c} size={AVATAR_SIZE} />
+          </div>
+        )
+      })}
+      {extra > 0 ? (
+        <div
+          style={{
+            marginLeft: -AVATAR_OVERLAP,
+            width: AVATAR_SIZE,
+            height: AVATAR_SIZE,
+            borderRadius: '50%',
+            border: '2px solid var(--color-paper-cream-light)',
+            background: 'var(--color-surface-elevated)',
+            color: 'var(--color-text-primary)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontFamily: 'Outfit, sans-serif',
+            fontWeight: 700,
+            fontSize: '11px',
+            lineHeight: 1,
+            zIndex: 0,
+          }}
+          aria-hidden="true"
+        >
+          +{extra}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
 var BANNER_OUTER = {
   position: 'relative',
   background: 'linear-gradient(180deg, var(--color-paper-cream-light) 0%, var(--color-paper-cream-dark) 100%)',
@@ -58,16 +162,6 @@ var CTA = {
   color: 'var(--color-primary)',
   marginTop: '8px',
 }
-var STAMP_WRAP = {
-  position: 'relative',
-  zIndex: 2,
-  width: '72px',
-  height: '72px',
-  flexShrink: 0,
-  borderRadius: '16px',
-  overflow: 'hidden',
-  boxShadow: '0 4px 12px rgba(228, 68, 10, 0.18)',
-}
 
 export function LocalsPicksBanner() {
   var navigate = useNavigate()
@@ -97,8 +191,23 @@ export function LocalsPicksBanner() {
         </div>
         <div style={CTA}>See what they order <span style={{ fontWeight: 800, marginLeft: '1px' }}>&rarr;</span></div>
       </div>
-      <div style={STAMP_WRAP}>
-        <Seal variant="icon" size={72} />
+      <div
+        style={{
+          position: 'relative',
+          zIndex: 2,
+          flexShrink: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-end',
+          gap: '6px',
+        }}
+      >
+        <CuratorAvatarStack curators={curators} />
+        {/* Tiny Seal kept as a small endorsement mark below the stack so
+            the editorial "Locals' Picks" identity doesn't get lost. */}
+        <div style={{ width: '36px', height: '36px', opacity: 0.85 }}>
+          <Seal variant="icon" size={36} />
+        </div>
       </div>
     </button>
   )

--- a/src/components/home/LocalsPicksBanner.test.jsx
+++ b/src/components/home/LocalsPicksBanner.test.jsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { LocalsPicksBanner } from './LocalsPicksBanner'
+
+// Stub Seal so the banner renders without depending on its internal SVG details.
+vi.mock('../Seal', () => ({
+  Seal: () => <div data-testid="seal-mock" />,
+}))
+
+const mockCurators = vi.fn()
+vi.mock('../../hooks/useLocalPicksCurators', () => ({
+  useLocalPicksCurators: () => mockCurators(),
+}))
+
+afterEach(() => {
+  cleanup()
+  mockCurators.mockReset()
+})
+
+function renderBanner() {
+  return render(
+    <MemoryRouter>
+      <LocalsPicksBanner />
+    </MemoryRouter>
+  )
+}
+
+describe('LocalsPicksBanner — curator avatars', () => {
+  it('renders nothing when loading', () => {
+    mockCurators.mockReturnValue({ curators: [], loading: true })
+    const { container } = renderBanner()
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when there are no curators', () => {
+    mockCurators.mockReturnValue({ curators: [], loading: false })
+    const { container } = renderBanner()
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders curator avatar images when avatar_url is present', () => {
+    mockCurators.mockReturnValue({
+      curators: [
+        { user_id: 'u1', display_name: 'Maya', avatar_url: 'https://cdn/avatars/maya.jpg', item_count: 5 },
+        { user_id: 'u2', display_name: 'Sam', avatar_url: 'https://cdn/avatars/sam.jpg', item_count: 3 },
+      ],
+      loading: false,
+    })
+    renderBanner()
+    const imgs = document.querySelectorAll('img[src^="https://cdn/avatars/"]')
+    expect(imgs.length).toBe(2)
+  })
+
+  it('falls back to an initial chip when a curator has no avatar_url', () => {
+    mockCurators.mockReturnValue({
+      curators: [
+        { user_id: 'u1', display_name: 'Lucy', avatar_url: null, item_count: 4 },
+      ],
+      loading: false,
+    })
+    renderBanner()
+    expect(screen.getByText('L')).toBeInTheDocument()
+  })
+
+  it('shows a +N overflow chip when there are more curators than MAX_VISIBLE', () => {
+    mockCurators.mockReturnValue({
+      curators: [
+        { user_id: 'a', display_name: 'A', avatar_url: 'https://cdn/a.jpg', item_count: 1 },
+        { user_id: 'b', display_name: 'B', avatar_url: 'https://cdn/b.jpg', item_count: 1 },
+        { user_id: 'c', display_name: 'C', avatar_url: 'https://cdn/c.jpg', item_count: 1 },
+        { user_id: 'd', display_name: 'D', avatar_url: 'https://cdn/d.jpg', item_count: 1 },
+        { user_id: 'e', display_name: 'E', avatar_url: 'https://cdn/e.jpg', item_count: 1 },
+        { user_id: 'f', display_name: 'F', avatar_url: 'https://cdn/f.jpg', item_count: 1 },
+      ],
+      loading: false,
+    })
+    renderBanner()
+    expect(screen.getByText('+2')).toBeInTheDocument()
+  })
+
+  it('renders "?" placeholder when display_name and avatar_url are both missing', () => {
+    mockCurators.mockReturnValue({
+      curators: [
+        { user_id: 'u1', display_name: null, avatar_url: null, item_count: 1 },
+      ],
+      loading: false,
+    })
+    renderBanner()
+    expect(screen.getByText('?')).toBeInTheDocument()
+  })
+
+  it('does not show an overflow chip when curators ≤ MAX_VISIBLE', () => {
+    mockCurators.mockReturnValue({
+      curators: [
+        { user_id: 'a', display_name: 'A', avatar_url: 'https://cdn/a.jpg', item_count: 1 },
+        { user_id: 'b', display_name: 'B', avatar_url: 'https://cdn/b.jpg', item_count: 1 },
+      ],
+      loading: false,
+    })
+    renderBanner()
+    expect(screen.queryByText(/^\+\d+$/)).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
Per design feedback: *"if a user is on the local list for homepage, then their avatar should be there too so people can actually see the local."*

The banner was only showing a generic Seal graphic + count text. The `get_local_picks_curators` RPC has been returning `avatar_url` all along (`schema.sql:3602`) — we just never rendered it. Same pattern as the dish-description bug: data fetched, UI silently dropped it.

## Changes
- New `CuratorAvatar` + `CuratorAvatarStack` helpers inside the banner.
- Renders up to **4 overlapping circles**; coral initial chip when a curator hasn't uploaded an avatar; `?` fallback when both `display_name` and `avatar_url` are missing.
- `+N` overflow chip when there are more than 4 curators.
- Tiny Seal mark kept *below* the stack so the editorial identity of "Locals' Picks" doesn't get lost.
- Removed the unused `STAMP_WRAP` style block.

## Codex
Reviewed; no medium/high findings. Added the `?` fallback test codex suggested.

## Test plan
- [ ] Homepage shows the banner with 1-4 curator faces visible
- [ ] Curators without uploaded avatars show a coral initial chip (first letter of display_name)
- [ ] If there are >4 curators, a `+N` chip appears on the right
- [ ] Tapping the banner still navigates to `/locals`

🤖 Generated with [Claude Code](https://claude.com/claude-code)