### PR TITLE
Add Deno CI job for hermetic edge-function tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,31 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run test -- --run
+
+  deno-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      # Hermetic edge-function tests only — no database, no secrets.
+      # Covers the menu-refresh BentoBox parser (#290) and the Apple-functions
+      # log-hygiene checks. Permissions: --allow-read because observability.test.ts
+      # statically scans source files for secret leaks; --allow-env for harmless
+      # env reads (no secret values required).
+      - name: Run hermetic Deno tests
+        run: >
+          deno test --allow-read --allow-env
+          supabase/functions/menu-refresh/bentobox.test.ts
+          supabase/functions/_test/observability.test.ts
+      # NOT run here: the 5 integration tests require a live staging Supabase +
+      # SUPABASE_SERVICE_ROLE_KEY + the apple_encryption_master_key_v1 Vault secret
+      # (they create auth users, write auth.identities, and POST to deployed
+      # functions). Wiring those into CI is a separate infra/secret decision.
+      # Run them manually against staging with:
+      #   deno test --allow-net --allow-env supabase/functions/_shared/apple.test.ts
+      #   deno test --allow-net --allow-env supabase/functions/apple-token-exchange/index.test.ts
+      #   deno test --allow-net --allow-env supabase/functions/apple-token-persist/index.test.ts
+      #   deno test --allow-net --allow-env supabase/functions/apple-revocation-retry/index.test.ts
+      #   deno test --allow-net --allow-env supabase/functions/delete-account/index.test.ts


### PR DESCRIPTION
## Why this job exists

The Supabase edge-function test suite is split across two runners. The **Deno-native** tests import from `https://deno.land/...` / `https://esm.sh/...`, which the Node/Vitest runner cannot load (`ERR_UNSUPPORTED_ESM_URL_SCHEME`). They're correctly **excluded** from the Vitest job — but until now they had **no runner of their own**, so they were *written but never executed in CI*. (That gap is what let #290's `bentobox.test.ts` silently break `main`.)

This adds a separate `deno-tests` job (`denoland/setup-deno@v2`) running in parallel with the existing `build-and-test` job. **The Vitest job is unchanged.**

## Which Deno tests now run (hermetic — no DB, no secrets)
- `supabase/functions/menu-refresh/bentobox.test.ts` — the #290 BentoBox JSON-LD parser
- `supabase/functions/_test/observability.test.ts` — asserts the Apple edge functions never leak tokens / Apple sub / userId into logs (a security check)

Command: `deno test --allow-read --allow-env <the 2 files>`
`--allow-read` is needed because `observability.test.ts` statically scans source files for secret leaks; `--allow-env` covers harmless env reads (no secret *values* required). No `--allow-net` — the `https://` deps resolve at module load, not via runtime `fetch()`.

## Which Deno tests remain deferred (documented in the workflow file)
The 5 **integration** tests are **not** run here:
- `_shared/apple.test.ts` (its crypto fetches the `apple_encryption_master_key_v1` Vault secret)
- `apple-token-exchange/index.test.ts`, `apple-token-persist/index.test.ts`, `apple-revocation-retry/index.test.ts`, `delete-account/index.test.ts` (all import `_test/harness.ts`)

## Why the integration tests are excluded
They are genuine integration tests: they **create real auth users, write `auth.identities`, and POST to deployed Edge Functions**. They require a live Supabase project, a `SUPABASE_SERVICE_ROLE_KEY`, and a seeded Vault secret. Dummy env values can't satisfy them, and faking the env to force them green would be exactly the kind of lying-green signal we're trying to avoid. Their local failures were classified as **missing-infrastructure**, not bugs — `bentobox.test.ts` passing confirms #290's logic is sound.

## Why production Supabase service-role keys should NOT be used in CI
The `SUPABASE_SERVICE_ROLE_KEY` bypasses RLS and can read/write any row, including `auth.*`. Storing the **production** key as a CI secret would expose a full-database credential to every workflow run (and anyone who can trigger one). If these integration tests are ever wired into CI, they must point at a **throwaway/staging project** with its own service-role key — never production. That's a separate infra decision, intentionally kept out of this PR.

## Local Deno test result
```
deno test --allow-read --allow-env \
  supabase/functions/menu-refresh/bentobox.test.ts \
  supabase/functions/_test/observability.test.ts
→ ok | 33 passed | 0 failed
```

## Production code
**None changed.** This PR touches only `.github/workflows/ci.yml` (+28 lines, one new job). No production code, no refactor, no test-file renames.

### Known follow-up (not in this PR)
The job lists the 2 hermetic files explicitly, so a future hermetic Deno test must be added here by hand — the same fragility (inverted) that caused #290. The durable fix is a `*.deno.test.ts` naming convention so both runners glob cleanly; that requires renames and is deferred.