### PR TITLE
test: restore trustworthy vitest signal

### DIFF
--- a/src/lib/nativeAuth.test.js
+++ b/src/lib/nativeAuth.test.js
@@ -46,11 +46,24 @@ describe('signInWithGoogleNative', () => {
   })
 
   it('maps plugin init failure to AUTH_CONFIG', async () => {
-    initializeMock.mockRejectedValueOnce(new Error('Missing client id'))
-    await expect(signInWithGoogleNative()).rejects.toMatchObject({
-      code: 'AUTH_CONFIG',
-      subcode: 'google_sdk_missing_clientid',
-    })
+    // Pin VITE_GOOGLE_IOS_CLIENT_ID instead of inheriting it from the developer's
+    // .env.local. The module reads it once at import time, so stub the env and
+    // re-import to exercise the no-client-id branch deterministically — this
+    // matches CI, where the var is unset and the subcode is google_sdk_missing_clientid.
+    vi.stubEnv('VITE_GOOGLE_IOS_CLIENT_ID', '')
+    vi.resetModules()
+    try {
+      const { signInWithGoogleNative: signIn } = await import('./nativeAuth')
+      initializeMock.mockRejectedValueOnce(new Error('Missing client id'))
+      await expect(signIn()).rejects.toMatchObject({
+        code: 'AUTH_CONFIG',
+        subcode: 'google_sdk_missing_clientid',
+      })
+    } finally {
+      // Always restore env even if the assertion throws, so a failure here can't
+      // leak the stubbed client id into later tests in this file.
+      vi.unstubAllEnvs()
+    }
   })
 })
 

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -10,7 +10,8 @@ export default defineConfig({
     exclude: [
       'e2e/**',
       'whats-good-here-soul/**',
-      'node_modules/**',
+      '**/node_modules/**',
+      '.claude/**',
       // Deno-native tests — these use `https://deno.land/std/...` + `https://esm.sh/...`
       // URL imports that Node's ESM loader rejects. Run them with:
       //   deno test --allow-net --allow-env <path>
@@ -22,6 +23,7 @@ export default defineConfig({
       'supabase/functions/apple-token-exchange/index.test.ts',
       'supabase/functions/apple-token-persist/index.test.ts',
       'supabase/functions/delete-account/index.test.ts',
+      'supabase/functions/menu-refresh/bentobox.test.ts',
     ],
   },
 })


### PR DESCRIPTION
## What was broken

CI on `main` has been **red** since #290 (BentoBox menu-groups). The failure is **not** a test assertion — it's a *suite load* error:

```
FAIL supabase/functions/menu-refresh/bentobox.test.ts
Error: Only URLs with a scheme in: file, data, and node are supported by the
default ESM loader. Received protocol 'https:'  (ERR_UNSUPPORTED_ESM_URL_SCHEME)
Test Files  1 failed | 37 passed (38)   Tests  645 passed (645)
```

`bentobox.test.ts` is a **Deno-native** test (`import … from 'https://deno.land/std@0.177.0/…'`). The Node/Vitest runner can't load `https:` imports. #290 added the file but didn't add it to the existing Deno-exclude list (which already lists its 6 siblings), so Vitest tried to load it and the whole run failed. **645 tests actually pass; one suite just fails to load.**

## What was changed (test/config only — 2 files)

**`vitest.config.js`**
- Added `supabase/functions/menu-refresh/bentobox.test.ts` to the Deno-native exclude list, alongside its 6 siblings. **This is the line that turns CI green.**
- `'node_modules/**'` → `'**/node_modules/**'` — the old glob only matched root-level `node_modules`, so a leftover agent worktree's nested `node_modules` (zod's own internal test suite) got collected and reported dozens of bogus failures on a local `npm run test`. Recursive glob is the correct form.
- Added `'.claude/**'` — agent worktrees under `.claude/` aren't project test surface and shouldn't be scanned. *(Slightly broader than strictly required for green CI; called out explicitly, not slipped in.)*

**`src/lib/nativeAuth.test.js`**
- The "maps plugin init failure to AUTH_CONFIG" test asserted `subcode: 'google_sdk_missing_clientid'`, which only holds when `VITE_GOOGLE_IOS_CLIENT_ID` is unset. The module captures that env var **once at import time**, and a developer's `.env.local` sets it — so the test **passed in CI but failed locally**. Pinned the env via `vi.stubEnv('VITE_GOOGLE_IOS_CLIENT_ID', '')` + `vi.resetModules()` + dynamic re-import so it exercises the no-client-id branch deterministically everywhere.

### Why the nativeAuth test was environment-dependent
It never owned its environment — it relied on the ambient absence of `VITE_GOOGLE_IOS_CLIENT_ID`. The production code's `subcode` ternary (`GOOGLE_IOS_CLIENT_ID ? 'google_plugin_init_failed' : 'google_sdk_missing_clientid'`) is **correct and intentional**, so the assertion was kept as-is — only the test's env handling was fixed. No production code changed.

### Why the BentoBox test was excluded from Vitest
It's Deno-native (`https://` std imports) and physically cannot run under Node/Vitest. Exclusion matches the established pattern for the other 6 Deno tests. It must instead run under `deno test` — see remaining risk.

## Test command + result
```
npm run test -- --run
→ 37 files, 645 tests, all pass (~5s)
```
This is the exact set CI runs; it goes from `1 failed | 37 passed (38)` to `37 passed (37)` / `645 passed`.

## Production behavior
**Unchanged.** Only `vitest.config.js` and a `*.test.js` were touched — neither ships in the app bundle, iOS binary, or any edge function. Nothing deploys.

## Remaining risk
The 7 Deno-native edge-function tests are correctly excluded from Vitest but **have no CI job that runs them** — they're written but not executed. Follow-up PR (Phase 1.5) will add a dedicated `deno test` job before the upcoming edge-function security work.