### PR TITLE
chore(ios): bump MARKETING_VERSION to 1.5 for App Store submission

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -313,7 +313,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.whatsgoodhere.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -337,7 +337,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whatsgoodhere.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";


### PR DESCRIPTION
## Summary
Rolls the iOS marketing version 1.4 → 1.5 so the audit-fix series can ship through TestFlight + App Store:

- **#275** — rating_10 CHECK constraint + RPC param clamps (audit P0/P1)
- **#276** — SIWA flag default-on, env files untracked (audit P1 hygiene)
- **#277** — CI test fix (no app behavior change)

User-visible diff vs 1.4 is small (mostly hardening). The bump exists so the new code paths get exercised by real users on production.

## Test plan
- [x] \`npm run build\` succeeds
- [x] \`npx cap sync ios\` syncs the fresh bundle into \`ios/App/App/public/\`
- [ ] Open Xcode → Product → Archive → Distribute App → App Store Connect → Upload
- [ ] If 1.5 build 1 has been uploaded before (which it hasn't), bump CURRENT_PROJECT_VERSION in Xcode before archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)