### PR TITLE
feat(admin): send restaurant invites via Resend (+ review fixes)

### DIFF
--- a/src/api/restaurantManagerApi.js
+++ b/src/api/restaurantManagerApi.js
@@ -76,7 +76,7 @@ export const restaurantManagerApi = {
   /**
    * Create an invite link for a restaurant (admin only)
    * @param {string} restaurantId
-   * @returns {Promise<{token: string, expiresAt: string}>}
+   * @returns {Promise<{id: string, token: string, expiresAt: string}>}
    */
   async createInvite(restaurantId) {
     try {
@@ -89,7 +89,7 @@ export const restaurantManagerApi = {
           restaurant_id: restaurantId,
           created_by: user.id,
         })
-        .select('token, expires_at')
+        .select('id, token, expires_at')
         .single()
 
       if (error) {
@@ -97,11 +97,51 @@ export const restaurantManagerApi = {
         throw createClassifiedError(error)
       }
 
-      return { token: data.token, expiresAt: data.expires_at }
+      return { id: data.id, token: data.token, expiresAt: data.expires_at }
     } catch (error) {
       logger.error('Error in createInvite:', error)
       throw error.type ? error : createClassifiedError(error)
     }
+  },
+
+  /**
+   * Send the invite via the send-invite-email Edge Function (Resend).
+   * Returns a structured result so the UI can fall back to "Copy link" on failure.
+   * @param {{ inviteId: string, inviteUrl: string, recipientEmail: string }} params
+   * @returns {Promise<{ok: boolean, messageId?: string, errorCode?: string, message?: string, retryAfterSeconds?: number}>}
+   */
+  async sendInviteEmail({ inviteId, inviteUrl, recipientEmail }) {
+    const { data, error } = await supabase.functions.invoke('send-invite-email', {
+      body: { invite_id: inviteId, invite_url: inviteUrl, recipient_email: recipientEmail },
+    })
+
+    if (error) {
+      // The function returned non-2xx OR the request itself failed. Try to
+      // surface the structured error payload from the function body.
+      const ctx = error.context
+      let parsed = null
+      if (ctx && typeof ctx.json === 'function') {
+        try { parsed = await ctx.json() } catch { /* ignore */ }
+      }
+      logger.error('sendInviteEmail failed:', { error, parsed })
+      return {
+        ok: false,
+        errorCode: parsed?.error_code || 'request_failed',
+        message: parsed?.message || error.message || 'Failed to send invite email',
+        retryAfterSeconds: parsed?.retry_after_seconds,
+      }
+    }
+
+    if (data && data.ok === false) {
+      return {
+        ok: false,
+        errorCode: data.error_code,
+        message: data.message,
+        retryAfterSeconds: data.retry_after_seconds,
+      }
+    }
+
+    return { ok: true, messageId: data?.message_id }
   },
 
   /**

--- a/src/api/restaurantManagerApi.js
+++ b/src/api/restaurantManagerApi.js
@@ -133,6 +133,9 @@ export const restaurantManagerApi = {
     }
 
     if (data && data.ok === false) {
+      // Server-side structured failure (rate limit, invite_not_found, resend rejection, etc).
+      // Log so it surfaces in Sentry — UI alone would swallow it.
+      logger.error('sendInviteEmail server-side failure:', data)
       return {
         ok: false,
         errorCode: data.error_code,

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -8,6 +8,18 @@ import { adminApi } from '../api/adminApi'
 import { restaurantManagerApi } from '../api/restaurantManagerApi'
 import { ALL_CATEGORIES } from '../constants/categories'
 
+function formatRetryAfter(seconds) {
+  if (seconds >= 3600) {
+    const hours = Math.ceil(seconds / 3600)
+    return hours === 1 ? '1 hour' : `${hours} hours`
+  }
+  if (seconds >= 60) {
+    const minutes = Math.ceil(seconds / 60)
+    return minutes === 1 ? '1 minute' : `${minutes} minutes`
+  }
+  return seconds === 1 ? '1 second' : `${seconds} seconds`
+}
+
 export function Admin() {
   const navigate = useNavigate()
   const { user, loading: authLoading } = useAuth()
@@ -41,6 +53,10 @@ export function Admin() {
   const [recipientEmail, setRecipientEmail] = useState('')
   const [sendingEmail, setSendingEmail] = useState(false)
   const [sendResult, setSendResult] = useState(null)
+  // Synchronous guard — React state updates aren't atomic, so a fast double-click
+  // could fire two sends before sendingEmail re-renders the disabled attribute.
+  // Refs flip immediately and are unaffected by render batching.
+  const sendingRef = useRef(false)
   const inviteInputRef = useRef(null)
   const [managers, setManagers] = useState([])
   const [managersLoading, setManagersLoading] = useState(false)
@@ -330,10 +346,15 @@ export function Admin() {
   }
 
   async function handleSendInviteEmail() {
+    if (sendingRef.current) return
     setSendResult(null)
     const email = recipientEmail.trim()
     if (!email) {
       setSendResult({ ok: false, message: 'Enter a recipient email first' })
+      return
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setSendResult({ ok: false, message: 'That doesn\'t look like a valid email address' })
       return
     }
     if (!inviteId || !inviteLink) {
@@ -341,6 +362,7 @@ export function Admin() {
       return
     }
 
+    sendingRef.current = true
     setSendingEmail(true)
     try {
       const result = await restaurantManagerApi.sendInviteEmail({
@@ -361,6 +383,7 @@ export function Admin() {
       logger.error('handleSendInviteEmail unexpected:', err)
       setSendResult({ ok: false, message: 'Failed to send. Use Copy link instead.' })
     } finally {
+      sendingRef.current = false
       setSendingEmail(false)
     }
   }
@@ -890,11 +913,16 @@ export function Admin() {
 
                   {/* Primary: send via Resend through the Edge Function */}
                   <div className="mt-3 pt-3 border-t" style={{ borderColor: 'var(--color-divider)' }}>
