### PR TITLE
fix(profile): restore updateProfile destructure — Save click was a silent no-op

### DIFF
--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
+import { toast } from 'sonner'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useAuth } from '../context/AuthContext'
 import { logger } from '../utils/logger'
@@ -36,7 +37,7 @@ export function Profile() {
   const [newName, setNewName] = useState('')
   const [nameStatus, setNameStatus] = useState(null) // null | 'checking' | 'available' | 'taken' | 'same'
 
-  const { profile, error: profileError, loading: profileLoading, refetch: refetchProfile } = useProfile(user?.id)
+  const { profile, error: profileError, loading: profileLoading, refetch: refetchProfile, updateProfile } = useProfile(user?.id)
   const { ratedDishes, stats, loading: votesLoading, refetch: refetchVotes } = useUserVotes(user?.id)
   const { dishes: unratedDishes, count: unratedCount, refetch: refetchUnrated } = useUnratedDishes(user?.id)
 
@@ -142,20 +143,17 @@ export function Profile() {
   }, [newName, editingName, profile?.display_name])
 
   const handleSaveName = async () => {
-    // Don't save if name is taken
-    if (nameStatus === 'taken') {
+    if (nameStatus === 'taken') return
+    if (!newName.trim()) return
+
+    const { error } = await updateProfile({ display_name: newName.trim() })
+    if (error) {
+      logger.error('Profile: failed to save display name', error)
+      toast.error(error?.message || "Couldn't save your name. Try again.")
       return
     }
-
-    try {
-      if (newName.trim()) {
-        await updateProfile({ display_name: newName.trim() })
-      }
-      setEditingName(false)
-      setNameStatus(null)
-    } catch (error) {
-      logger.error('Profile: failed to save display name', error)
-    }
+    setEditingName(false)
+    setNameStatus(null)
   }
 
   // Handle vote from unrated dish


### PR DESCRIPTION
## Summary
- `useProfile()` destructure in `Profile.jsx:39` was missing `updateProfile` (regressed in PR #172). `handleSaveName` called `await updateProfile(...)` → `ReferenceError` → caught silently → editor stayed open, name unchanged. Matches the user-reported "Save button looks normal, click does nothing."
- Also retired the dead try/catch in `handleSaveName`. `useProfile.updateProfile` returns `{data, error}` and never throws, so the previous catch only ever fired on the ReferenceError above. Now we check `error`, toast on failure, and only close the editor on success — real save failures (uniqueness clash, content-filter, RLS, network) finally surface to the user.

## Test plan
- [x] `npm run lint` clean on `src/pages/Profile.jsx`
- [x] `npm run build` succeeds
- [x] `npm run test -- profile` → 16/16 passing
- [x] Codex review (gpt-5.3-codex, high reasoning): no blocking findings
- [ ] Smoke: open `/profile` → tap name → type a new name → tap Save → editor closes, name updates everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)