### PR TITLE
fix(home): inline DP's filter + drop dish counts from Locals copy

### DIFF
--- a/src/components/DietButton.jsx
+++ b/src/components/DietButton.jsx
@@ -1,13 +1,13 @@
 /**
- * DietButton — homepage dietary-filter trigger.
+ * DietButton — dietary-filter trigger.
  *
- * Sibling of the homepage search bar. Renders one of three states based on
- * the `selected` array length so a user can see at a glance whether the
- * feed is filtered:
- *
- *   []                   → "Diet · Off"        (tertiary text, neutral pill)
- *   ['vegan']            → "Diet · Vegan"      (primary text, coral wash)
- *   ['vegan', 'gluten_free'] → "Diet · 2 selected" (primary text, coral wash)
+ * Two variants:
+ *   - Default (large pill): used in Map mode. Shows "DP's · Off / Vegan /
+ *     N selected" so the selection is legible at a glance.
+ *   - `compact`: used inline inside the homepage search bar next to the
+ *     radius pill. Always reads "DP's" — active state is communicated by
+ *     the coral border so the pill stays narrow enough not to squeeze the
+ *     search input. The exact selection is revealed in the sheet on tap.
  *
  * Tap → calls `onOpen()` so the parent can mount DietSheet.
  */
@@ -31,7 +31,26 @@ function leafIcon(active) {
   )
 }
 