-                    <label className="block text-xs font-medium mb-1" style={{ color: 'var(--color-text-tertiary)' }}>
+                    <label
+                      htmlFor="invite-recipient-email"
+                      className="block text-xs font-medium mb-1"
+                      style={{ color: 'var(--color-text-tertiary)' }}
+                    >
                       Send directly to restaurant owner:
                     </label>
                     <div className="flex items-center gap-2">
                       <input
+                        id="invite-recipient-email"
                         type="email"
                         value={recipientEmail}
                         onChange={(e) => setRecipientEmail(e.target.value)}
@@ -919,7 +947,7 @@ export function Admin() {
                       >
                         {sendResult.ok ? '✓ ' : '⚠ '}
                         {sendResult.message}
-                        {sendResult.retryAfterSeconds ? ` (retry in ${sendResult.retryAfterSeconds}s)` : ''}
+                        {sendResult.retryAfterSeconds ? ` (try again in ${formatRetryAfter(sendResult.retryAfterSeconds)})` : ''}
                       </p>
                     )}
                   </div>

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -802,6 +802,38 @@ export function Admin() {
                     >
                       Copy
                     </button>
+                    <button
+                      onClick={() => {
+                        const restaurantName =
+                          restaurants.find((r) => r.id === inviteRestaurantId)?.name || 'your restaurant'
+                        const subject = `You're invited to manage ${restaurantName} on What's Good Here`
+                        const body = [
+                          `Hi,`,
+                          ``,
+                          `You've been invited to manage ${restaurantName} on What's Good Here — a mobile-first food discovery app for Martha's Vineyard.`,
+                          ``,
+                          `Once you accept, you'll be able to:`,
+                          `  • Add your menu (paste text or upload a PDF — we'll parse it automatically)`,
+                          `  • Update dish names, prices, and photos`,
+                          `  • Post specials (happy hour, daily deals)`,
+                          `  • Schedule events (live music, trivia nights)`,
+                          ``,
+                          `Click the link below to get started. The link expires in 7 days.`,
+                          ``,
+                          inviteLink,
+                          ``,
+                          `Questions? Just reply to this email.`,
+                          ``,
+                          `— The What's Good Here team`,
+                        ].join('\n')
+                        const mailto = `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`
+                        window.location.href = mailto
+                      }}
+                      className="px-3 py-1 rounded text-xs font-medium"
+                      style={{ background: 'var(--color-accent-gold)', color: 'var(--color-text-on-primary)' }}
+                    >
+                      Email
+                    </button>
                   </div>
                 </div>
               )}

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -37,6 +37,10 @@ export function Admin() {
   // Restaurant manager state
   const [inviteRestaurantId, setInviteRestaurantId] = useState('')
   const [inviteLink, setInviteLink] = useState('')
+  const [inviteId, setInviteId] = useState('')
+  const [recipientEmail, setRecipientEmail] = useState('')
+  const [sendingEmail, setSendingEmail] = useState(false)
+  const [sendResult, setSendResult] = useState(null)
   const inviteInputRef = useRef(null)
   const [managers, setManagers] = useState([])
   const [managersLoading, setManagersLoading] = useState(false)
@@ -313,13 +317,51 @@ export function Admin() {
     }
 
     try {
-      const { token } = await restaurantManagerApi.createInvite(inviteRestaurantId)
+      const { id, token } = await restaurantManagerApi.createInvite(inviteRestaurantId)
       const link = `${window.location.origin}/invite/${token}`
       setInviteLink(link)
+      setInviteId(id)
+      setSendResult(null)
       setMessage({ type: 'success', text: 'Invite link generated!' })
     } catch (error) {
       logger.error('Error generating invite:', error)
       setMessage({ type: 'error', text: `Failed to generate invite: ${getUserMessage(error, 'generating invite')}` })
+    }
+  }
+
+  async function handleSendInviteEmail() {
+    setSendResult(null)
+    const email = recipientEmail.trim()
+    if (!email) {
+      setSendResult({ ok: false, message: 'Enter a recipient email first' })
+      return
+    }
+    if (!inviteId || !inviteLink) {
+      setSendResult({ ok: false, message: 'Generate the invite link first' })
+      return
+    }
+
+    setSendingEmail(true)
+    try {
+      const result = await restaurantManagerApi.sendInviteEmail({
+        inviteId,
+        inviteUrl: inviteLink,
+        recipientEmail: email,
+      })
+      if (result.ok) {
+        setSendResult({ ok: true, message: `Email sent to ${email}` })
+      } else {
+        setSendResult({
+          ok: false,
+          message: result.message || 'Failed to send. Use Copy link instead.',
+          retryAfterSeconds: result.retryAfterSeconds,
+        })
+      }
+    } catch (err) {
+      logger.error('handleSendInviteEmail unexpected:', err)
+      setSendResult({ ok: false, message: 'Failed to send. Use Copy link instead.' })
+    } finally {
+      setSendingEmail(false)
     }
   }
 
