### PR TITLE
fix(share): canonical wghapp.com URLs for share + invite links

### DIFF
--- a/src/components/profile/SharePicksButton.jsx
+++ b/src/components/profile/SharePicksButton.jsx
@@ -1,4 +1,4 @@
-import { shareOrCopy } from '../../utils/share'
+import { shareOrCopy, canonicalShareUrl } from '../../utils/share'
 import { capture } from '../../lib/analytics'
 import { toast } from 'sonner'
 
@@ -12,10 +12,11 @@ import { toast } from 'sonner'
  */
 export function SharePicksButton({ userId, userName, location }) {
   var handleShare = async function () {
-    var url = window.location.origin + '/user/' + userId
+    var path = '/user/' + userId
     if (location) {
-      url += '?location=' + encodeURIComponent(location)
+      path += '?location=' + encodeURIComponent(location)
     }
+    var url = canonicalShareUrl(path)
 
     var result = await shareOrCopy({
       url: url,
@@ -30,7 +31,9 @@ export function SharePicksButton({ userId, userName, location }) {
       success: result.success,
     })
 
-    if (result.success && result.method !== 'native') {
+    // shareOrCopy returns 'native_capacitor' or 'web_share' for OS share sheets
+    // (which have their own UI feedback) — toast only for clipboard fallbacks.
+    if (result.success && result.method !== 'native_capacitor' && result.method !== 'web_share') {
       toast.success('Link copied!', { duration: 2000 })
     }
   }

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -7,6 +7,7 @@ import { restaurantsApi } from '../api/restaurantsApi'
 import { adminApi } from '../api/adminApi'
 import { restaurantManagerApi } from '../api/restaurantManagerApi'
 import { ALL_CATEGORIES } from '../constants/categories'
+import { canonicalShareUrl } from '../utils/share'
 
 function formatRetryAfter(seconds) {
   if (seconds >= 3600) {
@@ -295,7 +296,7 @@ export function Admin() {
         setMessage({ type: 'error', text: result?.error || 'Failed to mint invite' })
         return
       }
-      const link = `${window.location.origin}/curator-invite/${result.token}`
+      const link = canonicalShareUrl(`/curator-invite/${result.token}`)
       setCuratorInviteLink(link)
       setCuratorInviteExpires(result.expires_at || '')
 
@@ -334,7 +335,7 @@ export function Admin() {
 
     try {
       const { id, token } = await restaurantManagerApi.createInvite(inviteRestaurantId)
-      const link = `${window.location.origin}/invite/${token}`
+      const link = canonicalShareUrl(`/invite/${token}`)
       setInviteLink(link)
       setInviteId(id)
       setSendResult(null)

--- a/src/pages/Playlist.jsx
+++ b/src/pages/Playlist.jsx
@@ -9,7 +9,7 @@ import { PlaylistOwnerMenu } from '../components/playlists/PlaylistOwnerMenu'
 import { getCategoryNeonImage, categoryEmojiFor } from '../constants/categories'
 import { AddDishSearchSheet } from '../components/playlists/AddDishSearchSheet'
 import { capture } from '../lib/analytics'
-import { shareOrCopy } from '../utils/share'
+import { shareOrCopy, canonicalShareUrl } from '../utils/share'
 import { toast } from 'sonner'
 
 export function Playlist() {
@@ -95,8 +95,11 @@ export function Playlist() {
   }
 
   var handleShare = async function () {
+    // canonicalShareUrl returns wghapp.com on Capacitor where window.location
+    // origin is 'WhatsGoodHere://localhost' (unshareable). On web, this is
+    // the same as window.location.href for /playlist/:id.
     var result = await shareOrCopy({
-      url: window.location.href,
+      url: canonicalShareUrl('/playlist/' + id),
       title: playlist.title,
       text: playlist.title + ' — a food playlist on What\'s Good Here',
     })

--- a/src/pages/RestaurantDetail.jsx
+++ b/src/pages/RestaurantDetail.jsx
@@ -7,7 +7,7 @@ import { ReportModal } from '../components/ReportModal'
 import { PlaceAttributions } from '../components/PlaceAttributions'
 import { logger } from '../utils/logger'
 import { getUserMessage } from '../utils/errorHandler'
-import { shareOrCopy } from '../utils/share'
+import { shareOrCopy, canonicalShareUrl } from '../utils/share'
 import { sanitizeUrl } from '../utils/sanitize'
 import { openExternalLink } from '../utils/openExternalLink'
 import { restaurantsApi } from '../api/restaurantsApi'
@@ -390,7 +390,7 @@ export function RestaurantDetail() {
           <button
             onClick={async () => {
               const result = await shareOrCopy({
-                url: `${window.location.origin}/restaurants/${restaurantId}`,
+                url: canonicalShareUrl(`/restaurants/${restaurantId}`),
                 title: restaurant.name,
                 text: `Check out ${restaurant.name} on What's Good Here!`,
               })

--- a/src/utils/share.js
+++ b/src/utils/share.js
@@ -2,6 +2,27 @@ import { Capacitor } from '@capacitor/core'
 import { Share } from '@capacitor/share'
 import { logger } from './logger'
 
+// Canonical public origin for share/invite URLs. Inside the iOS Capacitor
+// WebView, window.location.origin is 'WhatsGoodHere://localhost' (per the
+// scheme set in capacitor.config.ts); Android uses 'https://localhost'.
+// Neither is shareable — recipients can't open those schemes, so links
+// silently fall back to the homepage. Always serve external links from
+// the canonical public domain instead.
+const CANONICAL_ORIGIN = 'https://wghapp.com'
+
+/**
+ * Build an absolute URL safe to share/copy. On Capacitor (native iOS/Android)
+ * returns a wghapp.com URL; on web returns window.location.origin + path.
+ * @param {string} path - Path beginning with '/', e.g. '/playlist/abc'.
+ * @returns {string} Absolute URL.
+ */
+export function canonicalShareUrl(path) {
+  if (Capacitor?.isNativePlatform?.()) {
+    return `${CANONICAL_ORIGIN}${path}`
+  }
+  return `${window.location.origin}${path}`
+}
+
 /**
  * Share or copy a URL with platform-appropriate behavior.
  *
@@ -86,7 +107,7 @@ export async function shareOrCopy({ url, title, text }) {
  * @returns {{ url: string, title: string, text: string }}
  */
 export function buildDishShareData(dish) {
-  const url = `${window.location.origin}/dish/${dish.dish_id}`
+  const url = canonicalShareUrl(`/dish/${dish.dish_id}`)
   return {
     url,
     title: `${dish.dish_name} at ${dish.restaurant_name}`,
@@ -100,7 +121,7 @@ export function buildDishShareData(dish) {
  * @returns {{ url: string, title: string, text: string }}
  */
 export function buildRestaurantShareData(restaurant) {
-  const url = `${window.location.origin}/restaurants/${restaurant.id}`
+  const url = canonicalShareUrl(`/restaurants/${restaurant.id}`)
   return {
     url,
     title: restaurant.name,


### PR DESCRIPTION
## Summary
Fixes two bug reports that share one root cause: share/invite links built inside the iOS Capacitor WebView use \`window.location.origin\` which is \`WhatsGoodHere://localhost\` (the iOS scheme set in \`capacitor.config.ts\`). Recipients can't open that URL, so it silently falls back to the homepage.

## The bugs
1. **Playlist share** — tap Share on a playlist in iOS, send the link to someone, they land on the homepage instead of the playlist.
2. **Curator (top-10) invite copy** — mint a curator invite, copy the link, paste to a recipient; the link doesn't work for them.

Both have the same root cause; same vulnerability also exists for dish share, restaurant share, and "Share my picks" buttons.

## Fix
New \`canonicalShareUrl(path)\` helper in \`src/utils/share.js\`:
\`\`\`js
export function canonicalShareUrl(path) {
  if (Capacitor?.isNativePlatform?.()) {
    return \`https://wghapp.com\${path}\`
  }
  return \`\${window.location.origin}\${path}\`
}
\`\`\`

Applied at all 6 callsites that produce shareable / copyable links:
- \`src/utils/share.js\` — \`buildDishShareData\`, \`buildRestaurantShareData\`
- \`src/pages/Playlist.jsx\` — \`handleShare\`
- \`src/pages/Admin.jsx\` — curator invite + restaurant manager invite generation
- \`src/pages/RestaurantDetail.jsx\` — inline share button
- \`src/components/profile/SharePicksButton.jsx\` — share user picks (also fixed a separate toast bug: \`result.method !== 'native'\` didn't match the actual returned \`'native_capacitor'\` / \`'web_share'\` strings, so the "Link copied!" toast was firing for OS share sheets too — now correctly suppressed.)

Intentionally NOT touching auth redirect URLs (\`src/api/authApi.js\`, \`src/pages/AuthCallback.jsx\`) — those are OAuth same-origin redirects that need to come back to the WebView's origin, not the public web domain.

## Verification
- [x] \`npm run build\` passes
- [x] \`npx eslint\` clean on changed files
- [x] Codex review (gpt-5.3-codex / medium) — caught \`SharePicksButton.jsx\` initially missed + the toast-string mismatch, both fixed in this PR
- [ ] After deploy: tap Share on a playlist in iOS, paste the URL anywhere, verify it starts with \`https://wghapp.com\`
- [ ] After deploy: mint a curator invite, paste to test recipient, verify they reach the \`/curator-invite/:token\` accept page

## Out of scope (separate diagnosis)
Bug A from the original report — "Denis's top-10 link opens in the web app but not the installed iOS app" — is a **Universal Links** issue, not a code bug. The \`apple-app-site-association\` file and Xcode \`Associated Domains\` entitlement both look correct (paths include \`/playlist/*\`). Most likely the recipient either doesn't have the iOS app installed, or iOS has cached an old AASA file from before deep links were registered. Reinstalling the app forces a fresh AASA fetch. If the recipient does have v1.4+ installed and UL still doesn't trigger, separate debugging needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)