### PR TITLE
fix(menu-refresh): batch pre-stamp + script-level timeout tolerance

### DIFF
--- a/scripts/backfill-menu-descriptions.sh
+++ b/scripts/backfill-menu-descriptions.sh
@@ -38,7 +38,12 @@ ENDPOINT="$SUPABASE_URL/functions/v1/menu-refresh?force_all=true&limit=$LIMIT"
 # Safety cap so a buggy "processed > 0 forever" loop can't run unbounded.
 # 30 iterations × 8 restaurants = 240 ceiling; well above the ~177 inventory.
 MAX_ITERATIONS=30
+# Bail after this many consecutive IDLE_TIMEOUTs — if we never see a normal
+# response across several batches, rotation isn't recovering and there's a
+# real upstream problem to investigate (network, runtime config, etc).
+MAX_CONSECUTIVE_TIMEOUTS=5
 TOTAL=0
+CONSECUTIVE_TIMEOUTS=0
 
 for ((i=1; i<=MAX_ITERATIONS; i++)); do
   echo "→ Iteration $i: POST $ENDPOINT"
@@ -47,12 +52,29 @@ for ((i=1; i<=MAX_ITERATIONS; i++)); do
     -H "Content-Type: application/json")
   echo "  response: $RESPONSE"
 
-  # Detect timeout / explicit error responses — these have no "processed" field
-  # and previously caused the script to falsely exit "done" with 0 work done.
-  if echo "$RESPONSE" | grep -qE '"code":"IDLE_TIMEOUT"|"error":'; then
+  # IDLE_TIMEOUT used to abort the script — that was protective when the
+  # function would loop on a stuck cluster. With PR #232 + #236 + this PR's
+  # batch pre-stamp, a timeout safely rotates the whole batch, so we just
+  # log + continue. The next iteration picks a different batch.
+  if echo "$RESPONSE" | grep -qE '"code":"IDLE_TIMEOUT"'; then
+    CONSECUTIVE_TIMEOUTS=$((CONSECUTIVE_TIMEOUTS + 1))
+    echo "  ⚠ IDLE_TIMEOUT (consecutive: $CONSECUTIVE_TIMEOUTS/$MAX_CONSECUTIVE_TIMEOUTS) — batch rotated by pre-stamp, continuing."
+    if [ "$CONSECUTIVE_TIMEOUTS" -ge "$MAX_CONSECUTIVE_TIMEOUTS" ]; then
+      echo "✗ Hit $MAX_CONSECUTIVE_TIMEOUTS consecutive IDLE_TIMEOUTs — rotation isn't recovering. Aborting to surface real problem."
+      echo "  Total restaurants successfully processed before abort: $TOTAL"
+      exit 1
+    fi
+    sleep 5
+    continue
+  fi
+  # Any non-timeout response resets the streak — we just made forward progress.
+  CONSECUTIVE_TIMEOUTS=0
+
+  # Other errors (auth, server) still abort — those indicate a config problem
+  # the rotation logic can't fix.
+  if echo "$RESPONSE" | grep -qE '"error":'; then
     echo "✗ Edge function returned an error response. Backfill aborted."
     echo "  Total restaurants successfully processed before error: $TOTAL"
-    echo "  Re-run the script — already-backfilled restaurants are hash-skipped fast."
     exit 1
   fi
 

--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -1796,22 +1796,33 @@ serve(async (req) => {
     // days. Acceptable — Path A's queue retry/backoff handles short-term
     // retries, and burning Sonnet on the same broken URL every cron cycle
     // would be worse.
-    const stampChecked = async (restaurantId: string) => {
-      await supabase
+    // Batch pre-stamp: update menu_last_checked = now() for the WHOLE batch
+    // in a single UPDATE before processing any restaurant. The earlier
+    // per-restaurant pre-stamp inside the loop only rotated the row
+    // currently being processed on IDLE_TIMEOUT, leaving its 7 batch-mates
+    // unstamped at the front of the queue — so the next invocation hit the
+    // same slow cluster again. Batch-stamping at the top guarantees
+    // full-batch rotation on any timeout, anywhere in the loop.
+    //
+    // Supabase JS resolves with { error } on PostgREST/SQL failures rather
+    // than throwing, so inspect .error explicitly. The try/catch is still
+    // there for transport-level throws (fetch failures, etc.). Either way
+    // we log loudly and continue — rotation that didn't happen is loud, not
+    // silent.
+    try {
+      const { error: batchStampErr } = await supabase
         .from('restaurants')
         .update({ menu_last_checked: new Date().toISOString() })
-        .eq('id', restaurantId)
+        .in('id', restaurants.map(r => r.id))
+      if (batchStampErr) {
+        console.error('Batch pre-stamp returned error (continuing):', batchStampErr)
+      }
+    } catch (stampErr) {
+      console.error('Batch pre-stamp threw (continuing):', stampErr)
     }
 
     for (const restaurant of restaurants) {
       try {
-        // Pre-stamp inside the try so a transient DB write failure here is
-        // caught and recorded as a single-restaurant error rather than
-        // aborting the whole batch. The stamp still commits before any of
-        // the slow work (fetch / Sonnet / Browserless render), which is all
-        // we need for the IDLE_TIMEOUT rotation guarantee.
-        await stampChecked(restaurant.id)
-
         console.log(`Processing menu for: ${restaurant.name}`)
 
         // Fetch menu content


### PR DESCRIPTION
## Summary

Third menu-refresh fix tonight. After PR #236 deployed, the v1.3 backfill still hit IDLE_TIMEOUT every 1-2 iterations because PR #236's pre-stamp was per-restaurant — only protecting the row currently being processed. When a slow restaurant earlier in the batch eats the 150s budget, the OTHER 7 rows in the batch never reach their stamp and re-appear at the front of the queue → one-slow-restaurant-per-invocation forward progress.

## What changed

**Edge function:** batch UPDATE `menu_last_checked = now()` for the WHOLE batch at the top of the for loop, before any processing. Removes the per-restaurant pre-stamp inside the try block (now redundant). Supabase JS returns `{ error }` on PostgREST failures rather than throwing, so we inspect `.error` explicitly AND keep try/catch for transport-level throws. Either failure mode logs loudly and proceeds — rotation-that-didn't-happen is now loud rather than silent (per codex).

**Script:** `IDLE_TIMEOUT` no longer aborts the backfill — rotation guarantees forward progress. Tracks consecutive IDLE_TIMEOUTs and bails after 5 in a row so a runaway pathology surfaces instead of being masked (per codex). Non-timeout errors still abort.

## Test plan

- [x] \`bash -n\` on the script passes
- [x] \`npm run test -- --run\` — 621/622 (same pre-existing nativeAuth failure)
- [x] Codex review at gpt-5.3-codex high effort — 2 issues caught + fixed before this PR
- [ ] Deploy edge function, re-run backfill, watch for: IDLE_TIMEOUTs continuing the loop instead of aborting + batch rotation actually working (different 8 restaurants every invocation regardless of timeouts)

## Not done

Path A untouched. Queue mode has \`menu_import_jobs\` ownership + \`lock_expires_at\` recovery + retry/backoff — pre-stamping there would muddy freshness semantics without solving a queue problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)