### PR TITLE
feat(ui): show curator avatar on the local list detail page

### DIFF
--- a/src/pages/LocalsCurator.jsx
+++ b/src/pages/LocalsCurator.jsx
@@ -26,9 +26,30 @@ var PAGENO = { fontFamily: "'Amatic SC', cursive", fontSize: '16px', fontWeight:
 
 var STAMP_TINY = { position: 'absolute', top: '54px', right: '24px', width: '44px', height: '44px', transform: 'rotate(10deg)', opacity: 0.8, zIndex: 2 }
 
-var EYEBROW = { fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'var(--color-accent-gold)', marginBottom: '-2px' }
+var EYEBROW = { fontFamily: "'Amatic SC', cursive", fontSize: '18px', fontWeight: 700, color: 'var(--color-accent-gold)', marginBottom: '6px' }
 var TITLE = { fontFamily: "'Amatic SC', cursive", fontWeight: 700, fontSize: '52px', lineHeight: 0.95, color: 'var(--color-text-primary)' }
 var BYLINE = { fontSize: '12px', color: 'var(--color-text-secondary)', marginBottom: '16px' }
+
+var AVATAR_SIZE = 88
+var AVATAR_WRAP = {
+  width: AVATAR_SIZE,
+  height: AVATAR_SIZE,
+  borderRadius: '50%',
+  overflow: 'hidden',
+  background: 'var(--color-primary)',
+  color: '#FFFFFF',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontFamily: 'Outfit, sans-serif',
+  fontWeight: 700,
+  fontSize: '34px',
+  letterSpacing: '0.01em',
+  lineHeight: 1,
+  marginBottom: '10px',
+  boxShadow: '0 2px 8px rgba(0,0,0,0.10)',
+  border: '2px solid var(--color-paper-cream-light)',
+}
 
 var ITEM = { marginBottom: '11px', padding: '0 2px' }
 var ITEM_HEAD = { display: 'flex', alignItems: 'baseline', gap: '6px', marginBottom: '1px' }
@@ -72,6 +93,18 @@ export function LocalsCurator() {
         </div>
 
         <div style={EYEBROW}>a local's picks</div>
+        <div style={AVATAR_WRAP} aria-hidden="true">
+          {first.avatar_url ? (
+            <img
+              src={first.avatar_url}
+              alt=""
+              style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+              draggable={false}
+            />
+          ) : (
+            (first.display_name || '?').charAt(0).toUpperCase()
+          )}
+        </div>
         <h1 style={TITLE}>{first.display_name || 'Anonymous'}</h1>
         <div style={BYLINE}>{first.description || (first.title || '')}</div>
 

--- a/supabase/migrations/2026-05-19-add-avatar-url-to-local-list-by-user.sql
+++ b/supabase/migrations/2026-05-19-add-avatar-url-to-local-list-by-user.sql
@@ -1,0 +1,50 @@
+-- 2026-05-19: Add avatar_url to get_local_list_by_user RPC return shape.
+-- Spec: enables the curator detail page (LocalsCurator.jsx) to render a
+-- profile photo above the curator's name so people can actually see who
+-- the local is.
+--
+-- IMPORTANT: This RPC has TWO definitions in schema.sql — the second
+-- (around line 5550) is the LIVE version because it adds the H3 viewer-
+-- blocked-curator WHERE clause. This migration replaces the live one,
+-- preserving the `is_blocked_pair` check.
+--
+-- RETURNS TABLE shape changes require DROP FUNCTION first — CREATE OR
+-- REPLACE alone rejects return-type changes. Wrap in BEGIN/COMMIT so RPC
+-- callers block-and-wait instead of seeing "function does not exist"
+-- during the DROP→CREATE window.
+--
+-- No SQL rollback needed (drop the column from RETURNS TABLE if absolutely
+-- needed). Readding it manually would just mean restoring the prior body
+-- without `p.avatar_url`.
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS get_local_list_by_user(UUID);
+
+CREATE OR REPLACE FUNCTION get_local_list_by_user(target_user_id UUID)
+RETURNS TABLE (
+  list_id UUID, title TEXT, description TEXT, user_id UUID,
+  display_name TEXT, avatar_url TEXT, "position" INT, dish_id UUID, dish_name TEXT,
+  restaurant_name TEXT, restaurant_id UUID, avg_rating NUMERIC,
+  total_votes BIGINT, category TEXT, note TEXT,
+  restaurant_lat FLOAT, restaurant_lng FLOAT
+)
+LANGUAGE SQL STABLE AS $$
+  SELECT ll.id, ll.title, ll.description, ll.user_id, p.display_name, p.avatar_url,
+    li."position", d.id, d.name, r.name, r.id, d.avg_rating, d.total_votes,
+    d.category, li.note, r.lat, r.lng
+  FROM local_lists ll
+  JOIN profiles p ON p.id = ll.user_id
+  JOIN local_list_items li ON li.list_id = ll.id
+  JOIN dishes d ON d.id = li.dish_id
+  JOIN restaurants r ON r.id = d.restaurant_id
+  WHERE ll.user_id = target_user_id
+    AND ll.is_active = true
+    AND ((select auth.uid()) IS NULL
+         OR NOT is_blocked_pair((select auth.uid()), target_user_id))
+  ORDER BY li."position";
+$$;
+
+GRANT EXECUTE ON FUNCTION get_local_list_by_user(UUID) TO anon, authenticated;
+
+COMMIT;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -3225,6 +3225,10 @@ AS $$
 $$;
 
 -- RPC: Full list detail by user ID (for profile pages)
+-- RETURNS TABLE shape changes need a DROP first — Postgres' CREATE OR REPLACE
+-- rejects return-type changes. Done atomically inside a transaction in the
+-- companion migration file.
+DROP FUNCTION IF EXISTS get_local_list_by_user(UUID);
 CREATE OR REPLACE FUNCTION get_local_list_by_user(target_user_id UUID)
 RETURNS TABLE (
   list_id UUID,
@@ -3232,6 +3236,7 @@ RETURNS TABLE (
   description TEXT,
   user_id UUID,
   display_name TEXT,
+  avatar_url TEXT,
   "position" INT,
   dish_id UUID,
   dish_name TEXT,
@@ -3252,6 +3257,7 @@ AS $$
     ll.description,
     ll.user_id,
     p.display_name,
+    p.avatar_url,
     li."position",
     d.id AS dish_id,
     d.name AS dish_name,
@@ -5541,17 +5547,21 @@ LANGUAGE SQL STABLE AS $$
 $$;
 
 
--- get_local_list_by_user — empty result when viewer blocked curator
+-- get_local_list_by_user — empty result when viewer blocked curator.
+-- Live version (overrides the earlier definition above). Keep both
+-- in sync: 2026-05-19 added avatar_url so the curator detail page
+-- can render a profile photo above the title.
+DROP FUNCTION IF EXISTS get_local_list_by_user(UUID);
 CREATE OR REPLACE FUNCTION get_local_list_by_user(target_user_id UUID)
 RETURNS TABLE (
   list_id UUID, title TEXT, description TEXT, user_id UUID,
-  display_name TEXT, "position" INT, dish_id UUID, dish_name TEXT,
+  display_name TEXT, avatar_url TEXT, "position" INT, dish_id UUID, dish_name TEXT,
   restaurant_name TEXT, restaurant_id UUID, avg_rating NUMERIC,
   total_votes BIGINT, category TEXT, note TEXT,
   restaurant_lat FLOAT, restaurant_lng FLOAT
 )
 LANGUAGE SQL STABLE AS $$
-  SELECT ll.id, ll.title, ll.description, ll.user_id, p.display_name,
+  SELECT ll.id, ll.title, ll.description, ll.user_id, p.display_name, p.avatar_url,
     li."position", d.id, d.name, r.name, r.id, d.avg_rating, d.total_votes,
     d.category, li.note, r.lat, r.lng
   FROM local_lists ll
@@ -5565,6 +5575,7 @@ LANGUAGE SQL STABLE AS $$
          OR NOT is_blocked_pair((select auth.uid()), target_user_id))
   ORDER BY li."position";
 $$;
+GRANT EXECUTE ON FUNCTION get_local_list_by_user(UUID) TO anon, authenticated;
 
 
 -- get_ranked_dishes — only best_photos CTE changes. Full final body lives in


### PR DESCRIPTION
## Summary
When you tap a curator on the homepage banner and land on their list page (`/locals/:userId`), the curator's avatar should be there above their name — design ask: *"avatar first, then name, then the list."*

## Schema
- `get_local_list_by_user` RPC now returns `p.avatar_url` alongside `display_name`.
- Both `schema.sql` definitions updated (the second one at line ~5550 is the H3-protected live version — preserved the `is_blocked_pair` WHERE clause in the new body so this migration doesn't regress the block check).
- Migration: `supabase/migrations/2026-05-19-add-avatar-url-to-local-list-by-user.sql` wraps DROP + CREATE OR REPLACE in BEGIN/COMMIT (return-type change requires DROP first; transaction prevents the "function does not exist" window between drop and create).
- `GRANT EXECUTE` restored after the recreate.

## UI (`LocalsCurator.jsx`)
- 88px round avatar above the eyebrow/title row.
- Falls back to a coral chip with the first letter of `display_name` (or `?` when name is null) — **null-safe** so the page renders fine *before* the migration is applied to prod.

## Codex
Reviewed. Caught a duplicate-function-definition issue inside schema.sql; both copies now match and include `avatar_url`.

## Deploy steps
1. Merge this PR.
2. Open Supabase Dashboard → SQL Editor → paste contents of `supabase/migrations/2026-05-19-add-avatar-url-to-local-list-by-user.sql` → Run.
3. Verify: `SELECT avatar_url FROM get_local_list_by_user('<a-curator-uuid>') LIMIT 1;` returns the column.

## Test plan
- [ ] Before migration: page renders with coral initial chip (UI null-safe)
- [ ] After migration: page renders with real avatar image when curator has uploaded a photo
- [ ] After migration, curators without photos: still see the coral initial chip
- [ ] H3 viewer-blocked-curator check still works (blocked viewer gets empty list, not "function does not exist")

🤖 Generated with [Claude Code](https://claude.com/claude-code)