@@ -689,6 +731,9 @@ export function Admin() {
                 if (inviteRestaurantId) {
                   setInviteRestaurantId('')
                   setInviteLink('')
+                  setInviteId('')
+                  setRecipientEmail('')
+                  setSendResult(null)
                   setManagers([])
                 }
               }}
@@ -703,6 +748,9 @@ export function Admin() {
                   setInviteRestaurantId('')
                   setInviteSearch('')
                   setInviteLink('')
+                  setInviteId('')
+                  setRecipientEmail('')
+                  setSendResult(null)
                   setManagers([])
                 }}
                 className="absolute right-2 top-[34px] text-sm px-1"
@@ -730,6 +778,9 @@ export function Admin() {
                         setInviteSearch(r.name)
                         setInviteDropdownOpen(false)
                         setInviteLink('')
+                        setInviteId('')
+                        setRecipientEmail('')
+                        setSendResult(null)
                         fetchManagers(r.id)
                       }}
                       className="w-full text-left px-3 py-2 text-sm hover:bg-[color:var(--color-surface-elevated)] transition-colors"
@@ -831,9 +882,46 @@ export function Admin() {
                       }}
                       className="px-3 py-1 rounded text-xs font-medium"
                       style={{ background: 'var(--color-accent-gold)', color: 'var(--color-text-on-primary)' }}
+                      title="Open your mail client with the invite prefilled (fallback)"
                     >
-                      Email
+                      Email (mailto)
                     </button>
+                  </div>
+
+                  {/* Primary: send via Resend through the Edge Function */}
+                  <div className="mt-3 pt-3 border-t" style={{ borderColor: 'var(--color-divider)' }}>
+                    <label className="block text-xs font-medium mb-1" style={{ color: 'var(--color-text-tertiary)' }}>
+                      Send directly to restaurant owner:
+                    </label>
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="email"
+                        value={recipientEmail}
+                        onChange={(e) => setRecipientEmail(e.target.value)}
+                        placeholder="owner@example.com"
+                        disabled={sendingEmail}
+                        className="flex-1 px-2 py-1 border rounded text-xs"
+                        style={{ borderColor: 'var(--color-divider)', background: 'var(--color-surface)' }}
+                      />
+                      <button
+                        onClick={handleSendInviteEmail}
+                        disabled={sendingEmail || !recipientEmail.trim()}
+                        className="px-3 py-1 rounded text-xs font-medium disabled:opacity-50"
+                        style={{ background: 'var(--color-primary)', color: 'var(--color-text-on-primary)' }}
+                      >
+                        {sendingEmail ? 'Sending…' : 'Send Email'}
+                      </button>
+                    </div>
+                    {sendResult && (
+                      <p
+                        className="mt-2 text-xs"
+                        style={{ color: sendResult.ok ? 'var(--color-success)' : 'var(--color-danger)' }}
+                      >
+                        {sendResult.ok ? '✓ ' : '⚠ '}
+                        {sendResult.message}
+                        {sendResult.retryAfterSeconds ? ` (retry in ${sendResult.retryAfterSeconds}s)` : ''}
+                      </p>
+                    )}
                   </div>
                 </div>
               )}

