### PR TITLE
fix(profile): Best Find = highest user rating, no community gate

### DIFF
--- a/src/hooks/useUserVotes.js
+++ b/src/hooks/useUserVotes.js
@@ -67,40 +67,40 @@ function computeStandoutPicks(data, communityAvgs) {
   const MIN_COMMUNITY_VOTES = 3
   const picks = {}
 
-  // Build per-dish comparisons
+  // ratedVotes: every rated dish — feeds Best Find (just the user's top rating).
+  // comparisons: subset with community baseline — feeds Hottest Take (you-vs-crowd diff).
+  const ratedVotes = []
   const comparisons = []
   for (const vote of data) {
     if (vote.rating_10 == null) continue
     const dishId = vote.dishes.id
-    const community = communityAvgs[dishId]
-    if (!community || community.count < MIN_COMMUNITY_VOTES) continue
-
-    const diff = vote.rating_10 - community.avg
-    comparisons.push({
+    const item = {
       dish_id: dishId,
       dish_name: vote.dishes.name,
       category: vote.dishes.category,
       restaurant_id: vote.dishes.restaurants?.id,
       restaurant_name: vote.dishes.restaurants?.name,
       userRating: vote.rating_10,
+    }
+    ratedVotes.push(item)
+
+    const community = communityAvgs[dishId]
+    if (!community || community.count < MIN_COMMUNITY_VOTES) continue
+    comparisons.push({
+      ...item,
       communityAvg: community.avg,
-      diff,
+      diff: vote.rating_10 - community.avg,
     })
   }
 
-  if (comparisons.length === 0) return picks
+  if (ratedVotes.length > 0) {
+    const best = ratedVotes.slice().sort((a, b) => b.userRating - a.userRating)
+    picks.bestFind = best[0]
+  }
 
-  // Best find: highest user rating, tie-break by biggest positive diff
-  const sorted = comparisons.slice().sort((a, b) => {
-    if (b.userRating !== a.userRating) return b.userRating - a.userRating
-    return b.diff - a.diff
-  })
-  picks.bestFind = sorted[0]
-
-  // Hottest take: biggest negative diff (user rates much lower than community), min -1.0
-  const harsh = comparisons.slice().sort((a, b) => a.diff - b.diff)
-  if (harsh[0] && harsh[0].diff <= -1.0) {
-    picks.harshestTake = harsh[0]
+  if (comparisons.length > 0) {
+    const harsh = comparisons.slice().sort((a, b) => a.diff - b.diff)
+    if (harsh[0].diff <= -1.0) picks.harshestTake = harsh[0]
   }
 
   return picks

--- a/src/pages/UserProfile.jsx
+++ b/src/pages/UserProfile.jsx
@@ -256,6 +256,24 @@ export function UserProfile() {
           const MIN_COMMUNITY = 3
           const picks = {}
 
+          // Best Find = the user's highest-rated dish, no community gate (matches
+          // user expectation: "my favorite," not "consensus favorite").
+          const allRated = ratedVotes
+            .filter(v => v.dish?.id)
+            .map(v => ({
+              dish_id: v.dish.id,
+              dish_name: v.dish.name,
+              restaurant_id: v.dish.restaurant_id,
+              restaurant_name: v.dish.restaurant_name,
+              userRating: v.rating,
+            }))
+
+          if (allRated.length > 0) {
+            const best = allRated.slice().sort((a, b) => b.userRating - a.userRating)
+            picks.bestFind = best[0]
+          }
+
+          // Hottest Take still needs community comparison to be meaningful.
           const comparisons = ratedVotes
             .filter(v => v.dish?.id && communityAvgs[v.dish.id]?.count >= MIN_COMMUNITY)
             .map(v => ({
@@ -269,21 +287,11 @@ export function UserProfile() {
             }))
 
           if (comparisons.length > 0) {
-            // Best find: highest user rating, tie-break by positive diff
-            const best = comparisons.slice().sort((a, b) => {
-              if (b.userRating !== a.userRating) return b.userRating - a.userRating
-              return b.diff - a.diff
-            })
-            picks.bestFind = best[0]
-
-            // Hottest take: biggest negative diff (user rates much lower than community), min -1.0
             const harsh = comparisons.slice().sort((a, b) => a.diff - b.diff)
-            if (harsh[0] && harsh[0].diff <= -1.0) {
-              picks.harshestTake = harsh[0]
-            }
-
-            setStandoutPicks(picks)
+            if (harsh[0].diff <= -1.0) picks.harshestTake = harsh[0]
           }
+
+          if (picks.bestFind || picks.harshestTake) setStandoutPicks(picks)
         } catch (err) {
           logger.error('Failed to compute standout picks:', err)
         }


### PR DESCRIPTION
Best Find was hiding your actual top-rated dishes when the community hadn't piled in yet — the comparison filter required community_vote_count >= 3, so early-adopter 10/10s were invisible.

Split: Best Find uses ALL rated votes (no community gate). Hottest Take keeps the comparison subset since 'you vs. crowd' diff is its whole point.

Matches user expectation surfaced tonight: 'Best Find should be highest rated dish, period.'

Codex-reviewed: no Hottest Take regression, no null-rating path, setStandoutPicks gate correct. Tie-break for equal ratings is input-order dependent — acceptable for v1.2, can add deterministic secondary key later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)