### PR TITLE
feat(home): add Best Coffee NOW chalkboard to homepage

### DIFF
--- a/src/components/home/HomeListMode.jsx
+++ b/src/components/home/HomeListMode.jsx
@@ -322,7 +322,17 @@ function ChalkboardSection({ topRestaurant, mostVotedDish, bestValueMeal, bestIc
         onClick={function () { onExpandCategory('chowder') }}
       />
 
-      {/* Board 4: Most Talked About */}
+      {/* Board 4: Best Coffee NOW */}
+      <ChalkboardCard
+        icon="/categories/icons/coffee.png"
+        tag={'best coffee now'}
+        title="Coffee"
+        sub="freshly ranked by locals"
+        cta={'best on the island \u2192'}
+        onClick={function () { onExpandCategory('coffee') }}
+      />
+
+      {/* Board 5: Most Talked About */}
       {mostVotedDish && (
         <ChalkboardCard
           icon="/categories/icons/speech-bubble.png"
@@ -336,7 +346,7 @@ function ChalkboardSection({ topRestaurant, mostVotedDish, bestValueMeal, bestIc
         />
       )}
 
-      {/* Board 5: Best Meal Under $15 */}
+      {/* Board 6: Best Meal Under $15 */}
       {bestValueMeal && (
         <ChalkboardCard
           icon="/categories/icons/money-bag.png"
@@ -350,7 +360,7 @@ function ChalkboardSection({ topRestaurant, mostVotedDish, bestValueMeal, bestIc
         />
       )}
 
-      {/* Board 6: Best Ice Cream — clean cone top, melting cone bottom */}
+      {/* Board 7: Best Ice Cream — clean cone top, melting cone bottom */}
       {bestIceCream && (
         <ChalkboardCard
           icon="/categories/icons/ice-cream-clean.png"


### PR DESCRIPTION
## Summary

Adds a 7th editorial card to the homepage horizontal chalkboard scroll. Routes into the coffee category ranking.

- Sits between the Chowder board and the dynamic data-driven boards — visible early in scroll without disrupting the dynamic flow
- Matches existing peer card pattern (ChalkboardCard component, same editorial voice, same CTA arrow)
- Surfaces the coffee content that the v1.2 menu-refresh pipeline started extracting in #214 / #215 / #216

## Why now

This was queued for v1.2 ([[project_v1_2_best_coffee_chalkboard]] in memory). Coffee category + extractor are already live; the homepage just wasn't pointing at it yet.

## Codex note

Tried codex review on the small diff — codex flaked (hung with zero output for 6+ min, third such hang today on the same network/account). Diff is trivially correct: matches the Chowder peer card exactly except for icon + tag + title + sub + CTA copy + category ID.

## Test plan

- [ ] Open homepage → scroll through chalkboards horizontally → see "best coffee now" / "Coffee" / "freshly ranked by locals" / "best on the island →" between Chowder and Most Talked About
- [ ] Tap the card → routes to coffee category filter (same handler as other static category boards)
- [ ] Visual: warm coral A-frame chalkboard, white chalk text, matches peer cards (no AI-design pill chips, no uniform shadows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)