### PR TITLE
fix(ui): DP → DP's on filter button + sheet header

### DIFF
--- a/src/components/DietButton.jsx
+++ b/src/components/DietButton.jsx
@@ -70,7 +70,7 @@ export function DietButton({ selected, labels, onOpen }) {
       {leafIcon(active)}
       <span style={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
         <span style={{ color: active ? 'var(--color-primary)' : 'var(--color-text-tertiary)' }}>
-          DP
+          DP's
         </span>
         <span
           aria-hidden="true"

--- a/src/components/DietSheet.jsx
+++ b/src/components/DietSheet.jsx
@@ -110,7 +110,7 @@ export function DietSheet({
                 letterSpacing: '0.01em',
               }}
             >
-              DP
+              DP's
             </h2>
             <div
               aria-hidden="true"


### PR DESCRIPTION
## Summary

- Filter button + sheet header: "DP" → "DP's"
- Same component, copy-only change

## Test plan

- [ ] Homepage button reads "DP's · Off" by default
- [ ] Sheet header (Amatic SC) reads "DP's"

🤖 Generated with [Claude Code](https://claude.com/claude-code)