### PR TITLE
fix(location): use native @capacitor/geolocation on iOS to stop re-prompting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@capacitor/browser": "^8.0.3",
         "@capacitor/cli": "^8.3.1",
         "@capacitor/core": "^8.3.1",
+        "@capacitor/geolocation": "^8.2.0",
         "@capacitor/ios": "^8.3.1",
         "@capacitor/share": "^8.0.1",
         "@capgo/capacitor-social-login": "^8.3.20",
@@ -1774,6 +1775,18 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@capacitor/geolocation": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/geolocation/-/geolocation-8.2.0.tgz",
+      "integrity": "sha512-N29QcoIPmme0xSxRkm7+3hjoHp6mBAOarxecvtCCZKyOBeKiJsFUq981cezg2XWBa6fhCXJMCCjQPngKK/dIag==",
+      "license": "MIT",
+      "dependencies": {
+        "@capacitor/synapse": "^1.0.4"
+      },
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
     "node_modules/@capacitor/ios": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-8.3.1.tgz",
@@ -1791,6 +1804,12 @@
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
       }
+    },
+    "node_modules/@capacitor/synapse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.4.tgz",
+      "integrity": "sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw==",
+      "license": "ISC"
     },
     "node_modules/@capgo/capacitor-social-login": {
       "version": "8.3.20",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@capacitor/browser": "^8.0.3",
     "@capacitor/cli": "^8.3.1",
     "@capacitor/core": "^8.3.1",
+    "@capacitor/geolocation": "^8.2.0",
     "@capacitor/ios": "^8.3.1",
     "@capacitor/share": "^8.0.1",
     "@capgo/capacitor-social-login": "^8.3.20",

--- a/src/context/LocationContext.jsx
+++ b/src/context/LocationContext.jsx
@@ -1,5 +1,7 @@
 /* eslint-disable react-refresh/only-export-components */
-import { createContext, useContext, useState, useEffect, useCallback } from 'react'
+import { createContext, useContext, useRef, useState, useEffect, useCallback } from 'react'
+import { Capacitor } from '@capacitor/core'
+import { Geolocation } from '@capacitor/geolocation'
 import { capture } from '../lib/analytics'
 import { logger } from '../utils/logger'
 import { getStorageItem, setStorageItem, STORAGE_KEYS } from '../lib/storage'
@@ -10,6 +12,14 @@ const DEFAULT_LOCATION = {
   lat: 41.43,
   lng: -70.56,
 }
+
+// On native iOS (Capacitor WKWebView), browser `navigator.geolocation` does
+// not persist permission grants across cold launches — every app open shows
+// a fresh web-style prompt instead of iOS's native "While Using App" sheet.
+// Routing through @capacitor/geolocation uses CoreLocation: iOS shows the
+// native permission dialog once, persists the choice in Settings forever,
+// and silent reads return cached coordinates without re-prompting.
+const isNative = Capacitor.isNativePlatform()
 
 const LocationContext = createContext(null)
 
@@ -65,7 +75,75 @@ export function LocationProvider({ children }) {
     }
   }, [])
 
