### PR TITLE
fix(test): unbreak CI by mocking supabase in useDishDetail test

### DIFF
--- a/src/hooks/useDishDetail.test.js
+++ b/src/hooks/useDishDetail.test.js
@@ -1,4 +1,23 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+
+// useDishDetail.js transitively imports src/lib/supabase, which calls
+// createClient(VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY) at module-eval
+// time. In CI those env vars aren't set, so the createClient call errors
+// out with "supabaseUrl is required" before any test runs. transformDish
+// is a pure function that never touches the client, so we stub the
+// supabase module to a minimal shape that satisfies all transitive
+// imports without instantiating a real client.
+vi.mock('../lib/supabase', () => ({
+  supabase: {
+    auth: { getUser: vi.fn(), getSession: vi.fn(), onAuthStateChange: vi.fn() },
+    from: vi.fn(),
+    rpc: vi.fn(),
+    functions: { invoke: vi.fn() },
+    storage: { from: vi.fn() },
+  },
+  isSupabaseConfigured: false,
+}))
+
 import { transformDish } from './useDishDetail'
 
 const BASE_INPUT = {


### PR DESCRIPTION
## Summary
Last PR of three from the [2026-05-25 audit](https://github.com/PGD3311/What-s-Good-Here/blob/main/docs/audits/2026-05-25-codebase-audit.md). Unbreak CI so we can stop admin-merging through red.

## The failure
CI's \`build-and-test\` workflow has been failing on every recent run with:
\`\`\`
FAIL src/hooks/useDishDetail.test.js
Error: supabaseUrl is required.
  at validateSupabaseUrl node_modules/@supabase/supabase-js/src/lib/helpers.ts:86:11
  at new SupabaseClient ...
  at Module.createClient ...
  at src/lib/supabase.js:27:25
  at src/api/dishesApi.js:1:1
\`\`\`

\`useDishDetail.js\` transitively imports \`src/lib/supabase.js\` via \`dishesApi/followsApi/dishPhotosApi/votesApi\`. That module calls \`createClient(VITE_SUPABASE_URL, ...)\` at top level, which throws when the env var isn't set. CI doesn't set the var. The test itself only exercises \`transformDish\` — a pure function that never touches the client — so this is a pure import-graph side effect.

## Fix
\`vi.mock('../lib/supabase')\` at the top of the test file with a minimal shape that satisfies the transitive imports without instantiating a real client.

**Alternatives considered:**
- Set \`VITE_SUPABASE_URL\` in CI → works, but couples unit-test infra to secrets/env config.
- Lazy-init the client in \`lib/supabase.js\` → cleaner architectural fix but broader blast radius. Deferred.

## Verification
- [x] Locally: \`unset VITE_SUPABASE_URL VITE_SUPABASE_ANON_KEY && npm run test -- --run src/hooks/useDishDetail.test.js\` → 4 tests pass.
- [x] No regression in adjacent test files.
- [x] Codex review (gpt-5.3-codex / medium): LGTM — "smallest blast radius" fix; mock shape sufficient for module-eval safety; vitest auto-hoisting keeps it isolated.

After this lands, CI should go green on the next push to main and we can stop admin-merging. One unrelated pre-existing failure remains in \`src/lib/nativeAuth.test.js > signInWithGoogleNative > maps plugin init failure to AUTH_CONFIG\` — separate ticket if you want to chase it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)