### PR TITLE
chore(ios): bump MARKETING_VERSION to 1.3 for App Store submission

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -313,7 +313,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.whatsgoodhere.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -337,7 +337,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whatsgoodhere.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";


### PR DESCRIPTION
## Summary

v1.3 cuts on top of 18 commits since the v1.2 binary (\`feaab79\`).

## Notable v1.3 content (web shipped, iOS gets it now)

- **#266** — Homepage carousel ignored dietary preferences (just shipped)
- **#265** — Deep-link survival across email verification + latent OAuth returnPath fix
- **#264 / #262** — Auto-match drink icons by menu_section, frozens + cocktails overrides
- **#260** — Nancy's multi-menu (Snack Bar + Upstairs)
- **#258** — Per-tab data fetch — bypass 1000-row cap, surface unranked
- **#257** — get_ranked_dishes vote phantom fix
- **#256** — App icon as homepage brand mark + donut category icon
- **#255** — Surface unranked dishes — split into ranked + 'New on the menu'
- **#253 / #251** — Drinks → cocktails (alcohol-only), handcrafted-drinks extraction
- **#250 / #249** — Best Coffee NOW chalkboard, Best Find = highest user rating
- Misc menu-refresh hardening (#263, #261, #252), data cleanup (#259, #254)

## Version policy

\`CURRENT_PROJECT_VERSION\` left at \`1\`. App Store Connect keys uniqueness off the \`(MARKETING_VERSION, CURRENT_PROJECT_VERSION)\` pair, so \`1.3 (1)\` is valid even though prior versions also used build \`1\`. Same pattern as \`#248\` (v1.2 bump).

If TestFlight forces a fresh build (rejected for a typo, etc.), bump \`CURRENT_PROJECT_VERSION\` → 2 via Xcode UI without recommitting — bump is local and ASC keys off the pair.

## Verification done

- \`npm run build\` — clean
- \`npx cap sync ios\` — clean, dist copied into \`ios/App/App/public/\`
- pbxproj edit: 2 occurrences (Debug + Release configs) both set to \`1.3\`

## Test plan

- [ ] Open Xcode, confirm version shows \`1.3 (1)\` in target General tab
- [ ] Smoke test in iOS Simulator (golden path): browse home, vote, photo, map, dietary filter applies to list
- [ ] Archive → Distribute App → App Store Connect
- [ ] Submit for review in App Store Connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)