-  const requestLocation = useCallback(() => {
+  // Tracks whether the provider is still mounted across awaits — without it,
+  // async native paths can setState() after unmount and log a React warning.
+  const mountedRef = useRef(true)
+  useEffect(() => {
+    mountedRef.current = true
+    return () => { mountedRef.current = false }
+  }, [])
+
+  // Silent fetch — assumes permission is already granted. Never triggers a
+  // permission prompt. Used on mount when checkPermissions() returns granted,
+  // and from inside requestLocation() after explicit consent.
+  const fetchCurrentPositionNative = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const position = await Geolocation.getCurrentPosition({
+        enableHighAccuracy: false,
+        timeout: 5000,
+        maximumAge: 300000,
+      })
+      if (!mountedRef.current) return
+      setLocation({
+        lat: position.coords.latitude,
+        lng: position.coords.longitude,
+      })
+      setPermissionState('granted')
+      setLoading(false)
+    } catch (err) {
+      if (!mountedRef.current) return
+      logger.warn('Native getCurrentPosition error:', err?.message || err)
+      setError('unavailable')
+      setLocation(DEFAULT_LOCATION)
+      setLoading(false)
+    }
+  }, [])
+
+  const requestLocation = useCallback(async () => {
+    if (isNative) {
+      // Marks "we've asked in-app" — UX flag for showing the LocationBanner
+      // CTA differently. iOS itself remembers the OS-level grant in Settings,
+      // independent of this localStorage key.
+      setStorageItem(STORAGE_KEYS.LOCATION_PERMISSION, 'true')
+      setHasAskedBefore(true)
+      setLoading(true)
+      setError(null)
+      try {
+        // requestPermissions() triggers iOS's native "While Using App / Once
+        // / Don't Allow" sheet on first call. Subsequent calls return the
+        // persisted choice without re-prompting.
+        const perm = await Geolocation.requestPermissions({ permissions: ['location'] })
+        if (!mountedRef.current) return
+        if (perm.location === 'denied') {
+          setPermissionState('denied')
+          setError('denied')
+          setLocation(DEFAULT_LOCATION)
+          setLoading(false)
+          return
+        }
+        await fetchCurrentPositionNative()
+      } catch (err) {
+        if (!mountedRef.current) return
+        logger.warn('Native requestPermissions error:', err?.message || err)
+        setError('unavailable')
+        setLocation(DEFAULT_LOCATION)
+        setLoading(false)
+      }
+      return
+    }
+
     if (!navigator.geolocation) {
       setError('Geolocation is not supported by your browser')
       setPermissionState('unsupported')
@@ -80,6 +158,7 @@ export function LocationProvider({ children }) {
 
     navigator.geolocation.getCurrentPosition(
       (position) => {
+        if (!mountedRef.current) return
         setLocation({
           lat: position.coords.latitude,
           lng: position.coords.longitude,
@@ -89,6 +168,7 @@ export function LocationProvider({ children }) {
         setError(null)
       },
       (err) => {
+        if (!mountedRef.current) return
         logger.warn('Geolocation error:', err.message)
         // GeolocationPositionError codes:
         //   1 PERMISSION_DENIED — real denial, don't auto-reprompt.
@@ -114,10 +194,32 @@ export function LocationProvider({ children }) {
         maximumAge: 300000, // Cache for 5 minutes
       }
     )
-  }, [])
+  }, [fetchCurrentPositionNative])
 
   // Check permission state on mount and auto-request location if already granted
   useEffect(() => {
+    if (isNative) {
+      // checkPermissions() NEVER prompts — it only reads cached OS state.
+      // If already granted, fetch position silently (no native dialog).
+      Geolocation.checkPermissions()
+        .then((perm) => {
+          if (!mountedRef.current) return
+          // 'prompt-with-rationale' is an Android-only state; iOS returns
+          // prompt|granted|denied. Normalize to 'prompt' just in case.
+          const normalized = perm.location === 'prompt-with-rationale' ? 'prompt' : perm.location
+          setPermissionState(normalized)
+          if (normalized === 'granted') {
+            // Silent fetch — bypasses requestPermissions() so no dialog fires.
+            fetchCurrentPositionNative()
+          }
+        })
+        .catch((err) => {
+          if (!mountedRef.current) return
+          logger.warn('Native checkPermissions failed:', err?.message || err)
+        })
+      return
+    }
+
     if (!navigator.geolocation) {
       setPermissionState('unsupported')
       return
@@ -157,7 +259,7 @@ export function LocationProvider({ children }) {
         permissionStatus.removeEventListener('change', handlePermissionChange)
       }
     }
-  }, [requestLocation])
+  }, [requestLocation, fetchCurrentPositionNative])
 
   const useDefaultLocation = useCallback(() => {
     setLocation(DEFAULT_LOCATION)


### PR DESCRIPTION
## Summary
Users reported the app prompts for location every cold launch. Root cause: raw `navigator.geolocation` doesn't persist permission grants across WKWebView app launches, and the prompt was a web-style alert instead of iOS's native "While Using App" sheet.

Routes through `@capacitor/geolocation` when running natively. iOS now shows its standard CoreLocation dialog ("While Using App / Once / Don't Allow"), persists the choice in Settings forever, and silent reads return cached coordinates without re-prompting on launch.

PWA / web users keep the existing `navigator.geolocation` path — no behavior change.

## What changed
- New dep: `@capacitor/geolocation`
- `src/context/LocationContext.jsx`:
  - Native branch in `requestLocation()` uses `Geolocation.requestPermissions()` + `Geolocation.getCurrentPosition()`
  - New silent `fetchCurrentPositionNative()` helper used on mount when permission is already granted — bypasses `requestPermissions()` so no dialog fires on launch
  - `mountedRef` guards all async `setState` across native + web paths
  - Web path unchanged

## Codex review pass (gpt-5.3-codex / medium)
- ✅ Mount-path no longer calls `requestPermissions()` (silent fetch only)
- ✅ `mountedRef` guard added across all async paths
- Acceptable: `requestLocation` is now `Promise<void>` — every caller is a click handler that ignores the return value

## Test plan
- [x] `npm run build` clean
- [x] `eslint` clean
- [ ] On simulator / device: first launch shows iOS native "While Using App" dialog (NOT a web-style alert); subsequent launches do NOT re-prompt
- [ ] PWA in Safari still works (web path unchanged)
- [ ] Denying location still falls back to MV default coords

iOS Info.plist `NSLocationWhenInUseUsageDescription` already in place — no native config change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)