### PR TITLE
fix(diet-sheet): spell out "Dietary Preferences" in sheet header

### DIFF
--- a/src/components/DietSheet.jsx
+++ b/src/components/DietSheet.jsx
@@ -110,7 +110,7 @@ export function DietSheet({
                 letterSpacing: '0.01em',
               }}
             >
-              DP's
+              Dietary Preferences
             </h2>
             <div
               aria-hidden="true"


### PR DESCRIPTION
## Summary
Quick follow-up to #269. The bottom-sheet that opens when you tap the "DP's" filter pill was also titled "DP's" — that's fine inline (keeps the pill narrow), but new users won't know what they're choosing once the sheet is open. Header now reads "Dietary Preferences" spelled out.

Pill in the search bar stays "DP's" for width.

## Test plan
- [x] `vitest run` on `DietSheet.test.jsx` — 8/8 pass (no test asserted on header text)
- [ ] Verify on simulator after sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)