### PR TITLE
fix(deep-links): route Universal Links into the SPA + number Local List Top 10

### DIFF
--- a/src/components/Auth/AuthLifecycle.jsx
+++ b/src/components/Auth/AuthLifecycle.jsx
@@ -46,7 +46,33 @@ export function AuthLifecycle() {
 
       urlHandle = await App.addListener('appUrlOpen', async ({ url }) => {
         const parsed = parseAuthUrl(url)
-        if (!parsed) return // not an auth URL — leave it to the router / other handlers
+        if (!parsed) {
+          // Non-auth Universal Link: iOS launched (or foregrounded) the app
+          // via apple-app-site-association after the user tapped a wghapp.com
+          // link in iMessage / Mail / Safari. Without explicit navigation here,
+          // React Router stays on whatever route was last loaded (home on cold
+          // launch), so every shared /dish, /restaurants, /locals link looks
+          // broken. Custom-scheme URLs (WhatsGoodHere://) are auth-only and
+          // already handled above; only forward http(s) Universal Links.
+          try {
+            const u = new URL(url)
+            if (u.protocol === 'https:' || u.protocol === 'http:') {
+              // Strip extra leading slashes so a malformed link like
+              // https://wghapp.com//evil.com can't masquerade as an external
+              // path; React Router will then 404 cleanly on the bogus route.
+              const path = '/' + (u.pathname || '/').replace(/^\/+/, '')
+              const target = path + (u.search || '') + (u.hash || '')
+              if (target && target !== '/') {
+                // replace: true so the deep link doesn't leave '/' in the
+                // history stack underneath a cold-launched destination.
+                navigate(target, { replace: true })
+              }
+            }
+          } catch (err) {
+            logger.warn('AuthLifecycle non-auth deep link parse failed', err)
+          }
+          return
+        }
         const { code, type } = parsed
         if (inFlightCodes.has(code)) return // duplicate event for the same code
         inFlightCodes.add(code)

--- a/src/pages/LocalsCurator.jsx
+++ b/src/pages/LocalsCurator.jsx
@@ -59,6 +59,15 @@ var ITEM = { marginBottom: '11px', padding: '0 2px' }
 // below their intrinsic width (default flex min-width is 'auto'); without it,
 // long dish names push past the right edge and the rating clips off-screen.
 var ITEM_HEAD = { display: 'flex', alignItems: 'baseline', gap: '6px', marginBottom: '1px', minWidth: 0 }
+var RANK = {
+  fontFamily: "'Amatic SC', cursive",
+  fontWeight: 700,
+  fontSize: '22px',
+  lineHeight: 1,
+  color: 'var(--color-accent-gold)',
+  flexShrink: 0,
+  minWidth: '22px',
+}
 // overflow + ellipsis on the name span keeps the newspaper-list look (rating
 // stays right-aligned, dotted leader still connects) even for very long names.
 var ITEM_NAME = {
@@ -149,10 +158,11 @@ export function LocalsCurator() {
         <h1 style={TITLE}>{first.display_name || 'Anonymous'}</h1>
         <div style={BYLINE}>{first.description || (first.title || '')}</div>
 
-        {items.map(function (item) {
+        {items.map(function (item, idx) {
           return (
             <div key={item.dish_id} style={ITEM}>
               <div style={ITEM_HEAD}>
+                <span style={RANK}>{idx + 1}.</span>
                 <span style={ITEM_NAME}>
                   <button
                     type="button"


### PR DESCRIPTION
## Summary

Two bugs Dan caught from his phone, one shared root cause: shared `wghapp.com` links were broken end-to-end.

- **Universal Link routing** — Denis shared `https://wghapp.com/locals/<id>` over iMessage; tapping it launched the iOS app on the homepage instead of the curator page. Root cause: `AuthLifecycle.appUrlOpen` early-returned on any non-auth URL, and there was no fallback handler. `apple-app-site-association` advertises the app as handler for `/dish/*`, `/restaurants/*`, `/locals/*`, `/user/*`, `/playlist/*`, `/my-list` — but every one of those was silently dropping. Now non-auth `http(s)` URLs forward to React Router via `navigate(target, { replace: true })`, with leading-slash normalization to keep paths canonical.
- **Top 10 numbering** — `LocalsCurator` rendered the curator's Top 10 as a newspaper list with dotted leaders but no rank numbers. Added an Amatic SC rank prefix in `--color-accent-gold` sized to keep `9.` → `10.` from shifting layout. ITEM_NAME ellipsis on long dish names still engages.

## Review trail

- Each diff reviewed individually through Codex CLI (`gpt-5.3-codex` / medium), sequential not parallel, per the per-fix-codex rule.
- Codex caught the missing `{ replace: true }` (cold-launched deep link was leaving `/` in history) and flagged the `//evil.com` malformed-path edge case. Both addressed before commit.
- Codex on Fix 2: no blocking issues; ellipsis/baseline/access checks all clean.

## Out of scope (intentional)

- **Friend's `capacitor://localhost/dish/...` link.** That's an old-build artifact predating PR #279 (`canonicalShareUrl`). Her install needs to update; no patch helps her existing share message. All builds post-#279 already produce canonical `https://wghapp.com/...` URLs, and this PR makes those URLs actually navigate inside the app.
- **Cold-start URL race.** Pre-existing assumption (auth flow already depends on Capacitor buffering `appUrlOpen` until the listener attaches). Not introduced by this diff; not fixed by this diff.

## Test plan

- [ ] Web: visit `https://wghapp.com/locals/<curator-id>` — page loads with numbered Top 10 (1. through N.)
- [ ] iOS (after next Capacitor sync + TestFlight build):
  - [ ] Cold launch via tap on `https://wghapp.com/locals/<id>` in iMessage → opens curator page, NOT home
  - [ ] Cold launch via tap on `https://wghapp.com/dish/<id>` → opens dish detail
  - [ ] Cold launch via tap on `https://wghapp.com/restaurants/<id>` → opens restaurant detail
  - [ ] SIWA / magic-link auth callback still routes through `parseAuthUrl` (regression check)
  - [ ] After deep-link nav, swiping back doesn't return to a phantom `/` underneath
- [ ] LocalsCurator rank rendering:
  - [ ] Single-digit (1.–9.) and double-digit (10.) both render without layout shift
  - [ ] Long dish name still truncates with ellipsis; rating stays right-anchored

🤖 Generated with [Claude Code](https://claude.com/claude-code)