### PR TITLE
feat(icons): menu_section icon overrides — frozens + cocktails

### DIFF
--- a/src/components/DishListItem.jsx
+++ b/src/components/DishListItem.jsx
@@ -2,7 +2,7 @@ import { memo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { MIN_VOTES_FOR_RANKING } from '../constants/app'
 import { getRatingColor } from '../utils/ranking'
-import { getCategoryNeonImage, getCategoryEmoji, getDishNameIcon } from '../constants/categories'
+import { getCategoryNeonImage, getCategoryEmoji, getDishNameIcon, getMenuSectionImage } from '../constants/categories'
 import { RestaurantAvatar } from './RestaurantAvatar'
 import { sanitizeUrl } from '../utils/sanitize'
 import { openExternalLink } from '../utils/openExternalLink'
@@ -63,6 +63,14 @@ export const DishListItem = memo(function DishListItem({
   const orderUrl = dish.order_url
   const restaurantLat = dish.restaurant_lat || dish.lat
   const restaurantLng = dish.restaurant_lng || dish.lng
+
+  // Resolve icon once, reuse across both icon render paths (category-icon
+  // mode and photo-thumbnail-fallback mode below). Precedence:
+  // dish-name keyword > menu_section override > category default.
+  const resolvedIcon =
+    getDishNameIcon(dishName) ||
+    getMenuSectionImage(dish.menu_section) ||
+    getCategoryNeonImage(category)
 
   var handleClick = onClick || function () { navigate('/dish/' + dishId) }
 
@@ -127,10 +135,11 @@ export const DishListItem = memo(function DishListItem({
           className="flex-shrink-0 flex items-center justify-center"
           style={{ width: isPodium ? '72px' : '64px', height: isPodium ? '72px' : '64px', marginLeft: '4px' }}
         >
-          {(getDishNameIcon(dishName) || getCategoryNeonImage(category)) ? (
+          {resolvedIcon ? (
             <img
-              src={getDishNameIcon(dishName) || getCategoryNeonImage(category)}
+              src={resolvedIcon}
               alt=""
+              aria-hidden="true"
               className="w-full h-full object-contain"
               loading="lazy"
             />
@@ -352,10 +361,11 @@ export const DishListItem = memo(function DishListItem({
           >
             {photoUrl ? (
               <img src={photoUrl} alt={dishName} loading="lazy" className="w-full h-full object-cover" />
-            ) : (getDishNameIcon(dishName) || getCategoryNeonImage(category)) ? (
+            ) : resolvedIcon ? (
               <img
-                src={getDishNameIcon(dishName) || getCategoryNeonImage(category)}
+                src={resolvedIcon}
                 alt=""
+                aria-hidden="true"
                 className="object-contain"
                 style={{ width: '56px', height: '56px' }}
                 loading="lazy"

--- a/src/components/restaurants/RestaurantMenu.jsx
+++ b/src/components/restaurants/RestaurantMenu.jsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { MIN_VOTES_FOR_RANKING } from '../../constants/app'
 import { getRatingColor } from '../../utils/ranking'
+import { getMenuSectionImage } from '../../constants/categories'
 
 // Split-pane restaurant menu: section nav on left, dishes on right
 export function RestaurantMenu({ dishes, loading, error, searchQuery = '', menuSectionOrder = [] }) {
@@ -263,6 +264,7 @@ export function RestaurantMenu({ dishes, loading, error, searchQuery = '', menuS
             const displayRating = (dish.has_variants && dish.best_variant_rating)
               ? dish.best_variant_rating
               : dish.avg_rating
+            const sectionIcon = getMenuSectionImage(dish.menu_section)
 
             return (
               <button
@@ -279,6 +281,16 @@ export function RestaurantMenu({ dishes, loading, error, searchQuery = '', menuS
                 <div className="flex items-start justify-between gap-2">
                   <div className="min-w-0 flex-1">
                     <span className="flex items-center gap-1.5">
+                      {sectionIcon && (
+                        <img
+                          src={sectionIcon}
+                          alt=""
+                          aria-hidden="true"
+                          loading="lazy"
+                          className="flex-shrink-0 object-contain"
+                          style={{ width: '18px', height: '18px' }}
+                        />
+                      )}
                       <span
                         className="font-semibold"
                         style={{

--- a/src/constants/categories.js
+++ b/src/constants/categories.js
@@ -310,9 +310,31 @@ export function getCategoryNeonImage(id) {
   return src ? src + '?v=4' : null
 }
 
+// menu_section → icon overrides. Useful when multiple dishes share the same
+// `category` but the menu section says something more specific (e.g. all of
+// Nancy's drinks are category='cocktails', but the Famous Frozens section
+// wants a frozen-glass icon vs the Cocktails section's collins-glass icon).
+// Keys are normalized (trim + lowercase) so DB drift in casing/whitespace
+// doesn't silently break the lookup.
+const MENU_SECTION_IMAGES = {
+  'famous frozens': '/categories/icons/frozen_drinks.png',
+  'cocktails': '/categories/icons/cocktails.png',
+}
+
+export function getMenuSectionImage(menuSection) {
+  if (!menuSection) return null
+  const key = String(menuSection).trim().toLowerCase()
+  const src = MENU_SECTION_IMAGES[key] || null
+  return src ? src + '?v=4' : null
+}
+
 // Preload category images for smooth Browse page loading
 export function preloadCategoryImages() {
-  Object.values(CATEGORY_IMAGES).forEach(src => {
+  const sources = [
+    ...Object.values(CATEGORY_IMAGES),
+    ...Object.values(MENU_SECTION_IMAGES),
+  ]
+  sources.forEach(src => {
     const img = new Image()
     img.src = src
   })


### PR DESCRIPTION
## Summary

All of Nancy's drinks share `category='cocktails'`, so by default they all get the same `cocktails.png` icon. This PR adds a thin `menu_section → icon` lookup so:

- **Famous Frozens** section → `frozen_drinks.png` (frozen-drink artwork)
- **Cocktails** section → `cocktails.png` (collins glass)

Generalizes to any future case where dishes share a category but the menu_section is more specific (e.g. coffee subtypes, sushi roll variants).

## Implementation

- `categories.js` — `MENU_SECTION_IMAGES` map + `getMenuSectionImage()` helper. Keys are lowercase-normalized so DB casing drift can't silently miss. `preloadCategoryImages()` extended to cover these.
- `DishListItem.jsx` — icon resolution precedence: `dish-name keyword > menu_section override > category default`. Computed once per render, reused at both icon render paths.
- `RestaurantMenu.jsx` — shows an 18×18 icon left of the dish name only when `menu_section` resolves to one. Most rows stay text-only.

## Test plan

- [ ] Visit Nancy's → Upstairs pill → Cocktails section → each row shows collins-glass icon left of name
- [ ] Same page → Famous Frozens section → each row shows frozen-drink icon
- [ ] Top Rated tab on Nancy's → cocktails/frozens dishes also get the right icon (DishListItem path)
- [ ] Non-Nancy's restaurants — no icons in menu rows (no `menu_section` match), unchanged
- [ ] Verify icons preload smoothly on first paint

🤖 Generated with [Claude Code](https://claude.com/claude-code)