### PR TITLE
feat(local-lists): shareable Local Lists + AI vote cleanup + v1.6 prep

### DIFF
--- a/api/share.ts
+++ b/api/share.ts
@@ -41,7 +41,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   // Validate type against allowlist to prevent open redirect
-  const ALLOWED_TYPES: Record<string, string> = { dish: 'dish', restaurant: 'restaurants' }
+  const ALLOWED_TYPES: Record<string, string> = {
+    dish: 'dish',
+    restaurant: 'restaurants',
+    local_list: 'locals',
+  }
   const routePath = ALLOWED_TYPES[type]
   if (!routePath) {
     return res.redirect(302, '/')
@@ -120,6 +124,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         title = restaurant.name
         description = `See what's good at ${restaurant.name}${restaurant.town ? ' in ' + restaurant.town : ''}`
         imageUrl = `${BASE_URL}/api/og-image?type=restaurant&id=${id}`
+      }
+    } else if (type === 'local_list') {
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('display_name, avatar_url')
+        .eq('id', id)
+        .maybeSingle()
+
+      if (profile) {
+        const name = profile.display_name || 'A local'
+        title = `${name}'s picks on What's Good Here`
+        description = `${name}'s Top 10 dishes on Martha's Vineyard`
+        if (profile.avatar_url) imageUrl = profile.avatar_url
+        else imageUrl = `${BASE_URL}/og-image.png`
       }
     }
   } catch {

--- a/e2e/pioneer/save-local-list.spec.ts
+++ b/e2e/pioneer/save-local-list.spec.ts
@@ -7,9 +7,13 @@ import { test, expect } from '@playwright/test'
 // browser arrives already authenticated. The signed-out test below opts
 // out of that storage state explicitly.
 
-// Before running: set E2E_CURATOR_ID to a real userId that has an active
-// local_list with >=3 items. Find one via Supabase SQL Editor:
-//   SELECT user_id FROM local_lists WHERE is_active = true LIMIT 1;
+// Before running: set E2E_CURATOR_ID to a userId that:
+//   1. has an active local_list with >=3 items
+//   2. is NOT the signed-in pioneer account (else the page shows Edit, not Save)
+//   3. is not blocked by the pioneer account
+// Find a candidate via Supabase SQL Editor:
+//   SELECT user_id FROM local_lists WHERE is_active = true
+//     AND user_id <> '<PIONEER_USER_ID>' LIMIT 1;
 
 test.describe('Save a Local List into my playlists', () => {
   test('signed-in user clones a curator list and lands on the new playlist', async ({ page }) => {

--- a/e2e/pioneer/save-local-list.spec.ts
+++ b/e2e/pioneer/save-local-list.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test'
+
+// Auth model note:
+// Pioneer specs run under the `pioneer-chromium` Playwright project, which
+// applies storageState from e2e/.auth/pioneer.json (produced by
+// e2e/pioneer/auth.setup.js). There is no signInAsFoodie() helper — the
+// browser arrives already authenticated. The signed-out test below opts
+// out of that storage state explicitly.
+
+// Before running: set E2E_CURATOR_ID to a real userId that has an active
+// local_list with >=3 items. Find one via Supabase SQL Editor:
+//   SELECT user_id FROM local_lists WHERE is_active = true LIMIT 1;
+
+test.describe('Save a Local List into my playlists', () => {
+  test('signed-in user clones a curator list and lands on the new playlist', async ({ page }) => {
+    const CURATOR_ID = process.env.E2E_CURATOR_ID
+    test.skip(!CURATOR_ID, 'set E2E_CURATOR_ID env var to a seeded curator with an active list')
+
+    await page.goto(`/locals/${CURATOR_ID}`)
+
+    await expect(page.getByRole('button', { name: /save to my list/i })).toBeVisible()
+
+    await page.getByRole('button', { name: /save to my list/i }).click()
+
+    await expect(page.getByText(/saved \d+ dishes/i)).toBeVisible({ timeout: 5000 })
+    await expect(page).toHaveURL(/\/playlist\/[0-9a-f-]{36}/)
+  })
+
+  test.describe('signed-out', () => {
+    // Opt out of the pioneer project's authenticated storage state.
+    test.use({ storageState: { cookies: [], origins: [] } })
+
+    test('signed-out user is redirected to /login with a return URL', async ({ page }) => {
+      const CURATOR_ID = process.env.E2E_CURATOR_ID
+      test.skip(!CURATOR_ID, 'set E2E_CURATOR_ID env var to a seeded curator with an active list')
+
+      await page.goto(`/locals/${CURATOR_ID}`)
+      await page.getByRole('button', { name: /save to my list/i }).click()
+
+      await expect(page).toHaveURL(/\/login\?next=/)
+      expect(page.url()).toContain(encodeURIComponent(`/locals/${CURATOR_ID}`))
+    })
+  })
+})

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -313,7 +313,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.6;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.whatsgoodhere.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -337,7 +337,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whatsgoodhere.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,105 @@
+{
+  "originHash" : "d3edd4a0cb8c61e1dba49d5567b538c934d806d07c654b3fc521d75db6390285",
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "e938f8c66708e7352fc7e3512647fa54255b267a",
+        "version" : "5.11.2"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "appauth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openid/AppAuth-iOS.git",
+      "state" : {
+        "revision" : "145104f5ea9d58ae21b60add007c33c1cc0c948e",
+        "version" : "2.0.0"
+      }
+    },
+    {
+      "identity" : "capacitor-swift-pm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ionic-team/capacitor-swift-pm.git",
+      "state" : {
+        "revision" : "f1a8fadf1437c23b825c818fb6509c9dbbae2f61",
+        "version" : "8.3.1"
+      }
+    },
+    {
+      "identity" : "facebook-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/facebook/facebook-ios-sdk.git",
+      "state" : {
+        "revision" : "8c90832bf2302d9ecd0d23cb63b81f1fb9a36497",
+        "version" : "18.0.3"
+      }
+    },
+    {
+      "identity" : "googlesignin-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleSignIn-iOS.git",
+      "state" : {
+        "revision" : "913b4005ea26aebe1c97d54e35ad82a515924c71",
+        "version" : "9.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "gtmappauth",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GTMAppAuth.git",
+      "state" : {
+        "revision" : "56e0ccf09a6dd29dc7e68bdf729598240ca8aa16",
+        "version" : "5.0.0"
+      }
+    },
+    {
+      "identity" : "ion-ios-geolocation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ionic-team/ion-ios-geolocation.git",
+      "state" : {
+        "revision" : "db363927d3a954e3ea24d2e72b6e9814769a84be",
+        "version" : "2.1.1"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.3.1"),
         .package(name: "CapacitorApp", path: "../../../node_modules/@capacitor/app"),
         .package(name: "CapacitorBrowser", path: "../../../node_modules/@capacitor/browser"),
+        .package(name: "CapacitorGeolocation", path: "../../../node_modules/@capacitor/geolocation"),
         .package(name: "CapacitorShare", path: "../../../node_modules/@capacitor/share"),
         .package(name: "CapgoCapacitorSocialLogin", path: "../../../node_modules/@capgo/capacitor-social-login")
     ],
@@ -25,6 +26,7 @@ let package = Package(
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
                 .product(name: "CapacitorApp", package: "CapacitorApp"),
                 .product(name: "CapacitorBrowser", package: "CapacitorBrowser"),
+                .product(name: "CapacitorGeolocation", package: "CapacitorGeolocation"),
                 .product(name: "CapacitorShare", package: "CapacitorShare"),
                 .product(name: "CapgoCapacitorSocialLogin", package: "CapgoCapacitorSocialLogin")
             ]

--- a/src/api/userPlaylistsApi.js
+++ b/src/api/userPlaylistsApi.js
@@ -99,6 +99,28 @@ export const userPlaylistsApi = {
     }
   },
 
+  async cloneLocalList(curatorUserId) {
+    if (!curatorUserId) throw contentError('Missing curator')
+    const rl = checkPlaylistCreateRateLimit()
+    if (!rl.allowed) throw rateLimitError(rl.retryAfterMs)
+    try {
+      const { data, error } = await supabase.rpc('clone_local_list_to_playlist', {
+        p_curator_user_id: curatorUserId,
+      })
+      if (error) throw createClassifiedError(error)
+      const row = Array.isArray(data) ? data[0] : data
+      return {
+        playlistId: row?.playlist_id,
+        copiedCount: row?.copied_count ?? 0,
+        slug: row?.slug,
+        title: row?.title,
+      }
+    } catch (error) {
+      logger.error('userPlaylistsApi.cloneLocalList:', error)
+      throw error.type ? error : createClassifiedError(error)
+    }
+  },
+
   async removeDish(playlistId, dishId) {
     try {
       const { error } = await supabase.rpc('remove_dish_from_playlist', {

--- a/src/components/locals/SaveLocalListButton.jsx
+++ b/src/components/locals/SaveLocalListButton.jsx
@@ -1,0 +1,63 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { toast } from 'sonner'
+import { userPlaylistsApi } from '../../api/userPlaylistsApi'
+import { useAuth } from '../../context/AuthContext'
+import { capture } from '../../lib/analytics'
+import { getUserMessage } from '../../utils/errorHandler'
+
+/**
+ * SaveLocalListButton — clone a curator's Local List into the viewer's playlists.
+ * Logged-out viewers are redirected to /login with a return URL.
+ *
+ * Props:
+ *   curatorUserId   - the curator whose list we're saving
+ *   curatorName     - display name (for toast + share text)
+ */
+export function SaveLocalListButton({ curatorUserId, curatorName }) {
+  const { user } = useAuth()
+  const navigate = useNavigate()
+  const [pending, setPending] = useState(false)
+
+  async function handleClick() {
+    if (!user) {
+      navigate('/login?next=' + encodeURIComponent('/locals/' + curatorUserId))
+      return
+    }
+    if (pending) return
+    setPending(true)
+    try {
+      const result = await userPlaylistsApi.cloneLocalList(curatorUserId)
+      capture('local_list_cloned', {
+        curator_id: curatorUserId,
+        copied_count: result.copiedCount,
+      })
+      toast.success('Saved ' + result.copiedCount + ' dishes', { duration: 2500 })
+      navigate('/playlist/' + result.playlistId)
+    } catch (error) {
+      toast.error(getUserMessage(error, 'saving this list'))
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={pending}
+      style={{
+        fontSize: '12px',
+        fontWeight: 700,
+        color: 'var(--color-primary)',
+        background: 'none',
+        border: 'none',
+        padding: 0,
+        cursor: pending ? 'wait' : 'pointer',
+        opacity: pending ? 0.5 : 1,
+      }}
+    >
+      {pending ? 'Saving…' : 'Save to my list'}
+    </button>
+  )
+}

--- a/src/components/locals/ShareLocalListButton.jsx
+++ b/src/components/locals/ShareLocalListButton.jsx
@@ -25,8 +25,12 @@ export function ShareLocalListButton({ curatorUserId, curatorName }) {
       method: result.method,
       success: result.success,
     })
-    if (result.success && result.method !== 'native_capacitor' && result.method !== 'web_share') {
-      toast.success('Link copied!', { duration: 2000 })
+    if (result.method === 'clipboard' || result.method === 'execCommand') {
+      if (result.success) {
+        toast.success('Link copied!', { duration: 2000 })
+      } else {
+        toast.error("Couldn't copy link — please try again", { duration: 3000 })
+      }
     }
   }
 

--- a/src/components/locals/ShareLocalListButton.jsx
+++ b/src/components/locals/ShareLocalListButton.jsx
@@ -1,0 +1,50 @@
+import { toast } from 'sonner'
+import { shareOrCopy, canonicalShareUrl } from '../../utils/share'
+import { capture } from '../../lib/analytics'
+
+/**
+ * ShareLocalListButton — share a curator's Local List URL via OS share sheet
+ * or clipboard fallback. Uses canonicalShareUrl so iOS Capacitor links resolve
+ * to https://wghapp.com instead of the WhatsGoodHere:// scheme.
+ *
+ * Props:
+ *   curatorUserId - the curator whose list we're sharing
+ *   curatorName   - display name for share title/text
+ */
+export function ShareLocalListButton({ curatorUserId, curatorName }) {
+  async function handleClick() {
+    const url = canonicalShareUrl('/locals/' + curatorUserId)
+    const name = curatorName || 'a local'
+    const result = await shareOrCopy({
+      url: url,
+      title: name + "'s picks on What's Good Here",
+      text: 'Check out ' + name + "'s Top 10 dishes on What's Good Here!",
+    })
+    capture('share_local_list', {
+      curator_id: curatorUserId,
+      method: result.method,
+      success: result.success,
+    })
+    if (result.success && result.method !== 'native_capacitor' && result.method !== 'web_share') {
+      toast.success('Link copied!', { duration: 2000 })
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      style={{
+        fontSize: '12px',
+        fontWeight: 700,
+        color: 'var(--color-accent-gold)',
+        background: 'none',
+        border: 'none',
+        padding: 0,
+        cursor: 'pointer',
+      }}
+    >
+      Share
+    </button>
+  )
+}

--- a/src/constants/app.js
+++ b/src/constants/app.js
@@ -1,8 +1,9 @@
 // App-wide constants
 
 // Minimum votes required for a dish to be considered "ranked"
-// Dishes with fewer votes show as "Early" with less prominent display
-export const MIN_VOTES_FOR_RANKING = 5
+// Dishes with fewer votes show as "Early" with less prominent display.
+// Pre-launch / low traffic: 1 (show any rated dish). Bump to 5, then 10 as volume grows.
+export const MIN_VOTES_FOR_RANKING = 1
 
 // Maximum character length for review text
 export const MAX_REVIEW_LENGTH = 200

--- a/src/pages/LocalsCurator.jsx
+++ b/src/pages/LocalsCurator.jsx
@@ -3,6 +3,8 @@ import { useLocalListDetail } from '../hooks/useLocalListDetail'
 import { LocalsPicksStamp } from '../components/home/LocalsPicksStamp'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useAuth } from '../context/AuthContext'
+import { ShareLocalListButton } from '../components/locals/ShareLocalListButton'
+import { SaveLocalListButton } from '../components/locals/SaveLocalListButton'
 
 var PAGE = {
   background: 'linear-gradient(180deg, var(--color-paper-cream-light) 0%, var(--color-paper-cream-dark) 100%)',
@@ -104,25 +106,28 @@ export function LocalsCurator() {
       <div style={INNER}>
         <div style={NAV_ROW}>
           <button type="button" style={CLOSE} onClick={function () { navigate('/locals') }}>&larr; All locals</button>
-          {isOwner ? (
-            <button
-              type="button"
-              onClick={function () { navigate('/my-list') }}
-              style={{
-                fontSize: '12px',
-                fontWeight: 700,
-                color: 'var(--color-accent-gold)',
-                background: 'none',
-                border: 'none',
-                padding: 0,
-                cursor: 'pointer',
-              }}
-            >
-              Edit &rarr;
-            </button>
-          ) : (
-            <span style={PAGENO}>the menu</span>
-          )}
+          <div style={{ display: 'flex', gap: '14px', alignItems: 'center' }}>
+            <ShareLocalListButton curatorUserId={userId} curatorName={first.display_name} />
+            {isOwner ? (
+              <button
+                type="button"
+                onClick={function () { navigate('/my-list') }}
+                style={{
+                  fontSize: '12px',
+                  fontWeight: 700,
+                  color: 'var(--color-accent-gold)',
+                  background: 'none',
+                  border: 'none',
+                  padding: 0,
+                  cursor: 'pointer',
+                }}
+              >
+                Edit &rarr;
+              </button>
+            ) : (
+              <SaveLocalListButton curatorUserId={userId} curatorName={first.display_name} />
+            )}
+          </div>
         </div>
         <div style={STAMP_TINY}>
           <LocalsPicksStamp seed={11} includeRibbon={false} size={44} />

--- a/supabase/migrations/2026-05-27-delete-ai-estimated-votes.sql
+++ b/supabase/migrations/2026-05-27-delete-ai-estimated-votes.sql
@@ -1,0 +1,37 @@
+-- Delete all AI-estimated votes pre-launch
+-- 2026-05-27
+-- Context: Dan decided to nuke seeded ai_estimated votes so the launch app shows real user signal only.
+-- MIN_VOTES_FOR_RANKING also drops from 5 → 1 in src/constants/app.js so dishes with even 1 user vote
+-- still appear ranked in the top 10. Raise back to 5/10 as traffic grows.
+
+-- PREVIEW: what will be deleted
+SELECT
+  COUNT(*) FILTER (WHERE source = 'ai_estimated') AS ai_votes_to_delete,
+  COUNT(*) FILTER (WHERE source = 'user')          AS user_votes_kept,
+  COUNT(DISTINCT dish_id) FILTER (WHERE source = 'ai_estimated') AS dishes_affected
+FROM votes;
+
+-- DELETE: triggers update_dish_avg_rating per row → dishes.avg_rating + total_votes + weighted_vote_count
+-- automatically recompute. No FKs reference votes.id, no cascade risk.
+DELETE FROM votes WHERE source = 'ai_estimated';
+
+-- VERIFY: should show 0 ai_estimated, real user vote count unchanged
+SELECT
+  source,
+  COUNT(*) AS vote_count,
+  COUNT(DISTINCT dish_id) AS dishes
+FROM votes
+GROUP BY source
+ORDER BY source;
+
+-- SANITY: how many dishes still have ≥1 vote (these are the only ones that'll rank now)
+SELECT COUNT(*) AS dishes_with_votes
+FROM dishes
+WHERE total_votes > 0;
+
+-- ROLLBACK: no SQL rollback possible — deleted ai_estimated votes are gone.
+-- Recovery requires re-running the original seed scripts:
+--   supabase/seed/seed-google-reviews.sql
+--   supabase/seed/seed-curated-reviews.sql
+--   supabase/seed/seed-broader-mv.sql
+-- Those scripts are idempotent enough to re-seed cleanly if needed.

--- a/supabase/migrations/2026-05-27-save-local-list-to-playlist.sql
+++ b/supabase/migrations/2026-05-27-save-local-list-to-playlist.sql
@@ -16,7 +16,7 @@ BEGIN
     RAISE EXCEPTION 'Not authenticated' USING ERRCODE = '28000';
   END IF;
   IF v_user = p_curator_user_id THEN
-    RAISE EXCEPTION 'Cannot clone your own list' USING ERRCODE = '22023';
+    RAISE EXCEPTION 'Cannot clone your own list' USING ERRCODE = 'P0001';
   END IF;
   IF is_blocked_pair(v_user, p_curator_user_id) THEN
     RAISE EXCEPTION 'Cannot clone this list' USING ERRCODE = '42501';
@@ -28,6 +28,8 @@ BEGIN
   IF v_curator_name IS NULL THEN
     RAISE EXCEPTION 'Curator not found' USING ERRCODE = 'P0002';
   END IF;
+
+  PERFORM fn_check_content_blocklist(LEFT(v_curator_name || '''s picks', 60), 'Playlist title');
 
   -- Verify the curator has an active list. Defensive: client should already
   -- know this from get_local_list_by_user, but RLS allows arbitrary user IDs.
@@ -48,6 +50,16 @@ BEGIN
   )
   RETURNING * INTO v_new_playlist;
 
+  -- Validate curator-supplied notes against the content blocklist before
+  -- copying. add_dish_to_playlist enforces this on every new note; mirror
+  -- that behavior on clone so the blocklist can be tightened after the fact.
+  PERFORM fn_check_content_blocklist(li.note, 'Note')
+  FROM local_list_items li
+  JOIN local_lists ll ON ll.id = li.list_id
+  WHERE ll.user_id = p_curator_user_id
+    AND ll.is_active = true
+    AND li.note IS NOT NULL;
+
   -- Copy items in curator's order. We renumber positions starting at 1 in case
   -- the curator's list has gaps (constraint is 1..10, so usually 1..N already).
   WITH src AS (
@@ -62,6 +74,10 @@ BEGIN
   FROM src;
 
   GET DIAGNOSTICS v_copied = ROW_COUNT;
+
+  IF v_copied = 0 THEN
+    RAISE EXCEPTION 'Curator has no items to clone' USING ERRCODE = 'P0002';
+  END IF;
 
   RETURN QUERY SELECT v_new_playlist.id, v_copied, v_new_playlist.slug, v_new_playlist.title;
 END;

--- a/supabase/migrations/2026-05-27-save-local-list-to-playlist.sql
+++ b/supabase/migrations/2026-05-27-save-local-list-to-playlist.sql
@@ -25,9 +25,13 @@ BEGIN
   -- Curator's display_name drives the new playlist title.
   SELECT p.display_name INTO v_curator_name
   FROM profiles p WHERE p.id = p_curator_user_id;
-  IF v_curator_name IS NULL THEN
+  IF NOT FOUND THEN
     RAISE EXCEPTION 'Curator not found' USING ERRCODE = 'P0002';
   END IF;
+  -- profiles.display_name is NOT NULL via the handle_new_user trigger
+  -- (eater-XXXX placeholder). Defensive fallback if that invariant ever
+  -- regresses so we don't blow up the recipient flow.
+  v_curator_name := COALESCE(v_curator_name, 'A local');
 
   PERFORM fn_check_content_blocklist(LEFT(v_curator_name || '''s picks', 60), 'Playlist title');
 
@@ -49,6 +53,17 @@ BEGIN
     fn_playlist_slug_from_title(LEFT(v_curator_name || '''s picks', 60), v_user)
   )
   RETURNING * INTO v_new_playlist;
+
+  -- Lock the curator's items for the duration of this transaction so the
+  -- curator can't modify notes between blocklist validation and the items
+  -- copy below. FOR SHARE permits concurrent reads; the curator's own
+  -- update_local_list_items / equivalent path takes a stronger lock and
+  -- will wait for our commit.
+  PERFORM 1
+  FROM local_list_items li
+  JOIN local_lists ll ON ll.id = li.list_id
+  WHERE ll.user_id = p_curator_user_id AND ll.is_active = true
+  FOR SHARE OF li;
 
   -- Validate curator-supplied notes against the content blocklist before
   -- copying. add_dish_to_playlist enforces this on every new note; mirror

--- a/supabase/migrations/2026-05-27-save-local-list-to-playlist.sql
+++ b/supabase/migrations/2026-05-27-save-local-list-to-playlist.sql
@@ -1,0 +1,74 @@
+-- Clone a curator's Local List into the caller's playlists as a new private playlist.
+-- 2026-05-27
+-- Additive only: no schema changes. Single atomic copy avoids 10 round-trips
+-- + per-add rate limits when the recipient clones a full Top 10.
+
+CREATE OR REPLACE FUNCTION clone_local_list_to_playlist(p_curator_user_id UUID)
+RETURNS TABLE (playlist_id UUID, copied_count INT, slug TEXT, title TEXT)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_user UUID := auth.uid();
+  v_curator_name TEXT;
+  v_new_playlist user_playlists;
+  v_copied INT;
+BEGIN
+  IF v_user IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated' USING ERRCODE = '28000';
+  END IF;
+  IF v_user = p_curator_user_id THEN
+    RAISE EXCEPTION 'Cannot clone your own list' USING ERRCODE = '22023';
+  END IF;
+  IF is_blocked_pair(v_user, p_curator_user_id) THEN
+    RAISE EXCEPTION 'Cannot clone this list' USING ERRCODE = '42501';
+  END IF;
+
+  -- Curator's display_name drives the new playlist title.
+  SELECT p.display_name INTO v_curator_name
+  FROM profiles p WHERE p.id = p_curator_user_id;
+  IF v_curator_name IS NULL THEN
+    RAISE EXCEPTION 'Curator not found' USING ERRCODE = 'P0002';
+  END IF;
+
+  -- Verify the curator has an active list. Defensive: client should already
+  -- know this from get_local_list_by_user, but RLS allows arbitrary user IDs.
+  PERFORM 1 FROM local_lists ll
+   WHERE ll.user_id = p_curator_user_id AND ll.is_active = true;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Curator has no active list' USING ERRCODE = 'P0002';
+  END IF;
+
+  -- Create the destination playlist (private by default — recipient can publish later).
+  INSERT INTO user_playlists (user_id, title, description, is_public, slug)
+  VALUES (
+    v_user,
+    LEFT(v_curator_name || '''s picks', 60),
+    'Saved from ' || v_curator_name || '''s Local List',
+    false,
+    fn_playlist_slug_from_title(LEFT(v_curator_name || '''s picks', 60), v_user)
+  )
+  RETURNING * INTO v_new_playlist;
+
+  -- Copy items in curator's order. We renumber positions starting at 1 in case
+  -- the curator's list has gaps (constraint is 1..10, so usually 1..N already).
+  WITH src AS (
+    SELECT li.dish_id, li.note,
+           ROW_NUMBER() OVER (ORDER BY li."position") AS new_pos
+    FROM local_list_items li
+    JOIN local_lists ll ON ll.id = li.list_id
+    WHERE ll.user_id = p_curator_user_id AND ll.is_active = true
+  )
+  INSERT INTO user_playlist_items (playlist_id, dish_id, position, note)
+  SELECT v_new_playlist.id, src.dish_id, src.new_pos, src.note
+  FROM src;
+
+  GET DIAGNOSTICS v_copied = ROW_COUNT;
+
+  RETURN QUERY SELECT v_new_playlist.id, v_copied, v_new_playlist.slug, v_new_playlist.title;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION clone_local_list_to_playlist(UUID) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION clone_local_list_to_playlist(UUID) TO authenticated, service_role;
+
+-- ROLLBACK:
+-- DROP FUNCTION IF EXISTS clone_local_list_to_playlist(UUID);

--- a/supabase/migrations/2026-05-27-save-local-list-to-playlist.sql
+++ b/supabase/migrations/2026-05-27-save-local-list-to-playlist.sql
@@ -54,16 +54,16 @@ BEGIN
   )
   RETURNING * INTO v_new_playlist;
 
-  -- Lock the curator's items for the duration of this transaction so the
-  -- curator can't modify notes between blocklist validation and the items
-  -- copy below. FOR SHARE permits concurrent reads; the curator's own
-  -- update_local_list_items / equivalent path takes a stronger lock and
-  -- will wait for our commit.
+  -- Lock the curator's parent list row AND the existing item rows for the
+  -- duration of this transaction. FOR SHARE OF ll blocks the curator's
+  -- add/replace paths (which take FOR UPDATE on local_lists), so no new
+  -- items can be inserted between blocklist validation and the items copy
+  -- below. FOR SHARE OF li blocks direct UPDATE/DELETE on existing items.
   PERFORM 1
   FROM local_list_items li
   JOIN local_lists ll ON ll.id = li.list_id
   WHERE ll.user_id = p_curator_user_id AND ll.is_active = true
-  FOR SHARE OF li;
+  FOR SHARE OF ll, li;
 
   -- Validate curator-supplied notes against the content blocklist before
   -- copying. add_dish_to_playlist enforces this on every new note; mirror

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -5673,24 +5673,30 @@ BEGIN
     RAISE EXCEPTION 'Not authenticated' USING ERRCODE = '28000';
   END IF;
   IF v_user = p_curator_user_id THEN
-    RAISE EXCEPTION 'Cannot clone your own list' USING ERRCODE = '22023';
+    RAISE EXCEPTION 'Cannot clone your own list' USING ERRCODE = 'P0001';
   END IF;
   IF is_blocked_pair(v_user, p_curator_user_id) THEN
     RAISE EXCEPTION 'Cannot clone this list' USING ERRCODE = '42501';
   END IF;
 
+  -- Curator's display_name drives the new playlist title.
   SELECT p.display_name INTO v_curator_name
   FROM profiles p WHERE p.id = p_curator_user_id;
   IF v_curator_name IS NULL THEN
     RAISE EXCEPTION 'Curator not found' USING ERRCODE = 'P0002';
   END IF;
 
+  PERFORM fn_check_content_blocklist(LEFT(v_curator_name || '''s picks', 60), 'Playlist title');
+
+  -- Verify the curator has an active list. Defensive: client should already
+  -- know this from get_local_list_by_user, but RLS allows arbitrary user IDs.
   PERFORM 1 FROM local_lists ll
    WHERE ll.user_id = p_curator_user_id AND ll.is_active = true;
   IF NOT FOUND THEN
     RAISE EXCEPTION 'Curator has no active list' USING ERRCODE = 'P0002';
   END IF;
 
+  -- Create the destination playlist (private by default — recipient can publish later).
   INSERT INTO user_playlists (user_id, title, description, is_public, slug)
   VALUES (
     v_user,
@@ -5701,6 +5707,18 @@ BEGIN
   )
   RETURNING * INTO v_new_playlist;
 
+  -- Validate curator-supplied notes against the content blocklist before
+  -- copying. add_dish_to_playlist enforces this on every new note; mirror
+  -- that behavior on clone so the blocklist can be tightened after the fact.
+  PERFORM fn_check_content_blocklist(li.note, 'Note')
+  FROM local_list_items li
+  JOIN local_lists ll ON ll.id = li.list_id
+  WHERE ll.user_id = p_curator_user_id
+    AND ll.is_active = true
+    AND li.note IS NOT NULL;
+
+  -- Copy items in curator's order. We renumber positions starting at 1 in case
+  -- the curator's list has gaps (constraint is 1..10, so usually 1..N already).
   WITH src AS (
     SELECT li.dish_id, li.note,
            ROW_NUMBER() OVER (ORDER BY li."position") AS new_pos
@@ -5713,6 +5731,10 @@ BEGIN
   FROM src;
 
   GET DIAGNOSTICS v_copied = ROW_COUNT;
+
+  IF v_copied = 0 THEN
+    RAISE EXCEPTION 'Curator has no items to clone' USING ERRCODE = 'P0002';
+  END IF;
 
   RETURN QUERY SELECT v_new_playlist.id, v_copied, v_new_playlist.slug, v_new_playlist.title;
 END;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -5682,9 +5682,13 @@ BEGIN
   -- Curator's display_name drives the new playlist title.
   SELECT p.display_name INTO v_curator_name
   FROM profiles p WHERE p.id = p_curator_user_id;
-  IF v_curator_name IS NULL THEN
+  IF NOT FOUND THEN
     RAISE EXCEPTION 'Curator not found' USING ERRCODE = 'P0002';
   END IF;
+  -- profiles.display_name is NOT NULL via the handle_new_user trigger
+  -- (eater-XXXX placeholder). Defensive fallback if that invariant ever
+  -- regresses so we don't blow up the recipient flow.
+  v_curator_name := COALESCE(v_curator_name, 'A local');
 
   PERFORM fn_check_content_blocklist(LEFT(v_curator_name || '''s picks', 60), 'Playlist title');
 
@@ -5706,6 +5710,17 @@ BEGIN
     fn_playlist_slug_from_title(LEFT(v_curator_name || '''s picks', 60), v_user)
   )
   RETURNING * INTO v_new_playlist;
+
+  -- Lock the curator's items for the duration of this transaction so the
+  -- curator can't modify notes between blocklist validation and the items
+  -- copy below. FOR SHARE permits concurrent reads; the curator's own
+  -- update_local_list_items / equivalent path takes a stronger lock and
+  -- will wait for our commit.
+  PERFORM 1
+  FROM local_list_items li
+  JOIN local_lists ll ON ll.id = li.list_id
+  WHERE ll.user_id = p_curator_user_id AND ll.is_active = true
+  FOR SHARE OF li;
 
   -- Validate curator-supplied notes against the content blocklist before
   -- copying. add_dish_to_playlist enforces this on every new note; mirror

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -5660,6 +5660,67 @@ LANGUAGE SQL STABLE AS $$
 $$;
 GRANT EXECUTE ON FUNCTION get_local_list_by_user(UUID) TO anon, authenticated;
 
+CREATE OR REPLACE FUNCTION clone_local_list_to_playlist(p_curator_user_id UUID)
+RETURNS TABLE (playlist_id UUID, copied_count INT, slug TEXT, title TEXT)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_user UUID := auth.uid();
+  v_curator_name TEXT;
+  v_new_playlist user_playlists;
+  v_copied INT;
+BEGIN
+  IF v_user IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated' USING ERRCODE = '28000';
+  END IF;
+  IF v_user = p_curator_user_id THEN
+    RAISE EXCEPTION 'Cannot clone your own list' USING ERRCODE = '22023';
+  END IF;
+  IF is_blocked_pair(v_user, p_curator_user_id) THEN
+    RAISE EXCEPTION 'Cannot clone this list' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT p.display_name INTO v_curator_name
+  FROM profiles p WHERE p.id = p_curator_user_id;
+  IF v_curator_name IS NULL THEN
+    RAISE EXCEPTION 'Curator not found' USING ERRCODE = 'P0002';
+  END IF;
+
+  PERFORM 1 FROM local_lists ll
+   WHERE ll.user_id = p_curator_user_id AND ll.is_active = true;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Curator has no active list' USING ERRCODE = 'P0002';
+  END IF;
+
+  INSERT INTO user_playlists (user_id, title, description, is_public, slug)
+  VALUES (
+    v_user,
+    LEFT(v_curator_name || '''s picks', 60),
+    'Saved from ' || v_curator_name || '''s Local List',
+    false,
+    fn_playlist_slug_from_title(LEFT(v_curator_name || '''s picks', 60), v_user)
+  )
+  RETURNING * INTO v_new_playlist;
+
+  WITH src AS (
+    SELECT li.dish_id, li.note,
+           ROW_NUMBER() OVER (ORDER BY li."position") AS new_pos
+    FROM local_list_items li
+    JOIN local_lists ll ON ll.id = li.list_id
+    WHERE ll.user_id = p_curator_user_id AND ll.is_active = true
+  )
+  INSERT INTO user_playlist_items (playlist_id, dish_id, position, note)
+  SELECT v_new_playlist.id, src.dish_id, src.new_pos, src.note
+  FROM src;
+
+  GET DIAGNOSTICS v_copied = ROW_COUNT;
+
+  RETURN QUERY SELECT v_new_playlist.id, v_copied, v_new_playlist.slug, v_new_playlist.title;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION clone_local_list_to_playlist(UUID) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION clone_local_list_to_playlist(UUID) TO authenticated, service_role;
+
 
 -- get_ranked_dishes — only best_photos CTE changes. Full final body lives in
 -- supabase/migrations/20260415_h3_ugc_reporting_blocking.sql since the

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -5711,16 +5711,16 @@ BEGIN
   )
   RETURNING * INTO v_new_playlist;
 
-  -- Lock the curator's items for the duration of this transaction so the
-  -- curator can't modify notes between blocklist validation and the items
-  -- copy below. FOR SHARE permits concurrent reads; the curator's own
-  -- update_local_list_items / equivalent path takes a stronger lock and
-  -- will wait for our commit.
+  -- Lock the curator's parent list row AND the existing item rows for the
+  -- duration of this transaction. FOR SHARE OF ll blocks the curator's
+  -- add/replace paths (which take FOR UPDATE on local_lists), so no new
+  -- items can be inserted between blocklist validation and the items copy
+  -- below. FOR SHARE OF li blocks direct UPDATE/DELETE on existing items.
   PERFORM 1
   FROM local_list_items li
   JOIN local_lists ll ON ll.id = li.list_id
   WHERE ll.user_id = p_curator_user_id AND ll.is_active = true
-  FOR SHARE OF li;
+  FOR SHARE OF ll, li;
 
   -- Validate curator-supplied notes against the content blocklist before
   -- copying. add_dish_to_playlist enforces this on every new note; mirror

--- a/supabase/seed/data/menus/larsens-fish-market-full-menu.sql
+++ b/supabase/seed/data/menus/larsens-fish-market-full-menu.sql
@@ -1,0 +1,49 @@
+-- Larsen's Fish Market - Full Menu (kitchen / prepared items only)
+-- Source: larsensfishmarket.com/our-menu
+-- Note: Larsen's is a market — all items are market price (price = NULL).
+-- Skips raw fish/shellfish counter (whole striped bass, scallops by the pound, etc.) —
+-- those aren't "dishes" people rate on WGH.
+-- Run this in Supabase SQL Editor
+
+-- Delete old dishes
+DELETE FROM dishes
+WHERE restaurant_id = (SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market');
+
+-- Insert prepared menu (21 items)
+INSERT INTO dishes (restaurant_id, name, category, menu_section, price) VALUES
+-- Cooked to Order
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Whole Lobster', 'lobster', 'Cooked to Order', NULL),
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Clam Chowder', 'chowder', 'Cooked to Order', NULL),
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Lobster Bisque', 'soup', 'Cooked to Order', NULL),
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Stuffed Quahogs', 'apps', 'Cooked to Order', NULL),
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Stuffed Scallops', 'scallops', 'Cooked to Order', NULL),
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Crab Cakes', 'crab', 'Cooked to Order', NULL),
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Steamers', 'clams', 'Cooked to Order', NULL),
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Mussels', 'mussels', 'Cooked to Order', NULL),
+
+-- Raw Bar
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Oysters on the Half Shell', 'apps', 'Raw Bar', NULL),
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Littlenecks on the Half Shell', 'apps', 'Raw Bar', NULL),
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Cherrystones on the Half Shell', 'apps', 'Raw Bar', NULL),
+
+-- In the Cooler
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Warm Lobster Roll', 'lobster roll', 'In the Cooler', NULL),
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Cold Lobster Salad Roll', 'lobster roll', 'In the Cooler', NULL),
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Shrimp Cocktail', 'shrimp', 'In the Cooler', NULL),
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Seafood Spread', 'apps', 'In the Cooler', NULL),
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Smoked Bluefish Spread', 'apps', 'In the Cooler', NULL),
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Smoked Tuna Spread', 'apps', 'In the Cooler', NULL),
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Seaweed Salad', 'salad', 'In the Cooler', NULL),
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Pesto Tortellini Salad', 'salad', 'In the Cooler', NULL),
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Asian Noodle Salad', 'salad', 'In the Cooler', NULL),
+((SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market'), 'Smoked Whitefish Salad', 'salad', 'In the Cooler', NULL);
+
+-- Update menu_section_order to match Larsen's actual menu layout
+UPDATE restaurants
+SET menu_section_order = ARRAY['Cooked to Order', 'Raw Bar', 'In the Cooler']
+WHERE name = 'Larsen''s Fish Market';
+
+-- Verify import
+SELECT COUNT(*) as dish_count
+FROM dishes
+WHERE restaurant_id = (SELECT id FROM restaurants WHERE name = 'Larsen''s Fish Market');

--- a/vercel.json
+++ b/vercel.json
@@ -18,6 +18,11 @@
       "has": [{ "type": "header", "key": "user-agent", "value": "(?i).*(facebookexternalhit|Facebot|Twitterbot|LinkedInBot|WhatsApp|Slackbot|Discordbot|TelegramBot|Applebot|Pinterestbot|redditbot|Googlebot|bingbot|Embedly|vkShare).*" }],
       "destination": "/api/share?type=restaurant&id=:id"
     },
+    {
+      "source": "/locals/:id",
+      "has": [{ "type": "header", "key": "user-agent", "value": "(?i).*(facebookexternalhit|Facebot|Twitterbot|LinkedInBot|WhatsApp|Slackbot|Discordbot|TelegramBot|Applebot|Pinterestbot|redditbot|Googlebot|bingbot|Embedly|vkShare).*" }],
+      "destination": "/api/share?type=local_list&id=:id"
+    },
     { "source": "/logo-concepts.html", "destination": "/logo-concepts.html" },
     { "source": "/profile-redesign.html", "destination": "/profile-redesign.html" },
     { "source": "/profile-soul.html", "destination": "/profile-soul.html" },


### PR DESCRIPTION
## Summary

Three bundles of work for the v1.6 cut:

**1. Shareable Local Lists (the headline feature)**
- New `clone_local_list_to_playlist` Postgres RPC — atomically copies a curator's Top 10 into the recipient's private playlist. SECURITY DEFINER with manual auth/blocked-pair gates, empty-clone guard, content-blocklist re-validation on cloned notes + derived title, and `FOR SHARE OF ll, li` lock to close the TOCTOU race against concurrent curator edits.
- `cloneLocalList` API method on `userPlaylistsApi` with rate limiting + camelCase normalization.
- `SaveLocalListButton` — auth-gated; signed-out → `/login?next=...`, signed-in → toast + nav to `/playlist/:id`.
- `ShareLocalListButton` — wraps `shareOrCopy` + `canonicalShareUrl('/locals/:userId')` so iOS share sheet gets a wghapp.com URL. Toasts on copy success AND failure.
- Wired into `LocalsCurator.jsx`: owner sees Share + Edit, visitor sees Share + Save.
- OG preview pipeline extended — `api/share.ts` `local_list` branch + `vercel.json` bot rewrite. iMessage/Slack/Twitter previews render the curator's name + avatar.
- Playwright E2E spec (skip-when-env-missing) for the save flow.

**2. Pre-launch data cleanup**
- Deleted all `ai_estimated` votes — production now shows only real user signal (37 dishes with user votes).
- `MIN_VOTES_FOR_RANKING` dropped 5 → 1 so any dish with ≥1 real vote ranks. Ratchets back up as traffic grows.
- Larsen's Fish Market — 21 kitchen-menu dishes seeded (NULL prices, market-price spot).

**3. iOS v1.6 prep**
- `MARKETING_VERSION` 1.5 → 1.6.
- Wired `CapacitorGeolocation` into Package.swift (finishes the iOS side of PR #281) + checked in `Package.resolved`.

## Review pipeline

Every change went through three gates: a spec-compliance subagent, a code-quality subagent, and a codex peer review. Task 1 specifically went through 4 fix rounds addressing real issues codex caught — TOCTOU race, lock-scope (item-only vs parent list row), empty-clone artifact, NULL `display_name` conflation.

## Test plan

- [ ] RPC smoke from Supabase SQL Editor returns correct `copied_count` + private playlist
- [ ] Logged-in user taps Save → toast + navigates to `/playlist/:id`
- [ ] Logged-out user taps Save → `/login?next=/locals/:id`
- [ ] Tap Share on iOS → native share sheet with wghapp.com URL
- [ ] Tap Share on web → "Link copied!" toast
- [ ] `curl -A facebookexternalhit /locals/:id` returns OG meta tags with curator name + avatar
- [ ] iOS v1.6 builds in Xcode + geolocation no longer re-prompts

## Migration

`supabase/migrations/2026-05-27-save-local-list-to-playlist.sql` needs to run in Supabase SQL Editor against the production project (vpioftosgdkyiwvhxewy). The migration that wiped AI votes (`2026-05-27-delete-ai-estimated-votes.sql`) already ran live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)