### PR TITLE
fix(local-list): truncate overflow + add curator entry points to /my-list

### DIFF
--- a/src/pages/LocalsCurator.jsx
+++ b/src/pages/LocalsCurator.jsx
@@ -2,6 +2,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 import { useLocalListDetail } from '../hooks/useLocalListDetail'
 import { LocalsPicksStamp } from '../components/home/LocalsPicksStamp'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { useAuth } from '../context/AuthContext'
 
 var PAGE = {
   background: 'linear-gradient(180deg, var(--color-paper-cream-light) 0%, var(--color-paper-cream-dark) 100%)',
@@ -52,10 +53,23 @@ var AVATAR_WRAP = {
 }
 
 var ITEM = { marginBottom: '11px', padding: '0 2px' }
-var ITEM_HEAD = { display: 'flex', alignItems: 'baseline', gap: '6px', marginBottom: '1px' }
-var ITEM_NAME = { fontSize: '14px', fontWeight: 600, color: 'var(--color-text-primary)', whiteSpace: 'nowrap' }
+// minWidth:0 on ITEM_HEAD lets the name + dotted-leader flex children shrink
+// below their intrinsic width (default flex min-width is 'auto'); without it,
+// long dish names push past the right edge and the rating clips off-screen.
+var ITEM_HEAD = { display: 'flex', alignItems: 'baseline', gap: '6px', marginBottom: '1px', minWidth: 0 }
+// overflow + ellipsis on the name span keeps the newspaper-list look (rating
+// stays right-aligned, dotted leader still connects) even for very long names.
+var ITEM_NAME = {
+  fontSize: '14px',
+  fontWeight: 600,
+  color: 'var(--color-text-primary)',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  minWidth: 0,
+}
 var DOTS = { flex: 1, minWidth: '8px', borderBottom: '1.5px dotted rgba(0,0,0,.25)', alignSelf: 'flex-end', marginBottom: '5px' }
-var RATING = { fontWeight: 700, fontSize: '16px', color: 'var(--color-rating)', fontVariantNumeric: 'tabular-nums' }
+var RATING = { fontWeight: 700, fontSize: '16px', color: 'var(--color-rating)', fontVariantNumeric: 'tabular-nums', flexShrink: 0 }
 var META = { display: 'flex', gap: '6px', fontSize: '11px', paddingLeft: '2px' }
 var REST = { color: 'var(--color-accent-gold)', fontWeight: 600 }
 var NOTE = { fontSize: '12.5px', color: 'var(--color-text-secondary)', lineHeight: 1.4, marginTop: '4px', paddingLeft: '2px', fontStyle: 'italic' }
@@ -66,7 +80,11 @@ export function LocalsCurator() {
   useDocumentTitle('A local’s picks')
   var { userId } = useParams()
   var navigate = useNavigate()
+  var { user } = useAuth()
   var { items, loading, error } = useLocalListDetail(userId)
+  // True when the logged-in curator is viewing their own published list.
+  // Surfaces an Edit shortcut so they don't have to remember the /my-list URL.
+  var isOwner = !!user && String(user.id) === String(userId)
 
   if (loading) {
     return <div style={PAGE}><div style={GRAIN} /><div style={INNER}><p style={EMPTY}>Loading&hellip;</p></div></div>
@@ -86,7 +104,25 @@ export function LocalsCurator() {
       <div style={INNER}>
         <div style={NAV_ROW}>
           <button type="button" style={CLOSE} onClick={function () { navigate('/locals') }}>&larr; All locals</button>
-          <span style={PAGENO}>the menu</span>
+          {isOwner ? (
+            <button
+              type="button"
+              onClick={function () { navigate('/my-list') }}
+              style={{
+                fontSize: '12px',
+                fontWeight: 700,
+                color: 'var(--color-accent-gold)',
+                background: 'none',
+                border: 'none',
+                padding: 0,
+                cursor: 'pointer',
+              }}
+            >
+              Edit &rarr;
+            </button>
+          ) : (
+            <span style={PAGENO}>the menu</span>
+          )}
         </div>
         <div style={STAMP_TINY}>
           <LocalsPicksStamp seed={11} includeRibbon={false} size={44} />
@@ -116,7 +152,24 @@ export function LocalsCurator() {
                   <button
                     type="button"
                     onClick={function () { navigate('/dish/' + item.dish_id) }}
-                    style={{ background: 'none', border: 'none', padding: 0, font: 'inherit', color: 'inherit', cursor: 'pointer' }}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      padding: 0,
+                      font: 'inherit',
+                      color: 'inherit',
+                      cursor: 'pointer',
+                      // Truncate at the button so very long names ellipsis
+                      // reliably (text-overflow on an outer span isn't
+                      // guaranteed to clip an inline-block child).
+                      display: 'block',
+                      maxWidth: '100%',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      textAlign: 'left',
+                    }}
+                    title={item.dish_name}
                   >
                     {item.dish_name}
                   </button>

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -452,6 +452,47 @@ export function Profile() {
             </div>
           )}
 
+          {/* Local Curator entry — visible only when profile.is_local_curator
+              is true. Routes to /my-list, where the curator manages and
+              saves their Top 10 + bio. Prior to this entry point, curators
+              had no obvious path back from the Profile page — the only
+              way in was the post-invite redirect or the buried "Add to my
+              list" buttons on dish detail pages. */}
+          {profile?.is_local_curator && (
+            <div className="px-4 py-3" style={{ background: 'var(--color-surface)' }}>
+              <Link
+                to="/my-list"
+                className="w-full rounded-2xl p-4 flex items-center gap-4 transition-all hover:scale-[0.99] active:scale-[0.98]"
+                style={{
+                  background: 'var(--color-surface-elevated)',
+                  border: '1px solid var(--color-accent-gold)',
+                  textDecoration: 'none',
+                }}
+              >
+                <div
+                  className="w-12 h-12 rounded-full flex items-center justify-center flex-shrink-0"
+                  style={{ background: 'var(--color-accent-gold)', color: 'var(--color-text-on-primary)' }}
+                  aria-hidden="true"
+                >
+                  <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897L16.862 4.487zM19.5 15.75v3.75a2.25 2.25 0 01-2.25 2.25H6.75a2.25 2.25 0 01-2.25-2.25V8.25A2.25 2.25 0 016.75 6H10.5" />
+                  </svg>
+                </div>
+                <div className="flex-1 text-left">
+                  <h3 className="font-bold" style={{ fontSize: '17px', letterSpacing: '-0.01em', color: 'var(--color-text-primary)' }}>
+                    Edit my Top 10
+                  </h3>
+                  <p style={{ fontSize: '13px', color: 'var(--color-text-secondary)' }}>
+                    Update your list and bio
+                  </p>
+                </div>
+                <svg className="w-5 h-5 flex-shrink-0" style={{ color: 'var(--color-text-tertiary)' }} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+              </Link>
+            </div>
+          )}
+
           {/* Tabs: Journal / Playlists / Saved */}
           <div
             className="flex"


### PR DESCRIPTION
## Summary
Three local-curator surface issues, all reported in one session:

1. **Long dish names overflow** the right edge of \`/locals/:userId\` — rating value clipped off-screen.
2. **Curators can't save their Top 10 / bio** because the manage page (\`/my-list\`) has no discoverable entry point from the Profile.
3. **Curator viewing their own published list** has no way to jump to the edit page.

All three fixed in one PR since they're the same UX surface.

## Fixes

### 1. Truncate overflowing names (\`src/pages/LocalsCurator.jsx\`)
- \`ITEM_HEAD\`: added \`minWidth: 0\` (default flex \`min-width: auto\` blocked shrinking).
- \`ITEM_NAME\`: ellipsis-truncation moved onto the inner \`button\` (text-overflow on an outer \`span\` isn't guaranteed to clip an \`inline-block\` child).
- \`RATING\`: \`flexShrink: 0\` — always visible.
- Hover-title on the button so truncated names still show on long-press.

### 2. \`Edit my Top 10\` card on Profile (\`src/pages/Profile.jsx\`)
Visible only when \`profile.is_local_curator\`. Mirrors the existing \"Unrated Photos\" banner pattern; accent-gold border so it doesn't compete with the coral banner above. Routes to \`/my-list\`.

### 3. \`Edit ->\` link in LocalsCurator nav row (\`src/pages/LocalsCurator.jsx\`)
When the logged-in user IS the curator (\`String(user.id) === String(userId)\`), replace the right-side \"the menu\" label with an \"Edit ->\" link. Non-owners see the existing label unchanged.

## Codex review per fix
- **Fix 1**: codex flagged that \`text-overflow\` on an outer span doesn't reliably clip an inline-block child button — moved truncation styles to the button itself.
- **Fix 2**: codex noted minor UX concern about stacking two high-emphasis cards; accepted with weaker visual weight on the new card (thin border vs gradient).
- **Fix 3**: codex flagged potential string-equality false-negative on \`user.id\` vs \`userId\` from \`useParams\` — switched to \`String(...) === String(...)\` defensive compare.

## Verification
- [x] \`npm run build\` passes
- [x] \`npx eslint\` clean on both files
- [ ] Manual after deploy:
  - Open \`/locals/:someUserId\` for a curator with a long dish name → name should ellipsis, rating still visible.
  - Open Profile on a curator account → \"Edit my Top 10\" card visible above the tabs.
  - Open Profile on a non-curator → card NOT visible.
  - Open \`/locals/:yourOwnUserId\` → \"Edit ->\" link in top right; tapping routes to \`/my-list\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)