### PR TITLE
fix(my-list): lift Save bar above BottomNav so curators can see it

### DIFF
--- a/src/pages/MyList.jsx
+++ b/src/pages/MyList.jsx
@@ -224,7 +224,7 @@ export function MyList() {
   }
 
   return (
-    <div style={{ background: 'var(--color-bg)', minHeight: '100vh', paddingBottom: '100px' }}>
+    <div style={{ background: 'var(--color-bg)', minHeight: '100vh', paddingBottom: 'calc(160px + env(safe-area-inset-bottom, 0px))' }}>
       {/* Header */}
       <div className="px-4 pt-4 pb-2">
         <h1 style={{
@@ -537,18 +537,24 @@ export function MyList() {
         </div>
       )}
 
-      {/* Save button (fixed bottom) */}
+      {/* Save button (fixed bottom).
+          IMPORTANT: this page is wrapped in <Layout>, which renders <BottomNav>
+          at position: fixed; bottom: 0; z-index: 50. Without a vertical offset,
+          this Save bar sits at the same bottom: 0 and same z-index — BottomNav
+          renders last in the DOM, so it visually covers the Save bar entirely.
+          That's why curators previously saw no Save button.
+          Fix: anchor this bar at the top edge of the BottomNav (64px nav height
+          + safe-area-inset-bottom), and bump z-index to 51 as defense in depth. */}
       <div
         style={{
           position: 'fixed',
-          bottom: 0,
+          bottom: 'calc(64px + env(safe-area-inset-bottom, 0px))',
           left: 0,
           right: 0,
           padding: '12px 16px',
-          paddingBottom: 'max(12px, env(safe-area-inset-bottom))',
           background: 'var(--color-bg)',
           borderTop: '1px solid var(--color-divider)',
-          zIndex: 50,
+          zIndex: 51,
         }}
       >
         {saveMessage && (


### PR DESCRIPTION
## Summary
**The real \"I can't save\" bug.** PR #280 added discoverable entry points to \`/my-list\` but didn't fix why curators couldn't see the Save button once they got there.

## Root cause
\`/my-list\` is wrapped in \`<Layout>\`. \`Layout.jsx\` renders \`<BottomNav>\` AFTER \`<main>\`, both at \`position: fixed; bottom: 0; z-index: 50\`. Same z-index → DOM order wins → BottomNav (rendered last) visually **covers** the Save bar entirely.

Dan's screenshot confirmed it: tagline filled, dish #1 added, button should be enabled — but no Save button anywhere on screen because the global tab bar was rendered on top of it.

## Fix
1. Anchor Save bar at the top edge of the BottomNav: \`bottom: 'calc(64px + env(safe-area-inset-bottom, 0px))'\` (matches BottomNav's own height formula).
2. Bump Save bar \`z-index\` 50 → 51 (defense in depth so the DOM-order ambiguity can't cause this again).
3. Bump page root \`paddingBottom\` 100px → \`'calc(160px + env(safe-area-inset-bottom, 0px))'\` so the last dish row in the list clears the lifted Save bar (~70px) sitting above the ~80px BottomNav.

## Verification
- [x] \`npm run build\` passes
- [x] \`npx eslint\` clean
- [ ] Manual after deploy: open \`/my-list\`, type in tagline, confirm Save button appears at the bottom of the screen above the Restaurants/Home/You tab bar; confirm tap saves and the "Saved!" message appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)