-export function DietButton({ selected, labels, onOpen }) {
+function compactLeafIcon(active) {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={active ? 'var(--color-primary)' : 'var(--color-text-secondary)'}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M5 21c.5-6 4.5-13 16-15-1 11-7.5 14-13 14" />
+      <path d="M5 21c5-3 8-6 11-9" />
+    </svg>
+  )
+}
+
+export function DietButton({ selected, labels, onOpen, compact = false }) {
   var count = Array.isArray(selected) ? selected.length : 0
   var active = count > 0
 
@@ -42,6 +61,35 @@ export function DietButton({ selected, labels, onOpen }) {
     trailing = (labels && labels[selected[0]]) || selected[0]
   } else {
     trailing = count + ' selected'
+  }
+
+  if (compact) {
+    // Inline variant — matches the sibling radius pill inside the search bar's
+    // rightSlot. Label stays "DP's" in every state so the pill width is
+    // bounded (was overflowing the search row on small phones when the
+    // trailing text grew to "2 selected" / "Gluten-free"). Coral border +
+    // muted wash communicate the filtered state; details live in the sheet.
+    return (
+      <button
+        type="button"
+        onClick={onOpen}
+        aria-label={active ? 'Edit dietary filter, ' + count + ' selected' : 'Open dietary filter'}
+        className="flex items-center gap-1 px-2 py-1 rounded-lg font-bold flex-shrink-0"
+        style={{
+          fontSize: '12px',
+          background: active ? 'var(--color-primary-muted)' : 'var(--color-bg)',
+          color: active ? 'var(--color-primary)' : 'var(--color-text-secondary)',
+          border: active
+            ? '1px solid var(--color-primary)'
+            : '1px solid var(--color-divider)',
+          cursor: 'pointer',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {compactLeafIcon(active)}
+        <span>DP's</span>
+      </button>
+    )
   }
 
   return (

--- a/src/components/home/HomeListMode.jsx
+++ b/src/components/home/HomeListMode.jsx
@@ -105,40 +105,37 @@ export const HomeListMode = memo(function HomeListMode({
               onSearchChange={onSearchChange}
               initialQuery={searchQuery}
               rightSlot={
-                <button
-                  onClick={function (e) { e.stopPropagation(); onRadiusSheetOpen() }}
-                  aria-label={radius === 0 ? 'Showing dishes everywhere' : 'Search radius: ' + radius + ' miles'}
-                  className="flex items-center gap-1 px-2 py-1 rounded-lg font-bold flex-shrink-0"
-                  style={{
-                    fontSize: '12px',
-                    background: 'var(--color-bg)',
-                    color: 'var(--color-text-secondary)',
-                    border: '1px solid var(--color-divider)',
-                    cursor: 'pointer',
-                  }}
-                >
-                  {radius === 0 ? 'All' : radius + ' mi'}
-                  <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={3}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-                  </svg>
-                </button>
+                <div className="flex items-center gap-1 flex-shrink-0">
+                  {onDietOpen ? (
+                    <DietButton
+                      compact
+                      selected={dietaryTags}
+                      labels={dietaryLabels}
+                      onOpen={onDietOpen}
+                    />
+                  ) : null}
+                  <button
+                    onClick={function (e) { e.stopPropagation(); onRadiusSheetOpen() }}
+                    aria-label={radius === 0 ? 'Showing dishes everywhere' : 'Search radius: ' + radius + ' miles'}
+                    className="flex items-center gap-1 px-2 py-1 rounded-lg font-bold flex-shrink-0"
+                    style={{
+                      fontSize: '12px',
+                      background: 'var(--color-bg)',
+                      color: 'var(--color-text-secondary)',
+                      border: '1px solid var(--color-divider)',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {radius === 0 ? 'All' : radius + ' mi'}
+                    <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={3}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </button>
+                </div>
               }
             />
           </div>
         </div>
-
-        {/* Dietary filter trigger — sits just under the search row, right-aligned
-            so it doesn't compete with the search bar visually. Only render when a
-            handler is wired in (keeps the test/storybook surfaces simple). */}
-        {onDietOpen ? (
-          <div className="px-5 pt-1 pb-1 flex justify-end">
-            <DietButton
-              selected={dietaryTags}
-              labels={dietaryLabels}
-              onOpen={onDietOpen}
-            />
-          </div>
-        ) : null}
 
         {/* Location banner */}
         <div className="px-4">

--- a/src/components/home/LocalsPicksBanner.jsx
+++ b/src/components/home/LocalsPicksBanner.jsx
@@ -171,7 +171,6 @@ export function LocalsPicksBanner() {
   if (!curators || curators.length === 0) return null
 
   var curatorCount = curators.length
-  var dishCount = curators.reduce(function (sum, c) { return sum + (c.item_count || 0) }, 0)
 
   return (
     <button
@@ -179,7 +178,7 @@ export function LocalsPicksBanner() {
       onClick={function () { navigate('/locals') }}
       style={BANNER_OUTER}
       className="active:scale-[0.99] transition-transform"
-      aria-label={'Open Locals’ Picks. ' + curatorCount + ' islanders, ' + dishCount + ' dishes.'}
+      aria-label={'Open Locals’ Picks. ' + curatorCount + ' islander' + (curatorCount === 1 ? '' : 's') + '.'}
     >
       <div style={BANNER_GRAIN} />
       <div style={BANNER_BODY}>
@@ -187,7 +186,7 @@ export function LocalsPicksBanner() {
         <div style={TITLE}>The Locals&rsquo; <span style={TITLE_ACCENT}>Picks</span></div>
         <div style={SUB}>
           What <span style={SUB_BOLD}>{curatorCount} islander{curatorCount === 1 ? '' : 's'}</span> actually order &mdash;<br />
-          their {dishCount} favorite dish{dishCount === 1 ? '' : 'es'}.
+          see their favorites.
         </div>
         <div style={CTA}>See what they order <span style={{ fontWeight: 800, marginLeft: '1px' }}>&rarr;</span></div>
       </div>

--- a/src/pages/Locals.jsx
+++ b/src/pages/Locals.jsx
@@ -124,12 +124,12 @@ export function Locals() {
   )
 }
 
-function Header({ curatorCount, dishCount, year }) {
+function Header({ year }) {
   return (
     <div style={HEADER}>
       <div style={EYEBROW}>ask a local</div>
       <div style={TITLE}>The Locals' <span style={TITLE_ACCENT}>Picks</span></div>
-      <div style={SUB}>{curatorCount} islander{curatorCount === 1 ? '' : 's'} &middot; {dishCount} dish{dishCount === 1 ? '' : 'es'} &middot; {year}</div>
+      <div style={SUB}>What islanders actually order &middot; {year}</div>
     </div>
   )
 }
@@ -144,14 +144,12 @@ function ReadTab() {
   var loading = consensusData.loading || curatorsData.loading
   var error = consensusData.error || curatorsData.error
 
-  var curatorCount = curators.length
-  var dishCount = curators.reduce(function (s, c) { return s + (c.item_count || 0) }, 0)
   var year = new Date().getFullYear()
 
   if (error) {
     return (
       <>
-        <Header curatorCount={0} dishCount={0} year={year} />
+        <Header year={year} />
         <p style={EMPTY}>{error?.message || 'Could not load picks.'}</p>
       </>
     )
@@ -159,7 +157,7 @@ function ReadTab() {
   if (loading && curators.length === 0) {
     return (
       <>
-        <Header curatorCount={0} dishCount={0} year={year} />
+        <Header year={year} />
         <p style={EMPTY}>Loading&hellip;</p>
       </>
     )
@@ -167,7 +165,7 @@ function ReadTab() {
 
   return (
     <>
-      <Header curatorCount={curatorCount} dishCount={dishCount} year={year} />
+      <Header year={year} />
 
       {consensus.length > 0 && (
         <>


### PR DESCRIPTION
## Summary
Two homepage polish fixes from real-device review with Dan:

- **Inline DP's filter pill in the search bar.** Was its own row below the search input, leaving an awkward empty band on the left. Now sits next to the radius pill inside the search bar's rightSlot. Added a `compact` variant to `DietButton` sized to match the radius pill; active state is communicated by the coral border so the label stays "DP's" (~58px fixed) and never squeezes the input on narrow phones.
- **Drop dynamic dish counts from "The Locals' Picks" copy.** Homepage banner now reads "What N islanders actually order — see their favorites." and the dedicated `/locals` page header reads "What islanders actually order · 2026". The count read punchy at small N ("3 favorite dishes") but undermines the recommendation as the collection grows.

Codex review caught + fixed: mobile overflow risk (always-"DP's" label keeps pill width bounded), apostrophe inconsistency (`'` vs `'`), stale `DietButton` docstring.

## Test plan
- [x] `vitest run` on `LocalsPicksBanner.test.jsx` + `DietSheet.test.jsx` — 15/15 pass
- [x] `eslint` on all 4 changed files — clean
- [x] Visual verification in Chrome dev server: DP's pill sits inline next to "All" inside the search bar; awkward space gone; banner copy + page header copy updated
- [x] Width math at simulated 320px viewport: DP's (~58px) + All (~45px) = ~103px combined → input retains ~200px, no overflow
- [ ] Verify on physical iPhone after Vercel preview deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)