### PR TITLE
fix(home): homepage carousel ignored dietary preferences

### DIFF
--- a/src/components/home/HomeListMode.jsx
+++ b/src/components/home/HomeListMode.jsx
@@ -211,7 +211,7 @@ export const HomeListMode = memo(function HomeListMode({
 
             {/* Top 10 carousel — swipe between Near You, Pizza, Burgers, etc. */}
             <div id="top10-carousel">
-              <Top10Carousel ref={carouselRef} location={location} radius={radius} onCategoryChange={onCategoryChange} />
+              <Top10Carousel ref={carouselRef} location={location} radius={radius} dietaryTags={dietaryTags} onCategoryChange={onCategoryChange} />
             </div>
           </>
         ) : rankedError ? (

--- a/src/components/home/Top10Carousel.jsx
+++ b/src/components/home/Top10Carousel.jsx
@@ -25,7 +25,7 @@ var LOAD_MORE_COUNT = 5
  * is at most 3 queries. React Query caches by key so scrolling back to a
  * visited tab is instant.
  */
-export var Top10Carousel = forwardRef(function Top10Carousel({ location, radius, onCategoryChange }, ref) {
+export var Top10Carousel = forwardRef(function Top10Carousel({ location, radius, onCategoryChange, dietaryTags = null }, ref) {
   var [activeIndex, setActiveIndex] = useState(0)
   var [limits, setLimits] = useState({}) // { tabId: visibleCount }
   var scrollRef = useRef(null)
@@ -104,7 +104,7 @@ export var Top10Carousel = forwardRef(function Top10Carousel({ location, radius,
   // Parent fetches the active tab's data for the count badge. React Query
   // dedupes — the same query key from CarouselTabContent hits the cache.
   var activeCategoryFilter = activeTab.id === 'nearby' ? null : activeTab.id
-  var activeDishesQuery = useDishes(location, radius, activeCategoryFilter, null, null)
+  var activeDishesQuery = useDishes(location, radius, activeCategoryFilter, null, dietaryTags)
   var activeTotal = (activeDishesQuery.dishes || []).length
   var visibleCount = Math.min(activeTotal, activeLimit)
 
@@ -229,6 +229,7 @@ export var Top10Carousel = forwardRef(function Top10Carousel({ location, radius,
                   tab={tab}
                   location={location}
                   radius={radius}
+                  dietaryTags={dietaryTags}
                   tabLimit={getLimit(tab.id)}
                   onShowMore={function () { handleShowMore(tab.id) }}
                 />
@@ -253,9 +254,9 @@ export var Top10Carousel = forwardRef(function Top10Carousel({ location, radius,
  *   unranked (0-vote) dishes so sparse categories aren't half-empty
  * - "Show N more" reveals additional ranked + unranked beyond tabLimit
  */
-function CarouselTabContent({ tab, location, radius, tabLimit, onShowMore }) {
+function CarouselTabContent({ tab, location, radius, dietaryTags = null, tabLimit, onShowMore }) {
   var categoryFilter = tab.id === 'nearby' ? null : tab.id
-  var { dishes, loading } = useDishes(location, radius, categoryFilter, null, null)
+  var { dishes, loading } = useDishes(location, radius, categoryFilter, null, dietaryTags)
   var allDishes = dishes || []
 
   // Split ranked vs unranked (vote-phantom fix in PR #257 makes this honest).


### PR DESCRIPTION
## Summary

Picking a dietary preference in the DP's sheet updated the URL `?diet=` and the DietButton label, but the visible homepage list never filtered. Map mode and search-results were fine.

## Root cause

The homepage default render is `Top10Carousel` (`src/components/home/Top10Carousel.jsx`). It does its own data fetch — per PR #258, to bypass the Supabase 1000-row cap that was truncating less-popular categories. It called \`useDishes(location, radius, categoryFilter, null, null)\` — dropping \`dietaryTags\` on the floor.

The wiring above the carousel was correct: \`Map.jsx\` → \`HomeListMode\` already passed \`dietaryTags\`, \`HomeListMode\` already rendered the DietButton with the right state. Break was between \`HomeListMode\` and \`Top10Carousel\`.

## Fix (4 spots, +6/-5)

1. \`Top10Carousel\` accepts \`dietaryTags\` prop
2. \`Top10Carousel\`'s own \`useDishes\` (count badge query) passes \`dietaryTags\`
3. \`CarouselTabContent\` accepts \`dietaryTags\`, passes to its \`useDishes\`
4. \`HomeListMode\` forwards \`dietaryTags\` into \`<Top10Carousel>\`

\`useDishes\` already keys React Query on a sorted \`tagsKey\` — changing tags triggers refetch on each active tab. Active ±1 tabs re-render on prop change; further tabs aren't mounted (lazy gate), so no work wasted.

## Verification

- \`npm run build\` — clean
- \`vitest\` (diet-related tests): 32/32 pass (\`dietaryTags\`, \`dietUrlParams\`, \`DietSheet\`)
- ESLint: clean on touched files
- Codex (gpt-5.3-codex @ medium) reviewed the diff: confirmed query-key plumbing, no missed call-sites, no stale-render risk (upstream produces new array refs)

## Not in this PR

- Search results (\`useDishSearch\`) also ignores diet — separate behavior question (intentional whole-island scope, or bug?). Worth a follow-up issue.
- \`CategoryExpand.jsx\` is exported but never mounted — dead code, separate cleanup.

## Test plan

- [ ] On wghapp.com (or v1.3 simulator build), open homepage, tap DP's
- [ ] Select Vegetarian, Apply
- [ ] Top10Carousel list should now show only dishes with \`dietary_tags @> ['vegetarian']\`
- [ ] Swipe to other category tabs — filter persists
- [ ] Tap DP's again, deselect, Apply — full list returns
- [ ] Map mode toggle — filter persists there too

## Why this matters for v1.3

iOS v1.2 ships with this bug bundled. Users on native can't see filtered results until v1.3 cuts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)