### PR TITLE
chore(ios): bump MARKETING_VERSION to 1.4 for App Store submission

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -313,7 +313,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.whatsgoodhere.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -337,7 +337,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whatsgoodhere.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";


### PR DESCRIPTION
v1.4 ships the **check-ins v1** loop (PR #271 merged as \`4b7003c\`):

- Proximity banner on homepage when GPS shows you're ≤150m of a restaurant
- "Check in here" / "I've been here" button + bottom sheet on RestaurantDetail
- Optional note + dish-tag multi-select per check-in
- "Rate it →" toast nudge after a tagged check-in routes to dish detail
- "You've been here N times" strip on restaurant page
- **Profile → Visits tab** — chronological feed of all visits

Server-side migration already applied (\`supabase/migrations/2026-05-25-check-ins.sql\` — Denis project \`vpioftosgdkyiwvhxewy\`). Native-iOS gated; web shows "Check-ins live in the iOS app" link.

## Version

\`MARKETING_VERSION 1.3 → 1.4\`. \`CURRENT_PROJECT_VERSION\` left at 1 (resets per marketing version on App Store Connect — same pattern as #248 and #267). If TestFlight rejects and a re-upload is needed, bump build via Xcode UI without recommitting.

## Done autonomously before opening this PR

- ✅ \`npm run build\` clean (170 precache entries)
- ✅ \`npx cap sync ios\` — fresh \`dist/\` copied into \`ios/App/App/public/\`, all 4 Capacitor plugins synced
- ✅ Verified the check-ins client chunk landed in iOS bundle (\`useUserCheckIns-*.js\`)

## What Dan still does

1. Open Xcode (already running with the project from the v1.3 cut)
2. Confirm General tab reads \`Version: 1.4\`, \`Build: 1\`
3. Smoke test on iOS Simulator:
   - Any restaurant → tap "I've been here" → log a past visit → confirm Visits tab populates
   - Spoof GPS to a restaurant location → confirm proximity banner pops → tap → live mode + check in
4. Product → Archive (any iOS Device destination, ~5-10 min)
5. Distribute App → App Store Connect → Upload
6. appstoreconnect.apple.com → TestFlight or Submit for Review

🤖 Generated with [Claude Code](https://claude.com/claude-code)