--- a/supabase/functions/send-invite-email/index.ts
+++ b/supabase/functions/send-invite-email/index.ts
@@ -1,0 +1,206 @@
+// send-invite-email
+//
+// Sends a restaurant manager invite email via Resend.
+//
+// Inputs (JSON body):
+//   invite_id: UUID of the row in restaurant_invites (admin already minted it)
+//   invite_url: full /invite/:token URL the admin already resolved client-side
+//   recipient_email: address to send to
+//
+// Contracts (per Dan):
+//   - This function does NOT mint tokens. The admin flow inserts the
+//     restaurant_invites row first; we only send.
+//   - Sender: wghapp@wghapp.com (DKIM/SPF/DMARC verified on Resend).
+//   - Reply-to: wghapp@wghapp.com.
+//   - Body copy reused verbatim from the mailto: handler in
+//     src/pages/Admin.jsx (the explainer is calibrated for restaurant
+//     owners who haven't heard of us). Keep these two strings in sync.
+//   - Rate limit: 20 sends/hour per admin (RPC).
+//   - Every attempt — success and failure — is recorded in
+//     invite_email_sends for audit.
+//   - On Resend error we return a structured error so the UI can fall
+//     back to "Copy link". No catch-and-swallow.
+
+import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY')
+const SENDER = 'What\'s Good Here <wghapp@wghapp.com>'
+const REPLY_TO = 'wghapp@wghapp.com'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': 'https://whats-good-here.vercel.app',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  })
+}
+
+function buildBody(restaurantName: string, inviteUrl: string): string {
+  // Keep in sync with src/pages/Admin.jsx mailto handler.
+  return [
+    `Hi,`,
+    ``,
+    `You've been invited to manage ${restaurantName} on What's Good Here — a mobile-first food discovery app for Martha's Vineyard.`,
+    ``,
+    `Once you accept, you'll be able to:`,
+    `  • Add your menu (paste text or upload a PDF — we'll parse it automatically)`,
+    `  • Update dish names, prices, and photos`,
+    `  • Post specials (happy hour, daily deals)`,
+    `  • Schedule events (live music, trivia nights)`,
+    ``,
+    `Click the link below to get started. The link expires in 7 days.`,
+    ``,
+    inviteUrl,
+    ``,
+    `Questions? Just reply to this email.`,
+    ``,
+    `— The What's Good Here team`,
+  ].join('\n')
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
+
+  try {
+    if (!RESEND_API_KEY) {
+      return json({ ok: false, error_code: 'config_missing', message: 'RESEND_API_KEY not configured' }, 500)
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+
+    // --- Auth gate: require an authenticated admin ---
+    const authHeader = req.headers.get('Authorization')
+    if (!authHeader) return json({ ok: false, error_code: 'unauthorized', message: 'Missing Authorization header' }, 401)
+
+    const supabaseAuth = createClient(supabaseUrl, supabaseAnonKey, {
+      global: { headers: { Authorization: authHeader } },
+    })
+    const { data: { user } } = await supabaseAuth.auth.getUser()
+    if (!user) return json({ ok: false, error_code: 'unauthorized', message: 'Invalid session' }, 401)
+
+    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+    const { data: admin } = await supabase
+      .from('admins')
+      .select('id')
+      .eq('user_id', user.id)
+      .maybeSingle()
+    if (!admin) return json({ ok: false, error_code: 'forbidden', message: 'Admin only' }, 403)
+
+    // --- Parse + validate input ---
+    let payload: { invite_id?: string; invite_url?: string; recipient_email?: string }
+    try {
+      payload = await req.json()
+    } catch {
+      return json({ ok: false, error_code: 'bad_request', message: 'Invalid JSON body' }, 400)
+    }
+    const { invite_id, invite_url, recipient_email } = payload
+
+    if (!invite_id || typeof invite_id !== 'string') {
+      return json({ ok: false, error_code: 'bad_request', message: 'invite_id is required' }, 400)
+    }
+    if (!invite_url || typeof invite_url !== 'string' || !invite_url.startsWith('http')) {
+      return json({ ok: false, error_code: 'bad_request', message: 'invite_url must be an http(s) URL' }, 400)
+    }
+    if (!recipient_email || !EMAIL_RE.test(recipient_email)) {
+      return json({ ok: false, error_code: 'bad_request', message: 'recipient_email is not a valid email' }, 400)
+    }
+
+    // --- Look up the invite + restaurant ---
+    // We trust the DB row, not the client, for restaurant_name and token. The
+    // invite_url must contain the matching token so we never email a URL that
+    // points to a different invite.
+    const { data: invite, error: inviteErr } = await supabase
+      .from('restaurant_invites')
+      .select('id, token, restaurants:restaurant_id (name)')
+      .eq('id', invite_id)
+      .maybeSingle()
+
+    if (inviteErr || !invite) {
+      return json({ ok: false, error_code: 'invite_not_found', message: 'Invite not found' }, 404)
+    }
+    if (!invite_url.includes(invite.token)) {
+      return json({ ok: false, error_code: 'invite_url_mismatch', message: 'invite_url does not match the token for this invite_id' }, 400)
+    }
+
+    // deno-lint-ignore no-explicit-any
+    const restaurantName = (invite.restaurants as any)?.name || 'your restaurant'
+
+    // --- Rate limit (20/hour/admin) ---
+    const { data: limitData } = await supabaseAuth.rpc('check_invite_email_rate_limit')
+    if (limitData && limitData.allowed === false) {
+      return json({
+        ok: false,
+        error_code: 'rate_limited',
+        message: limitData.message || 'Rate limit exceeded',
+        retry_after_seconds: limitData.retry_after_seconds,
+      }, 429)
+    }
+
+    // --- Send via Resend ---
+    const body = buildBody(restaurantName, invite_url)
+    const subject = `You're invited to manage ${restaurantName} on What's Good Here`
+
+    const resendRes = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${RESEND_API_KEY}`,
+      },
+      body: JSON.stringify({
+        from: SENDER,
+        to: [recipient_email],
+        reply_to: REPLY_TO,
+        subject,
+        text: body,
+      }),
+    })
+
+    const resendBody = await resendRes.json().catch(() => ({}))
+
+    if (!resendRes.ok) {
+      const errorCode = resendBody?.name || `resend_${resendRes.status}`
+      const errorMessage = resendBody?.message || `Resend returned ${resendRes.status}`
+      // Audit the failure so admin attempts are visible even when delivery fails.
+      await supabase.from('invite_email_sends').insert({
+        invite_id,
+        recipient_email,
+        sent_by: user.id,
+        status: 'failed',
+        error_code: errorCode,
+        error_message: errorMessage,
+      })
+      return json({ ok: false, error_code: errorCode, message: errorMessage }, 502)
+    }
+
+    const messageId = resendBody?.id || null
+
+    // Audit the successful send.
+    const { error: auditErr } = await supabase.from('invite_email_sends').insert({
+      invite_id,
+      recipient_email,
+      sent_by: user.id,
+      status: 'sent',
+      resend_message_id: messageId,
+    })
+    if (auditErr) {
+      // The email DID send. Surface a soft warning but still return ok so the
+      // admin's UI reflects reality (the recipient got the email).
+      console.error('Audit log insert failed after successful send:', auditErr)
+    }
+
+    return json({ ok: true, message_id: messageId })
+  } catch (err) {
+    console.error('send-invite-email unexpected error:', err)
+    return json({ ok: false, error_code: 'internal_error', message: (err as Error).message || 'Internal error' }, 500)
+  }
+})

--- a/supabase/functions/send-invite-email/index.ts
+++ b/supabase/functions/send-invite-email/index.ts
@@ -23,22 +23,18 @@
 
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { corsHeaders } from '../_shared/cors.ts'
 
 const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY')
 const SENDER = 'What\'s Good Here <wghapp@wghapp.com>'
 const REPLY_TO = 'wghapp@wghapp.com'
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': 'https://whats-good-here.vercel.app',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
-
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
-function json(body: unknown, status = 200) {
+function json(body: unknown, status: number, req: Request) {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
   })
 }
 
@@ -66,11 +62,11 @@ function buildBody(restaurantName: string, inviteUrl: string): string {
 }
 
 serve(async (req) => {
-  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders(req) })
 
   try {
     if (!RESEND_API_KEY) {
-      return json({ ok: false, error_code: 'config_missing', message: 'RESEND_API_KEY not configured' }, 500)
+      return json({ ok: false, error_code: 'config_missing', message: 'RESEND_API_KEY not configured' }, 500, req)
     }
 
     const supabaseUrl = Deno.env.get('SUPABASE_URL')!
@@ -79,13 +75,13 @@ serve(async (req) => {
 
     // --- Auth gate: require an authenticated admin ---
     const authHeader = req.headers.get('Authorization')
-    if (!authHeader) return json({ ok: false, error_code: 'unauthorized', message: 'Missing Authorization header' }, 401)
+    if (!authHeader) return json({ ok: false, error_code: 'unauthorized', message: 'Missing Authorization header' }, 401, req)
 
     const supabaseAuth = createClient(supabaseUrl, supabaseAnonKey, {
       global: { headers: { Authorization: authHeader } },
     })
     const { data: { user } } = await supabaseAuth.auth.getUser()
-    if (!user) return json({ ok: false, error_code: 'unauthorized', message: 'Invalid session' }, 401)
+    if (!user) return json({ ok: false, error_code: 'unauthorized', message: 'Invalid session' }, 401, req)
 
     const supabase = createClient(supabaseUrl, supabaseServiceKey)
 
@@ -94,25 +90,25 @@ serve(async (req) => {
       .select('id')
       .eq('user_id', user.id)
       .maybeSingle()
-    if (!admin) return json({ ok: false, error_code: 'forbidden', message: 'Admin only' }, 403)
+    if (!admin) return json({ ok: false, error_code: 'forbidden', message: 'Admin only' }, 403, req)
 
     // --- Parse + validate input ---
     let payload: { invite_id?: string; invite_url?: string; recipient_email?: string }
     try {
       payload = await req.json()
     } catch {
-      return json({ ok: false, error_code: 'bad_request', message: 'Invalid JSON body' }, 400)
+      return json({ ok: false, error_code: 'bad_request', message: 'Invalid JSON body' }, 400, req)
     }
     const { invite_id, invite_url, recipient_email } = payload
 
     if (!invite_id || typeof invite_id !== 'string') {
-      return json({ ok: false, error_code: 'bad_request', message: 'invite_id is required' }, 400)
+      return json({ ok: false, error_code: 'bad_request', message: 'invite_id is required' }, 400, req)
     }
     if (!invite_url || typeof invite_url !== 'string' || !invite_url.startsWith('http')) {
-      return json({ ok: false, error_code: 'bad_request', message: 'invite_url must be an http(s) URL' }, 400)
+      return json({ ok: false, error_code: 'bad_request', message: 'invite_url must be an http(s) URL' }, 400, req)
     }
     if (!recipient_email || !EMAIL_RE.test(recipient_email)) {
-      return json({ ok: false, error_code: 'bad_request', message: 'recipient_email is not a valid email' }, 400)
+      return json({ ok: false, error_code: 'bad_request', message: 'recipient_email is not a valid email' }, 400, req)
     }
 
     // --- Look up the invite + restaurant ---
@@ -126,10 +122,10 @@ serve(async (req) => {
       .maybeSingle()
 
     if (inviteErr || !invite) {
-      return json({ ok: false, error_code: 'invite_not_found', message: 'Invite not found' }, 404)
+      return json({ ok: false, error_code: 'invite_not_found', message: 'Invite not found' }, 404, req)
     }
     if (!invite_url.includes(invite.token)) {
-      return json({ ok: false, error_code: 'invite_url_mismatch', message: 'invite_url does not match the token for this invite_id' }, 400)
+      return json({ ok: false, error_code: 'invite_url_mismatch', message: 'invite_url does not match the token for this invite_id' }, 400, req)
     }
 
     // deno-lint-ignore no-explicit-any
@@ -143,7 +139,7 @@ serve(async (req) => {
         error_code: 'rate_limited',
         message: limitData.message || 'Rate limit exceeded',
         retry_after_seconds: limitData.retry_after_seconds,
-      }, 429)
+      }, 429, req)
     }
 
     // --- Send via Resend ---
@@ -179,28 +175,27 @@ serve(async (req) => {
         error_code: errorCode,
         error_message: errorMessage,
       })
-      return json({ ok: false, error_code: errorCode, message: errorMessage }, 502)
+      return json({ ok: false, error_code: errorCode, message: errorMessage }, 502, req)
     }
 
     const messageId = resendBody?.id || null
 
-    // Audit the successful send.
-    const { error: auditErr } = await supabase.from('invite_email_sends').insert({
+    // Audit fire-and-forget — the email already sent, so don't make the user
+    // wait on a DB write that doesn't affect outcome. Failure is logged for
+    // Sentry visibility but the response goes out immediately.
+    supabase.from('invite_email_sends').insert({
       invite_id,
       recipient_email,
       sent_by: user.id,
       status: 'sent',
       resend_message_id: messageId,
+    }).then(({ error: auditErr }) => {
+      if (auditErr) console.error('Audit log insert failed after successful send:', auditErr)
     })
-    if (auditErr) {
-      // The email DID send. Surface a soft warning but still return ok so the
-      // admin's UI reflects reality (the recipient got the email).
-      console.error('Audit log insert failed after successful send:', auditErr)
-    }
 
-    return json({ ok: true, message_id: messageId })
+    return json({ ok: true, message_id: messageId }, 200, req)
   } catch (err) {
     console.error('send-invite-email unexpected error:', err)
-    return json({ ok: false, error_code: 'internal_error', message: (err as Error).message || 'Internal error' }, 500)
+    return json({ ok: false, error_code: 'internal_error', message: (err as Error).message || 'Internal error' }, 500, req)
   }
 })

--- a/supabase/migrations/invite-email-audit.sql
+++ b/supabase/migrations/invite-email-audit.sql
@@ -1,0 +1,44 @@
+-- Invite email audit log
+--
+-- Why a new table (and not columns on restaurant_invites)?
+-- An invite can be emailed multiple times (wrong address, lost, re-send after
+-- a forward). Columns on restaurant_invites would only capture the LAST send
+-- and silently lose retries + failure history. A separate event-log table
+-- keeps the full audit trail (every successful send AND every failed attempt)
+-- and is what Dan asked for: {invite_id, recipient_email, sent_at,
+-- resend_message_id}, with status/error fields added so failures are auditable
+-- alongside successes.
+
+CREATE TABLE IF NOT EXISTS invite_email_sends (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  invite_id UUID NOT NULL REFERENCES restaurant_invites(id) ON DELETE CASCADE,
+  recipient_email TEXT NOT NULL,
+  sent_by UUID NOT NULL REFERENCES auth.users(id) ON DELETE SET NULL,
+  sent_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  status TEXT NOT NULL CHECK (status IN ('sent', 'failed')),
+  resend_message_id TEXT,
+  error_code TEXT,
+  error_message TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_invite_email_sends_invite ON invite_email_sends(invite_id);
+CREATE INDEX IF NOT EXISTS idx_invite_email_sends_sent_by ON invite_email_sends(sent_by, sent_at DESC);
+
+ALTER TABLE invite_email_sends ENABLE ROW LEVEL SECURITY;
+
+-- Admins read all; only the service role (via the edge function) writes.
+CREATE POLICY "Admins view invite email sends"
+  ON invite_email_sends FOR SELECT
+  USING (is_admin());
+
+-- Rate limit RPC: 20 sends per hour per admin. Wraps the shared limiter.
+CREATE OR REPLACE FUNCTION check_invite_email_rate_limit()
+RETURNS JSONB LANGUAGE sql SECURITY DEFINER SET search_path = public AS $$
+  SELECT check_and_record_rate_limit('invite_email', 20, 3600);
+$$;
+
+GRANT EXECUTE ON FUNCTION check_invite_email_rate_limit TO authenticated;
+
+-- ROLLBACK:
+-- DROP FUNCTION IF EXISTS check_invite_email_rate_limit();
+-- DROP TABLE IF EXISTS invite_email_sends;

--- a/supabase/migrations/invite-email-audit.sql
+++ b/supabase/migrations/invite-email-audit.sql
@@ -13,7 +13,11 @@ CREATE TABLE IF NOT EXISTS invite_email_sends (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   invite_id UUID NOT NULL REFERENCES restaurant_invites(id) ON DELETE CASCADE,
   recipient_email TEXT NOT NULL,
-  sent_by UUID NOT NULL REFERENCES auth.users(id) ON DELETE SET NULL,
+  -- NOT NULL would contradict ON DELETE SET NULL: deleting the admin user would
+  -- fail on the constraint. We need SET NULL so account deletion (which is shipped)
+  -- never blocks on this audit table — sender attribution becomes null, audit row
+  -- survives for forensics.
+  sent_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
   sent_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   status TEXT NOT NULL CHECK (status IN ('sent', 'failed')),
   resend_message_id TEXT,

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -318,7 +318,7 @@ CREATE TABLE IF NOT EXISTS invite_email_sends (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   invite_id UUID NOT NULL REFERENCES restaurant_invites(id) ON DELETE CASCADE,
   recipient_email TEXT NOT NULL,
-  sent_by UUID NOT NULL REFERENCES auth.users(id) ON DELETE SET NULL,
+  sent_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
   sent_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   status TEXT NOT NULL CHECK (status IN ('sent', 'failed')),
   resend_message_id TEXT,

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -313,6 +313,18 @@ CREATE TABLE IF NOT EXISTS ip_rate_limits (
 CREATE INDEX IF NOT EXISTS ip_rate_limits_lookup_idx
   ON ip_rate_limits (ip_address, action, created_at DESC);
 
+-- 1t. invite_email_sends (audit log for the send-invite-email Edge Function)
+CREATE TABLE IF NOT EXISTS invite_email_sends (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  invite_id UUID NOT NULL REFERENCES restaurant_invites(id) ON DELETE CASCADE,
+  recipient_email TEXT NOT NULL,
+  sent_by UUID NOT NULL REFERENCES auth.users(id) ON DELETE SET NULL,
+  sent_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  status TEXT NOT NULL CHECK (status IN ('sent', 'failed')),
+  resend_message_id TEXT,
+  error_code TEXT,
+  error_message TEXT
+);
 
 -- 1s. jitter_profiles (Jitter Protocol: behavioral biometrics for human verification)
 CREATE TABLE IF NOT EXISTS jitter_profiles (
@@ -544,6 +556,10 @@ CREATE INDEX IF NOT EXISTS idx_curator_invites_created_by ON curator_invites(cre
 CREATE INDEX IF NOT EXISTS idx_rate_limits_user_action ON rate_limits(user_id, action, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_rate_limits_cleanup ON rate_limits(created_at);
 
+-- invite_email_sends
+CREATE INDEX IF NOT EXISTS idx_invite_email_sends_invite ON invite_email_sends(invite_id);
+CREATE INDEX IF NOT EXISTS idx_invite_email_sends_sent_by ON invite_email_sends(sent_by, sent_at DESC);
+
 -- events
 CREATE INDEX IF NOT EXISTS idx_events_restaurant ON events(restaurant_id);
 CREATE INDEX IF NOT EXISTS idx_events_active_upcoming ON events(event_date, is_promoted DESC) WHERE is_active = true;
@@ -587,6 +603,7 @@ ALTER TABLE restaurant_managers ENABLE ROW LEVEL SECURITY;
 ALTER TABLE restaurant_invites ENABLE ROW LEVEL SECURITY;
 ALTER TABLE rate_limits ENABLE ROW LEVEL SECURITY;
 ALTER TABLE ip_rate_limits ENABLE ROW LEVEL SECURITY;
+ALTER TABLE invite_email_sends ENABLE ROW LEVEL SECURITY;
 
 -- restaurants: public read, admin + manager write (column-level protection via trigger)
 CREATE POLICY "Public read access" ON restaurants FOR SELECT USING (true);
@@ -727,6 +744,9 @@ CREATE POLICY "Admins manage all managers" ON restaurant_managers FOR ALL USING 
 
 -- restaurant_invites: admins only (public preview via SECURITY DEFINER function)
 CREATE POLICY "Admins manage invites" ON restaurant_invites FOR ALL USING (is_admin());
+
+-- invite_email_sends: admins read; service role writes via Edge Function
+CREATE POLICY "Admins view invite email sends" ON invite_email_sends FOR SELECT USING (is_admin());
 
 -- curator_invites: admins only (public preview via SECURITY DEFINER function)
 ALTER TABLE curator_invites ENABLE ROW LEVEL SECURITY;
@@ -2964,6 +2984,12 @@ RETURNS JSONB LANGUAGE sql SECURITY DEFINER SET search_path = public AS $$
   SELECT check_and_record_rate_limit('dish_create', 20, 3600);
 $$;
 
+-- Invite email rate limit: 20 sends per hour per admin
+CREATE OR REPLACE FUNCTION check_invite_email_rate_limit()
+RETURNS JSONB LANGUAGE sql SECURITY DEFINER SET search_path = public AS $$
+  SELECT check_and_record_rate_limit('invite_email', 20, 3600);
+$$;
+
 -- Find nearby restaurants (for duplicate detection and "you're here" suggestions)
 CREATE OR REPLACE FUNCTION find_nearby_restaurants(
   p_name TEXT DEFAULT NULL,
@@ -3695,6 +3721,7 @@ GRANT EXECUTE ON FUNCTION submit_vote_atomic(UUID, UUID, DECIMAL, TEXT, DECIMAL,
 GRANT EXECUTE ON FUNCTION check_photo_upload_rate_limit TO authenticated;
 GRANT EXECUTE ON FUNCTION check_restaurant_create_rate_limit TO authenticated;
 GRANT EXECUTE ON FUNCTION check_dish_create_rate_limit TO authenticated;
+GRANT EXECUTE ON FUNCTION check_invite_email_rate_limit TO authenticated;
 GRANT EXECUTE ON FUNCTION find_nearby_restaurants TO authenticated;
 GRANT EXECUTE ON FUNCTION find_nearby_restaurants TO anon;
 GRANT EXECUTE ON FUNCTION get_restaurants_within_radius(DECIMAL, DECIMAL, INT) TO authenticated;


### PR DESCRIPTION
## Summary

Admins can now email a restaurant invite directly to the owner from `/admin` instead of copy-pasting a link.

Stacks Denis's two commits from `claude/admin-menu-management-lWngH` on top of current main, plus a fixes commit covering the review findings.

- Admin types recipient email → "Send Email" → real email goes out via Resend (sender `wghapp@wghapp.com`)
- Audit table records every attempt (sent + failed) with Resend message ID + error code
- Server-side rate limit (20/hr/admin) via `check_invite_email_rate_limit` RPC
- Structured failures → UI falls back to Copy link / mailto cleanly
- Existing Copy + mailto buttons retained as fallback paths

## Review trail

- **Read each file**, then dispatched 5 codex-cli reviews — surfaced 2 real bugs (FK contradiction + CORS allowlist) + 4 small fixes
- **Codex re-reviewed 4 of 6 fixes** (sequential, after parallel hangs taught us not to batch)
- **Simplify pass** via 3 parallel reviewer agents (reuse / quality / efficiency) surfaced 3 more worth-doing fixes:
  1. Edge Function reinvented CORS — swapped to existing `_shared/cors.ts` (also restores Vercel preview deploy + dashboard testing support)
  2. Success-path audit was awaited before returning — now fire-and-forget for ~100ms faster response
  3. Fast double-click could fire two sends — added `useRef` guard (React state isn't atomic across the same tick)

## Real bugs caught and fixed

1. **FK contradiction**: `sent_by NOT NULL` + `ON DELETE SET NULL` would block account deletion for any admin who'd sent an invite. Dropped NOT NULL.
2. **CORS misconfig**: hardcoded `whats-good-here.vercel.app` blocked canonical `wghapp.com` and iOS Capacitor origins. Now uses the shared helper that also handles Vercel previews + dashboard.
3. **Pluralization bug** (caught by codex): `formatRetryAfter(1)` returned "1 seconds". Fixed.
4. **Sentry blind spot**: structured-failure path (`data.ok === false`) wasn't logged. Added `logger.error`.
5. **A11y**: `<label>` had no `htmlFor` association. Fixed.
6. **No client email validation**: 400 from server instead of instant feedback. Added regex mirror of server.

## Deployment status (not yet deployed)

These steps need to run **before** this PR is merged or as part of the merge — code alone won't enable the feature:

- [ ] `supabase secrets set RESEND_API_KEY=<key>` on Denis's project
- [ ] `supabase functions deploy send-invite-email`
- [ ] Run `supabase/migrations/invite-email-audit.sql` in the SQL Editor

Per [[reference_supabase_mcp_limitation]] in my memory: the migration is run via the Supabase dashboard SQL Editor (cleaner than CLI). The Edge Function deploy is Denis's lane (he has the CLI token + project access).

## Test plan

- [ ] Run the migration SQL in Supabase dashboard; verify `invite_email_sends` table exists and `check_invite_email_rate_limit()` RPC works (`SELECT check_invite_email_rate_limit()` returns `{"allowed": true, ...}`)
- [ ] Set `RESEND_API_KEY` secret, deploy the Edge Function
- [ ] Log in as admin, go to `/admin` → Restaurant Managers → search a restaurant → "Generate Invite Link"
- [ ] Type a test email (your own), click "Send Email" → verify it arrives in inbox, sender is `wghapp@wghapp.com`, body is the friendly explainer, link works
- [ ] Verify `invite_email_sends` table has a row with `status='sent'` and a `resend_message_id`
- [ ] Type an invalid email (`foo`) → "Send Email" → verify instant client-side rejection ("That doesn't look like a valid email address")
- [ ] Type a recipient on a fresh browser tab from `wghapp.com` AND from a Vercel preview URL → both should work (CORS allowlist)
- [ ] Double-click "Send Email" fast → verify only ONE email + ONE audit row (useRef guard works)
- [ ] Send 21 emails within an hour → 21st should hit rate limit with "try again in X minutes" (humanized)
- [ ] Network throttle → trigger a Resend failure → verify UI shows the error AND `invite_email_sends` row has `status='failed'` with `error_code` populated AND Sentry sees a `logger.error`
- [ ] mailto button still works as fallback (admin's own mail client)

## Pre-existing repo state (not blockers)

- `useDishDetail.test.js` fails in the test suite due to missing `VITE_SUPABASE_URL` env var — pre-existing, unrelated to this work
- Repo-wide lint: 51 issues across files I didn't touch. My 2 touched files (`Admin.jsx`, `restaurantManagerApi.js`) lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)