### PR TITLE
fix(menu-refresh): fuzzy-match upsert to prevent duplicate dish rows

### DIFF
--- a/scripts/find-duplicate-dishes.mjs
+++ b/scripts/find-duplicate-dishes.mjs
@@ -1,0 +1,152 @@
+import { createClient } from '@supabase/supabase-js'
+import { readFileSync } from 'node:fs'
+for (const line of readFileSync('.env.local', 'utf8').split('\n')) {
+  const m = line.match(/^([A-Z_]+)=(.*)$/)
+  if (m) process.env[m[1]] = m[2].replace(/^["']|["']$/g, '')
+}
+
+const supabase = createClient(process.env.VITE_SUPABASE_URL, process.env.VITE_SUPABASE_ANON_KEY)
+
+const ABBREV = {
+  brgr: 'burger',
+  burg: 'burger',
+  chix: 'chicken',
+  chkn: 'chicken',
+  veg: 'veggie',
+  sweeties: 'sweet potato fries',
+  rings: 'onion rings',
+  fishnchips: 'fish and chips',
+  fish: 'fish',
+  mac: 'macaroni',
+  bbq: 'barbecue',
+  hbc: 'honey buffalo chicken',
+  cgb: 'chopped ground beef',
+}
+
+const STOPWORDS = new Set(['the', 'a', 'an', 'and', 'with', 'of', 'on', 'in', 'or', 'n', 'over'])
+
+function tokenize(name) {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .split(' ')
+    .map((t) => ABBREV[t] || t)
+    .filter((t) => t && !STOPWORDS.has(t))
+}
+
+function similarity(a, b) {
+  if (!a.length || !b.length) return 0
+  const setA = new Set(a)
+  const setB = new Set(b)
+  const inter = [...setA].filter((t) => setB.has(t)).length
+  const union = new Set([...setA, ...setB]).size
+  return inter / union
+}
+
+// Pull all dishes
+const allDishes = []
+const PAGE = 1000
+let from = 0
+for (;;) {
+  const { data, error } = await supabase
+    .from('dishes')
+    .select('id, name, category, description, price, restaurant_id, created_at')
+    .range(from, from + PAGE - 1)
+    .order('id')
+  if (error) { console.error('Fetch error:', error); process.exit(1) }
+  if (!data?.length) break
+  allDishes.push(...data)
+  if (data.length < PAGE) break
+  from += PAGE
+}
+
+// Pull restaurant names
+const restIds = [...new Set(allDishes.map((d) => d.restaurant_id).filter(Boolean))]
+const restMap = {}
+for (let i = 0; i < restIds.length; i += 100) {
+  const { data } = await supabase
+    .from('restaurants')
+    .select('id, name, town')
+    .in('id', restIds.slice(i, i + 100))
+  for (const r of data || []) restMap[r.id] = r
+}
+
+console.log(`Loaded ${allDishes.length} dishes across ${restIds.length} restaurants.`)
+
+// Group by restaurant
+const byRest = {}
+for (const d of allDishes) {
+  byRest[d.restaurant_id] ||= []
+  byRest[d.restaurant_id].push({ ...d, tokens: tokenize(d.name) })
+}
+
+const SIM_THRESHOLD = 0.6
+const allDupes = []
+
+for (const [restId, dishes] of Object.entries(byRest)) {
+  for (let i = 0; i < dishes.length; i++) {
+    for (let j = i + 1; j < dishes.length; j++) {
+      const a = dishes[i]
+      const b = dishes[j]
+      const sim = similarity(a.tokens, b.tokens)
+      const samePrice = a.price && b.price && Math.abs(a.price - b.price) < 0.01
+      const oneContainsOther =
+        a.tokens.length && b.tokens.length &&
+        (a.tokens.every((t) => b.tokens.includes(t)) || b.tokens.every((t) => a.tokens.includes(t)))
+
+      // Confidence:
+      // HIGH: same price + (sim>=0.6 OR one tokens subset of other)
+      // MED:  same price + sim>=0.4, or different price + sim>=0.75
+      // LOW:  sim>=0.6, no price match
+      let conf = null
+      if (samePrice && (sim >= SIM_THRESHOLD || oneContainsOther)) conf = 'HIGH'
+      else if (samePrice && sim >= 0.4) conf = 'MED'
+      else if (!samePrice && sim >= 0.75) conf = 'MED'
+      else if (sim >= SIM_THRESHOLD) conf = 'LOW'
+
+      if (conf) {
+        allDupes.push({
+          restId,
+          rest: restMap[restId]?.name || '???',
+          town: restMap[restId]?.town || '',
+          a, b, sim, samePrice, oneContainsOther, conf,
+        })
+      }
+    }
+  }
+}
+
+const order = { HIGH: 0, MED: 1, LOW: 2 }
+allDupes.sort((x, y) => order[x.conf] - order[y.conf] || x.rest.localeCompare(y.rest))
+
+const summary = { HIGH: 0, MED: 0, LOW: 0 }
+const byRestaurant = {}
+for (const d of allDupes) {
+  summary[d.conf]++
+  byRestaurant[d.rest] = (byRestaurant[d.rest] || 0) + 1
+}
+
+console.log('\n========================================')
+console.log(`Suspected duplicates: HIGH=${summary.HIGH}  MED=${summary.MED}  LOW=${summary.LOW}  TOTAL=${allDupes.length}`)
+console.log('========================================\n')
+
+console.log('Worst-offender restaurants:')
+const sortedRests = Object.entries(byRestaurant).sort((a, b) => b[1] - a[1]).slice(0, 15)
+for (const [name, n] of sortedRests) console.log(`  ${n.toString().padStart(3)}  ${name}`)
+
+console.log('\n--- HIGH-confidence pairs ---\n')
+for (const d of allDupes.filter((x) => x.conf === 'HIGH').slice(0, 200)) {
+  console.log(`[${d.rest} / ${d.town}]`)
+  console.log(`  A: "${d.a.name}" $${d.a.price ?? '?'} cat=${d.a.category} id=${d.a.id.slice(0, 8)}`)
+  console.log(`  B: "${d.b.name}" $${d.b.price ?? '?'} cat=${d.b.category} id=${d.b.id.slice(0, 8)}`)
+  console.log(`  sim=${d.sim.toFixed(2)} subset=${d.oneContainsOther}`)
+}
+
+console.log('\n--- MED-confidence pairs (first 40) ---\n')
+for (const d of allDupes.filter((x) => x.conf === 'MED').slice(0, 40)) {
+  console.log(`[${d.rest}]`)
+  console.log(`  A: "${d.a.name}" $${d.a.price ?? '?'} cat=${d.a.category}`)
+  console.log(`  B: "${d.b.name}" $${d.b.price ?? '?'} cat=${d.b.category}`)
+  console.log(`  sim=${d.sim.toFixed(2)} samePrice=${d.samePrice}`)
+}

--- a/supabase/functions/menu-refresh/extractors.test.ts
+++ b/supabase/functions/menu-refresh/extractors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { sanitizeDescription, sanitizeDietaryTags, sortedArraysEqual, ALLOWED_DIETARY_TAGS } from './extractors.ts'
+import { sanitizeDescription, sanitizeDietaryTags, sortedArraysEqual, ALLOWED_DIETARY_TAGS, normalizeDishKey } from './extractors.ts'
 
 describe('sanitizeDescription', () => {
   it('returns null for non-string input', () => {
@@ -115,5 +115,105 @@ describe('sortedArraysEqual', () => {
   it('returns false when one is empty and other is not', () => {
     expect(sortedArraysEqual([], ['vegan'])).toBe(false)
     expect(sortedArraysEqual(['vegan'], [])).toBe(false)
+  })
+})
+
+describe('normalizeDishKey', () => {
+  // SHOULD MERGE: real duplicate patterns observed in production data
+  it('collapses category-suffix variants', () => {
+    expect(normalizeDishKey('Boston Cream', 'donuts'))
+      .toBe(normalizeDishKey('Boston Cream Donut', 'donuts'))
+    expect(normalizeDishKey('Old Fashioned', 'donuts'))
+      .toBe(normalizeDishKey('Old Fashioned Donut', 'donuts'))
+  })
+
+  it('strips identity-neutral parenthetical tags (region, notes)', () => {
+    expect(normalizeDishKey('Jollof Rice', 'entree'))
+      .toBe(normalizeDishKey('Jollof Rice (Ghana)', 'entree'))
+    expect(normalizeDishKey('SOS Pwa', 'entree'))
+      .toBe(normalizeDishKey('SOS Pwa (Haiti)', 'entree'))
+  })
+
+  it('strips asterisks (raw/footnote markers)', () => {
+    expect(normalizeDishKey('Littleneck Clams', 'clams'))
+      .toBe(normalizeDishKey('Littleneck Clams*', 'clams'))
+  })
+
+  it('expands common abbreviations', () => {
+    expect(normalizeDishKey('Chix Sandwich', 'sandwich'))
+      .toBe(normalizeDishKey('Chicken Sandwich', 'sandwich'))
+    expect(normalizeDishKey('Brgr Wrap', 'wrap'))
+      .toBe(normalizeDishKey('Burger Wrap', 'wrap'))
+  })
+
+  it('normalizes punctuation and connective words', () => {
+    expect(normalizeDishKey('Fish & Chips', 'fish-and-chips'))
+      .toBe(normalizeDishKey('Fish-n- Chips', 'fish-and-chips'))
+    expect(normalizeDishKey('Fish and Chips', 'fish-and-chips'))
+      .toBe(normalizeDishKey('Fish & Chips', 'fish-and-chips'))
+  })
+
+  it('normalizes apostrophes and quote variants', () => {
+    expect(normalizeDishKey("Atria's Truffle Fries", 'fries'))
+      .toBe(normalizeDishKey("Atrias Truffle Fries", 'fries'))
+    expect(normalizeDishKey('Atria’s Truffle Fries', 'fries'))
+      .toBe(normalizeDishKey("Atria's Truffle Fries", 'fries'))
+  })
+
+  it('normalizes diacritics so accents do not split keys', () => {
+    expect(normalizeDishKey('Jalapeño Poppers', 'appetizer'))
+      .toBe(normalizeDishKey('Jalapeno Poppers', 'appetizer'))
+    expect(normalizeDishKey('Café Latte', 'coffee'))
+      .toBe(normalizeDishKey('Cafe Latte', 'coffee'))
+  })
+
+  it('treats whitespace and minor punctuation differences as equal', () => {
+    expect(normalizeDishKey('Hummus ,Veggie & Quinoa Wrap', 'wrap'))
+      .toBe(normalizeDishKey('Hummus, Veggie & Quinoa Wrap', 'wrap'))
+  })
+
+  // SHOULD NOT MERGE: legitimately different dishes
+  it('keeps size modifiers distinct', () => {
+    expect(normalizeDishKey('Half Roast Chicken', 'chicken'))
+      .not.toBe(normalizeDishKey('Whole Roast Chicken', 'chicken'))
+  })
+
+  it('keeps kid/adult portion variants distinct', () => {
+    expect(normalizeDishKey('Kids Burger', 'burger'))
+      .not.toBe(normalizeDishKey('Burger', 'burger'))
+  })
+
+  it('keeps modifier-prefixed versions distinct from base', () => {
+    expect(normalizeDishKey('Cod Sandwich', 'fish-sandwich'))
+      .not.toBe(normalizeDishKey('Fat Cod Sandwich', 'fish-sandwich'))
+  })
+
+  it('preserves numeric/quantity parentheticals', () => {
+    // Quantity is identity-bearing — must NOT collapse different counts.
+    expect(normalizeDishKey('Tacos (3)', 'taco'))
+      .not.toBe(normalizeDishKey('Tacos (6)', 'taco'))
+    expect(normalizeDishKey('Wings (10 pc)', 'wings'))
+      .not.toBe(normalizeDishKey('Wings (6 pc)', 'wings'))
+  })
+
+  it('strips dietary shorthand letters (already in dietary_tags column)', () => {
+    // "Plain GF" and "Plain GF Donut" are the same dish; the gluten-free
+    // marker belongs in dietary_tags, not the name.
+    expect(normalizeDishKey('Plain GF', 'donuts'))
+      .toBe(normalizeDishKey('Plain GF Donut', 'donuts'))
+  })
+
+  it('returns empty string for empty/whitespace input', () => {
+    expect(normalizeDishKey('', 'donuts')).toBe('')
+    expect(normalizeDishKey('   ', 'donuts')).toBe('')
+    // Caller must guard against empty keys to avoid bad matches.
+  })
+
+  it('is stable when category is null/undefined', () => {
+    expect(normalizeDishKey('Boston Cream Donut', null))
+      .toBe(normalizeDishKey('Boston Cream Donut', undefined))
+    // Without the donuts category, "donut" no longer strips.
+    expect(normalizeDishKey('Boston Cream Donut', null))
+      .not.toBe(normalizeDishKey('Boston Cream', null))
   })
 })

--- a/supabase/functions/menu-refresh/extractors.ts
+++ b/supabase/functions/menu-refresh/extractors.ts
@@ -39,3 +39,112 @@ export function sortedArraysEqual(a: string[], b: string[]): boolean {
   }
   return true
 }
+
+// Tokens collapsed away during normalization. Glue words plus dietary
+// shorthand letters that belong in dietary_tags, not the name.
+const NORMALIZE_STOPWORDS = new Set([
+  'the', 'a', 'an', 'and', 'with', 'of', 'on', 'in', 'or', 'over', 'n',
+  'gf', 'df', 'v', 've', 'vg', 'vgn',
+])
+
+// Common menu-code abbreviations that get expanded so "Chix Wrap" matches
+// "Chicken Wrap". Conservative list — only widely-used menu shorthand.
+const NORMALIZE_ABBREV: Record<string, string> = {
+  chix: 'chicken',
+  chkn: 'chicken',
+  brgr: 'burger',
+  burg: 'burger',
+}
+
+// Tokens that are redundant inside a name because they restate the dish's
+// category. Keyed by the category column value. Add carefully — anything
+// listed here will collapse "Foo X" and "Foo" into the same key when
+// category=X. Only include words specific enough that they uniquely restate
+// the category (e.g., 'donut' for category=donuts is safe; 'roll' for
+// category=lobster-roll is too broad because lots of dishes are rolls).
+const CATEGORY_REDUNDANT_WORDS: Record<string, string[]> = {
+  donuts: ['donut', 'donuts'],
+  burger: ['burger', 'burgers'],
+  pizza: ['pizza', 'pizzas'],
+  salad: ['salad', 'salads'],
+  sandwich: ['sandwich', 'sandwiches'],
+  'fish-sandwich': ['sandwich', 'sandwiches'],
+  taco: ['taco', 'tacos'],
+  burrito: ['burrito', 'burritos'],
+  enchiladas: ['enchilada', 'enchiladas'],
+  fries: ['fries'],
+  'onion rings': ['rings'],
+  pasta: ['pasta', 'pastas'],
+  wrap: ['wrap', 'wraps'],
+  wings: ['wings', 'wing'],
+  cookie: ['cookie', 'cookies'],
+}
+
+// Matches parenthetical groups that contain at least one digit — used to
+// PRESERVE quantity/size info like "(3)", "(10 pc)", "(7-8 oz)". Identity-
+// bearing parentheticals (counts, sizes, weights) should stay; identity-
+// neutral parentheticals (region tags, descriptive notes) get stripped.
+const NUMERIC_PAREN_RE = /\([^)]*\d[^)]*\)/g
+const ANY_PAREN_RE = /\([^)]*\)/g
+
+/**
+ * Build a normalized matching key for a dish name. Two dishes with the same
+ * normalized key (within the same restaurant and category) should be treated
+ * as the same dish for upsert purposes.
+ *
+ * Conservative — strips only structural noise (punctuation, parenthetical
+ * tags, asterisks, dietary shorthand, redundant category words, common
+ * menu-code abbreviations). Token order is normalized but content tokens
+ * (sizes, modifiers, ingredients) are preserved, so "Half Roast Chicken"
+ * and "Whole Roast Chicken" stay distinct.
+ */
+export function normalizeDishKey(rawName: string, category: string | null | undefined): string {
+  if (!rawName) return ''
+  const cat = (category || '').toLowerCase().trim()
+
+  // Step 1: lowercase + Unicode-normalize so "café" matches "cafe" and
+  // "jalapeño" matches "jalapeno". U+0300–U+036F is the combining-
+  // diacritical-marks block, separated out by NFKD decomposition.
+  const lowered = rawName
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+
+  // Step 2: protect parentheticals containing digits (quantity/size info
+  // like "(3)" or "(10 pc)") by collapsing their contents into a single
+  // identity token before stripping other parens. We replace e.g.
+  // "Tacos (3)" with "tacos qty3"; quantity differences then survive
+  // the rest of the pipeline.
+  const protectedParens = lowered.replace(NUMERIC_PAREN_RE, (m) => {
+    const digits = m.match(/\d+/g)?.join('-') ?? ''
+    return ` qty${digits} `
+  })
+
+  // Step 3: strip remaining (non-numeric) parentheticals, asterisks,
+  // apostrophes, and collapse punctuation.
+  const cleaned = protectedParens
+    .replace(ANY_PAREN_RE, ' ')
+    .replace(/[*]/g, ' ')
+    .replace(/['’`"]/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (!cleaned) return ''
+
+  const redundant = new Set(CATEGORY_REDUNDANT_WORDS[cat] || [])
+
+  const tokens = cleaned
+    .split(' ')
+    .map((t) => NORMALIZE_ABBREV[t] ?? t)
+    .filter((t) => t && !NORMALIZE_STOPWORDS.has(t))
+
+  const filtered = tokens.filter((t) => !redundant.has(t))
+
+  // If stripping category words would leave the name empty (rare — a dish
+  // literally named "Donut" in category=donuts), fall back to the unfiltered
+  // tokens so the key isn't ambiguous.
+  const final = filtered.length > 0 ? filtered : tokens
+
+  return final.slice().sort().join(' ')
+}

--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -47,6 +47,62 @@ function sortedArraysEqual(a: string[], b: string[]): boolean {
   return true
 }
 
+// Secondary upsert-match key — collapses dishes that exact-name match misses.
+// MUST stay in sync with normalizeDishKey in ./extractors.ts (which has the
+// Vitest coverage). See test cases there for the rationale on each rule.
+const NORMALIZE_STOPWORDS_INLINE = new Set([
+  'the', 'a', 'an', 'and', 'with', 'of', 'on', 'in', 'or', 'over', 'n',
+  'gf', 'df', 'v', 've', 'vg', 'vgn',
+])
+const NORMALIZE_ABBREV_INLINE: Record<string, string> = {
+  chix: 'chicken', chkn: 'chicken', brgr: 'burger', burg: 'burger',
+}
+const CATEGORY_REDUNDANT_WORDS_INLINE: Record<string, string[]> = {
+  donuts: ['donut', 'donuts'],
+  burger: ['burger', 'burgers'],
+  pizza: ['pizza', 'pizzas'],
+  salad: ['salad', 'salads'],
+  sandwich: ['sandwich', 'sandwiches'],
+  'fish-sandwich': ['sandwich', 'sandwiches'],
+  taco: ['taco', 'tacos'],
+  burrito: ['burrito', 'burritos'],
+  enchiladas: ['enchilada', 'enchiladas'],
+  fries: ['fries'],
+  'onion rings': ['rings'],
+  pasta: ['pasta', 'pastas'],
+  wrap: ['wrap', 'wraps'],
+  wings: ['wings', 'wing'],
+  cookie: ['cookie', 'cookies'],
+}
+const NUMERIC_PAREN_RE_INLINE = /\([^)]*\d[^)]*\)/g
+const ANY_PAREN_RE_INLINE = /\([^)]*\)/g
+
+function normalizeDishKey(rawName: string, category: string | null | undefined): string {
+  if (!rawName) return ''
+  const cat = (category || '').toLowerCase().trim()
+  const lowered = rawName.toLowerCase().normalize('NFKD').replace(/[̀-ͯ]/g, '')
+  const protectedParens = lowered.replace(NUMERIC_PAREN_RE_INLINE, (m) => {
+    const digits = m.match(/\d+/g)?.join('-') ?? ''
+    return ` qty${digits} `
+  })
+  const cleaned = protectedParens
+    .replace(ANY_PAREN_RE_INLINE, ' ')
+    .replace(/[*]/g, ' ')
+    .replace(/['’`"]/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  if (!cleaned) return ''
+  const redundant = new Set(CATEGORY_REDUNDANT_WORDS_INLINE[cat] || [])
+  const tokens = cleaned
+    .split(' ')
+    .map((t) => NORMALIZE_ABBREV_INLINE[t] ?? t)
+    .filter((t) => t && !NORMALIZE_STOPWORDS_INLINE.has(t))
+  const filtered = tokens.filter((t) => !redundant.has(t))
+  const final = filtered.length > 0 ? filtered : tokens
+  return final.slice().sort().join(' ')
+}
+
 /**
  * Menu Refresh Edge Function
  *
@@ -955,28 +1011,150 @@ async function upsertDishes(
   supabase: ReturnType<typeof createClient>,
   restaurantId: string,
   extracted: MenuExtractionResult
-): Promise<{ inserted: number; updated: number; unchanged: number }> {
-  // Get existing dishes
+): Promise<{ inserted: number; updated: number; unchanged: number; fuzzyMatched: number; batchDedupSkipped: number; crossCategorySkipped: number }> {
+  // Get existing dishes. Ordered by created_at so "first row wins" ties in
+  // the normalized-key lookup are deterministic and stable across runs —
+  // older rows are more likely to be the canonical ones holding votes.
   const { data: existingDishes, error: fetchErr } = await supabase
     .from('dishes')
-    .select('id, name, category, menu_section, price, photo_url, description, dietary_tags')
+    .select('id, name, category, menu_section, price, photo_url, description, dietary_tags, created_at')
     .eq('restaurant_id', restaurantId)
+    .order('created_at', { ascending: true })
 
   if (fetchErr) {
     throw new Error(`Failed to fetch existing dishes: ${fetchErr.message}`)
   }
 
+  // Primary lookup: exact lowercase name (cheap, unambiguous).
+  // Secondary lookup: normalized key — catches near-duplicate name variants
+  // ("Boston Cream" vs "Boston Cream Donut", "Chix Sandwich" vs
+  // "Chicken Sandwich", "Jollof Rice" vs "Jollof Rice (Ghana)") so a refresh
+  // doesn't insert a parallel row for a dish that already exists under a
+  // slightly different spelling. Oldest row wins ties.
   const existingByName = new Map<string, typeof existingDishes[0]>()
+  const existingByNormKey = new Map<string, typeof existingDishes[0]>()
   for (const d of (existingDishes || [])) {
-    existingByName.set(d.name.toLowerCase(), d)
+    // Oldest row wins both maps — guarded by has() so a later same-name row
+    // doesn't overwrite the canonical (vote-bearing) one. The fetch is
+    // ordered by created_at ASC so "first seen" == "oldest".
+    const nameKey = d.name.toLowerCase()
+    if (!existingByName.has(nameKey)) {
+      existingByName.set(nameKey, d)
+    }
+    const normKey = normalizeDishKey(d.name, d.category)
+    if (normKey && !existingByNormKey.has(normKey)) {
+      existingByNormKey.set(normKey, d)
+    }
+  }
+
+  // Within-batch dedup: collapse name-variants the LLM emitted twice in a
+  // single extraction. When two extracted dishes collide on
+  // (category, normalized-key) we keep the one that's most useful to upsert:
+  //   1. Prefer the variant whose name exact-matches an existing DB row
+  //      (stable update target, preserves vote attribution).
+  //   2. Otherwise prefer the variant with more populated fields
+  //      (non-null price, description, non-empty dietary_tags).
+  //   3. Otherwise prefer the longer/more descriptive name.
+  // This avoids silently dropping the better data when the LLM emits both
+  // "Boston Cream" and "Boston Cream Donut" in one extraction.
+  // Weighted by trust: price is the highest-signal column (always sourced
+  // directly from the menu), description is moderately reliable, dietary
+  // tags are the noisiest LLM-derived field. These weights only affect the
+  // within-batch tiebreaker — exact-name matches still dominate.
+  function dataRichness(d: typeof extracted.dishes[0]): number {
+    return (
+      (d.price != null ? 3 : 0) +
+      (d.description ? 2 : 0) +
+      (Array.isArray(d.dietary_tags) && d.dietary_tags.length > 0 ? 1 : 0)
+    )
+  }
+  function shouldReplace(
+    current: typeof extracted.dishes[0],
+    candidate: typeof extracted.dishes[0],
+  ): boolean {
+    const currentExact = existingByName.has(current.name.toLowerCase())
+    const candidateExact = existingByName.has(candidate.name.toLowerCase())
+    if (candidateExact && !currentExact) return true
+    if (currentExact && !candidateExact) return false
+    const curRich = dataRichness(current)
+    const candRich = dataRichness(candidate)
+    if (candRich !== curRich) return candRich > curRich
+    return candidate.name.length > current.name.length
+  }
+
+  const dedupedByBatchKey = new Map<string, typeof extracted.dishes[0]>()
+  const unkeyedDishes: typeof extracted.dishes = []
+  let batchDedupSkipped = 0
+  for (const dish of extracted.dishes) {
+    const dishNormKey = normalizeDishKey(dish.name, dish.category)
+    if (!dishNormKey) {
+      // Names that don't yield a normalized key (e.g. non-Latin or
+      // symbol-only) skip batch-dedup and go straight through.
+      unkeyedDishes.push(dish)
+      continue
+    }
+    const batchKey = `${(dish.category || '').toLowerCase()}|${dishNormKey}`
+    const incumbent = dedupedByBatchKey.get(batchKey)
+    if (!incumbent) {
+      dedupedByBatchKey.set(batchKey, dish)
+    } else if (shouldReplace(incumbent, dish)) {
+      dedupedByBatchKey.set(batchKey, dish)
+      batchDedupSkipped++
+    } else {
+      batchDedupSkipped++
+    }
+  }
+  const candidateDishes = [...dedupedByBatchKey.values(), ...unkeyedDishes]
+
+  // Second-pass dedup: resolve each candidate to its target existing row,
+  // then collapse any candidates that point at the same row. The first-pass
+  // dedup keyed on (category, normKey), so cross-category collisions slip
+  // through (e.g. LLM emits the same dish under both "donuts" and "dessert").
+  // Without this pass we'd update the same DB row twice with last-write-wins
+  // semantics on the category field.
+  type Candidate = typeof extracted.dishes[0]
+  const resolutions: Array<{ dish: Candidate; existing: typeof existingDishes[0] | undefined; viaFuzzy: boolean }> = []
+  const claimedExistingIds = new Map<string, number>()  // existing.id -> resolutions[] index
+  let fuzzyMatchedCount = 0
+  let crossCategorySkipped = 0
+
+  for (const dish of candidateDishes) {
+    const dishNormKey = normalizeDishKey(dish.name, dish.category)
+    let existing = existingByName.get(dish.name.toLowerCase())
+    let viaFuzzy = false
+    if (!existing && dishNormKey) {
+      existing = existingByNormKey.get(dishNormKey)
+      if (existing) viaFuzzy = true
+    }
+
+    if (!existing) {
+      resolutions.push({ dish, existing: undefined, viaFuzzy: false })
+      continue
+    }
+
+    const claimedIdx = claimedExistingIds.get(existing.id)
+    if (claimedIdx === undefined) {
+      claimedExistingIds.set(existing.id, resolutions.length)
+      resolutions.push({ dish, existing, viaFuzzy })
+      if (viaFuzzy) fuzzyMatchedCount++
+    } else {
+      // Collision — two candidates target the same existing row. Keep the
+      // one with richer data (same tiebreaker as the first-pass dedup).
+      const incumbent = resolutions[claimedIdx]
+      if (shouldReplace(incumbent.dish, dish)) {
+        if (incumbent.viaFuzzy) fuzzyMatchedCount--
+        resolutions[claimedIdx] = { dish, existing, viaFuzzy }
+        if (viaFuzzy) fuzzyMatchedCount++
+      }
+      crossCategorySkipped++
+    }
   }
 
   let inserted = 0
   let updated = 0
   let unchanged = 0
 
-  for (const dish of extracted.dishes) {
-    const existing = existingByName.get(dish.name.toLowerCase())
+  for (const { dish, existing } of resolutions) {
 
     if (existing) {
       // Check if anything changed
@@ -1029,7 +1207,14 @@ async function upsertDishes(
       .eq('id', restaurantId)
   }
 
-  return { inserted, updated, unchanged }
+  return {
+    inserted,
+    updated,
+    unchanged,
+    fuzzyMatched: fuzzyMatchedCount,
+    batchDedupSkipped,
+    crossCategorySkipped,
+  }
 }
 
 serve(async (req) => {
@@ -1271,6 +1456,9 @@ serve(async (req) => {
                   resolved_pdf_url: fetchResult.pdfUrl,
                   winning_strategy: 'pdf-direct',
                   attempts: pdfAttempts,
+                  fuzzy_matched: stats.fuzzyMatched,
+                  batch_dedup_skipped: stats.batchDedupSkipped,
+                  cross_category_skipped: stats.crossCategorySkipped,
                 },
                 lock_expires_at: null,
                 updated_at: new Date().toISOString(),
@@ -1278,6 +1466,9 @@ serve(async (req) => {
               results.push({
                 job_id: job.id, status: 'success', restaurant: restaurant.name,
                 dishes: pdfExtracted.dishes.length, inserted: stats.inserted, updated: stats.updated,
+                fuzzy_matched: stats.fuzzyMatched,
+                batch_dedup_skipped: stats.batchDedupSkipped,
+                cross_category_skipped: stats.crossCategorySkipped,
                 strategy: 'pdf-direct',
               })
               continue
@@ -1714,6 +1905,9 @@ serve(async (req) => {
               candidates_found: candidates.length,
               winning_strategy: winningStrategy,
               attempts,
+              fuzzy_matched: stats.fuzzyMatched,
+              batch_dedup_skipped: stats.batchDedupSkipped,
+              cross_category_skipped: stats.crossCategorySkipped,
             },
             lock_expires_at: null,
             updated_at: new Date().toISOString(),
@@ -1722,6 +1916,9 @@ serve(async (req) => {
           results.push({
             job_id: job.id, status: 'success', restaurant: restaurant.name,
             dishes: extracted.dishes.length, inserted: stats.inserted, updated: stats.updated,
+            fuzzy_matched: stats.fuzzyMatched,
+            batch_dedup_skipped: stats.batchDedupSkipped,
+            cross_category_skipped: stats.crossCategorySkipped,
             rendered: renderSucceeded,
             strategy: winningStrategy,
           })
@@ -1836,6 +2033,9 @@ serve(async (req) => {
       inserted?: number
       updated?: number
       unchanged?: number
+      fuzzy_matched?: number
+      batch_dedup_skipped?: number
+      cross_category_skipped?: number
       total_dishes?: number
     }> = []
 
@@ -1951,6 +2151,9 @@ serve(async (req) => {
           inserted: stats.inserted,
           updated: stats.updated,
           unchanged: stats.unchanged,
+          fuzzy_matched: stats.fuzzyMatched,
+          batch_dedup_skipped: stats.batchDedupSkipped,
+          cross_category_skipped: stats.crossCategorySkipped,
           total_dishes: extracted.dishes.length,
         })
       } catch (err) {


### PR DESCRIPTION
## Summary

- **The problem:** A DB scan across 157 restaurants found ~885 suspected duplicate dish pairs (295 HIGH-confidence). Worst offenders: Edgartown Pizza (44), Town Bar (40), Black Joy Kitchen (38), Back Door Donuts (37). Pattern is consistent: ${'`'}Boston Cream${'`'} / ${'`'}Boston Cream Donut${'`'}, ${'`'}Jollof Rice${'`'} / ${'`'}Jollof Rice (Ghana)${'`'}, ${'`'}Chix Sandwich${'`'} / ${'`'}Chicken Sandwich${'`'}.
- **Root cause:** Upsert dedup key in ${'`'}menu-refresh/index.ts:971${'`'} was exact lowercase name match. Whenever the LLM emitted a slightly different spelling, the row got inserted as new — fragmenting votes.
- **The fix:** New ${'`'}normalizeDishKey(name, category)${'`'} helper in ${'`'}extractors.ts${'`'} acts as a secondary lookup key alongside exact name. Conservative — strips parens, asterisks, diacritics, dietary shorthand, common abbreviations, and redundant category words. Token-set comparison preserves size modifiers and numeric quantities.

## Three guard layers

1. **Within-batch dedup** — collapses LLM-emitted name-variants in one extraction. Tiebreaker prefers the variant whose name exact-matches an existing DB row, then by data richness (price=3, description=2, dietary_tags=1).
2. **Cross-category second pass** — catches dishes targeting the same existing row from different category buckets (codex-flagged edge case).
3. **Oldest-row-wins lookups** — both ${'`'}existingByName${'`'} and ${'`'}existingByNormKey${'`'} guarded with ${'`'}if (!has)${'`'} so vote-bearing canonical rows stay stable across runs.

## What stays distinct

- ${'`'}Half Roast Chicken${'`'} vs ${'`'}Whole Roast Chicken${'`'} (size modifiers preserved)
- ${'`'}Kids Burger${'`'} vs ${'`'}Burger${'`'} (modifier preserved)
- ${'`'}Tacos (3)${'`'} vs ${'`'}Tacos (6)${'`'} (numeric parens preserved as quantity tokens)

## Observability

New counters in ${'`'}upsertDishes${'`'} return value, surfaced to ${'`'}menu_import_jobs.error_context${'`'} and all results.push() summary paths:
- ${'`'}fuzzy_matched${'`'} — extracted dishes that matched an existing row via normalized key (not exact name)
- ${'`'}batch_dedup_skipped${'`'} — LLM-emitted variants collapsed in first pass
- ${'`'}cross_category_skipped${'`'} — variants collapsed in cross-category second pass

## Diagnostic script

Adds ${'`'}scripts/find-duplicate-dishes.mjs${'`'} — sweeps the whole dishes table, classifies pairs as HIGH/MED/LOW by token overlap + price match. Useful for monitoring whether new dupes accumulate post-deploy.

## Code review

Reviewed in 3 rounds with Codex (gpt-5.3-codex, medium effort). All findings addressed: dedup-before-exact-match regression, nondeterministic existing-row tiebreaker, missing observability counters in PDF/main paths, cross-category collision edge case.

## Deploy

The edge function does NOT auto-deploy from git. After merge, paste the new ${'`'}supabase/functions/menu-refresh/index.ts${'`'} into Supabase dashboard's edge-function editor on Denis's project.

## Follow-ups (out of scope)

1. Cleanup the existing 885 suspected dupes (vote-bearer wins; ${'`'}find-duplicate-dishes.mjs${'`'} is the scanner; merge script TBD).
2. Move direct-batch refresh path through ${'`'}menu_import_jobs${'`'} to close cross-invocation race codex flagged.

## Test plan

- [x] ${'`'}npx vitest run supabase/functions/menu-refresh/${'`'} — 144/144 passing (14 new ${'`'}normalizeDishKey${'`'} tests)
- [x] ${'`'}deno check supabase/functions/menu-refresh/index.ts${'`'} — 13→15 typecheck cascade errors, all stem from pre-existing ${'`'}SupabaseClient${'`'} generics mismatch; no functional regression
- [x] ${'`'}npm run lint${'`'} — 0 warnings on changed files
- [ ] After deploy: run a single-restaurant refresh against a known dupe-heavy restaurant (e.g., Back Door Donuts) and verify no new inserts, only updates
- [ ] After deploy: ${'`'}node scripts/find-duplicate-dishes.mjs${'`'} weekly to confirm no new HIGH-confidence pairs accumulating

🤖 Generated with [Claude Code](https://claude.com/claude-code)