### PR TITLE
feat(menu-refresh): BentoBox JSON-LD adapter, confidence gate, conservas curation, menu groups

### DIFF
--- a/docs/superpowers/plans/2026-05-31-auto-menu-groups.md
+++ b/docs/superpowers/plans/2026-05-31-auto-menu-groups.md
@@ -1,0 +1,121 @@
+# Auto Menu Groups (pills) from menu-refresh
+
+**Date:** 2026-05-31
+**Status:** Design approved (decisions locked below); implementation pending
+**Context:** Saltie Girl (BentoBox) and Nancy's (manual) both want multiple menu "pills"
+(Saltie: All Day vs Brunch; Nancy's: Snack Bar vs Upstairs). Today only Nancy's has pills,
+set by hand. We want menu-refresh to create pills automatically when the source clearly
+provides distinct menus — without over-pilling or clobbering manual setups.
+
+## Data model (already exists)
+- `restaurants.menu_group_order TEXT[]` — ordered pill labels. `>= 2` ⇒ the restaurant page
+  shows pills (plus a pooled "Top Rated" tab). `RestaurantDetail.jsx` keys off this.
+- `dishes.menu_group TEXT` — which pill a dish belongs to. `NULL` ⇒ shows in the first pill.
+- `dishes.menu_section TEXT` — section within a pill (already populated by the extractor).
+
+## Decisions (locked)
+1. **Only auto-group from STRUCTURED sources.** Don't ask Sonnet to guess "separate menus vs
+   sections" from flat HTML/PDF — too unreliable.
+   - **BentoBox JSON-LD** — each tab is a named `@type:Menu` object (All Day, Brunch, Caviar,
+     Cocktails, Dessert, Tin List). Deterministic. **Phase 1.**
+   - **Sub-page menus** — menu-refresh already crawls `/brunch`, `/dinner`, `/lunch`; the
+     slug/page-title names the group. **Phase 2.**
+   - Everything else stays single-menu (current behavior), `menu_group = NULL`.
+2. **Pill rule = HYBRID (main food menu + named meal-service/venue pills).** We tried two
+   rejected approaches first: a service/venue name allow-list (too arbitrary, missed
+   idiosyncratic names) and a pure structural "substantial multi-section menu" rule. A corpus
+   scan of all 23 BentoBox sites proved the structural rule **over-pills badly** — drink lists
+   (Wine, Cocktails, Beverages) and course-tabs (Antipasti, Entrees, Dessert) are multi-section
+   too, so Capo got 6 pills incl. Wine/Cocktails. The hybrid that survived:
+   - **Main group** = the largest FOOD menu (named, non-drink, non-retail), whatever it's called
+     (All Day, Menu, Dinner, Luncheons…).
+   - **Extra pill** = a food menu whose name denotes a distinct meal service or venue
+     (`MEAL_VENUE_PATTERN`: breakfast, brunch, lunch, dinner, supper, happy hour, late night,
+     upstairs, downstairs, patio, rooftop). NOT raw/oyster bar (those are sections).
+   - **Fold into main** (NOT pills): drink menus (`DRINK_MENU_PATTERN`: wine/beer/cocktails/
+     libations/beverages/drinks/cider…), retail/conservas (`RETAIL_MENU_PATTERN`), and
+     course-tabs (Antipasti/Entrees/Dessert and anything else not meal/venue-named).
+   - **≥2 groups required** or it stays flat.
+   - Validated on the real corpus: 17/23 flat, 6/23 pill — all genuine meal splits (Saltie
+     All Day/Brunch; Loco Brunch/Lunch/Dinner/Late Night/Happy Hour; Lincoln's weekday/weekend),
+     zero drink or course pills. `MEAL_VENUE_PATTERN` / `DRINK_MENU_PATTERN` are the tunable knobs.
+   - Saltie → pills `[All Day, Brunch]`; Caviar/Cocktails/Dessert fold into All Day as sections.
+     (Tin List already dropped by the conservas rule.)
+3. **The "main" group.** When ≥1 pill-worthy menu exists, all non-pill menus collapse into one
+   default group named after the largest non-pill menu (Saltie: "All Day"; fallback label
+   "Menu"). `menu_group_order = [mainName, ...pillNames]`.
+4. **Only create pills when ≥2 groups result.** Single-group extractions leave `menu_group`
+   NULL and DON'T touch `menu_group_order` — preserves today's behavior for the ~150 normal
+   restaurants.
+5. **Never clobber a manual grouping.** If an extraction yields NO groups but the restaurant
+   already has `menu_group_order` set (e.g. Nancy's, sourced non-BentoBox), the upsert must
+   PRESERVE existing `menu_group` values instead of nulling them. Guard: only write
+   `menu_group` (incl. NULL) when the current extraction actually produced group labels.
+   Consider a `restaurants.menu_groups_locked BOOLEAN` for hand-curated cases.
+
+## Architecture
+The product logic (pill rule) lives in **code** (testable); Sonnet only propagates labels.
+
+1. **Adapter computes groups** (`bentobox.ts`): each parsed item already carries its source
+   Menu name. Apply the pill rule → assign every item a `group` (pill name or the main label).
+   Dedup across menus by (group? no —) by (name, section): shared items (towers, crudo) resolve
+   to the FIRST menu encountered; iterate main-menu-first so shared items land in the main group
+   and the Brunch pill shows only brunch-exclusive items. (Matches one-group-per-dish; the
+   pooled "Top Rated" tab still shows everything.)
+2. **Serialize with GROUP markers**:
+   ```
+   GROUP: All Day
+   SECTION: Starters
+   - ...
+   GROUP: Brunch
+   SECTION: Brunch Specials
+   - ...
+   ```
+3. **Sonnet propagates** (`MENU_EXTRACTION_PROMPT` + schema): "Lines `GROUP: X` assign every
+   following dish to menu_group X until the next GROUP marker. Output `menu_group` per dish, or
+   `null` if the menu has no GROUP markers." Sonnet still does category/section/price/dietary —
+   it just carries the group label through. (Keeps product logic out of the prompt.)
+4. **upsertDishes writes `menu_group`** (new field, same pattern as menu_section).
+5. **Handler sets `menu_group_order`** from the distinct groups in extraction order, but only
+   when ≥2 groups exist (decision 4) and respecting the no-clobber guard (decision 5).
+
+## Schema / pipeline changes
+- `dishes.menu_group` — already exists. No migration.
+- `MENU_EXTRACTION_PROMPT` — add the GROUP-marker rule + `menu_group` to the output schema.
+- `extractMenuWithClaude` validate/map — pass `menu_group` through (default null).
+- `bentobox.ts` — `BentoMenuItem.group`; pill-rule helper `classifyMenuGroups(menuNames)`;
+  group-aware serialize; main-menu-first dedup ordering.
+- `upsertDishes` — include `menu_group` in insert/update.
+- Handler — compute + set `menu_group_order` (guarded); no-clobber on group-less extractions.
+- Bump `CURRENT_EXTRACTOR_FINGERPRINT` (`|menu-groups-v1`).
+
+## Phasing
+- **Phase 1 — BentoBox.** Covers Saltie now + the other 22 BentoBox sites as they refresh.
+  Deterministic, lowest risk. Ship + re-extract Saltie → verify `[All Day, Brunch]` pills.
+- **Phase 2 — Sub-page menus.** Name groups from sub-page slug/title; reuse the same pill rule
+  + Sonnet propagation. Larger blast radius; do after Phase 1 proves out.
+
+## Risks / edge cases
+- **Over-pilling** — mitigated by the service/venue allow-list (decision 2). Revisit the list
+  as real menus surface odd names.
+- **Shared-item placement** — towers/crudo land in the main group, not Brunch. Acceptable;
+  Top Rated pools everything. Document so it's not mistaken for a bug.
+- **Nancy's clobber** — decision 5 guard. Verify Nancy's stays `[Snack Bar, Upstairs]` after a
+  refresh (her source yields no BentoBox groups).
+- **Sonnet drops the GROUP label** — validate post-extraction; if a dish has a section that
+  belongs to a known group but `menu_group` is null, backfill from the section→group map the
+  adapter already knows.
+- **Prompt regression** — adding a field can shift other outputs; validate against real menus
+  (Saltie + a single-menu control) per the "validate prompts against real data" rule.
+- **Stale `menu_group_order` (known Phase-1 limitation)** — `menu_group_order` is only *set*
+  (when ≥2 groups), never *cleared*. If a BentoBox restaurant that had auto-pills later drops
+  a menu (e.g. stops brunch), the old pills persist. We can't safely auto-clear because that
+  same code path can't distinguish an auto-grouped restaurant from a manually-grouped one
+  (Nancy's) without a `menu_groups_locked` flag. Deferred to Phase 2 (add the flag, then
+  unlocked restaurants get full set/clear ownership). For now: rare, cosmetic, fixable by hand.
+
+## Verification
+- Saltie → `menu_group_order = [All Day, Brunch]`; Brunch pill = brunch-exclusive dishes;
+  no tinned items; cocktails/dessert/caviar appear as sections under All Day.
+- A normal single-menu restaurant re-extracts unchanged (`menu_group` NULL, no pills).
+- Nancy's untouched after a refresh.

--- a/supabase/functions/menu-refresh/bentobox.test.ts
+++ b/supabase/functions/menu-refresh/bentobox.test.ts
@@ -1,0 +1,312 @@
+import { assertEquals } from 'https://deno.land/std@0.177.0/testing/asserts.ts'
+import {
+  detectBentoBox,
+  parseSchemaOrgMenuItems,
+  findBentoMenuTabUrls,
+  dedupeBentoItems,
+  serializeBentoItems,
+  buildBentoBoxMenuText,
+  classifyMenuGroups,
+  type BentoMenuItem,
+} from './bentobox.ts'
+
+const menu = (name: string, itemCount: number) => ({ name, itemCount })
+
+const item = (o: Partial<BentoMenuItem> & { name: string; section: string }): BentoMenuItem => ({
+  price: null, description: null, sourceMenu: '', ...o,
+})
+
+const MENU_LD = (sections: string) =>
+  `<html><head>
+   <script type="application/ld+json">
+   {"@context":"https://schema.org","@type":"Menu","hasMenuSection":[${sections}]}
+   </script></head><body>shell</body></html>`
+
+Deno.test('detectBentoBox matches getbento hosts', () => {
+  assertEquals(detectBentoBox('<script src="https://theme-assets.getbento.com/x/bentobox.min.js"></script>'), true)
+  assertEquals(detectBentoBox('<img src="https://images.getbento.com/accounts/abc.png">'), true)
+  assertEquals(detectBentoBox('<html>plain squarespace site</html>'), false)
+})
+
+Deno.test('parseSchemaOrgMenuItems pulls name + price + description', () => {
+  const html = MENU_LD(`
+    {"@type":"MenuSection","name":"Starters","hasMenuItem":[
+      {"@type":"MenuItem","name":"Clam Chowder","description":"potato, bacon","offers":{"@type":"Offer","price":"14.00"}},
+      {"@type":"MenuItem","name":"Crispy Clams","offers":{"price":"MKT"}}
+    ]}
+  `)
+  const items = parseSchemaOrgMenuItems(html)
+  assertEquals(items.length, 2)
+  assertEquals(items[0], { section: 'Starters', name: 'Clam Chowder', price: 14, description: 'potato, bacon', sourceMenu: '' })
+  // "MKT" coerces to null price; no description -> null
+  assertEquals(items[1], { section: 'Starters', name: 'Crispy Clams', price: null, description: null, sourceMenu: '' })
+})
+
+Deno.test('parseSchemaOrgMenuItems handles offers array + nested sections', () => {
+  const html = MENU_LD(`
+    {"@type":"MenuSection","name":"Raw Bar","hasMenuSection":[
+      {"@type":"MenuSection","name":"Oysters","hasMenuItem":[
+        {"@type":"MenuItem","name":"Wellfleet","offers":[{"price":"3.50"},{"price":"4.00"}]}
+      ]}
+    ]}
+  `)
+  const items = parseSchemaOrgMenuItems(html)
+  assertEquals(items.length, 1)
+  assertEquals(items[0].section, 'Oysters') // nearest named section wins
+  assertEquals(items[0].price, 3.5) // first usable offer price
+})
+
+Deno.test('parseSchemaOrgMenuItems finds Menu nested under Restaurant -> hasMenu', () => {
+  // Common schema.org shape: the Menu is not top-level, it hangs off a
+  // Restaurant (or @graph / mainEntity). The walker must recurse to find it.
+  const html = `<script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Restaurant","name":"X","hasMenu":{
+      "@type":"Menu","hasMenuSection":[
+        {"@type":"MenuSection","name":"Mains","hasMenuItem":[
+          {"@type":"MenuItem","name":"Steak","offers":{"price":"42.00"}}
+        ]}
+      ]}}
+  </script>`
+  const items = parseSchemaOrgMenuItems(html)
+  assertEquals(items.length, 1)
+  assertEquals(items[0], { section: 'Mains', name: 'Steak', price: 42, description: null, sourceMenu: '' })
+})
+
+Deno.test('parseSchemaOrgMenuItems finds Menu inside @graph', () => {
+  const html = `<script type="application/ld+json">
+    {"@context":"https://schema.org","@graph":[
+      {"@type":"Organization","name":"X"},
+      {"@type":"Menu","hasMenuSection":[
+        {"@type":"MenuSection","name":"S","hasMenuItem":[{"@type":"MenuItem","name":"Foo","offers":{"price":"5"}}]}
+      ]}
+    ]}
+  </script>`
+  const items = parseSchemaOrgMenuItems(html)
+  assertEquals(items.map(i => i.name), ['Foo'])
+})
+
+Deno.test('parseSchemaOrgMenuItems matches ld+json type with charset suffix', () => {
+  const html = `<script type="application/ld+json; charset=utf-8">
+    {"@type":"Menu","hasMenuSection":[
+      {"@type":"MenuSection","name":"S","hasMenuItem":[{"@type":"MenuItem","name":"Bar","offers":{"price":"7"}}]}
+    ]}
+  </script>`
+  assertEquals(parseSchemaOrgMenuItems(html).map(i => i.name), ['Bar'])
+})
+
+Deno.test('parseSchemaOrgMenuItems handles @type array containing Menu', () => {
+  const html = MENU_LD(`{"@type":"MenuSection","name":"S","hasMenuItem":[{"@type":"MenuItem","name":"Z"}]}`)
+    .replace('"@type":"Menu"', '"@type":["Menu","CreativeWork"]')
+  assertEquals(parseSchemaOrgMenuItems(html).map(i => i.name), ['Z'])
+})
+
+Deno.test('findBentoMenuTabUrls tolerates uppercase + underscore slugs', () => {
+  const html = `<a href="/menu/All_Day/">A</a><a href="/menu/late-night/">B</a>`
+  const urls = findBentoMenuTabUrls(html, 'https://x.com/menus/', 8)
+  assertEquals(urls.sort(), ['https://x.com/menu/All_Day/', 'https://x.com/menu/late-night/'])
+})
+
+Deno.test('parseSchemaOrgMenuItems is resilient to junk', () => {
+  // String items, missing names, malformed JSON-LD blocks must not throw.
+  const html = `<html>
+    <script type="application/ld+json">{ not valid json </script>
+    <script type="application/ld+json">{"@type":"Menu","hasMenuSection":[
+      {"@type":"MenuSection","name":"X","hasMenuItem":["a string item",{"@type":"MenuItem"},{"@type":"MenuItem","name":"Real"}]}
+    ]}</script>
+    <script type="application/ld+json">{"@type":"Organization","name":"Not a menu"}</script>
+  </html>`
+  const items = parseSchemaOrgMenuItems(html)
+  assertEquals(items.map(i => i.name), ['Real'])
+})
+
+Deno.test('parseSchemaOrgMenuItems decodes entities + strips html in descriptions', () => {
+  const html = MENU_LD(`{"@type":"MenuSection","name":"S","hasMenuItem":[
+    {"@type":"MenuItem","name":"Mac &amp; Cheese","description":"<b>aged</b> cheddar&nbsp;/ panko"}
+  ]}`)
+  const items = parseSchemaOrgMenuItems(html)
+  assertEquals(items[0].name, 'Mac & Cheese')
+  assertEquals(items[0].description, 'aged cheddar / panko')
+})
+
+Deno.test('findBentoMenuTabUrls returns same-origin /menu/<slug>/ links, deduped + capped', () => {
+  const html = `
+    <a href="/menu/all-day/">All Day</a>
+    <a href="https://x.com/menu/brunch/">Brunch</a>
+    <a href="https://evil.com/menu/steal/">offsite</a>
+    <a href="/menu/all-day/">dupe</a>
+    <a href="/about/">not a menu</a>`
+  const urls = findBentoMenuTabUrls(html, 'https://x.com/boston-menus/', 8)
+  assertEquals(urls.sort(), ['https://x.com/menu/all-day/', 'https://x.com/menu/brunch/'])
+})
+
+Deno.test('dedupeBentoItems keeps first by (section|name), case-insensitive', () => {
+  const deduped = dedupeBentoItems([
+    item({ section: 'S', name: 'Foo', price: 1 }),
+    item({ section: 's', name: 'foo', price: 2, description: 'later' }),
+    item({ section: 'S', name: 'Bar', price: 3 }),
+  ])
+  assertEquals(deduped.length, 2)
+  assertEquals(deduped[0].price, 1) // first wins
+})
+
+Deno.test('serializeBentoItems groups by section with prices + descriptions', () => {
+  const text = serializeBentoItems([
+    item({ section: 'Starters', name: 'Chowder', price: 14, description: 'potato, bacon' }),
+    item({ section: 'Starters', name: 'Clams' }),
+  ])
+  assertEquals(
+    text,
+    'SECTION: Starters\n- Chowder — $14.00 — potato, bacon\n- Clams',
+  )
+})
+
+Deno.test('parseSchemaOrgMenuItems: unnamed section falls back to the tab name', () => {
+  // BentoBox course-tab pattern: an "Appetizers" Menu with one UNNAMED section.
+  // The items should get section "Appetizers" (the tab name), not "Menu".
+  const html = `<script type="application/ld+json">{"@type":"Menu","name":"Appetizers","hasMenuSection":[
+    {"@type":"MenuSection","hasMenuItem":[{"@type":"MenuItem","name":"Mozzarella Sticks","offers":{"price":"12"}}]}
+  ]}</script>`
+  const items = parseSchemaOrgMenuItems(html)
+  assertEquals(items[0].section, 'Appetizers')
+  assertEquals(items[0].sourceMenu, 'Appetizers')
+})
+
+Deno.test('parseSchemaOrgMenuItems captures the source Menu name', () => {
+  const html = `<script type="application/ld+json">{"@type":"Menu","name":"Brunch","hasMenuSection":[
+    {"@type":"MenuSection","name":"Eggs","hasMenuItem":[{"@type":"MenuItem","name":"Benedict","offers":{"price":"18"}}]}
+  ]}</script>`
+  assertEquals(parseSchemaOrgMenuItems(html)[0].sourceMenu, 'Brunch')
+})
+
+Deno.test('classifyMenuGroups: Saltie — All Day main + Brunch pill, drinks/courses fold', () => {
+  const res = classifyMenuGroups([
+    menu('All Day', 40), menu('Brunch', 36),
+    menu('Caviar', 11), menu('Cocktails', 10), menu('Dessert', 4),
+  ])!
+  assertEquals(res.order, ['All Day', 'Brunch'])
+  assertEquals(res.groupOf.get('Caviar'), 'All Day')    // course-ish food → fold
+  assertEquals(res.groupOf.get('Cocktails'), 'All Day')  // drink → fold
+  assertEquals(res.groupOf.get('Dessert'), 'All Day')    // course → fold
+  assertEquals(res.groupOf.get('Brunch'), 'Brunch')      // meal service → pill
+})
+
+Deno.test('classifyMenuGroups: main = largest FOOD menu by items', () => {
+  const res = classifyMenuGroups([menu('Brunch', 12), menu('Menu', 40)])!
+  assertEquals(res.order, ['Menu', 'Brunch']) // Menu bigger → main, listed first
+})
+
+Deno.test('classifyMenuGroups: drink menus never pill (Landfall: Wines/Dinner → flat)', () => {
+  assertEquals(classifyMenuGroups([menu('Wines', 60), menu('Dinner', 40)]), null)
+})
+
+Deno.test('classifyMenuGroups: course-tabs fold into one flat menu (Capo-style)', () => {
+  assertEquals(classifyMenuGroups([menu('Antipasti', 10), menu('Entrees', 40), menu('Dessert', 5)]), null)
+})
+
+Deno.test('classifyMenuGroups: multi-meal restaurant pills each meal (Loco/Lincoln-style)', () => {
+  const res = classifyMenuGroups([
+    menu('Drinks', 40), menu('Lunch', 20), menu('Dinner', 30),
+    menu('Brunch', 15), menu('Wine', 25), menu('Happy Hour', 10),
+  ])!
+  assertEquals(res.order, ['Dinner', 'Lunch', 'Brunch', 'Happy Hour']) // Dinner largest → main
+  assertEquals(res.groupOf.get('Drinks'), 'Dinner') // drink → fold
+  assertEquals(res.groupOf.get('Wine'), 'Dinner')   // drink → fold
+})
+
+Deno.test('classifyMenuGroups: <2 groups → null (single flat menu)', () => {
+  assertEquals(classifyMenuGroups([menu('Menu', 50), menu('Cocktails', 10), menu('Dessert', 4)]), null)
+  assertEquals(classifyMenuGroups([menu('Menu', 40)]), null)
+})
+
+Deno.test('classifyMenuGroups: unnamed menu never pills (no blank GROUP label)', () => {
+  const res = classifyMenuGroups([menu('All Day', 40), menu('Brunch', 36), menu('', 20)])!
+  assertEquals(res.order, ['All Day', 'Brunch']) // no '' entry
+  assertEquals(res.groupOf.get(''), 'All Day')
+})
+
+Deno.test('serializeBentoItems emits GROUP markers when grouped', () => {
+  const text = serializeBentoItems([
+    item({ section: 'Starters', name: 'Chowder', price: 14, group: 'All Day' }),
+    item({ section: 'Brunch Specials', name: 'Benedict', price: 18, group: 'Brunch' }),
+  ], ['All Day', 'Brunch'])
+  assertEquals(text,
+    'GROUP: All Day\nSECTION: Starters\n- Chowder — $14.00\n\nGROUP: Brunch\nSECTION: Brunch Specials\n- Benedict — $18.00')
+})
+
+Deno.test('buildBentoBoxMenuText: tags items with groups + main-first dedup', async () => {
+  // Two substantial menus (3 sections each → pills). Both list "Crudo / Tuna"
+  // (shared) → it lands in All Day (main) only; Brunch shows its exclusives.
+  const sec = (name: string, dish: string, price: string) =>
+    `{"@type":"MenuSection","name":"${name}","hasMenuItem":[{"@type":"MenuItem","name":"${dish}","offers":{"price":"${price}"}}]}`
+  const hub = `<script type="application/ld+json">[
+    {"@type":"Menu","name":"All Day","hasMenuSection":[
+      ${sec('Crudo', 'Tuna', '24')}, ${sec('Starters', 'Chowder', '14')}, ${sec('Mains', 'Lobster Roll', '34')}
+    ]},
+    {"@type":"Menu","name":"Brunch","hasMenuSection":[
+      ${sec('Crudo', 'Tuna', '24')}, ${sec('Brunch Specials', 'Benedict', '18')}, ${sec('Eggs', 'Omelette', '19')}
+    ]}
+  ]</script>`
+  const res = await buildBentoBoxMenuText({ rawHtml: hub, menuUrl: 'https://x.com/menus/', fetchHtml: async () => '' })
+  assertEquals(res!.groupOrder, ['All Day', 'Brunch'])
+  assertEquals(res!.itemCount, 5) // 3 All Day + 2 Brunch-exclusive (Tuna deduped)
+  assertEquals(res!.sectionGroups['Brunch Specials'], 'Brunch')
+  assertEquals(res!.sectionGroups['Crudo'], 'All Day') // shared → main
+  // Tuna appears once, under All Day's GROUP (before the Brunch GROUP marker)
+  assertEquals(res!.text.indexOf('GROUP: Brunch') > res!.text.indexOf('Tuna'), true)
+})
+
+Deno.test('buildBentoBoxMenuText uses hub JSON-LD without crawling tabs', async () => {
+  const hub = MENU_LD(`{"@type":"MenuSection","name":"Big","hasMenuItem":[
+    ${Array.from({ length: 12 }, (_, i) => `{"@type":"MenuItem","name":"D${i}","offers":{"price":"${i + 1}.00"}}`).join(',')}
+  ]}`)
+  let fetched = 0
+  const res = await buildBentoBoxMenuText({
+    rawHtml: hub,
+    menuUrl: 'https://x.com/boston-menus/',
+    fetchHtml: async () => { fetched++; return '' },
+  })
+  assertEquals(res?.itemCount, 12)
+  assertEquals(res?.pagesUsed, 1)
+  assertEquals(fetched, 0) // 12 > threshold(10), so no tab crawl
+})
+
+Deno.test('buildBentoBoxMenuText augments a thin single-tab page from siblings', async () => {
+  const tabPage = `<a href="/menu/desserts/">Desserts</a>` + MENU_LD(`{"@type":"MenuSection","name":"All Day","hasMenuItem":[
+    {"@type":"MenuItem","name":"Only One","offers":{"price":"9.00"}}
+  ]}`)
+  const sibling = MENU_LD(`{"@type":"MenuSection","name":"Desserts","hasMenuItem":[
+    {"@type":"MenuItem","name":"Cookie","offers":{"price":"8.00"}},
+    {"@type":"MenuItem","name":"Tiramisu","offers":{"price":"16.00"}}
+  ]}`)
+  const res = await buildBentoBoxMenuText({
+    rawHtml: tabPage,
+    menuUrl: 'https://x.com/menu/all-day/',
+    fetchHtml: async (url) => (url === 'https://x.com/menu/desserts/' ? sibling : ''),
+  })
+  assertEquals(res?.itemCount, 3) // 1 from tab + 2 from sibling
+  assertEquals(res?.pagesUsed, 2)
+})
+
+Deno.test('buildBentoBoxMenuText with crawlTabs:false never fetches siblings (generic JSON-LD)', async () => {
+  const tabPage = `<a href="/menu/desserts/">Desserts</a>` + MENU_LD(`{"@type":"MenuSection","name":"All Day","hasMenuItem":[
+    {"@type":"MenuItem","name":"Only One","offers":{"price":"9.00"}}
+  ]}`)
+  let fetched = 0
+  const res = await buildBentoBoxMenuText({
+    rawHtml: tabPage,
+    menuUrl: 'https://x.com/menu/all-day/',
+    fetchHtml: async () => { fetched++; return '' },
+    crawlTabs: false,
+  })
+  assertEquals(res?.itemCount, 1) // only the page's own JSON-LD
+  assertEquals(fetched, 0) // no sibling crawl for non-BentoBox sites
+})
+
+Deno.test('buildBentoBoxMenuText returns null when no menu JSON-LD exists', async () => {
+  const res = await buildBentoBoxMenuText({
+    rawHtml: '<html><script type="application/ld+json">{"@type":"Organization"}</script></html>',
+    menuUrl: 'https://x.com/menu/',
+    fetchHtml: async () => '',
+  })
+  assertEquals(res, null)
+})

--- a/supabase/functions/menu-refresh/bentobox.ts
+++ b/supabase/functions/menu-refresh/bentobox.ts
@@ -1,0 +1,449 @@
+/**
+ * BentoBox menu adapter.
+ *
+ * BentoBox (getbento.com) is a restaurant CMS used by many upscale spots. Its
+ * menus render client-side as JS tabs on a single URL, so the static HTML is a
+ * navigation shell with no dish data — which makes the generic HTML-text
+ * extractor hallucinate a handful of fake dishes (observed: Saltie Girl Boston
+ * produced 6 wrong dishes, all priceless).
+ *
+ * BUT every BentoBox page embeds its menu as schema.org `@type: "Menu"`
+ * JSON-LD (`hasMenuSection` -> `hasMenuItem` with `offers.price`). That data is
+ * deterministic and price-complete, so parsing it is hallucination-proof.
+ *
+ * This module turns that JSON-LD into clean menu text. The caller feeds that
+ * text into the existing Sonnet extractor, which keeps category mapping,
+ * dietary/cuisine tagging, dedup, the price gate, and the "skip canned/retail
+ * products" curation rules intact — we only fix the *input*.
+ *
+ * Hub vs tab pages: a BentoBox "menus" hub page (e.g. /boston-menus/) aggregates
+ * every tab's JSON-LD, so one fetch usually suffices. When the configured URL is
+ * a single tab, we follow same-origin /menu/<slug>/ links to gather siblings.
+ */
+
+export interface BentoMenuItem {
+  section: string
+  name: string
+  price: number | null
+  description: string | null
+  /** Name of the schema.org Menu (BentoBox tab) this item came from, e.g. "All
+   * Day" / "Brunch". '' when the Menu object had no name. Drives menu groups. */
+  sourceMenu: string
+  /** Resolved menu_group (pill label) — set by buildBentoBoxMenuText after the
+   * pill rule runs. Undefined when the restaurant has no service/venue pills. */
+  group?: string
+}
+
+/** Cheap signature check — BentoBox stamps getbento.com asset/CDN hosts everywhere. */
+export function detectBentoBox(html: string): boolean {
+  return /getbento\.com|bentoboxcloud|bentobox\.min\.js/i.test(html)
+}
+
+/** Coerce a schema.org price (string "14.00" | number | null) to a number or null. */
+function parsePrice(raw: unknown): number | null {
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw
+  if (typeof raw === 'string') {
+    const cleaned = raw.replace(/[^0-9.]/g, '')
+    if (!cleaned) return null
+    const n = Number.parseFloat(cleaned)
+    return Number.isFinite(n) ? n : null
+  }
+  return null
+}
+
+/** Pull the first price out of an `offers` field that may be an object or array. */
+function priceFromOffers(offers: unknown): number | null {
+  if (Array.isArray(offers)) {
+    for (const o of offers) {
+      const p = o && typeof o === 'object' ? parsePrice((o as Record<string, unknown>).price) : null
+      if (p != null) return p
+    }
+    return null
+  }
+  if (offers && typeof offers === 'object') {
+    return parsePrice((offers as Record<string, unknown>).price)
+  }
+  return null
+}
+
+function cleanText(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null
+  // Decode the few HTML entities BentoBox leaves in descriptions, collapse space.
+  const t = raw
+    .replace(/&amp;/g, '&')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#39;|&rsquo;|&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return t.length ? t : null
+}
+
+/**
+ * Recursively collect MenuItems from a MenuSection tree. Sections can nest
+ * (`hasMenuSection` inside `hasMenuSection`); items live under `hasMenuItem`.
+ * `inheritedSection` carries the nearest named ancestor so items always get a
+ * section label even when their immediate parent is unnamed.
+ */
+function collectFromSection(
+  section: unknown,
+  inheritedSection: string,
+  sourceMenu: string,
+  out: BentoMenuItem[]
+): void {
+  if (!section || typeof section !== 'object') return
+  const s = section as Record<string, unknown>
+  // When a section is unnamed in the JSON-LD, fall back to the menu/tab name
+  // (e.g. an "Appetizers" tab with one unnamed section → section "Appetizers")
+  // rather than a useless literal "Menu". Many BentoBox sites tab their courses
+  // and leave the inner section blank.
+  const sectionName = cleanText(s.name) || inheritedSection || sourceMenu || 'Menu'
+
+  const items = s.hasMenuItem
+  const itemArr = Array.isArray(items) ? items : items ? [items] : []
+  for (const item of itemArr) {
+    if (!item || typeof item !== 'object') continue
+    const it = item as Record<string, unknown>
+    const name = cleanText(it.name)
+    if (!name) continue
+    out.push({
+      section: sectionName,
+      name,
+      price: priceFromOffers(it.offers),
+      description: cleanText(it.description),
+      sourceMenu,
+    })
+  }
+
+  const nested = s.hasMenuSection
+  const nestedArr = Array.isArray(nested) ? nested : nested ? [nested] : []
+  for (const child of nestedArr) {
+    collectFromSection(child, sectionName, sourceMenu, out)
+  }
+}
+
+/** Walk an arbitrary JSON-LD value, harvesting every `@type: "Menu"` it contains. */
+function collectFromNode(node: unknown, out: BentoMenuItem[]): void {
+  if (Array.isArray(node)) {
+    for (const n of node) collectFromNode(n, out)
+    return
+  }
+  if (!node || typeof node !== 'object') return
+  const obj = node as Record<string, unknown>
+  const type = obj['@type']
+  const isMenu = type === 'Menu' || (Array.isArray(type) && type.includes('Menu'))
+  if (isMenu) {
+    const menuName = cleanText(obj.name) || ''
+    const sections = obj.hasMenuSection
+    const sectionArr = Array.isArray(sections) ? sections : sections ? [sections] : []
+    for (const sec of sectionArr) collectFromSection(sec, '', menuName, out)
+  }
+  // Recurse into every nested value so a Menu nested under another type is still
+  // found — e.g. Restaurant -> hasMenu -> Menu, WebPage -> mainEntity, @graph
+  // containers. MenuSection / MenuItem nodes never match isMenu, so this can't
+  // double-collect items. Skip hasMenuSection (already consumed above) to avoid
+  // re-walking the section tree.
+  for (const key of Object.keys(obj)) {
+    if (key === 'hasMenuSection') continue
+    const value = obj[key]
+    if (value && typeof value === 'object') collectFromNode(value, out)
+  }
+}
+
+/** Extract every schema.org MenuItem from a page's JSON-LD blocks. */
+export function parseSchemaOrgMenuItems(html: string): BentoMenuItem[] {
+  const out: BentoMenuItem[] = []
+  // Tolerate `type="application/ld+json; charset=utf-8"` and similar suffixes —
+  // [^"']* after the media type matches any trailing parameters/whitespace.
+  const re = /<script[^>]*type=["']application\/ld\+json[^"']*["'][^>]*>([\s\S]*?)<\/script>/gi
+  let m: RegExpExecArray | null
+  while ((m = re.exec(html)) !== null) {
+    const blob = m[1].trim()
+    if (!blob) continue
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(blob)
+    } catch {
+      continue
+    }
+    collectFromNode(parsed, out)
+  }
+  return out
+}
+
+/** Find same-origin /menu/<slug>/ tab links on a hub page (deduped, capped). */
+export function findBentoMenuTabUrls(html: string, baseUrl: string, max = 8): string[] {
+  let base: URL
+  try {
+    base = new URL(baseUrl)
+  } catch {
+    return []
+  }
+  const urls = new Set<string>()
+  // Slugs are usually lowercase-kebab, but tolerate uppercase + underscores.
+  const re = /href=["']([^"']*\/menu\/[A-Za-z0-9_-]+\/?)["']/gi
+  let m: RegExpExecArray | null
+  while ((m = re.exec(html)) !== null && urls.size < max) {
+    let abs: URL
+    try {
+      abs = new URL(m[1], base)
+    } catch {
+      continue
+    }
+    if (abs.hostname !== base.hostname) continue // bound SSRF: same-origin only
+    abs.hash = ''
+    urls.add(abs.toString())
+  }
+  return [...urls]
+}
+
+// Menu grouping (pills) mirrors a restaurant's distinct DINING menus. The clean
+// structural signal ("multi-section tab") over-pills, because drink lists and
+// course-tabs are multi-section too. So we use a hybrid: one "main" food menu
+// (the largest), plus an extra pill ONLY for tabs whose name denotes a separate
+// meal service or venue. Drinks and course-tabs fold into the main as sections.
+// See docs/superpowers/plans/2026-05-31-auto-menu-groups.md.
+
+// Distinct meal services / venues → eligible to be their own pill alongside
+// main. Deliberately excludes "raw bar"/"oyster bar" (those are sections, not
+// separate menus) and all drink terms (handled by DRINK_MENU_PATTERN).
+const MEAL_VENUE_PATTERN =
+  /\b(breakfast|brunch|lunch|dinner|supper|happy[\s-]*hour|late[\s-]*night|upstairs|downstairs|patio|rooftop)\b/i
+
+// Drink-only menus — never a dining pill. Their items fold into main (wine/beer
+// get dropped by the extractor's beverage rules anyway; cocktails become a
+// section). Listed BEFORE meal/venue so "Bar" stays out of pills.
+const DRINK_MENU_PATTERN =
+  /\b(wines?|beers?|cocktails?|libations?|beverages?|drinks?|ciders?|spirits?|sake|mocktails?|on[\s-]*tap|by[\s-]*the[\s-]*glass)\b/i
+
+// Retail/conservas tabs (Tin List, Conservas…) — never a pill, fold into main;
+// the tinned program is then dropped by the conservas prompt rule.
+const RETAIL_MENU_PATTERN =
+  /\b(tin|tins|tinned|conservas?|retail|market|merch|bottle\s*shop|cellar)\b/i
+
+export interface SourceMenuStats {
+  name: string
+  itemCount: number
+}
+
+/** A drink or retail tab that can never be a dining pill (folds into main). */
+function isFoldMenu(name: string): boolean {
+  return DRINK_MENU_PATTERN.test(name) || RETAIL_MENU_PATTERN.test(name)
+}
+
+/**
+ * Decide menu groups (pills) from the source menus.
+ *
+ * Hybrid rule: the "main" group is the largest FOOD menu (non-drink/retail,
+ * named). An additional pill is created only for a food menu whose name denotes
+ * a distinct meal service or venue (Brunch, Lunch, Dinner, Happy Hour,
+ * Upstairs…). Course-tabs (Antipasti/Entrees/Dessert), drink lists, and retail
+ * tabs all fold into the main group as sections. Returns null (stay flat) unless
+ * ≥2 groups result. Returns each source-menu → resolved group + ordered groups.
+ */
+export function classifyMenuGroups(
+  menus: SourceMenuStats[]
+): { groupOf: Map<string, string>; order: string[] } | null {
+  // Food menus: named, not drink/retail, with at least one dish.
+  const foodMenus = menus.filter((m) => m.name.trim() !== '' && m.itemCount > 0 && !isFoldMenu(m.name))
+  if (foodMenus.length === 0) return null
+
+  // main = largest food menu by item count (tie → first in source order).
+  let main = foodMenus[0]
+  for (const m of foodMenus) {
+    if (m.itemCount > main.itemCount) main = m
+  }
+  const mainName = main.name
+
+  // Extra pills = food menus (other than main) named like a meal service/venue.
+  const groupOf = new Map<string, string>()
+  const order: string[] = [mainName]
+  for (const m of menus) {
+    if (m.name === mainName) {
+      groupOf.set(m.name, mainName)
+    } else if (!isFoldMenu(m.name) && m.name.trim() !== '' && m.itemCount > 0 && MEAL_VENUE_PATTERN.test(m.name)) {
+      groupOf.set(m.name, m.name) // distinct meal/venue → its own pill
+      if (!order.includes(m.name)) order.push(m.name)
+    } else {
+      groupOf.set(m.name, mainName) // courses, drinks, retail → fold into main
+    }
+  }
+
+  if (order.length < 2) return null
+  return { groupOf, order }
+}
+
+/** Dedup items by (section|name), keeping the first occurrence. */
+export function dedupeBentoItems(items: BentoMenuItem[]): BentoMenuItem[] {
+  const seen = new Set<string>()
+  const out: BentoMenuItem[] = []
+  for (const it of items) {
+    const key = `${it.section.toLowerCase()}|${it.name.toLowerCase()}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(it)
+  }
+  return out
+}
+
+function itemLine(it: BentoMenuItem): string {
+  const price = it.price != null ? ` — $${it.price.toFixed(2)}` : ''
+  const desc = it.description ? ` — ${it.description}` : ''
+  return `- ${it.name}${price}${desc}`
+}
+
+/**
+ * Serialize structured items into clean menu text for Sonnet.
+ *
+ * When `groupOrder` is given (the restaurant has pills), emit `GROUP: <label>`
+ * markers above each group's sections so Sonnet can carry menu_group through.
+ * Otherwise emit a flat section list (single-menu restaurants).
+ */
+export function serializeBentoItems(items: BentoMenuItem[], groupOrder?: string[]): string {
+  const lines: string[] = []
+  const emitSections = (groupItems: BentoMenuItem[]) => {
+    const bySection = new Map<string, BentoMenuItem[]>()
+    for (const it of groupItems) {
+      const arr = bySection.get(it.section) ?? []
+      arr.push(it)
+      bySection.set(it.section, arr)
+    }
+    for (const [section, arr] of bySection) {
+      lines.push(`SECTION: ${section}`)
+      for (const it of arr) lines.push(itemLine(it))
+      lines.push('')
+    }
+  }
+
+  if (groupOrder && groupOrder.length > 0) {
+    for (const group of groupOrder) {
+      const groupItems = items.filter((it) => (it.group ?? '') === group)
+      if (groupItems.length === 0) continue
+      lines.push(`GROUP: ${group}`)
+      emitSections(groupItems)
+    }
+  } else {
+    emitSections(items)
+  }
+  return lines.join('\n').trim()
+}
+
+export interface BentoBoxMenuResult {
+  text: string
+  itemCount: number
+  pagesUsed: number
+  /** Ordered pill labels (≥2 ⇒ the restaurant gets pills). Empty when flat. */
+  groupOrder: string[]
+  /** menu_section → menu_group for sections that map to exactly one group.
+   * Lets the handler deterministically backfill menu_group if Sonnet drops a
+   * GROUP label. Ambiguous sections (same name in >1 group) are omitted. */
+  sectionGroups: Record<string, string>
+}
+
+/**
+ * Build clean menu text from a BentoBox site's JSON-LD.
+ *
+ * Parses the current page first. If that already yields a substantial menu
+ * (more than `tabAugmentThreshold` items — i.e. it was a hub page), we stop.
+ * Otherwise we follow same-origin /menu/<slug>/ tab links and merge their
+ * JSON-LD so a single-tab menu_url still gathers the full menu.
+ *
+ * Returns null when no MenuItems are found (caller falls back to the normal
+ * extraction path). `fetchHtml` is injected so this module stays network- and
+ * test-agnostic; it should return '' for any non-HTML (e.g. PDF) response.
+ */
+export async function buildBentoBoxMenuText(opts: {
+  rawHtml: string
+  menuUrl: string
+  fetchHtml: (url: string) => Promise<string>
+  maxTabPages?: number
+  tabAugmentThreshold?: number
+  /**
+   * Whether to follow same-origin /menu/<slug>/ sibling links to augment a thin
+   * page. That crawl is BentoBox's tab convention, so it's only meaningful for
+   * BentoBox sites. The JSON-LD parse itself is generic — any page exposing
+   * schema.org Menu data benefits even with crawlTabs off. Defaults true.
+   */
+  crawlTabs?: boolean
+}): Promise<BentoBoxMenuResult | null> {
+  const { rawHtml, menuUrl, fetchHtml } = opts
+  const maxTabPages = opts.maxTabPages ?? 8
+  const tabAugmentThreshold = opts.tabAugmentThreshold ?? 10
+  const crawlTabs = opts.crawlTabs ?? true
+
+  const items = parseSchemaOrgMenuItems(rawHtml)
+  let pagesUsed = 1
+
+  // Only crawl sibling tabs when the current page didn't already aggregate a
+  // full menu — avoids 6 redundant fetches on a hub page that has everything.
+  if (crawlTabs && items.length <= tabAugmentThreshold) {
+    const tabUrls = findBentoMenuTabUrls(rawHtml, menuUrl, maxTabPages)
+    for (const url of tabUrls) {
+      if (url === menuUrl) continue
+      try {
+        const tabHtml = await fetchHtml(url)
+        if (!tabHtml) continue
+        const tabItems = parseSchemaOrgMenuItems(tabHtml)
+        if (tabItems.length > 0) {
+          items.push(...tabItems)
+          pagesUsed++
+        }
+      } catch {
+        // Best-effort: a failed tab fetch just contributes nothing.
+      }
+    }
+  }
+
+  if (items.length === 0) return null
+
+  // Decide menu groups (pills) from each source menu's item count, in first-seen
+  // order.
+  const counts = new Map<string, number>()
+  const menuOrder: string[] = []
+  for (const it of items) {
+    const m = it.sourceMenu || ''
+    if (!counts.has(m)) menuOrder.push(m)
+    counts.set(m, (counts.get(m) ?? 0) + 1)
+  }
+  const menus: SourceMenuStats[] = menuOrder.map((name) => ({ name, itemCount: counts.get(name)! }))
+  const classified = classifyMenuGroups(menus)
+
+  let groupOrder: string[] = []
+  if (classified) {
+    groupOrder = classified.order
+    for (const it of items) it.group = classified.groupOf.get(it.sourceMenu || '')
+    // Order items so groups appear main-first; dedup then keeps the main-group
+    // copy of any dish shared across menus (e.g. towers listed in All Day AND
+    // Brunch), so a pill shows only its exclusive dishes.
+    const rank = new Map(groupOrder.map((g, i) => [g, i]))
+    items.sort((a, b) => (rank.get(a.group ?? '') ?? 999) - (rank.get(b.group ?? '') ?? 999))
+  }
+
+  const deduped = dedupeBentoItems(items)
+  if (deduped.length === 0) return null
+
+  // Build section → group, omitting sections that span more than one group
+  // (ambiguous — those rely on Sonnet's per-dish GROUP label instead).
+  const sectionGroups: Record<string, string> = {}
+  if (classified) {
+    const seen = new Map<string, string | null>()
+    for (const it of deduped) {
+      if (!it.group) continue
+      const prev = seen.get(it.section)
+      if (prev === undefined) seen.set(it.section, it.group)
+      else if (prev !== it.group) seen.set(it.section, null) // ambiguous
+    }
+    for (const [section, group] of seen) {
+      if (group) sectionGroups[section] = group
+    }
+  }
+
+  return {
+    text: serializeBentoItems(deduped, groupOrder),
+    itemCount: deduped.length,
+    pagesUsed,
+    groupOrder,
+    sectionGroups,
+  }
+}

--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -4,6 +4,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { detectCms, cmsRequiresRender } from './cms-detect.ts'
 import { fetchRenderedHtml, BrowserlessError } from './browserless.ts'
 import { discoverMenuCandidates, findMenuIframes, findSubMenuPages, isBlockedHostname, isKnownMenuIframeHost, type MenuCandidate } from './menu-candidates.ts'
+import { detectBentoBox, buildBentoBoxMenuText, parseSchemaOrgMenuItems } from './bentobox.ts'
 
 // v1.3 dietary tag + description sanitizers (kept in sync with
 // ./extractors.ts which exists for Vitest test coverage — Vitest can't
@@ -143,6 +144,8 @@ Keep sections in the same order they appear on the menu. If "Raw Bar" comes befo
 
 Use the restaurant's exact dish names. If they call it "The Big Kahuna Burger", write that — don't shorten to "Kahuna Burger".
 
+**Menu groups (GROUP markers).** Some sources mark distinct menus with a line \`GROUP: <name>\` (e.g. \`GROUP: All Day\`, \`GROUP: Brunch\`). When present, assign every dish below a GROUP marker to that group via the \`menu_group\` field, until the next GROUP marker. If the input has NO GROUP markers, set \`menu_group\` to \`null\` for every dish. Never invent groups — only use the exact GROUP labels given.
+
 ## WGH Category (Internal — Separate from Menu Section)
 
 Each dish also gets a "category" field. This is OUR internal classification, NOT the restaurant's. A dish in the restaurant's "From The Sea" section might get category "lobster roll" or "scallops" or "fish-and-chips" depending on what it actually is.
@@ -244,15 +247,16 @@ Pick the MOST SPECIFIC category that fits. Prefer "lobster roll" over "seafood",
 6. **Skip condiments** — extra sauce, side of dressing, bread roll
 7. **Skip side dishes** — mashed potatoes, green beans, rice, coleslaw, steamed veggies, etc. NOT rateable.
 8. **EXCEPTION: Fries and onion rings ARE included** — people rate these. Keep them.
-9. **Deduplicate sizes, portions, and near-duplicate names within a menu section**:
+9. **Skip tinned/canned/jarred seafood (conservas)** — fish or shellfish sold by the tin/can/jar as a RETAIL product, not a plated dish. Recognize the pattern: many single-species listings grouped by fish type (Sardines, Anchovies, Mackerel, Tuna, Mussels, Cockles, Squid, Octopus, Herring, Cod, etc.), brand/origin names, and descriptions that are only a preservation medium ("in olive oil", "in EVOO", "in escabeche", "in spiced oil", "with lemon", "smoked, tinned") rather than a cooked or composed preparation. A restaurant with a "Tinned Fish" / "Conservas" / "Tins" program lists dozens of these — they are retail items diners buy, not dishes they order and rate, so skip the entire program. **KEEP prepared seafood**: chowders, fried/grilled/roasted preparations, crudo, raw oysters/clams on the half shell, lobster rolls, seafood towers — anything cooked, plated, or composed with accompaniments.
+10. **Deduplicate sizes, portions, and near-duplicate names within a menu section**:
    - **Size/portion variants** (Small/Medium/Large, 10"/14", Cup/Bowl, half/whole, lunch/dinner): output ONE entry per dish. Use the larger/dinner price.
    - **Near-duplicate names** (same menu_section, same category): if two dishes differ only by a redundant category suffix — "Margherita" vs "Margherita Pizza", "Caesar" vs "Caesar Salad", "Lobster" vs "Lobster Roll" when both are in the pizza / salad / lobster-roll section — they are the SAME dish listed twice. Output ONE entry. Prefer the shorter name (without the redundant category word).
    - **Genuinely different portions stay separate:** "Half Roast Chicken" vs "Whole Roast Chicken", "Kids Burger" vs "Burger" — output both.
    - **When in doubt:** if two dishes in the same section have names that a normal human would read as "the same dish at different prices," collapse them. Better to under-count than to duplicate.
-10. **Prices: NEVER INVENT OR GUESS PRICES.** Only set a price if you can see an exact dollar amount next to that specific dish on the source page. If no explicit price is shown for a dish, the price field MUST be \`null\`. Do NOT infer prices from nearby dishes, category averages, or typical market values. Do NOT fill in \`18\` or any default. A null price is always better than a guessed price. If a range is shown (e.g. "$14-18"), use the lower number.
-11. **One category per dish** — pick the most specific match
-12. **Description rule:** Output an ingredient/preparation line **150 chars or fewer** as \`description\`. Format: comma-separated nouns. List the dish's defining ingredients in the order the menu presents them — protein, signature accompaniments, sauce/finish. Skip filler adjectives ("fresh", "house-made", "perfectly"). If the menu copy fits under 150 chars, keep all of it. **Never truncate mid-word.** Examples: "Hot lobster meat, drawn butter, split-top bun" / "Fried cauliflower, brussels sprouts, sun-dried tomato melange, crispy garlic, smoked sea salt, vichyssoise sauce" / "Wagyu beef, bacon jam, brioche bun". If the menu has only marketing copy ("OUR SIGNATURE HAND-CRAFTED..."), output \`null\`. Never invent ingredients you don't see in the source.
-13. **Dietary tags rule:** Output a \`dietary_tags\` array. Allowed tags (and only these): \`vegan\`, \`vegetarian\`, \`gluten_free\`, \`dairy_free\`, \`nut_free\`. **Only emit a tag when the menu definitively labels the dish as that diet** (not "available" or "on request"). This is an allergen-safety contract — a celiac diner trusts \`gluten_free\` to mean the dish is gluten-free as served, not "can be modified."
+11. **Prices: NEVER INVENT OR GUESS PRICES.** Only set a price if you can see an exact dollar amount next to that specific dish on the source page. If no explicit price is shown for a dish, the price field MUST be \`null\`. Do NOT infer prices from nearby dishes, category averages, or typical market values. Do NOT fill in \`18\` or any default. A null price is always better than a guessed price. If a range is shown (e.g. "$14-18"), use the lower number.
+12. **One category per dish** — pick the most specific match
+13. **Description rule:** Output an ingredient/preparation line **150 chars or fewer** as \`description\`. Format: comma-separated nouns. List the dish's defining ingredients in the order the menu presents them — protein, signature accompaniments, sauce/finish. Skip filler adjectives ("fresh", "house-made", "perfectly"). If the menu copy fits under 150 chars, keep all of it. **Never truncate mid-word.** Examples: "Hot lobster meat, drawn butter, split-top bun" / "Fried cauliflower, brussels sprouts, sun-dried tomato melange, crispy garlic, smoked sea salt, vichyssoise sauce" / "Wagyu beef, bacon jam, brioche bun". If the menu has only marketing copy ("OUR SIGNATURE HAND-CRAFTED..."), output \`null\`. Never invent ingredients you don't see in the source.
+14. **Dietary tags rule:** Output a \`dietary_tags\` array. Allowed tags (and only these): \`vegan\`, \`vegetarian\`, \`gluten_free\`, \`dairy_free\`, \`nut_free\`. **Only emit a tag when the menu definitively labels the dish as that diet** (not "available" or "on request"). This is an allergen-safety contract — a celiac diner trusts \`gluten_free\` to mean the dish is gluten-free as served, not "can be modified."
 
     **Conventional shorthand markers** — treat these as definitive when they appear as a badge, suffix, or column marker on a dish, even without a printed legend. These conventions are standard across restaurant menus:
     - \`V\` → \`vegetarian\`
@@ -302,6 +306,7 @@ Return ONLY valid JSON (no markdown, no code fences):
     {
       "name": "Dish Name",
       "category": "category_id",
+      "menu_group": "All Day",
       "menu_section": "Section Name",
       "price": 18.00,
       "description": "ingredient, ingredient, prep",
@@ -309,11 +314,14 @@ Return ONLY valid JSON (no markdown, no code fences):
     }
   ],
   "menu_section_order": ["Section 1", "Section 2"]
-}`
+}
+
+(menu_group is null when the input has no GROUP markers.)`
 
 interface ExtractedDish {
   name: string
   category: string
+  menu_group: string | null
   menu_section: string
   price: number | null
   description: string | null
@@ -341,7 +349,7 @@ const STALE_DAYS = 14
 //   - features      : output-schema features (e.g. desc+dietary tags from PR #229)
 // Format is intentionally human-readable so the stored value alone tells you
 // which extractor produced a row — easier to debug than a bare integer.
-const CURRENT_EXTRACTOR_FINGERPRINT = 'sonnet-4-6|prompt-v6|pipeline-v2|desc150+dietary-v2|cocktails-v1|thin-fallback-v1'
+const CURRENT_EXTRACTOR_FINGERPRINT = 'sonnet-4-6|prompt-v6|pipeline-v2|desc150+dietary-v2|cocktails-v1|thin-fallback-v1|bentobox-jsonld-v1|conservas-skip-v1|menu-groups-v2'
 
 // Signals that a restaurant is closed (check before wasting Claude API call)
 const CLOSED_SIGNALS = [
@@ -677,7 +685,7 @@ async function fetchMenuContent(url: string): Promise<string> {
 }
 
 interface ExtractionAttempt {
-  strategy: 'image' | 'pdf' | 'html' | 'sub-page' | 'iframe'
+  strategy: 'image' | 'pdf' | 'html' | 'sub-page' | 'iframe' | 'jsonld-menu'
   url_count: number
   top_score?: number
   dishes_found: number
@@ -701,6 +709,15 @@ const THIN_EXTRACTION_THRESHOLD = 10
 // might just be a JS-loaded shell. One Browserless call per failed job is cheap
 // insurance vs. another dead-letter restaurant.
 const SPARSE_TEXT_THRESHOLD = 2000
+
+// Confidence gate: a thin, price-less, plain-HTML extraction that no sub-page
+// rescued is the signature of Sonnet hallucinating dishes from a navigation
+// shell (e.g. a JS tab menu it can't read). We refuse to write those — they go
+// to the needs_manual_menu queue instead of polluting the dishes table. The
+// floor is deliberately low (and the gate also requires a thin count) so a real
+// small menu that happens to list MKT/no-price items isn't falsely gated; the
+// worst case of a false positive is "waits for a human" rather than "garbage".
+const PRICE_COVERAGE_FLOOR = 0.2
 
 // Merge two candidate lists by URL (last-write-wins on score), then re-sort.
 // Used when Browserless renders surface JS-injected assets that weren't in the raw HTML.
@@ -755,7 +772,11 @@ async function extractMenuWithClaude(content: string, restaurantName: string): P
     },
     body: JSON.stringify({
       model: 'claude-sonnet-4-6',
-      max_tokens: 8192,
+      // 32k headroom for large structured menus — a multi-menu BentoBox source
+      // (e.g. Loco's 5 meal-menus = ~290 items) overran the old 16k cap,
+      // truncating the JSON mid-array → parse failure → 0 dishes. Billed only
+      // on actual output, so this is free for normal-size menus.
+      max_tokens: 32768,
       messages: [
         {
           role: 'user',
@@ -787,6 +808,7 @@ async function extractMenuWithClaude(content: string, restaurantName: string): P
     .map((d: ExtractedDish) => ({
       ...d,
       category: VALID_CATEGORIES.includes(d.category) ? d.category : 'entree',
+      menu_group: typeof d.menu_group === 'string' && d.menu_group.trim() ? d.menu_group.trim() : null,
       description: sanitizeDescription(d.description),
       dietary_tags: sanitizeDietaryTags(d.dietary_tags),
     }))
@@ -925,6 +947,7 @@ async function extractMenuFromImagesWithClaude(
     .map((d: ExtractedDish) => ({
       ...d,
       category: VALID_CATEGORIES.includes(d.category) ? d.category : 'entree',
+      menu_group: typeof d.menu_group === 'string' && d.menu_group.trim() ? d.menu_group.trim() : null,
       description: sanitizeDescription(d.description),
       dietary_tags: sanitizeDietaryTags(d.dietary_tags),
     }))
@@ -997,6 +1020,7 @@ async function extractMenuFromPdfsWithClaude(
     .map((d: ExtractedDish) => ({
       ...d,
       category: VALID_CATEGORIES.includes(d.category) ? d.category : 'entree',
+      menu_group: typeof d.menu_group === 'string' && d.menu_group.trim() ? d.menu_group.trim() : null,
       description: sanitizeDescription(d.description),
       dietary_tags: sanitizeDietaryTags(d.dietary_tags),
     }))
@@ -1013,14 +1037,20 @@ async function extractMenuFromPdfsWithClaude(
 async function upsertDishes(
   supabase: ReturnType<typeof createClient>,
   restaurantId: string,
-  extracted: MenuExtractionResult
+  extracted: MenuExtractionResult,
+  // Only write menu_group when THIS extraction is genuinely group-aware (a
+  // multi-menu source produced GROUP labels). Otherwise ignore any menu_group
+  // value entirely — Sonnet occasionally emits a stray group on a flat menu,
+  // and writing it would clobber a hand-curated grouping (e.g. Nancy's). Flat
+  // sources leave existing menu_group untouched and insert new dishes as NULL.
+  writeGroups = false
 ): Promise<{ inserted: number; updated: number; unchanged: number; fuzzyMatched: number; batchDedupSkipped: number; crossCategorySkipped: number; priceGateRejected: number }> {
   // Get existing dishes. Ordered by created_at so "first row wins" ties in
   // the normalized-key lookup are deterministic and stable across runs —
   // older rows are more likely to be the canonical ones holding votes.
   const { data: existingDishes, error: fetchErr } = await supabase
     .from('dishes')
-    .select('id, name, category, menu_section, price, photo_url, description, dietary_tags, created_at')
+    .select('id, name, category, menu_group, menu_section, price, photo_url, description, dietary_tags, created_at')
     .eq('restaurant_id', restaurantId)
     .order('created_at', { ascending: true })
 
@@ -1199,13 +1229,18 @@ async function upsertDishes(
       const priceChanged = dish.price !== null && dish.price !== existing.price
       const categoryChanged = dish.category !== existing.category
       const sectionChanged = dish.menu_section !== existing.menu_section
+      // Only touch menu_group when this extraction is group-aware (writeGroups)
+      // AND it produced a non-null group. A flat/group-less run never nulls or
+      // overwrites an existing group — preserves hand-curated pills (Nancy's).
+      const groupChanged = writeGroups && (dish.menu_group ?? null) !== null && dish.menu_group !== existing.menu_group
       const descriptionChanged = (dish.description ?? null) !== (existing.description ?? null)
       const tagsChanged = !sortedArraysEqual(dish.dietary_tags || [], existing.dietary_tags || [])
 
-      if (priceChanged || categoryChanged || sectionChanged || descriptionChanged || tagsChanged) {
+      if (priceChanged || categoryChanged || sectionChanged || groupChanged || descriptionChanged || tagsChanged) {
         const updates: Record<string, unknown> = {}
         if (categoryChanged) updates.category = dish.category
         if (sectionChanged) updates.menu_section = dish.menu_section
+        if (groupChanged) updates.menu_group = dish.menu_group
         if (priceChanged) updates.price = dish.price
         if (descriptionChanged) updates.description = dish.description
         if (tagsChanged) updates.dietary_tags = dish.dietary_tags
@@ -1227,6 +1262,8 @@ async function upsertDishes(
           restaurant_id: restaurantId,
           name: dish.name,
           category: dish.category,
+          // Insert NULL unless this is a group-aware run (see writeGroups).
+          menu_group: writeGroups ? (dish.menu_group ?? null) : null,
           menu_section: dish.menu_section || null,
           price: dish.price || null,
           description: dish.description ?? null,
@@ -1551,6 +1588,14 @@ serve(async (req) => {
           let renderSucceeded = false
           let renderError: string | null = null
           let renderedTextLen: number | null = null
+          // True once a structured source (e.g. BentoBox JSON-LD) replaced the
+          // raw shell text. Structured extractions are trusted — they can't
+          // hallucinate — so the confidence gate below exempts them.
+          let bentoSourced = false
+          // Menu-group (pill) metadata from the structured source, used after
+          // extraction to backfill dish.menu_group + set menu_group_order.
+          let bentoGroupOrder: string[] = []
+          let bentoSectionGroups: Record<string, string> = {}
 
           // Discover all menu candidates (PDFs + images) and rank by score.
           // Score combines URL keywords (+menu/+dinner/-beverage/-logo) with
@@ -1586,6 +1631,57 @@ serve(async (req) => {
             }).eq('id', job.id)
             results.push({ job_id: job.id, status: 'unchanged', restaurant: restaurant.name })
             continue
+          }
+
+          // Structured (schema.org JSON-LD) source. Many restaurant CMSs —
+          // BentoBox especially — render menus as JS tabs on one URL, so the raw
+          // HTML is a navigation shell that makes the plain-text extractor
+          // hallucinate. But those pages embed the menu as schema.org `Menu`
+          // JSON-LD: deterministic, price-complete, hallucination-proof. When a
+          // page exposes it, replace the shell text with serialized JSON-LD and
+          // let the normal Sonnet pass handle category/dietary/cuisine tagging +
+          // the canned/retail-product curation rules. The parse is generic (any
+          // CMS); only the /menu/<slug>/ sibling-tab crawl is BentoBox-specific,
+          // so we gate that on detectBentoBox. See bentobox.ts.
+          const isBento = detectBentoBox(rawHtml)
+          if (isBento || parseSchemaOrgMenuItems(rawHtml).length > 0) {
+            try {
+              const structured = await buildBentoBoxMenuText({
+                rawHtml,
+                menuUrl,
+                fetchHtml: async (url) => {
+                  const f = await fetchRawHtml(url)
+                  return f.type === 'html' ? f.html : ''
+                },
+                maxTabPages: MAX_SUB_PAGES,
+                tabAugmentThreshold: THIN_EXTRACTION_THRESHOLD,
+                crawlTabs: isBento,
+              })
+              // Adopt JSON-LD whenever it actually yielded items AND it's the
+              // trustworthy source for this page. Do NOT gate on text length:
+              // a BentoBox shell is padded with nav/footer text, so the real
+              // JSON-LD menu is often *shorter* than the raw text — the old
+              // length check silently skipped the fix (Codex #2). Trust JSON-LD
+              // when the site is BentoBox (HTML is always a shell there), when
+              // the raw text is sparse (shell), or when JSON-LD is simply richer
+              // than the raw text. This avoids regressing content-rich non-Bento
+              // HTML pages that merely carry a tiny "special of the day" snippet.
+              if (
+                structured &&
+                structured.itemCount > 0 &&
+                (isBento || rawTextLen < SPARSE_TEXT_THRESHOLD || structured.text.length > extractionContent.length)
+              ) {
+                extractionContent = structured.text
+                bentoSourced = true
+                bentoGroupOrder = structured.groupOrder
+                bentoSectionGroups = structured.sectionGroups
+                attempts.push({ strategy: 'jsonld-menu', url_count: structured.pagesUsed, dishes_found: structured.itemCount })
+                console.log(`${restaurant.name}: schema.org JSON-LD source${isBento ? ' (BentoBox)' : ''} — ${structured.itemCount} items from ${structured.pagesUsed} page(s)${bentoGroupOrder.length ? `, groups: ${bentoGroupOrder.join(' / ')}` : ''}`)
+              }
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err)
+              console.error(`${restaurant.name}: JSON-LD menu extraction failed:`, message)
+            }
           }
 
           // Render fallback #1: content too short AND CMS requires rendering
@@ -1960,20 +2056,99 @@ serve(async (req) => {
             continue
           }
 
+          const winningStrategy = attempts.find(a => a.dishes_found > 0)?.strategy ?? 'html'
+
+          // Confidence gate: refuse to write a thin, price-less extraction that
+          // came from the plain-text HTML strategy and that no sub-page rescued.
+          // That combination is a heuristic for Sonnet inventing dishes from a
+          // navigation shell (the Saltie Girl failure: 6 fake dishes, 0 prices).
+          // It is NOT a direct shell detector — a genuinely tiny, all-market-
+          // price menu (omakase, raw bar) can trip it. That's an accepted
+          // trade-off: a false positive only routes the restaurant to manual
+          // review (needs_manual_menu) instead of writing garbage — it fails
+          // safe. Structured sources (JSON-LD, PDFs, iframes) and sub-page-
+          // rescued extractions are exempt, since those can't hallucinate.
+          const finalCount = extracted.dishes.length
+          const pricedCount = extracted.dishes.filter(d => d.price != null).length
+          const priceCoverage = finalCount > 0 ? pricedCount / finalCount : 0
+          const subRescued = typeof mergeTelemetry?.added_count === 'number' && mergeTelemetry.added_count > 0
+          const lowConfidence =
+            winningStrategy === 'html' &&
+            !bentoSourced &&
+            !subRescued &&
+            finalCount <= THIN_EXTRACTION_THRESHOLD &&
+            priceCoverage < PRICE_COVERAGE_FLOOR
+          if (lowConfidence) {
+            console.warn(`${restaurant.name}: gated low-confidence extraction (${finalCount} dishes, ${Math.round(priceCoverage * 100)}% priced) — flagged for manual menu, not written`)
+            // Mark for manual review and stamp hash+fingerprint so the next cron
+            // short-circuits instead of re-burning Sonnet on the same shell. A
+            // future fingerprint bump (better extractor) re-tries automatically.
+            await supabase.from('restaurants').update({
+              needs_manual_menu: true,
+              menu_last_checked: new Date().toISOString(),
+              menu_content_hash: rawHash,
+              extractor_fingerprint: CURRENT_EXTRACTOR_FINGERPRINT,
+            }).eq('id', restaurant.id)
+            await supabase.from('menu_import_jobs').update({
+              status: 'completed',
+              completed_at: new Date().toISOString(),
+              dishes_found: finalCount,
+              dishes_inserted: 0, dishes_updated: 0, dishes_unchanged: 0,
+              error_context: {
+                menu_url: menuUrl,
+                cms_detected: cms,
+                reason: 'gated_low_confidence',
+                price_coverage: priceCoverage,
+                winning_strategy: winningStrategy,
+                attempts,
+                ...(mergeTelemetry ?? {}),
+              },
+              lock_expires_at: null,
+              updated_at: new Date().toISOString(),
+            }).eq('id', job.id)
+            results.push({ job_id: job.id, status: 'gated_low_confidence', restaurant: restaurant.name, dishes: finalCount })
+            continue
+          }
+
+          // Menu groups (pills): backfill any dish whose GROUP label Sonnet
+          // dropped, using the structured source's unambiguous section→group
+          // map. Then derive menu_group_order from the groups actually present,
+          // in the source's order. Only multi-menu (BentoBox-tab) restaurants
+          // reach this with a non-empty bentoGroupOrder.
+          if (bentoGroupOrder.length > 0) {
+            for (const dish of extracted.dishes) {
+              if (!dish.menu_group) {
+                const g = bentoSectionGroups[dish.menu_section]
+                if (g) dish.menu_group = g
+              }
+            }
+          }
+
           // Success path: upsert dishes, store raw hash + render telemetry
           // Note: we hash the raw text (rawHash), not the rendered text. Next run can skip
           // cheaply when the raw HTML shell is unchanged. Mild staleness on JS sites is
           // acceptable; the 14-day refresh cron eventually catches updates.
 
-          const stats = await upsertDishes(supabase, restaurant.id, extracted)
+          const stats = await upsertDishes(supabase, restaurant.id, extracted, bentoGroupOrder.length > 0)
 
-          await supabase.from('restaurants').update({
+          const restaurantUpdate: Record<string, unknown> = {
             menu_last_checked: new Date().toISOString(),
             menu_content_hash: rawHash,
             extractor_fingerprint: CURRENT_EXTRACTOR_FINGERPRINT,
-          }).eq('id', restaurant.id)
-
-          const winningStrategy = attempts.find(a => a.dishes_found > 0)?.strategy ?? 'html'
+            // Clear any prior manual-menu flag — a good extraction supersedes it.
+            needs_manual_menu: false,
+          }
+          // Set menu_group_order only when this extraction produced ≥2 real
+          // groups. A group-less extraction leaves the column untouched, so a
+          // hand-curated grouping (e.g. Nancy's) is never wiped.
+          const presentGroups = bentoGroupOrder.filter((g) =>
+            extracted.dishes.some((d) => d.menu_group === g)
+          )
+          if (presentGroups.length >= 2) {
+            restaurantUpdate.menu_group_order = presentGroups
+            console.log(`${restaurant.name}: menu_group_order = ${presentGroups.join(' / ')}`)
+          }
+          await supabase.from('restaurants').update(restaurantUpdate).eq('id', restaurant.id)
 
           await supabase.from('menu_import_jobs').update({
             status: 'completed',

--- a/supabase/migrations/2026-05-31-needs-manual-menu.sql
+++ b/supabase/migrations/2026-05-31-needs-manual-menu.sql
@@ -1,0 +1,44 @@
+-- 2026-05-31 — needs_manual_menu flag for the menu-refresh confidence gate.
+-- Run in Supabase SQL Editor (Denis's project).
+--
+-- The confidence gate refuses to write thin, price-less, plain-HTML extractions
+-- that no sub-page rescued (the signature of Sonnet hallucinating dishes from a
+-- JS-shell page — e.g. BentoBox tab menus). Those restaurants get flagged here
+-- for a hand-imported menu instead of polluting the dishes table.
+--
+-- Additive column + one frozen field in the manager-protection trigger. No
+-- rollback block needed (DROP COLUMN reverts; trigger reverts by removing the
+-- single NEW.needs_manual_menu line).
+
+ALTER TABLE restaurants
+  ADD COLUMN IF NOT EXISTS needs_manual_menu BOOLEAN NOT NULL DEFAULT false;
+
+-- Freeze needs_manual_menu against manager edits (menu-refresh bookkeeping,
+-- same as menu_content_hash / extractor_fingerprint). Service role + admin
+-- still bypass via the early RETURN NEW.
+CREATE OR REPLACE FUNCTION protect_restaurant_fields()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF current_user IN ('postgres', 'service_role', 'supabase_admin') THEN
+    RETURN NEW;
+  END IF;
+  IF is_admin() THEN
+    RETURN NEW;
+  END IF;
+  NEW.id := OLD.id;
+  NEW.name := OLD.name;
+  NEW.address := OLD.address;
+  NEW.lat := OLD.lat;
+  NEW.lng := OLD.lng;
+  NEW.region := OLD.region;
+  NEW.town := OLD.town;
+  NEW.google_place_id := OLD.google_place_id;
+  NEW.created_by := OLD.created_by;
+  NEW.created_at := OLD.created_at;
+  NEW.menu_last_checked := OLD.menu_last_checked;
+  NEW.menu_content_hash := OLD.menu_content_hash;
+  NEW.extractor_fingerprint := OLD.extractor_fingerprint;
+  NEW.needs_manual_menu := OLD.needs_manual_menu;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -51,6 +51,12 @@ CREATE TABLE IF NOT EXISTS restaurants (
   -- generation counter. Source of truth for the constant is
   -- CURRENT_EXTRACTOR_FINGERPRINT in supabase/functions/menu-refresh/index.ts.
   extractor_fingerprint TEXT,
+  -- Set true by menu-refresh's confidence gate when an auto-extraction looks
+  -- like garbage (thin + price-less + plain-HTML + no sub-page rescue — the
+  -- signature of hallucinating dishes from a JS-shell page). Flags the
+  -- restaurant for a hand-imported menu instead of writing bad dishes. Cleared
+  -- automatically when a later extraction succeeds. See menu-refresh/index.ts.
+  needs_manual_menu BOOLEAN NOT NULL DEFAULT false,
   menu_section_order TEXT[] DEFAULT '{}',
   menu_group_order TEXT[] DEFAULT '{}',
   toast_slug TEXT,
@@ -2771,6 +2777,7 @@ BEGIN
   NEW.menu_last_checked := OLD.menu_last_checked;
   NEW.menu_content_hash := OLD.menu_content_hash;
   NEW.extractor_fingerprint := OLD.extractor_fingerprint;
+  NEW.needs_manual_menu := OLD.needs_manual_menu;
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;

--- a/supabase/seed/data/menus/saltie-girl-full-menu.sql
+++ b/supabase/seed/data/menus/saltie-girl-full-menu.sql
@@ -1,0 +1,68 @@
+-- Saltie Girl (Boston) - Full Menu
+-- Source: Hand-imported from saltiegirl.com Boston menu (JS tab menu defeats auto-extraction).
+--   The site serves ALL DAY / BRUNCH / CAVIAR / TIN LIST / COCKTAILS / DESSERT as client-side
+--   tabs on a single URL, so menu-refresh (incl. thin-fallback-v1 sub-page crawl) cannot read it.
+-- Replaces 6 stale/incorrect auto-extracted dishes with the real menu.
+-- Run this in Supabase SQL Editor (postgres role) — DELETE needs RLS bypass.
+
+-- Delete old (incorrect) dishes
+DELETE FROM dishes
+WHERE restaurant_id = (SELECT id FROM restaurants WHERE name = 'Saltie Girl');
+
+-- Insert complete menu (32 items)
+INSERT INTO dishes (restaurant_id, name, category, menu_section, price) VALUES
+-- Starters
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Saltie Girl Clam Chowder', 'chowder', 'Starters', 14),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Caviar Dip', 'apps', 'Starters', 32),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Latke & Caviar', 'apps', 'Starters', 32),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Crispy Ipswich Clams', 'clams', 'Starters', NULL),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Pt. Judith Calamari', 'calamari', 'Starters', 21),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Warm Spicy Blue Crab Roll', 'crab', 'Starters', 29),
+-- Toasts
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Lump Crab', 'crab', 'Toasts', 28),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Hand-Chopped Dry Aged Steak Tartare', 'apps', 'Toasts', 24),
+-- Crudo
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Tuna Carpaccio', 'fish', 'Crudo', 24),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Hamachi Tiradito', 'fish', 'Crudo', 19),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Salmon Crudo', 'fish', 'Crudo', 19),
+-- Salads
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Boston Lettuce', 'salad', 'Salads', 17),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Gem Lettuce', 'salad', 'Salads', 18),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Spicy Caesar', 'salad', 'Salads', 16),
+-- Seafood Towers
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Petite Seafood Tower', 'seafood', 'Seafood Towers', NULL),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Grande Seafood Tower', 'seafood', 'Seafood Towers', NULL),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Royale Seafood Tower', 'seafood', 'Seafood Towers', NULL),
+-- New York Style Smoked Fish
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Smoked Atlantic Salmon', 'fish', 'New York Style Smoked Fish', 26),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Pastrami Smoked Salmon', 'fish', 'New York Style Smoked Fish', 26),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Smoked Whitefish Salad', 'fish', 'New York Style Smoked Fish', 26),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Smoked Trout', 'fish', 'New York Style Smoked Fish', 26),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Smoked Fish Platter', 'fish', 'New York Style Smoked Fish', 75),
+-- Cocktails
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Pineapple', 'cocktails', 'Cocktails', NULL),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Grapefruit', 'cocktails', 'Cocktails', NULL),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Mango', 'cocktails', 'Cocktails', NULL),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Passionfruit', 'cocktails', 'Cocktails', NULL),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Shiso', 'cocktails', 'Cocktails', NULL),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Saltie', 'cocktails', 'Cocktails', NULL),
+-- Desserts
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'SweetBoy Chocolate Chip Cookie', 'dessert', 'Desserts', 8),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Pistachio Tiramisu', 'dessert', 'Desserts', 16),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Sticky Toffee Madeleines', 'dessert', 'Desserts', 15),
+((SELECT id FROM restaurants WHERE name = 'Saltie Girl'), 'Ice Cream', 'ice cream', 'Desserts', 9);
+
+-- Update menu_section_order to mirror the real menu layout
+UPDATE restaurants
+SET menu_section_order = ARRAY['Starters', 'Toasts', 'Crudo', 'Salads', 'Seafood Towers', 'New York Style Smoked Fish', 'Cocktails', 'Desserts']
+WHERE name = 'Saltie Girl';
+
+-- NOTE: Do NOT touch extractor_fingerprint. It's already 'sonnet-4-6|...|thin-fallback-v1'
+-- (= CURRENT_EXTRACTOR_FINGERPRINT), which makes menu-refresh's hash short-circuit SKIP this
+-- restaurant on the next cron as long as the page's raw HTML is unchanged. Overwriting it
+-- would FORCE a re-extraction and re-pollute this manual menu with bad auto-extracted dishes.
+
+-- Verify import
+SELECT COUNT(*) AS dish_count
+FROM dishes
+WHERE restaurant_id = (SELECT id FROM restaurants WHERE name = 'Saltie Girl');


### PR DESCRIPTION
Fixes the **JS-tab-menu dead zone** (BentoBox and similar CMSs) where the HTML extractor hallucinated dishes from a navigation shell — Saltie Girl was producing **6 fake, price-less dishes**. Four layered changes, all deployed to the live project and validated end-to-end.

## What's in here

**1. schema.org JSON-LD adapter** (`bentobox.ts`, new)
- Parses `@type:Menu` → `hasMenuSection`/`hasMenuItem` into clean text fed to the **existing** Sonnet pipeline (keeps category/dietary/curation). Deterministic, price-complete, hallucination-proof.
- BentoBox-only `/menu/<slug>/` sibling-tab crawl gated on `detectBentoBox`; the JSON-LD parse itself triggers on any page exposing Menu data.
- Corpus scan: **23 BentoBox sites, 2,093 structured items**. Squarespace/Wix (43 sites) have no JSON-LD → flagged as a future render-based frontier.

**2. Confidence gate** (`index.ts`)
- Refuses to write a thin (≤10) + low-price-coverage (<20%) + plain-`html` + not-sub-rescued extraction (the hallucination signature). Flags `restaurants.needs_manual_menu` instead.
- New column + frozen in `protect_restaurant_fields` (migration `2026-05-31-needs-manual-menu.sql`). Fails **safe** to manual review corpus-wide.

**3. Conservas curation** (prompt rule #9)
- Skips tinned/canned retail seafood (Saltie's 114-item tinned-fish program) — products, not rateable dishes.

**4. Menu groups / pills**
- Derives `menu_group` + `menu_group_order` from named BentoBox tabs.
- **Hybrid pill rule**: largest food menu = "main"; extra pills only for distinct meal-services/venues (brunch/lunch/dinner/upstairs…); drink lists + course-tabs fold in; retail excluded. (A pure structural rule over-pilled Wine/Cocktails across the corpus — rejected.)
- Unnamed JSON-LD sections fall back to the **tab name** (no more "Menu" catch-all).
- `writeGroups` guard never clobbers a manual grouping (e.g. Nancy's Snack Bar/Upstairs).
- `max_tokens` 8k→32k for large multi-menu sites.

## Validated live
All **7 multi-menu restaurants** turned on and verified: Saltie (All Day/Brunch), Lincoln (weekday/weekend/late-night), Millie's ×2 (Lunch&Dinner/Breakfast), Landfall (Luncheons/Dinner), Layla's (Brunch/Dinner/Lunch), Loco (5 meals). The other ~148 restaurants stayed flat and untouched.

## Test plan
- [x] `deno test bentobox.test.ts` — 28 cases (parsing, pill classifier, dedup, serialization, edge cases)
- [x] `npm run build` — passes (no frontend changes)
- [x] Codex-reviewed across 5 passes (clobber-guard, recursion, edge cases all addressed)
- [x] Deployed to live project + re-extracted/verified all 7 pilled restaurants

## Notes
- The Edge Function + schema migration were already applied manually to the live project (dashboard); this PR makes the repo match production.
- `saltie-girl-full-menu.sql` kept as a seed record (superseded by the auto-extraction).
- Known minor: occasional drink leakage (a few "Blended & Frozen"/"Non-Alcoholic" items) — small prompt tweak later. Stale `menu_group_order` not auto-cleared (documented Phase-1 limitation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)