### PR TITLE
fix(icons): apps emoji 🍤 → 🧆 (no shrimp on vegan)

### DIFF
--- a/src/constants/categories.js
+++ b/src/constants/categories.js
@@ -63,7 +63,7 @@ export const ALL_CATEGORIES = [
   { id: 'pokebowl', label: 'Poke Bowl', emoji: '🥗' },
   { id: 'soup', label: 'Soup', emoji: '🍜' },
   { id: 'fries', label: 'Fries', emoji: '🍟' },
-  { id: 'apps', label: 'Appetizers', emoji: '🍤' },
+  { id: 'apps', label: 'Appetizers', emoji: '🧆' },
   { id: 'fried chicken', label: 'Fried Chicken', emoji: '🍗' },
   { id: 'entree', label: 'Entree', emoji: '🍽️' },
   { id: 'asian', label: 'Asian', emoji: '🥢' },


### PR DESCRIPTION
## Summary
- `ALL_CATEGORIES` had `apps` = 🍤 (fried shrimp); `CATEGORY_INFO` had `apps` = 🧆 (falafel).
- `getCategoryEmoji()` reads `ALL_CATEGORIES`, so any dish with `category='apps'` and no PNG match rendered as **shrimp**.
- Aligns the two sources on 🧆.

## Visible bug this fixes
Under the Vegan diet filter, both "Sweet & Spicy Cucumbers" (The Covington) and "Avocado Toast" (Waterside Market) showed the fried-shrimp emoji as their food icon. Both have `category='apps'` in the DB.

## Test plan
- [x] `npm run build` passes
- [ ] Verify on web: vegan filter no longer shows shrimp icon next to those two dishes
- [ ] Verify on iOS once next binary ships

## Follow-up (data, not code)
"Avocado Toast" at Waterside Market is `category='apps'` but `menu_section='Breakfast'` — should be `category='breakfast'`. Handled separately by SQL editor update (not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)