### PR TITLE
fix(ui): rename Diet filter label to DP

### DIFF
--- a/src/components/DietButton.jsx
+++ b/src/components/DietButton.jsx
@@ -70,7 +70,7 @@ export function DietButton({ selected, labels, onOpen }) {
       {leafIcon(active)}
       <span style={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
         <span style={{ color: active ? 'var(--color-primary)' : 'var(--color-text-tertiary)' }}>
-          Diet
+          DP
         </span>
         <span
           aria-hidden="true"

--- a/src/components/DietSheet.jsx
+++ b/src/components/DietSheet.jsx
@@ -110,7 +110,7 @@ export function DietSheet({
                 letterSpacing: '0.01em',
               }}
             >
-              Dietary preferences
+              DP
             </h2>
             <div
               aria-hidden="true"


### PR DESCRIPTION
## Summary

- Homepage filter button now reads **DP** (was "Diet · Off / · Vegan / · 2 selected")
- Bottom-sheet header reads **DP** (was "Dietary preferences" in Amatic SC)
- Same component, same selection semantics — copy-only change
- Aria-labels left descriptive so screen readers retain meaning

## Test plan

- [ ] Homepage: button shows "DP · Off" by default, "DP · Vegan" with one selected, "DP · 2 selected" with multiple
- [ ] Tap button → sheet opens with "DP" header, hairline + close button intact
- [ ] Toggle tiles, Apply commits, Reset clears
- [ ] Screen reader still announces "Open dietary filter" and "Dietary preferences" dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)