### PR TITLE
feat(home): app icon as brand mark + donut category icon

### DIFF
--- a/src/components/home/CategoryIcons.jsx
+++ b/src/components/home/CategoryIcons.jsx
@@ -26,6 +26,7 @@ const categoryIcons = {
   'ice cream': '/categories/icons/ice-cream.png',
   coffee: '/categories/icons/coffee.png',
   cocktails: '/categories/icons/cocktails.png',
+  donuts: '/categories/icons/donuts.png',
   // Missing poster icons: oysters (use SVG fallback)
 
   // === SUB-CATEGORIES ===

--- a/src/components/home/HomeListMode.jsx
+++ b/src/components/home/HomeListMode.jsx
@@ -63,16 +63,23 @@ export const HomeListMode = memo(function HomeListMode({
     >
       {/* Fixed header: brand + search + chips */}
       <div style={{ flexShrink: 0, background: 'var(--color-bg)', zIndex: 10, paddingTop: 'env(safe-area-inset-top, 0px)' }}>
-        {/* Brand header — coral wgh wordmark (no plate, no square: confidence
-            to let the mark stand on its own). PNG is 1600×640 (≈2.5:1
-            aspect); width controls the visual size. Map page already has an
-            <h1 className="sr-only">What's Good Here</h1> so the screen-reader
-            label here is the alt text. */}
+        {/* Brand header — the iOS app icon used as the homepage mark.
+            Rounded corners (22% radius matches Apple's icon mask) and a
+            soft shadow make it read as "icon," not bare PNG. Map page
+            already has an <h1 className="sr-only">What's Good Here</h1>
+            so this img carries the screen-reader label as alt text. */}
         <div className="text-center pt-4 pb-1">
           <img
-            src="/wgh-mark-coral.png"
+            src="/wgh-icon.png"
             alt="What's Good Here"
-            style={{ display: 'block', margin: '0 auto', width: '180px', height: 'auto' }}
+            style={{
+              display: 'block',
+              margin: '0 auto',
+              width: '120px',
+              height: '120px',
+              borderRadius: '26px',
+              boxShadow: '0 6px 16px rgba(26, 26, 26, 0.12)',
+            }}
           />
           <p style={{
             fontSize: '10px',


### PR DESCRIPTION
## Summary

- Swap bare coral wordmark for the full iOS app icon (coral square + plate + script wgh) at 120px with rounded corners and a soft shadow — gives the homepage real identity weight that the bare wordmark wasn't carrying.
- Add `donuts` to `CategoryIcons.jsx`'s icon map so the Donuts tab in the Top10Carousel uses the sprinkled-donut PNG instead of falling back to a generic plus-circle SVG.

## Review trail

Iterated live in the browser at `localhost:5173`. Three approaches considered for the brand mark — plate-roundel-behind-wordmark (rejected: "lost its charm"), masked plate-only (rejected: same), full app icon (shipped: charm intact).

Known drift: `CategoryIcons.jsx` (line 6+) and `constants/categories.js` (line 198+) both maintain icon-path maps for the same set of categories. The donuts gap was caused by drift between the two — worth consolidating to a single source post-launch.

## Test plan

- [ ] Open the homepage on a phone-width viewport — coral app-icon mark sits at the top, "TOP-RATED DISHES NEAR YOU" caption directly beneath.
- [ ] Scroll past the chalkboards and Locals' Picks to the Top10Carousel. Confirm the Donuts tab shows the sprinkled-donut icon (between Coffee and Cocktails).
- [ ] Tap the Donuts tab — should activate and show the donut-category top 10.
- [ ] Regression check: chalkboards above (Pizza/Wicked Island/Chowder/Coffee/etc.) still render with their respective icons.

## Notes

- 1 pre-existing test failure in `src/lib/nativeAuth.test.js` (Google native sign-in error subcode mapping) — unrelated to UI changes, on `main` already.
- Lint: 3 pre-existing `react-refresh/only-export-components` warnings in `CategoryIcons.jsx` — not caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)