### PR TITLE
fix(local-list): pass JSONB array directly to save_my_local_list RPC

### DIFF
--- a/src/api/localListsApi.js
+++ b/src/api/localListsApi.js
@@ -118,9 +118,13 @@ export const localListsApi = {
         validateContentField(item.note, 'Local list note')
       }
 
+      // Supabase JS client serializes JS arrays directly to JSONB. Calling
+      // JSON.stringify() first sends a JSON string, which Postgres receives
+      // as a JSONB scalar — and jsonb_array_length() on a scalar throws
+      // "cannot get array length of a scalar" inside save_my_local_list.
       const { data, error } = await supabase.rpc('save_my_local_list', {
         p_tagline: tagline || null,
-        p_items: JSON.stringify(items),
+        p_items: Array.isArray(items) ? items : [],
       })
       if (error) throw createClassifiedError(error)
       return data


### PR DESCRIPTION
## Summary
User hit **"cannot get array length of a scalar"** clicking *Save & Publish* on the local-list curator page (`My Top 10`).

**Root cause:** `localListsApi.saveMyList` was calling `JSON.stringify(items)` before passing `p_items` to the RPC. `supabase-js` v2 then sends that as a JSON string, which PostgREST types as a JSONB **scalar** (the string), not a JSONB array. The RPC `save_my_local_list` calls `jsonb_array_length(p_items)` on a scalar at `schema.sql:3529` and throws.

**Fix:** pass the raw JS array — `supabase-js` serializes it to JSONB natively. Added `Array.isArray()` guard so a future non-array slip can't silently re-introduce the same shape mismatch.

Codex review confirmed this is the only RPC call site in the codebase doing the bad stringify pattern.

## Test plan
- [x] Codex review (gpt-5.3-codex / medium) confirmed root cause + scanned for similar bad patterns elsewhere — none found
- [x] `eslint` clean
- [ ] Click *Save & Publish* on `/my-list` as a curator — should succeed silently and return success
- [ ] Empty list (no items) still saves correctly (tagline-only update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)