### PR TITLE
fix(follows): live follower counts in lists + harden trigger migrations

### DIFF
--- a/src/api/followsApi.js
+++ b/src/api/followsApi.js
@@ -42,24 +42,36 @@ async function _paginateFollows(userId, direction, { limit = 20, cursor = null }
   const results = hasMore ? followData.slice(0, limit) : followData
 
   const userIds = results.map(f => f[selectCol])
-  const { data: profiles, error: profileError } = await supabase
-    .from('profiles')
-    .select('id, display_name, avatar_url, follower_count')
-    .in('id', userIds)
 
-  if (profileError) {
-    logger.warn('Error fetching follower profiles:', profileError)
-    // Continue without profile data
+  // Profile metadata + live follower counts in parallel. follower_count is
+  // sourced from the live follows table (via get_follower_counts) rather
+  // than profiles.follower_count, which has a history of drift — see
+  // supabase/migrations/2026-05-25-follower-count-live-reads.sql.
+  const [profilesResult, countsResult] = await Promise.all([
+    supabase
+      .from('profiles')
+      .select('id, display_name, avatar_url')
+      .in('id', userIds),
+    supabase.rpc('get_follower_counts', { p_user_ids: userIds }),
+  ])
+
+  if (profilesResult.error) {
+    logger.warn('Error fetching follower profiles:', profilesResult.error)
+  }
+  if (countsResult.error) {
+    logger.warn('Error fetching live follower counts:', countsResult.error)
   }
 
   const profileMap = {}
-  ;(profiles || []).forEach(p => { profileMap[p.id] = p })
+  ;(profilesResult.data || []).forEach(p => { profileMap[p.id] = p })
+  const countMap = {}
+  ;(countsResult.data || []).forEach(r => { countMap[r.user_id] = r.follower_count })
 
   const users = results.map(f => ({
     id: f[selectCol],
     display_name: profileMap[f[selectCol]]?.display_name || 'Anonymous',
     avatar_url: profileMap[f[selectCol]]?.avatar_url || null,
-    follower_count: profileMap[f[selectCol]]?.follower_count || 0,
+    follower_count: countMap[f[selectCol]] || 0,
     followed_at: f.created_at,
   }))
 

--- a/supabase/migrations/2026-05-25-follower-count-live-reads.sql
+++ b/supabase/migrations/2026-05-25-follower-count-live-reads.sql
@@ -1,10 +1,39 @@
--- search_user_follows: paginated alphabetical search of a user's
--- followers or following list. Mirrors the hardening pattern in
--- search_users_with_followers (input validation, limit clamp, security
--- definer + locked search_path).
+-- Switch follower-list reads from the denormalized profiles.follower_count
+-- column to live COUNT(*) against the follows table.
 --
--- Returns (display_name, id) tuple-ordered rows for stable cursor pagination.
+-- The denormalized column has drifted multiple times (see
+-- 20260516_fix_follower_count_trigger.sql for the prior incident). The trigger
+-- architecture is load-bearing on protect_profile_fields honoring the
+-- 'app.allow_follow_count_update' bypass, but several sync migrations and the
+-- curator-flag-trigger-bypass migration redefine the trigger functions
+-- WITHOUT that bypass — re-running any of them silently downgrades the fix.
+-- This migration eliminates the read-side dependency so UX never sees drift.
+--
+-- The column itself stays for one release as a soak period; a follow-up
+-- migration drops it once we're confident no other readers remain.
 
+-- 1. get_follower_counts: batch live follower-count lookup for a set of
+--    user IDs. Used by _paginateFollows after fetching the recency-ordered
+--    follow rows. Returns one row per user_id present in the follows table;
+--    callers must default missing IDs to 0.
+CREATE OR REPLACE FUNCTION get_follower_counts(p_user_ids UUID[])
+RETURNS TABLE (
+  user_id UUID,
+  follower_count INT
+)
+LANGUAGE SQL STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT f.followed_id AS user_id, COUNT(*)::INT AS follower_count
+  FROM follows f
+  WHERE f.followed_id = ANY(p_user_ids)
+  GROUP BY f.followed_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_follower_counts(UUID[]) TO anon, authenticated;
+
+-- 2. search_user_follows: same shape as before, but follower_count is now
+--    a live subquery against follows instead of p.follower_count.
 CREATE OR REPLACE FUNCTION search_user_follows(
   p_user_id UUID,
   p_direction TEXT,
@@ -26,10 +55,6 @@ AS $$
 DECLARE
   v_limit INT := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 100);
   v_query TEXT := NULLIF(TRIM(COALESCE(p_query, '')), '');
-  -- Cursor is "active" only when both halves are present. A half-set cursor
-  -- would make the tuple comparison (display_name, id) > (cursor_name, NULL)
-  -- evaluate to NULL — filtering every row out (empty-page bug). Treat any
-  -- partial cursor as "no cursor" so callers degrade gracefully.
   v_use_cursor BOOLEAN := (p_cursor_name IS NOT NULL AND p_cursor_id IS NOT NULL);
 BEGIN
   IF p_direction NOT IN ('followers', 'following') THEN
@@ -40,11 +65,6 @@ BEGIN
     RAISE EXCEPTION 'p_user_id is required' USING ERRCODE = '22023';
   END IF;
 
-  -- follower_count is computed as a live subquery against follows rather
-  -- than read from p.follower_count (denormalized) — see
-  -- migrations/2026-05-25-follower-count-live-reads.sql for the rationale.
-  -- Backported here so re-applying this older migration is idempotent and
-  -- can't downgrade the live-count read.
   IF p_direction = 'followers' THEN
     RETURN QUERY
       SELECT p.id, p.display_name, p.avatar_url,
@@ -78,4 +98,5 @@ $$;
 GRANT EXECUTE ON FUNCTION search_user_follows(UUID, TEXT, TEXT, TEXT, UUID, INT) TO anon, authenticated;
 
 -- ROLLBACK:
--- DROP FUNCTION IF EXISTS search_user_follows(UUID, TEXT, TEXT, TEXT, UUID, INT);
+-- DROP FUNCTION IF EXISTS get_follower_counts(UUID[]);
+-- And restore search_user_follows from migrations/20260516_search_user_follows.sql.

--- a/supabase/migrations/comprehensive_schema_sync.sql
+++ b/supabase/migrations/comprehensive_schema_sync.sql
@@ -1680,9 +1680,14 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
 -- =============================================
 
 -- 13a. Update follow counts
+-- Opts into the protect_profile_fields bypass via the
+-- 'app.allow_follow_count_update' transaction-local flag — without this,
+-- every counter increment is silently reverted by the protect trigger.
+-- See migrations/20260516_fix_follower_count_trigger.sql for context.
 CREATE OR REPLACE FUNCTION update_follow_counts()
 RETURNS TRIGGER LANGUAGE plpgsql SET search_path = public AS $$
 BEGIN
+  PERFORM set_config('app.allow_follow_count_update', 'true', true);
   IF TG_OP = 'INSERT' THEN
     UPDATE profiles SET following_count = following_count + 1 WHERE id = NEW.follower_id;
     UPDATE profiles SET follower_count = follower_count + 1 WHERE id = NEW.followed_id;

--- a/supabase/migrations/curator-flag-trigger-bypass.sql
+++ b/supabase/migrations/curator-flag-trigger-bypass.sql
@@ -19,9 +19,14 @@ BEGIN;
 CREATE OR REPLACE FUNCTION protect_profile_fields()
 RETURNS TRIGGER AS $$
 BEGIN
-  -- Counters are derived state — never settable by anyone.
-  NEW.follower_count := OLD.follower_count;
-  NEW.following_count := OLD.following_count;
+  -- Counters: revert unless update_follow_counts opted in via
+  -- set_config('app.allow_follow_count_update', 'true', true) on the trigger
+  -- on follows. Without this guard, every legitimate counter increment is
+  -- silently dropped — see migrations/20260516_fix_follower_count_trigger.sql.
+  IF current_setting('app.allow_follow_count_update', true) IS DISTINCT FROM 'true' THEN
+    NEW.follower_count := OLD.follower_count;
+    NEW.following_count := OLD.following_count;
+  END IF;
 
   -- Curator flag: revert unless the caller explicitly opted in via
   -- set_config('app.allow_curator_grant', 'true', true) inside a
@@ -118,12 +123,17 @@ COMMIT;
 --
 -- ROLLBACK:
 -- BEGIN;
+--   -- Restore only the curator bypass; keep the follow-count bypass added
+--   -- in migrations/20260516_fix_follower_count_trigger.sql intact so the
+--   -- denormalized profiles.follower_count keeps tracking new follows.
 --   CREATE OR REPLACE FUNCTION protect_profile_fields()
 --   RETURNS TRIGGER AS $$
 --   BEGIN
+--     IF current_setting('app.allow_follow_count_update', true) IS DISTINCT FROM 'true' THEN
+--       NEW.follower_count := OLD.follower_count;
+--       NEW.following_count := OLD.following_count;
+--     END IF;
 --     NEW.is_local_curator := OLD.is_local_curator;
---     NEW.follower_count := OLD.follower_count;
---     NEW.following_count := OLD.following_count;
 --     RETURN NEW;
 --   END;
 --   $$ LANGUAGE plpgsql;

--- a/supabase/migrations/denis-sync/step-10-triggers.sql
+++ b/supabase/migrations/denis-sync/step-10-triggers.sql
@@ -3,9 +3,14 @@
 -- =============================================
 
 -- 10a. Update follow counts
+-- Opts into the protect_profile_fields bypass via the
+-- 'app.allow_follow_count_update' transaction-local flag — without this,
+-- every counter increment is silently reverted by the protect trigger.
+-- See migrations/20260516_fix_follower_count_trigger.sql for context.
 CREATE OR REPLACE FUNCTION update_follow_counts()
 RETURNS TRIGGER LANGUAGE plpgsql SET search_path = public AS $$
 BEGIN
+  PERFORM set_config('app.allow_follow_count_update', 'true', true);
   IF TG_OP = 'INSERT' THEN
     UPDATE profiles SET following_count = following_count + 1 WHERE id = NEW.follower_id;
     UPDATE profiles SET follower_count = follower_count + 1 WHERE id = NEW.followed_id;

--- a/supabase/migrations/full-schema-sync.sql
+++ b/supabase/migrations/full-schema-sync.sql
@@ -2575,9 +2575,14 @@ $$;
 -- =============================================
 
 -- 10a. Update follow counts
+-- Opts into the protect_profile_fields bypass via the
+-- 'app.allow_follow_count_update' transaction-local flag — without this,
+-- every counter increment is silently reverted by the protect trigger.
+-- See migrations/20260516_fix_follower_count_trigger.sql for context.
 CREATE OR REPLACE FUNCTION update_follow_counts()
 RETURNS TRIGGER LANGUAGE plpgsql SET search_path = public AS $$
 BEGIN
+  PERFORM set_config('app.allow_follow_count_update', 'true', true);
   IF TG_OP = 'INSERT' THEN
     UPDATE profiles SET following_count = following_count + 1 WHERE id = NEW.follower_id;
     UPDATE profiles SET follower_count = follower_count + 1 WHERE id = NEW.followed_id;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1485,6 +1485,27 @@ RETURNS INTEGER LANGUAGE SQL STABLE SET search_path = public AS $$
   SELECT COUNT(*)::INTEGER FROM follows WHERE follower_id = user_id;
 $$;
 
+-- Batch live follower-count lookup for a set of user IDs. Used by the
+-- follow-list API after fetching recency-ordered follow rows so per-row
+-- subtitles read live counts instead of the denormalized profiles
+-- column (which has drifted multiple times — see
+-- 20260516_fix_follower_count_trigger.sql and
+-- 2026-05-25-follower-count-live-reads.sql for context).
+CREATE OR REPLACE FUNCTION get_follower_counts(p_user_ids UUID[])
+RETURNS TABLE (
+  user_id UUID,
+  follower_count INT
+)
+LANGUAGE SQL STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT f.followed_id AS user_id, COUNT(*)::INT AS follower_count
+  FROM follows f
+  WHERE f.followed_id = ANY(p_user_ids)
+  GROUP BY f.followed_id;
+$$;
+GRANT EXECUTE ON FUNCTION get_follower_counts(UUID[]) TO anon, authenticated;
+
 -- Check if user A follows user B
 CREATE OR REPLACE FUNCTION is_following(follower UUID, followed UUID)
 RETURNS BOOLEAN LANGUAGE SQL STABLE SET search_path = public AS $$
@@ -1534,7 +1555,8 @@ BEGIN
 
   IF p_direction = 'followers' THEN
     RETURN QUERY
-      SELECT p.id, p.display_name, p.avatar_url, p.follower_count,
+      SELECT p.id, p.display_name, p.avatar_url,
+             (SELECT COUNT(*)::INT FROM follows ff WHERE ff.followed_id = p.id) AS follower_count,
              f.created_at AS followed_at
       FROM follows f
       JOIN profiles p ON p.id = f.follower_id
@@ -1546,7 +1568,8 @@ BEGIN
       LIMIT v_limit;
   ELSE
     RETURN QUERY
-      SELECT p.id, p.display_name, p.avatar_url, p.follower_count,
+      SELECT p.id, p.display_name, p.avatar_url,
+             (SELECT COUNT(*)::INT FROM follows ff WHERE ff.followed_id = p.id) AS follower_count,
              f.created_at AS followed_at
       FROM follows f
       JOIN profiles p ON p.id = f.followed_id

--- a/supabase/seed/test/demo-gamification-data.sql
+++ b/supabase/seed/test/demo-gamification-data.sql
@@ -166,18 +166,12 @@ INSERT INTO follows (follower_id, followed_id) VALUES
   ('aaaaaaaa-0005-4000-a000-000000000005', 'aaaaaaaa-0006-4000-a000-000000000006')
 ON CONFLICT (follower_id, followed_id) DO NOTHING;
 
--- Step 6: Update follower_count on profiles
-UPDATE profiles SET follower_count = (
-  SELECT COUNT(*) FROM follows WHERE followed_id = profiles.id
-)
-WHERE id IN (
-  'aaaaaaaa-0001-4000-a000-000000000001',
-  'aaaaaaaa-0002-4000-a000-000000000002',
-  'aaaaaaaa-0003-4000-a000-000000000003',
-  'aaaaaaaa-0004-4000-a000-000000000004',
-  'aaaaaaaa-0005-4000-a000-000000000005',
-  'aaaaaaaa-0006-4000-a000-000000000006'
-);
+-- profiles.follower_count / following_count are maintained by the
+-- trigger_update_follow_counts AFTER trigger on follows. The hand-rolled
+-- UPDATE that used to live here was both redundant and blocked by
+-- protect_profile_fields (no bypass flag set) — pure cruft that masked
+-- the underlying trigger bug. The follower-list API also reads counts
+-- live from the follows table, so the denorm column isn't a UX concern.
 
 -- =============================================
 -- IMPORTANT: After running this, log in as your


### PR DESCRIPTION
## Summary
- Profile header was showing the correct live count, but the follower-list per-row subtitle was reading the denormalized `profiles.follower_count` — which had drifted from the live `follows` table for 6 users (9 missing increments, all asymmetric on `follower_count` only).
- Root cause is a fragile architecture, not a one-off data corruption: 4 migrations in the repo ship trigger bodies that downgrade the May 16 fix if re-applied (`comprehensive_schema_sync.sql`, `full-schema-sync.sql`, `denis-sync/step-10-triggers.sql`, `curator-flag-trigger-bypass.sql`). A seed file hand-rolls the column. The denorm has been load-bearing on a chain of assumptions that has broken before and will break again.
- PR1 (this) eliminates the read-side dependency — list subtitles now compute follower counts live from the `follows` table. PR2 (later, after soak) drops the column + trigger entirely.

## Changes
- `search_user_follows` RPC: `follower_count` is now `(SELECT COUNT(*) FROM follows WHERE followed_id = p.id)`. Backported into `20260516_search_user_follows.sql` so re-applying that migration is idempotent.
- New `get_follower_counts(uuid[])` RPC: batch live lookup, SECURITY DEFINER (consistent with `search_user_follows`).
- `_paginateFollows` in `src/api/followsApi.js`: calls `get_follower_counts` in parallel with the profile-metadata query and reads the live map for `follower_count`.
- Harden the 4 replay-footgun migrations so re-running them preserves the May 16 bypass (`set_config('app.allow_follow_count_update', ...)`) — re-applying any of them is now safe.
- `supabase/seed/test/demo-gamification-data.sql`: drop the hand-rolled `UPDATE profiles SET follower_count = ...` (the trigger handles it; the manual write was both redundant AND silently blocked by `protect_profile_fields`).

## Deploy order
> ⚠️ Apply `supabase/migrations/2026-05-25-follower-count-live-reads.sql` to Denis's Supabase project BEFORE merging — `_paginateFollows` calls the new `get_follower_counts` RPC and will fail with 404 if the migration hasn't shipped yet.

## Test plan
- [x] `npm run test -- --run src/api/followsApi.test.js` passes
- [x] `npm run build` succeeds
- [x] `npx eslint src/api/followsApi.js` clean
- [x] Codex review (gpt-5.3-codex / medium) — flagged the older 20260516 migration replay risk; addressed in this PR
- [ ] After migration deploy: open follower list in app, confirm per-row subtitles match each user's profile-page follower-count header
- [ ] Smoke: follow a new user from a fresh account, confirm both lists update without refresh

## Follow-up (PR2, post-soak)
- DROP COLUMN `profiles.follower_count`, `profiles.following_count`
- DROP TRIGGER `trigger_update_follow_counts` + function
- Remove the follow-count bypass from `protect_profile_fields`
- Update sync migrations to not redefine the dropped columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)