### PR TITLE
fix(menu-refresh): close paren-strip + dietary-marker false positives (follow-up to #261)

### DIFF
--- a/scripts/analyze-dupe-attachments.mjs
+++ b/scripts/analyze-dupe-attachments.mjs
@@ -1,0 +1,129 @@
+import { createClient } from '@supabase/supabase-js'
+import { readFileSync } from 'node:fs'
+for (const line of readFileSync('.env.local', 'utf8').split('\n')) {
+  const m = line.match(/^([A-Z_]+)=(.*)$/)
+  if (m) process.env[m[1]] = m[2].replace(/^["']|["']$/g, '')
+}
+
+const supabase = createClient(process.env.VITE_SUPABASE_URL, process.env.VITE_SUPABASE_ANON_KEY)
+
+// Same normalizer logic as supabase/functions/menu-refresh/extractors.ts
+const STOPWORDS = new Set(['the', 'a', 'an', 'and', 'with', 'of', 'on', 'in', 'or', 'over', 'n', 'gf', 'df', 'v', 've', 'vg', 'vgn'])
+const ABBREV = { chix: 'chicken', chkn: 'chicken', brgr: 'burger', burg: 'burger' }
+const CATEGORY_REDUNDANT = {
+  donuts: ['donut', 'donuts'], burger: ['burger', 'burgers'], pizza: ['pizza', 'pizzas'],
+  salad: ['salad', 'salads'], sandwich: ['sandwich', 'sandwiches'],
+  'fish-sandwich': ['sandwich', 'sandwiches'], taco: ['taco', 'tacos'],
+  burrito: ['burrito', 'burritos'], enchiladas: ['enchilada', 'enchiladas'],
+  fries: ['fries'], 'onion rings': ['rings'], pasta: ['pasta', 'pastas'],
+  wrap: ['wrap', 'wraps'], wings: ['wings', 'wing'], cookie: ['cookie', 'cookies'],
+}
+const NUMERIC_PAREN_RE = /\([^)]*\d[^)]*\)/g
+const ANY_PAREN_RE = /\([^)]*\)/g
+
+function normalizeDishKey(name, category) {
+  if (!name) return ''
+  const cat = (category || '').toLowerCase().trim()
+  const lowered = name.toLowerCase().normalize('NFKD').replace(/[̀-ͯ]/g, '')
+  const protectedParens = lowered.replace(NUMERIC_PAREN_RE, (m) => {
+    const d = m.match(/\d+/g)?.join('-') ?? ''
+    return ` qty${d} `
+  })
+  const cleaned = protectedParens.replace(ANY_PAREN_RE, ' ').replace(/[*]/g, ' ')
+    .replace(/['’`"]/g, '').replace(/[^a-z0-9]+/g, ' ').replace(/\s+/g, ' ').trim()
+  if (!cleaned) return ''
+  const redundant = new Set(CATEGORY_REDUNDANT[cat] || [])
+  const tokens = cleaned.split(' ').map((t) => ABBREV[t] ?? t).filter((t) => t && !STOPWORDS.has(t))
+  const filtered = tokens.filter((t) => !redundant.has(t))
+  const final = filtered.length > 0 ? filtered : tokens
+  return final.slice().sort().join(' ')
+}
+
+// Pull all dishes
+const allDishes = []
+let from = 0
+for (;;) {
+  const { data } = await supabase.from('dishes')
+    .select('id, name, category, price, restaurant_id, created_at')
+    .range(from, from + 999).order('id')
+  if (!data?.length) break
+  allDishes.push(...data)
+  if (data.length < 1000) break
+  from += 1000
+}
+
+// Group by (restaurant_id, category, normKey)
+const groups = {}
+for (const d of allDishes) {
+  const key = `${d.restaurant_id}|${(d.category || '').toLowerCase()}|${normalizeDishKey(d.name, d.category)}`
+  if (!key.endsWith('|')) {
+    groups[key] ||= []
+    groups[key].push(d)
+  }
+}
+
+const dupeGroups = Object.values(groups).filter((g) => g.length > 1)
+const dupeIds = dupeGroups.flat().map((d) => d.id)
+
+console.log(`Total dupe groups (under new normalizer): ${dupeGroups.length}`)
+console.log(`Total dishes inside dupe groups: ${dupeIds.length}`)
+
+// Count attachments on dupe dishes
+async function countTable(table, col = 'dish_id') {
+  const counts = {}
+  for (let i = 0; i < dupeIds.length; i += 200) {
+    const batch = dupeIds.slice(i, i + 200)
+    const { data } = await supabase.from(table).select(`id, ${col}`).in(col, batch)
+    for (const r of data || []) counts[r[col]] = (counts[r[col]] || 0) + 1
+  }
+  return counts
+}
+
+const votes = await countTable('votes')
+const favorites = await countTable('favorites')
+const photos = await countTable('dish_photos')
+const playlist = await countTable('user_playlist_items')
+const localList = await countTable('local_list_items')
+
+console.log('\n--- Per-group attachment profile ---')
+let groupsWithBothSidesHavingData = 0
+let groupsWithOneSideOnly = 0
+let groupsWithNoAttachments = 0
+const merges = []
+
+for (const group of dupeGroups) {
+  const enriched = group.map((d) => ({
+    ...d,
+    votes: votes[d.id] || 0,
+    favorites: favorites[d.id] || 0,
+    photos: photos[d.id] || 0,
+    playlist: playlist[d.id] || 0,
+    localList: localList[d.id] || 0,
+    score: (votes[d.id] || 0) * 100 + (favorites[d.id] || 0) * 10 + (photos[d.id] || 0) + (playlist[d.id] || 0) + (localList[d.id] || 0),
+  }))
+  const sidesWithData = enriched.filter((d) => d.score > 0).length
+  if (sidesWithData === 0) groupsWithNoAttachments++
+  else if (sidesWithData === 1) groupsWithOneSideOnly++
+  else groupsWithBothSidesHavingData++
+
+  // pick winner: highest score, tiebreaker = longer name, oldest created_at
+  enriched.sort((a, b) =>
+    b.score - a.score ||
+    b.name.length - a.name.length ||
+    new Date(a.created_at) - new Date(b.created_at)
+  )
+  const [winner, ...losers] = enriched
+  merges.push({ winner, losers, sidesWithData })
+}
+
+console.log(`Groups with NO attachments on any side: ${groupsWithNoAttachments} (simple delete-the-rest)`)
+console.log(`Groups with ONE side having attachments: ${groupsWithOneSideOnly} (vote-bearer wins, others deleted)`)
+console.log(`Groups with MULTIPLE sides having attachments: ${groupsWithBothSidesHavingData} (need FK reassignment)`)
+
+console.log('\n--- Groups needing FK reassignment (multi-side data) ---')
+for (const m of merges.filter((x) => x.sidesWithData > 1).slice(0, 20)) {
+  console.log(`Winner: "${m.winner.name}" votes=${m.winner.votes} fav=${m.winner.favorites} photos=${m.winner.photos} pl=${m.winner.playlist} ll=${m.winner.localList}`)
+  for (const l of m.losers) {
+    console.log(`  Loser:  "${l.name}" votes=${l.votes} fav=${l.favorites} photos=${l.photos} pl=${l.playlist} ll=${l.localList}`)
+  }
+}

--- a/scripts/cleanup-duplicate-dishes.mjs
+++ b/scripts/cleanup-duplicate-dishes.mjs
@@ -1,0 +1,259 @@
+// Cleanup script for duplicate dish rows.
+//
+// Groups dishes by (restaurant_id, category, normalizeDishKey(name, category))
+// using the canonical normalizer from supabase/functions/menu-refresh/extractors.ts.
+// For each group with multiple rows: keeps the row with attachments (or the
+// longer/older name if none have attachments), deletes the rest.
+//
+// Usage:
+//   node scripts/cleanup-duplicate-dishes.mjs             # dry-run, prints plan
+//   node scripts/cleanup-duplicate-dishes.mjs --execute   # actually deletes
+//
+// Safety: aborts if any losing row has votes/favorites/photos/etc. attached.
+// That case should be impossible under the current data (analyze script
+// confirmed 0 attachments on 191 candidate losers) but the guard stays as a
+// belt-and-braces check in case the data shifts between scan and execute.
+
+import { createClient } from '@supabase/supabase-js'
+import { readFileSync } from 'node:fs'
+for (const line of readFileSync('.env.local', 'utf8').split('\n')) {
+  const m = line.match(/^([A-Z_]+)=(.*)$/)
+  if (m) process.env[m[1]] = m[2].replace(/^["']|["']$/g, '')
+}
+
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY
+if (process.argv.includes('--execute') && !SERVICE_KEY) {
+  console.error('--execute requires SUPABASE_SERVICE_ROLE_KEY in .env.local')
+  process.exit(1)
+}
+const supabase = createClient(
+  process.env.VITE_SUPABASE_URL,
+  SERVICE_KEY || process.env.VITE_SUPABASE_ANON_KEY,
+)
+const isDryRun = !process.argv.includes('--execute')
+
+// Canonical normalizer — MUST stay in sync with
+// supabase/functions/menu-refresh/extractors.ts normalizeDishKey().
+const STOPWORDS = new Set(['the', 'a', 'an', 'and', 'with', 'of', 'on', 'in', 'or', 'over', 'n', 'gf', 'df', 'v', 've', 'vg', 'vgn'])
+const ABBREV = { chix: 'chicken', chkn: 'chicken', brgr: 'burger', burg: 'burger' }
+const CATEGORY_REDUNDANT = {
+  donuts: ['donut', 'donuts'], burger: ['burger', 'burgers'], pizza: ['pizza', 'pizzas'],
+  salad: ['salad', 'salads'], sandwich: ['sandwich', 'sandwiches'],
+  'fish-sandwich': ['sandwich', 'sandwiches'], taco: ['taco', 'tacos'],
+  burrito: ['burrito', 'burritos'], enchiladas: ['enchilada', 'enchiladas'],
+  fries: ['fries'], 'onion rings': ['rings'], pasta: ['pasta', 'pastas'],
+  wrap: ['wrap', 'wraps'], wings: ['wings', 'wing'], cookie: ['cookie', 'cookies'],
+}
+const NUMERIC_PAREN_RE = /\([^)]*\d[^)]*\)/g
+const ANY_PAREN_RE = /\([^)]*\)/g
+
+function normalizeDishKey(name, category) {
+  if (!name) return ''
+  const cat = (category || '').toLowerCase().trim()
+  const lowered = name.toLowerCase().normalize('NFKD').replace(/[̀-ͯ]/g, '')
+  const protectedParens = lowered.replace(NUMERIC_PAREN_RE, (m) => {
+    const d = m.match(/\d+/g)?.join('-') ?? ''
+    return ` qty${d} `
+  })
+  const cleaned = protectedParens.replace(ANY_PAREN_RE, ' ').replace(/[*]/g, ' ')
+    .replace(/['’`"]/g, '').replace(/[^a-z0-9]+/g, ' ').replace(/\s+/g, ' ').trim()
+  if (!cleaned) return ''
+  const redundant = new Set(CATEGORY_REDUNDANT[cat] || [])
+  const tokens = cleaned.split(' ').map((t) => ABBREV[t] ?? t).filter((t) => t && !STOPWORDS.has(t))
+  const filtered = tokens.filter((t) => !redundant.has(t))
+  const final = filtered.length > 0 ? filtered : tokens
+  return final.slice().sort().join(' ')
+}
+
+console.log(`Mode: ${isDryRun ? 'DRY-RUN (no changes)' : '*** EXECUTE (will delete rows) ***'}`)
+
+// Pull all dishes
+const allDishes = []
+let from = 0
+for (;;) {
+  const { data } = await supabase.from('dishes')
+    .select('id, name, category, price, description, restaurant_id, created_at')
+    .range(from, from + 999).order('id')
+  if (!data?.length) break
+  allDishes.push(...data)
+  if (data.length < 1000) break
+  from += 1000
+}
+
+// Pull restaurant names for the log
+const restIds = [...new Set(allDishes.map((d) => d.restaurant_id).filter(Boolean))]
+const restMap = {}
+for (let i = 0; i < restIds.length; i += 100) {
+  const { data } = await supabase.from('restaurants').select('id, name').in('id', restIds.slice(i, i + 100))
+  for (const r of data || []) restMap[r.id] = r.name
+}
+
+// Group by (restaurant_id, category, normKey)
+const groups = {}
+for (const d of allDishes) {
+  const normKey = normalizeDishKey(d.name, d.category)
+  if (!normKey) continue
+  const key = `${d.restaurant_id}|${(d.category || '').toLowerCase()}|${normKey}`
+  groups[key] ||= []
+  groups[key].push(d)
+}
+const dupeGroups = Object.values(groups).filter((g) => g.length > 1)
+console.log(`Found ${dupeGroups.length} dupe groups across ${allDishes.length} dishes.`)
+
+// Pull attachment counts for ALL candidate dish ids (winners + losers).
+// We use this to (a) score winners and (b) safety-check that no loser has data.
+const candidateIds = dupeGroups.flat().map((d) => d.id)
+
+async function countTable(table, col = 'dish_id') {
+  const counts = {}
+  for (let i = 0; i < candidateIds.length; i += 200) {
+    const batch = candidateIds.slice(i, i + 200)
+    const { data, error } = await supabase.from(table).select(`id, ${col}`).in(col, batch)
+    if (error) { console.error(`Error reading ${table}:`, error); process.exit(1) }
+    for (const r of data || []) counts[r[col]] = (counts[r[col]] || 0) + 1
+  }
+  return counts
+}
+
+const [votes, favorites, photos, playlist, localList, biasEvents] = await Promise.all([
+  countTable('votes'),
+  countTable('favorites'),
+  countTable('dish_photos'),
+  countTable('user_playlist_items'),
+  countTable('local_list_items'),
+  countTable('bias_events'),
+])
+// Self-FK: any dishes whose parent_dish_id points at a loser?
+const parentRefs = {}
+{
+  const { data } = await supabase.from('dishes').select('id, parent_dish_id').in('parent_dish_id', candidateIds)
+  for (const r of data || []) parentRefs[r.parent_dish_id] = (parentRefs[r.parent_dish_id] || 0) + 1
+}
+
+function attachmentScore(id) {
+  return (votes[id] || 0) * 100 + (favorites[id] || 0) * 10 + (photos[id] || 0) * 5 + (playlist[id] || 0) * 2 + (localList[id] || 0) * 2 + (biasEvents[id] || 0) + (parentRefs[id] || 0)
+}
+
+// Decide winners + losers per group
+const plan = []
+let blockedByAttachments = 0
+for (const group of dupeGroups) {
+  const ranked = group.map((d) => ({
+    ...d,
+    attachmentScore: attachmentScore(d.id),
+    votes: votes[d.id] || 0,
+    favorites: favorites[d.id] || 0,
+    photos: photos[d.id] || 0,
+    playlist: playlist[d.id] || 0,
+    localList: localList[d.id] || 0,
+    biasEvents: biasEvents[d.id] || 0,
+    parentRefs: parentRefs[d.id] || 0,
+  })).sort((a, b) =>
+    b.attachmentScore - a.attachmentScore ||
+    (b.description?.length || 0) - (a.description?.length || 0) ||
+    b.name.length - a.name.length ||
+    new Date(a.created_at) - new Date(b.created_at),
+  )
+  const [winner, ...losers] = ranked
+  const losersWithAttachments = losers.filter((l) => l.attachmentScore > 0)
+  if (losersWithAttachments.length > 0) blockedByAttachments++
+  plan.push({ winner, losers, restName: restMap[winner.restaurant_id] || winner.restaurant_id })
+}
+
+console.log(`\nPlan: keep ${plan.length} winners, delete ${plan.reduce((n, p) => n + p.losers.length, 0)} losers.`)
+
+if (blockedByAttachments > 0) {
+  console.error(`\n!! ${blockedByAttachments} groups have a LOSER with attachments — refusing to proceed.`)
+  console.error('   This script only handles attachment-free losers. Run the analyze script for details.')
+  process.exit(1)
+}
+
+// Partition into safe merges vs suspect merges. Two false-positive classes
+// observed in dry-runs:
+//   (a) Same normKey but DIFFERENT prices — the parens or stripped tokens
+//       were probably identity-bearing modifiers (protein options, portion
+//       sizes like Half/Full or Cup/Bowl, prep styles).
+//   (b) Both prices are NULL but each side has DIFFERENT paren content
+//       (e.g., Larsen's "Shrimp (Cocktail & Jumbo)" vs "Shrimp (Cooked &
+//       Chilled)"). Without price as a tiebreaker, divergent paren content
+//       is the only signal that these are different dishes.
+const SAME_PRICE_TOL = 0.01
+function priceMatches(a, b) {
+  if (a == null || b == null) return null   // unknown — fall through to other guards
+  return Math.abs(a - b) <= SAME_PRICE_TOL
+}
+
+const PAREN_CONTENT_RE = /\(([^)]+)\)/g
+function parenContents(name) {
+  const out = []
+  let m
+  while ((m = PAREN_CONTENT_RE.exec(name)) !== null) {
+    const trimmed = m[1].trim().toLowerCase()
+    // Skip numeric-only parens — those are quantity (e.g. "(3)") and
+    // already preserved as identity tokens by the normalizer.
+    if (!/\d/.test(trimmed)) out.push(trimmed)
+  }
+  return out.sort().join('|')
+}
+
+function isSafeMerge(winner, loser) {
+  const priceOK = priceMatches(winner.price, loser.price)
+  if (priceOK === false) return false              // explicit price mismatch — defer
+  // Both prices null OR both same: check paren contents next.
+  const wParen = parenContents(winner.name)
+  const lParen = parenContents(loser.name)
+  if (wParen && lParen && wParen !== lParen) return false   // both have parens, different content
+  return true
+}
+
+const samePricePlan = []
+const diffPricePlan = []
+for (const p of plan) {
+  const allSafe = p.losers.every((l) => isSafeMerge(p.winner, l))
+  if (allSafe) samePricePlan.push(p)
+  else diffPricePlan.push(p)
+}
+
+console.log(`\nSafety partition:`)
+console.log(`  Safe merges (will execute):       ${samePricePlan.length} groups → ${samePricePlan.reduce((n, p) => n + p.losers.length, 0)} deletes`)
+console.log(`  Suspect merges (NEEDS REVIEW):    ${diffPricePlan.length} groups → ${diffPricePlan.reduce((n, p) => n + p.losers.length, 0)} skipped`)
+
+console.log('\n--- SUSPECT MERGES (likely identity-bearing differences — NOT executing) ---')
+for (const p of diffPricePlan) {
+  console.log(`[${p.restName}] cat=${p.winner.category}`)
+  console.log(`  KEEP   "${p.winner.name}" price=${p.winner.price ?? '?'}`)
+  for (const l of p.losers) {
+    const priceOK = priceMatches(p.winner.price, l.price)
+    const flag = priceOK === false ? '  ← PRICE DIFFERS'
+      : (parenContents(p.winner.name) && parenContents(l.name) && parenContents(p.winner.name) !== parenContents(l.name)) ? '  ← DIFFERENT PAREN CONTENT'
+      : ''
+    console.log(`  ???    "${l.name}" price=${l.price ?? '?'}${flag}`)
+  }
+}
+
+console.log('\n--- SAME-PRICE MERGES (will execute) ---')
+for (const p of samePricePlan.slice(0, 50)) {
+  console.log(`[${p.restName}] cat=${p.winner.category}`)
+  console.log(`  KEEP   "${p.winner.name}" price=${p.winner.price ?? '?'}`)
+  for (const l of p.losers) {
+    console.log(`  DELETE "${l.name}" price=${l.price ?? '?'}`)
+  }
+}
+if (samePricePlan.length > 50) console.log(`  ... and ${samePricePlan.length - 50} more same-price groups (not printed for brevity)`)
+
+if (isDryRun) {
+  console.log(`\nDRY-RUN — no changes. Re-run with --execute to delete ${samePricePlan.reduce((n, p) => n + p.losers.length, 0)} same-price rows. ${diffPricePlan.length} different-price groups will be skipped.`)
+  process.exit(0)
+}
+
+console.log('\n*** EXECUTING SAME-PRICE DELETES (different-price groups skipped) ***')
+const loserIds = samePricePlan.flatMap((p) => p.losers.map((l) => l.id))
+let deleted = 0
+for (let i = 0; i < loserIds.length; i += 100) {
+  const batch = loserIds.slice(i, i + 100)
+  const { error, count } = await supabase.from('dishes').delete({ count: 'exact' }).in('id', batch)
+  if (error) { console.error('Delete failed:', error); process.exit(1) }
+  deleted += count || 0
+  console.log(`  Deleted batch ${i / 100 + 1}/${Math.ceil(loserIds.length / 100)} (${count} rows)`)
+}
+console.log(`\nDone. Deleted ${deleted} duplicate dish rows.`)

--- a/src/constants/categories.js
+++ b/src/constants/categories.js
@@ -225,6 +225,18 @@ const DISH_NAME_ICON_RULES = [
   { keyword: 'rice bowl', icon: '/categories/icons/pokebowl.png' },
   { keyword: 'eggs benedict', icon: '/categories/icons/eggs-benedict.png' },
   { keyword: 'ice cream', icon: '/categories/icons/ice-cream.png' },
+  // Drinks — compound terms (specific variants beat single-word fallbacks)
+  { keyword: 'frozen margarita', icon: '/categories/icons/frozen_drinks.png' },
+  { keyword: 'frozen daiquiri', icon: '/categories/icons/frozen_drinks.png' },
+  { keyword: 'frozen lemonade', icon: '/categories/icons/frozen_drinks.png' },
+  { keyword: 'piña colada', icon: '/categories/icons/frozen_drinks.png' },
+  { keyword: 'pina colada', icon: '/categories/icons/frozen_drinks.png' },
+  { keyword: 'mai tai', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'moscow mule', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'bloody mary', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'old fashioned', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'espresso martini', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'rum punch', icon: '/categories/icons/cocktails.png' },
   // Single keywords
   { keyword: 'benedict', icon: '/categories/icons/eggs-benedict.png' },
   { keyword: 'burrito', icon: '/categories/icons/burrito.png' },
@@ -289,6 +301,26 @@ const DISH_NAME_ICON_RULES = [
   { keyword: 'pie', icon: '/categories/icons/dessert.png' },
   { keyword: 'brownie', icon: '/categories/icons/dessert.png' },
   { keyword: 'cookie', icon: '/categories/icons/dessert.png' },
+  // Drinks — single keywords. Order safe because these aren't substrings of
+  // any food keyword above. Margarita/etc. lose to the "frozen X" compound
+  // variants that appear earlier.
+  { keyword: 'margarita', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'daiquiri', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'martini', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'mojito', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'negroni', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'spritz', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'cosmopolitan', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'sangria', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'painkiller', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'paloma', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'gimlet', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'sidecar', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'boulevardier', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'caipirinha', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'mimosa', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'frosé', icon: '/categories/icons/frozen_drinks.png' },
+  { keyword: 'frose', icon: '/categories/icons/frozen_drinks.png' },
 ]
 
 // Match a dish name to an icon based on keywords
@@ -314,27 +346,47 @@ export function getCategoryNeonImage(id) {
 // `category` but the menu section says something more specific (e.g. all of
 // Nancy's drinks are category='cocktails', but the Famous Frozens section
 // wants a frozen-glass icon vs the Cocktails section's collins-glass icon).
-// Keys are normalized (trim + lowercase) so DB drift in casing/whitespace
-// doesn't silently break the lookup.
-const MENU_SECTION_IMAGES = {
-  'famous frozens': '/categories/icons/frozen_drinks.png',
-  'cocktails': '/categories/icons/cocktails.png',
-}
+//
+// Keyword-based so future menus get auto-matched without code changes —
+// "Signature Cocktails", "Classic Cocktails", "Frozen Drinks", etc. all
+// just work the next time menu-refresh ingests them. Order matters: more
+// specific keywords first (e.g. "frozen" before "cocktail" so a section
+// named "Frozen Cocktails" gets the frozen icon).
+const MENU_SECTION_ICON_RULES = [
+  // Frozen drink-y sections only. Avoid bare 'frozen' since that would
+  // false-match dessert sections like 'Frozen Treats' / 'Frozen Desserts'.
+  { keyword: 'frozen cocktail', icon: '/categories/icons/frozen_drinks.png' },
+  { keyword: 'frozen drink', icon: '/categories/icons/frozen_drinks.png' },
+  { keyword: 'frozens', icon: '/categories/icons/frozen_drinks.png' },
+  { keyword: 'slush', icon: '/categories/icons/frozen_drinks.png' },
+  { keyword: 'frosé', icon: '/categories/icons/frozen_drinks.png' },
+  { keyword: 'frose', icon: '/categories/icons/frozen_drinks.png' },
+  // Cocktail-y sections
+  { keyword: 'cocktail', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'martini', icon: '/categories/icons/cocktails.png' },
+  { keyword: 'margarita', icon: '/categories/icons/cocktails.png' },
+]
 
 export function getMenuSectionImage(menuSection) {
   if (!menuSection) return null
   const key = String(menuSection).trim().toLowerCase()
-  const src = MENU_SECTION_IMAGES[key] || null
-  return src ? src + '?v=4' : null
+  for (var i = 0; i < MENU_SECTION_ICON_RULES.length; i++) {
+    if (key.includes(MENU_SECTION_ICON_RULES[i].keyword)) {
+      return MENU_SECTION_ICON_RULES[i].icon + '?v=4'
+    }
+  }
+  return null
 }
 
 // Preload category images for smooth Browse page loading
 export function preloadCategoryImages() {
   const sources = [
     ...Object.values(CATEGORY_IMAGES),
-    ...Object.values(MENU_SECTION_IMAGES),
+    ...MENU_SECTION_ICON_RULES.map(r => r.icon),
   ]
-  sources.forEach(src => {
+  // Dedupe — multiple keywords can point at the same icon.
+  const unique = Array.from(new Set(sources))
+  unique.forEach(src => {
     const img = new Image()
     img.src = src
   })

--- a/supabase/functions/menu-refresh/extractors.test.ts
+++ b/supabase/functions/menu-refresh/extractors.test.ts
@@ -127,11 +127,36 @@ describe('normalizeDishKey', () => {
       .toBe(normalizeDishKey('Old Fashioned Donut', 'donuts'))
   })
 
-  it('strips identity-neutral parenthetical tags (region, notes)', () => {
+  it('keeps non-numeric parenthetical content as identity-bearing', () => {
+    // Region tags differ but the key conservatively keeps them separate —
+    // we can't tell "(Ghana)" (identity-neutral) from "(Shrimp)" (identity-
+    // bearing modifier) without a knowledge base. Cleanup happens in the
+    // separate cleanup-duplicate-dishes script which uses price as the gate.
     expect(normalizeDishKey('Jollof Rice', 'entree'))
-      .toBe(normalizeDishKey('Jollof Rice (Ghana)', 'entree'))
+      .not.toBe(normalizeDishKey('Jollof Rice (Ghana)', 'entree'))
     expect(normalizeDishKey('SOS Pwa', 'entree'))
-      .toBe(normalizeDishKey('SOS Pwa (Haiti)', 'entree'))
+      .not.toBe(normalizeDishKey('SOS Pwa (Haiti)', 'entree'))
+  })
+
+  it('keeps protein/portion variants in parens distinct', () => {
+    // Critical false-positive guard — Sharky's Cantina and similar
+    // menus offer the same dish with different proteins at different
+    // prices. These must NOT collapse.
+    expect(normalizeDishKey('Loaded Quesadilla Plato (Shrimp)', 'quesadilla'))
+      .not.toBe(normalizeDishKey('Loaded Quesadilla Plato (Steak)', 'quesadilla'))
+    expect(normalizeDishKey('Jumbo Shrimp Cocktail (Half Dozen)', 'shrimp'))
+      .not.toBe(normalizeDishKey('Jumbo Shrimp Cocktail (Dozen)', 'shrimp'))
+    expect(normalizeDishKey('French Onion Soup (Bowl)', 'apps'))
+      .not.toBe(normalizeDishKey('French Onion Soup (Cup)', 'apps'))
+  })
+
+  it('keeps dietary-marker variants distinct', () => {
+    // "GF Boston Cream" at $4 and "Boston Cream" at $3.50 are different
+    // SKUs — the marker is price-bearing identity.
+    expect(normalizeDishKey('GF Boston Cream', 'donuts'))
+      .not.toBe(normalizeDishKey('Boston Cream', 'donuts'))
+    expect(normalizeDishKey('Truffled Chicken Frites GF', 'chicken'))
+      .not.toBe(normalizeDishKey('Truffled Chicken Frites', 'chicken'))
   })
 
   it('strips asterisks (raw/footnote markers)', () => {

--- a/supabase/functions/menu-refresh/extractors.ts
+++ b/supabase/functions/menu-refresh/extractors.ts
@@ -40,11 +40,13 @@ export function sortedArraysEqual(a: string[], b: string[]): boolean {
   return true
 }
 
-// Tokens collapsed away during normalization. Glue words plus dietary
-// shorthand letters that belong in dietary_tags, not the name.
+// Glue words collapsed away during normalization. Dietary shorthand
+// letters (GF, V, VG, etc.) are intentionally NOT in this list — they
+// are price-bearing identity tokens in practice (e.g., "GF Boston Cream"
+// at $4 vs "Boston Cream" at $3.50 are different SKUs, not the same dish
+// with a redundant marker).
 const NORMALIZE_STOPWORDS = new Set([
   'the', 'a', 'an', 'and', 'with', 'of', 'on', 'in', 'or', 'over', 'n',
-  'gf', 'df', 'v', 've', 'vg', 'vgn',
 ])
 
 // Common menu-code abbreviations that get expanded so "Chix Wrap" matches
@@ -81,11 +83,14 @@ const CATEGORY_REDUNDANT_WORDS: Record<string, string[]> = {
 }
 
 // Matches parenthetical groups that contain at least one digit — used to
-// PRESERVE quantity/size info like "(3)", "(10 pc)", "(7-8 oz)". Identity-
-// bearing parentheticals (counts, sizes, weights) should stay; identity-
-// neutral parentheticals (region tags, descriptive notes) get stripped.
+// collapse quantity/size info like "(3)" or "(10 pc)" into a single qty
+// token so different counts stay distinct. Non-numeric parentheticals
+// (e.g., "(Shrimp)", "(Half Dozen)", "(Ghana)") are LEFT IN PLACE — we
+// can't reliably distinguish identity-neutral region tags from identity-
+// bearing modifiers like protein options or portion sizes without a
+// knowledge base. Erring on the side of "keep separate" prevents the
+// upsert from silently merging different SKUs at different prices.
 const NUMERIC_PAREN_RE = /\([^)]*\d[^)]*\)/g
-const ANY_PAREN_RE = /\([^)]*\)/g
 
 /**
  * Build a normalized matching key for a dish name. Two dishes with the same
@@ -110,20 +115,21 @@ export function normalizeDishKey(rawName: string, category: string | null | unde
     .normalize('NFKD')
     .replace(/[̀-ͯ]/g, '')
 
-  // Step 2: protect parentheticals containing digits (quantity/size info
-  // like "(3)" or "(10 pc)") by collapsing their contents into a single
-  // identity token before stripping other parens. We replace e.g.
-  // "Tacos (3)" with "tacos qty3"; quantity differences then survive
-  // the rest of the pipeline.
+  // Step 2: collapse numeric parens to qty tokens so quantity differences
+  // ("(3)" vs "(6)") survive the rest of the pipeline. Non-numeric parens
+  // are LEFT IN PLACE — their contents become regular tokens that
+  // differentiate variants like "(Shrimp)" vs "(Steak)" or "(Half Dozen)"
+  // vs "(Dozen)".
   const protectedParens = lowered.replace(NUMERIC_PAREN_RE, (m) => {
     const digits = m.match(/\d+/g)?.join('-') ?? ''
     return ` qty${digits} `
   })
 
-  // Step 3: strip remaining (non-numeric) parentheticals, asterisks,
-  // apostrophes, and collapse punctuation.
+  // Step 3: strip asterisks, apostrophes, and remaining punctuation.
+  // Paren BRACKETS are stripped here (punctuation), but their contents
+  // were already preserved as plain tokens by step 2 (for numeric) or
+  // left in place (for non-numeric).
   const cleaned = protectedParens
-    .replace(ANY_PAREN_RE, ' ')
     .replace(/[*]/g, ' ')
     .replace(/['’`"]/g, '')
     .replace(/[^a-z0-9]+/g, ' ')

--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -52,7 +52,6 @@ function sortedArraysEqual(a: string[], b: string[]): boolean {
 // Vitest coverage). See test cases there for the rationale on each rule.
 const NORMALIZE_STOPWORDS_INLINE = new Set([
   'the', 'a', 'an', 'and', 'with', 'of', 'on', 'in', 'or', 'over', 'n',
-  'gf', 'df', 'v', 've', 'vg', 'vgn',
 ])
 const NORMALIZE_ABBREV_INLINE: Record<string, string> = {
   chix: 'chicken', chkn: 'chicken', brgr: 'burger', burg: 'burger',
@@ -75,7 +74,6 @@ const CATEGORY_REDUNDANT_WORDS_INLINE: Record<string, string[]> = {
   cookie: ['cookie', 'cookies'],
 }
 const NUMERIC_PAREN_RE_INLINE = /\([^)]*\d[^)]*\)/g
-const ANY_PAREN_RE_INLINE = /\([^)]*\)/g
 
 function normalizeDishKey(rawName: string, category: string | null | undefined): string {
   if (!rawName) return ''
@@ -86,7 +84,6 @@ function normalizeDishKey(rawName: string, category: string | null | undefined):
     return ` qty${digits} `
   })
   const cleaned = protectedParens
-    .replace(ANY_PAREN_RE_INLINE, ' ')
     .replace(/[*]/g, ' ')
     .replace(/['’`"]/g, '')
     .replace(/[^a-z0-9]+/g, ' ')
@@ -1011,7 +1008,7 @@ async function upsertDishes(
   supabase: ReturnType<typeof createClient>,
   restaurantId: string,
   extracted: MenuExtractionResult
-): Promise<{ inserted: number; updated: number; unchanged: number; fuzzyMatched: number; batchDedupSkipped: number; crossCategorySkipped: number }> {
+): Promise<{ inserted: number; updated: number; unchanged: number; fuzzyMatched: number; batchDedupSkipped: number; crossCategorySkipped: number; priceGateRejected: number }> {
   // Get existing dishes. Ordered by created_at so "first row wins" ties in
   // the normalized-key lookup are deterministic and stable across runs —
   // older rows are more likely to be the canonical ones holding votes.
@@ -1093,10 +1090,28 @@ async function upsertDishes(
       unkeyedDishes.push(dish)
       continue
     }
+    // Include price in the batch key when both incumbent and candidate
+    // have explicit prices — this prevents collapsing size/protein
+    // variants the LLM emitted as separate items at different prices.
+    // When either price is null, fall back to normKey-only matching so
+    // the better-data row still wins the tiebreaker.
     const batchKey = `${(dish.category || '').toLowerCase()}|${dishNormKey}`
     const incumbent = dedupedByBatchKey.get(batchKey)
     if (!incumbent) {
       dedupedByBatchKey.set(batchKey, dish)
+    } else if (incumbent.price != null && dish.price != null && Math.abs(incumbent.price - dish.price) > 0.01) {
+      // Price disagreement — these are different SKUs, both keep going.
+      // Re-key the second under a price-suffixed batch key so it survives
+      // but still gets deduped against any subsequent identical-price hits.
+      const suffixedKey = `${batchKey}|p${dish.price}`
+      if (!dedupedByBatchKey.has(suffixedKey)) {
+        dedupedByBatchKey.set(suffixedKey, dish)
+      } else if (shouldReplace(dedupedByBatchKey.get(suffixedKey)!, dish)) {
+        dedupedByBatchKey.set(suffixedKey, dish)
+        batchDedupSkipped++
+      } else {
+        batchDedupSkipped++
+      }
     } else if (shouldReplace(incumbent, dish)) {
       dedupedByBatchKey.set(batchKey, dish)
       batchDedupSkipped++
@@ -1118,13 +1133,30 @@ async function upsertDishes(
   let fuzzyMatchedCount = 0
   let crossCategorySkipped = 0
 
+  // Price-equality gate for fuzzy matches — both null treated as "no
+  // signal" (allow), but two explicit prices that disagree means these
+  // are different SKUs (e.g., "GF Boston Cream" $4 vs "Boston Cream"
+  // $3.50, or "Loaded Plato (Shrimp)" $25 vs "(Steak)" $24). Exact-name
+  // matches bypass this gate because the name itself is strong evidence.
+  const PRICE_TOL = 0.01
+  function pricesAgree(a: number | null | undefined, b: number | null | undefined): boolean {
+    if (a == null || b == null) return true
+    return Math.abs(a - b) <= PRICE_TOL
+  }
+
+  let priceGateRejected = 0
   for (const dish of candidateDishes) {
     const dishNormKey = normalizeDishKey(dish.name, dish.category)
     let existing = existingByName.get(dish.name.toLowerCase())
     let viaFuzzy = false
     if (!existing && dishNormKey) {
-      existing = existingByNormKey.get(dishNormKey)
-      if (existing) viaFuzzy = true
+      const fuzzyCandidate = existingByNormKey.get(dishNormKey)
+      if (fuzzyCandidate && pricesAgree(dish.price ?? null, fuzzyCandidate.price ?? null)) {
+        existing = fuzzyCandidate
+        viaFuzzy = true
+      } else if (fuzzyCandidate) {
+        priceGateRejected++
+      }
     }
 
     if (!existing) {
@@ -1214,6 +1246,7 @@ async function upsertDishes(
     fuzzyMatched: fuzzyMatchedCount,
     batchDedupSkipped,
     crossCategorySkipped,
+    priceGateRejected,
   }
 }
 
@@ -1459,6 +1492,7 @@ serve(async (req) => {
                   fuzzy_matched: stats.fuzzyMatched,
                   batch_dedup_skipped: stats.batchDedupSkipped,
                   cross_category_skipped: stats.crossCategorySkipped,
+                  price_gate_rejected: stats.priceGateRejected,
                 },
                 lock_expires_at: null,
                 updated_at: new Date().toISOString(),
@@ -1469,6 +1503,7 @@ serve(async (req) => {
                 fuzzy_matched: stats.fuzzyMatched,
                 batch_dedup_skipped: stats.batchDedupSkipped,
                 cross_category_skipped: stats.crossCategorySkipped,
+                price_gate_rejected: stats.priceGateRejected,
                 strategy: 'pdf-direct',
               })
               continue
@@ -1908,6 +1943,7 @@ serve(async (req) => {
               fuzzy_matched: stats.fuzzyMatched,
               batch_dedup_skipped: stats.batchDedupSkipped,
               cross_category_skipped: stats.crossCategorySkipped,
+              price_gate_rejected: stats.priceGateRejected,
             },
             lock_expires_at: null,
             updated_at: new Date().toISOString(),
@@ -1919,6 +1955,7 @@ serve(async (req) => {
             fuzzy_matched: stats.fuzzyMatched,
             batch_dedup_skipped: stats.batchDedupSkipped,
             cross_category_skipped: stats.crossCategorySkipped,
+            price_gate_rejected: stats.priceGateRejected,
             rendered: renderSucceeded,
             strategy: winningStrategy,
           })
@@ -2036,6 +2073,7 @@ serve(async (req) => {
       fuzzy_matched?: number
       batch_dedup_skipped?: number
       cross_category_skipped?: number
+      price_gate_rejected?: number
       total_dishes?: number
     }> = []
 
@@ -2154,6 +2192,7 @@ serve(async (req) => {
           fuzzy_matched: stats.fuzzyMatched,
           batch_dedup_skipped: stats.batchDedupSkipped,
           cross_category_skipped: stats.crossCategorySkipped,
+          price_gate_rejected: stats.priceGateRejected,
           total_dishes: extracted.dishes.length,
         })
       } catch (err) {


### PR DESCRIPTION
## Summary

Follow-up to #261. A dry-run of the new cleanup script against production data exposed two false-positive classes in the normalizer I just deployed:

1. **Non-numeric paren stripping merged different SKUs.** Sharky's Cantina ${'`'}Loaded Quesadilla Plato (Shrimp)${'`'} \$25.98 and ${'`'}(Steak)${'`'} \$24.98 normalized to the same key. Same problem at Lookout (${'`'}(Half Dozen)${'`'} vs ${'`'}(Dozen)${'`'}) and Tony's (${'`'}(Small)${'`'} vs ${'`'}(Full)${'`'}).
2. **Dietary letters as stopwords merged GF variants with regular.** Back Door Donuts ${'`'}GF Boston Cream${'`'} \$4 and ${'`'}Boston Cream${'`'} \$3.50 normalized identically — would have silently overwritten the price.

## Changes

- **${'`'}extractors.ts${'`'}** + inline mirror in ${'`'}index.ts${'`'}: drop the ${'`'}ANY_PAREN${'`'} strip. Numeric parens still collapse to ${'`'}qty${'`'} tokens; non-numeric paren contents become identity-bearing tokens that differentiate variants.
- **${'`'}extractors.ts${'`'}** + inline mirror: drop ${'`'}gf${'`'}, ${'`'}df${'`'}, ${'`'}v${'`'}, ${'`'}ve${'`'}, ${'`'}vg${'`'}, ${'`'}vgn${'`'} from ${'`'}NORMALIZE_STOPWORDS${'`'}.
- **${'`'}upsertDishes${'`'}**: defensive price-equality gate (\$0.01 tolerance) around the fuzzy-match path. Disagreeing non-null prices reject the fuzzy match → the candidate inserts as new instead of overwriting.
- **Within-batch dedup**: price-suffix the batch key when prices disagree so multiple SKUs at different prices all survive the first pass (codex-flagged: works correctly with 3+ variants at \$10/\$12/\$15).
- New ${'`'}price_gate_rejected${'`'} counter in ${'`'}menu_import_jobs.error_context${'`'} and all ${'`'}results.push()${'`'} summary paths.

## What's distinct under the new rules

- ${'`'}Loaded Quesadilla Plato (Shrimp)${'`'} ≠ ${'`'}(Steak)${'`'} ≠ ${'`'}(Cod)${'`'}
- ${'`'}Half Dozen${'`'} ≠ ${'`'}Dozen${'`'} ≠ ${'`'}(3)${'`'} ≠ ${'`'}(6)${'`'}
- ${'`'}GF Boston Cream${'`'} ≠ ${'`'}Boston Cream${'`'}
- ${'`'}Jollof Rice (Ghana)${'`'} ≠ ${'`'}Jollof Rice${'`'} (lost — but cleanup script handles it on a one-time basis)

## What still merges

- ${'`'}Boston Cream${'`'} / ${'`'}Boston Cream Donut${'`'} (category-redundant strip)
- ${'`'}Chix Sandwich${'`'} / ${'`'}Chicken Sandwich${'`'} (abbreviation expansion)
- ${'`'}Acai Bowl${'`'} / ${'`'}Acaí Bowl${'`'} (diacritic normalization)
- ${'`'}Littleneck Clams${'`'} / ${'`'}Littleneck Clams*${'`'} (asterisk strip)
- ${'`'}Fish & Chips${'`'} / ${'`'}Fish-n- Chips${'`'} (punctuation strip)

## Diagnostic scripts

- ${'`'}scripts/cleanup-duplicate-dishes.mjs${'`'} — dry-run + execute modes. Vote-bearer wins (none exist in current data). Price-aware safety partition: 135 safe merges run, 42 suspect groups deferred for manual review.
- ${'`'}scripts/analyze-dupe-attachments.mjs${'`'} — confirms zero attachments on losers before bulk deletion.

## Code review

Reviewed with Codex (gpt-5.3-codex, medium effort). Confirmed:
- Normalizer correctly differentiates ${'`'}(Shrimp)/(Steak)${'`'} and ${'`'}GF/non-GF${'`'} variants.
- Batch dedup correctly preserves 3+ SKUs at different prices.
- ${'`'}pricesAgree(null, X)${'`'} returning true is the right default for null→price upgrades.
- Residual edge case (multiple existing DB rows with same normKey at different prices, oldest checked first) acknowledged as future enhancement.

## Test plan

- [x] ${'`'}npx vitest run supabase/functions/menu-refresh/${'`'} — 146/146 passing (2 new false-positive guard tests)
- [x] ${'`'}deno check supabase/functions/menu-refresh/index.ts${'`'} — same 15 pre-existing typecheck cascade errors from PR #261; no new errors
- [ ] After deploy: ${'`'}node scripts/cleanup-duplicate-dishes.mjs${'`'} dry-run shows 135 safe merges; running ${'`'}--execute${'`'} clears them
- [ ] After deploy: trigger a refresh on a known multi-protein restaurant (Sharky's Cantina) and verify no merge collapse

## Deploy

Edge function doesn't auto-deploy. After merge, paste ${'`'}supabase/functions/menu-refresh/index.ts${'`'} into the Supabase dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)