### PR TITLE
chore(ios): cut v1.8 — Universal Link deep-routing on iOS

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -305,7 +305,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = K447QTHBR9;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
@@ -313,7 +313,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7;
+				MARKETING_VERSION = 1.8;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.whatsgoodhere.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -329,7 +329,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = K447QTHBR9;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
@@ -337,7 +337,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7;
+				MARKETING_VERSION = 1.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whatsgoodhere.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";


### PR DESCRIPTION
## Summary

Bumps iOS to **v1.8 (build 3)** so PR #288's Universal Link routing fix actually reaches phones. v1.7 (currently in App Store) silently drops every shared `/dish`, `/restaurants`, `/locals` link; v1.8 forwards them to React Router on cold launch.

Diff is just `MARKETING_VERSION 1.7 → 1.8` and `CURRENT_PROJECT_VERSION 2 → 3` in `project.pbxproj`. `ios/App/App/public/` is gitignored — `npm run cap:sync` runs locally on the build box.

## What's in v1.8

From `main` since v1.7:
- **PR #288** — Universal Link deep-routing (fixes shared list/dish/restaurant links opening on home) + Local List Top 10 numbered

## Next steps (manual — Xcode required)

After merging this PR:
1. `npm run cap:sync` on the build box
2. Open Xcode: `npm run cap:open:ios`
3. Select **Any iOS Device (arm64)** scheme + **Release** config
4. Product → Archive
5. Distribute App → App Store Connect → Upload
6. App Store Connect: create v1.8 release, attach build 3, fill in "What's New"
7. Submit for review

## Test plan (post-release, on TestFlight or App Store install)

- [ ] Cold launch via tap on `https://wghapp.com/locals/<id>` from iMessage → opens curator page (NOT homepage)
- [ ] Cold launch via tap on `https://wghapp.com/dish/<id>` → opens dish detail
- [ ] Cold launch via tap on `https://wghapp.com/restaurants/<id>` → opens restaurant detail
- [ ] Swipe-back from a deep-linked page does NOT land on a phantom `/` underneath (the replace:true contract)
- [ ] SIWA + magic-link auth callback still routes through `parseAuthUrl` (regression)
- [ ] LocalsCurator shows numbered Top 10 (single + double digit don't shift layout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)