### PR TITLE
fix(edge): SSRF guard on restaurant-controlled URL fetches

### DIFF
--- a/supabase/functions/_shared/ssrf.test.ts
+++ b/supabase/functions/_shared/ssrf.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { isBlockedHostname, safeFetch } from './ssrf.ts'
+
+// isBlockedHostname has a fuller suite in menu-refresh/menu-candidates.test.ts;
+// these spot-check the cases that matter for the SSRF guard plus the URL-parser
+// normalization that safeFetch relies on.
+describe('isBlockedHostname', () => {
+  it('blocks localhost / loopback / private / link-local / metadata', () => {
+    for (const h of [
+      'localhost', '0.0.0.0', '127.0.0.1', '10.0.0.1',
+      '172.16.0.1', '172.31.255.254', '192.168.1.1',
+      '169.254.169.254', // AWS/GCP metadata
+      '::1', 'fc00:0:0:0:0:0:0:1',
+      // fe80::/10 link-local spans fe80–febf, not just fe80
+      'fe80::1', 'fe90::1', 'fea0::1', 'febf::1',
+      'service.local', 'api.internal', 'foo.localhost', 'localhost.',
+    ]) {
+      expect(isBlockedHostname(h), h).toBe(true)
+    }
+  })
+
+  it('allows public hosts', () => {
+    for (const h of ['example.com', 'www.restaurant.com', '8.8.8.8', '172.32.0.1', 'checkle.menu']) {
+      expect(isBlockedHostname(h), h).toBe(false)
+    }
+  })
+})
+
+describe('safeFetch', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const ok = (body = 'ok', status = 200) =>
+    new Response(body, { status, headers: { 'content-type': 'text/html' } })
+  const redirectTo = (location: string, status = 302) =>
+    new Response(null, { status, headers: { location } })
+
+  it('rejects non-http(s) schemes without fetching', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    await expect(safeFetch('file:///etc/passwd')).rejects.toThrow(/ssrf_bad_scheme/)
+    await expect(safeFetch('gopher://example.com')).rejects.toThrow(/ssrf_bad_scheme/)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects malformed URLs without fetching', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    await expect(safeFetch('not a url')).rejects.toThrow('ssrf_invalid_url')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects blocked hosts (incl. integer-IP literal) without fetching', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    for (const u of [
+      'http://localhost/x',
+      'http://127.0.0.1/x',
+      'http://169.254.169.254/latest/meta-data/',
+      'http://2130706433/', // decimal 127.0.0.1 — normalized by URL parser
+      'http://[::1]/',
+    ]) {
+      await expect(safeFetch(u), u).rejects.toThrow(/ssrf_blocked_host/)
+    }
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns the response for a direct public 200 and forces redirect:manual', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(ok())
+    const res = await safeFetch('https://example.com/menu', {
+      method: 'HEAD',
+      headers: { 'User-Agent': 'bot' },
+    })
+    expect(res.status).toBe(200)
+    const [calledUrl, init] = fetchSpy.mock.calls[0]
+    expect(calledUrl).toBe('https://example.com/menu')
+    expect(init).toMatchObject({ method: 'HEAD', redirect: 'manual' })
+    expect((init as RequestInit).headers).toMatchObject({ 'User-Agent': 'bot' })
+  })
+
+  it('follows a redirect to another PUBLIC host and returns the final response', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(redirectTo('https://cdn.example.net/final'))
+      .mockResolvedValueOnce(ok('final-body'))
+    const res = await safeFetch('https://example.com/menu')
+    expect(await res.text()).toBe('final-body')
+  })
+
+  it('blocks a redirect that points at an internal host (the core SSRF case)', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(redirectTo('http://169.254.169.254/latest/meta-data/'))
+    await expect(safeFetch('https://innocent.example.com/')).rejects.toThrow(/ssrf_blocked_host/)
+    // The first (public) hop was fetched; the internal redirect target was NOT.
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws too_many_redirects past the hop cap', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(redirectTo('https://example.com/loop'))
+    await expect(safeFetch('https://example.com/start', {}, 2)).rejects.toThrow('ssrf_too_many_redirects')
+  })
+
+  it('throws on a redirect with no Location header', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(null, { status: 302 }))
+    await expect(safeFetch('https://example.com/')).rejects.toThrow(/ssrf_redirect_no_location/)
+  })
+})

--- a/supabase/functions/_shared/ssrf.ts
+++ b/supabase/functions/_shared/ssrf.ts
@@ -1,0 +1,115 @@
+// Shared SSRF guard for edge functions that fetch restaurant-controlled URLs
+// (restaurant-scraper, menu-refresh). Restaurant managers can set website_url /
+// facebook_url / menu_url on their own row, and menu/image URLs are discovered
+// from page HTML — all untrusted. These helpers block fetches that would reach
+// loopback / private / link-local / cloud-metadata hosts or use a non-http(s)
+// scheme, and re-validate every redirect hop so a public URL can't 30x its way
+// to an internal host.
+//
+// LIMITATION: this validates the hostname string, not the resolved IP, so it
+// does NOT defend against DNS rebinding (a public hostname that resolves to a
+// private address). Defending that requires pinning the resolved IP, which Deno
+// `fetch` doesn't expose. This matches the guarantee of the original in-line
+// guard in menu-refresh's fetchRawHtml.
+
+// Block hostnames a fetch could otherwise be coaxed into reaching: loopback,
+// RFC1918 private space, link-local (incl. AWS/GCP metadata at 169.254.169.254),
+// and the *.local / *.internal suffixes used by service discovery on private
+// networks. A legitimate restaurant URL never points here.
+//
+// Integer/hex/octal IP literals (e.g. http://2130706433) are normalized to
+// dotted-quad by `new URL()` before this sees them, so the IPv4 branch catches
+// them too.
+export function isBlockedHostname(hostname: string): boolean {
+  // Normalize: strip IPv6 brackets, trailing FQDN dot, lowercase.
+  // Trailing-dot variants ('localhost.', 'service.local.') would otherwise
+  // sneak past the suffix and equality checks — DNS treats them as equivalent.
+  const lower = hostname.toLowerCase().replace(/^\[|\]$/g, '').replace(/\.+$/, '')
+  if (lower === 'localhost' || lower === '0.0.0.0' || lower === '') return true
+  if (lower.endsWith('.localhost') || lower.endsWith('.local') || lower.endsWith('.internal')) return true
+  // IPv4 numeric
+  if (/^(\d{1,3}\.){3}\d{1,3}$/.test(lower)) {
+    const parts = lower.split('.').map(Number)
+    if (parts[0] === 0) return true                                            // 0/8
+    if (parts[0] === 127) return true                                          // 127/8 loopback
+    if (parts[0] === 10) return true                                           // 10/8 private
+    if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true      // 172.16/12 private
+    if (parts[0] === 192 && parts[1] === 168) return true                      // 192.168/16 private
+    if (parts[0] === 169 && parts[1] === 254) return true                      // link-local + cloud metadata
+    return false
+  }
+  // Any IPv6 starting with `::` is unreachable on the public internet: those
+  // are the unspecified/loopback/IPv4-compatible/IPv4-mapped compatibility
+  // forms (::1, ::, ::1.2.3.4, ::ffff:1.2.3.4, parser-normalized variants
+  // like ::7f00:1). Real public IPv6 services live in 2000::/3 — none of
+  // them start with `::`. Block the whole class so we don't have to enumerate
+  // every parser-normalization quirk.
+  if (lower.startsWith('::')) return true
+  // IPv6 unique-local + link-local
+  if (/^fc[0-9a-f]{2}:/i.test(lower) || /^fd[0-9a-f]{2}:/i.test(lower)) return true  // fc00::/7 ULA
+  // fe80::/10 link-local spans first-hextet fe80–febf, NOT just fe80. The third
+  // hex digit is 8/9/a/b (binary 10xx); matching only `fe80:` would let fe90::,
+  // fea0::, febf:: through.
+  if (/^fe[89ab][0-9a-f]:/i.test(lower)) return true                                  // fe80::/10 link-local
+  return false
+}
+
+// Maximum redirect hops safeFetch will follow. Each hop is validated BEFORE the
+// request is issued, which is the SSRF defense that `redirect: 'follow'` doesn't
+// provide (it redirects internally before we can inspect the target).
+export const MAX_REDIRECT_HOPS = 5
+
+/**
+ * fetch() wrapper that validates the scheme + hostname of the URL and of every
+ * redirect hop before issuing each request, then returns the final non-3xx
+ * Response. Behaves like `redirect: 'follow'` but safe: it follows up to
+ * `maxHops` redirects, re-checking each Location against isBlockedHostname.
+ *
+ * Throws (rather than returning) on a malformed URL, non-http(s) scheme, blocked
+ * host, missing/invalid redirect Location, or too many redirects. Every current
+ * caller already treats a throw as "skip this URL" (return null / log + continue),
+ * so a blocked host degrades gracefully instead of crashing the run.
+ *
+ * `init` is forwarded verbatim except `redirect`, which is forced to 'manual'.
+ */
+export async function safeFetch(
+  url: string,
+  init: RequestInit = {},
+  maxHops: number = MAX_REDIRECT_HOPS,
+): Promise<Response> {
+  let currentUrl = url
+
+  for (let hop = 0; hop <= maxHops; hop++) {
+    let parsed: URL
+    try {
+      parsed = new URL(currentUrl)
+    } catch {
+      throw new Error('ssrf_invalid_url')
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error(`ssrf_bad_scheme:${parsed.protocol}`)
+    }
+    if (isBlockedHostname(parsed.hostname)) {
+      throw new Error(`ssrf_blocked_host:${parsed.hostname}`)
+    }
+
+    const response = await fetch(currentUrl, { ...init, redirect: 'manual' })
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location')
+      // Drain the redirect body so the connection can be reused / closed.
+      await response.body?.cancel()
+      if (!location) throw new Error(`ssrf_redirect_no_location:${response.status}`)
+      try {
+        currentUrl = new URL(location, currentUrl).href
+      } catch {
+        throw new Error('ssrf_invalid_redirect_location')
+      }
+      continue
+    }
+
+    return response
+  }
+
+  throw new Error('ssrf_too_many_redirects')
+}

--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -4,6 +4,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { detectCms, cmsRequiresRender } from './cms-detect.ts'
 import { fetchRenderedHtml, BrowserlessError } from './browserless.ts'
 import { discoverMenuCandidates, findMenuIframes, findSubMenuPages, isBlockedHostname, isKnownMenuIframeHost, type MenuCandidate } from './menu-candidates.ts'
+import { safeFetch } from '../_shared/ssrf.ts'
 import { detectBentoBox, buildBentoBoxMenuText, parseSchemaOrgMenuItems } from './bentobox.ts'
 
 // v1.3 dietary tag + description sanitizers (kept in sync with
@@ -401,10 +402,11 @@ async function findMenuUrl(websiteUrl: string): Promise<string | null> {
     try {
       const controller = new AbortController()
       const timeout = setTimeout(() => controller.abort(), 5000)
-      const res = await fetch(candidate, {
+      // safeFetch validates the host + every redirect hop (SSRF guard). A blocked,
+      // malformed, or over-redirecting candidate throws and is skipped by catch.
+      const res = await safeFetch(candidate, {
         method: 'HEAD',
         signal: controller.signal,
-        redirect: 'follow',
         headers: { 'User-Agent': 'Mozilla/5.0 (compatible; WhatsGoodHere-Bot/1.0)' },
       })
       clearTimeout(timeout)
@@ -834,7 +836,9 @@ async function downloadImageAsBase64(
   signal: AbortSignal
 ): Promise<{ data: string; mediaType: string } | null> {
   try {
-    const resp = await fetch(url, {
+    // safeFetch validates the host + every redirect hop (SSRF guard); a blocked
+    // or malformed image URL throws and is caught below (returns null).
+    const resp = await safeFetch(url, {
       signal,
       headers: {
         'User-Agent': 'Mozilla/5.0 (compatible; WhatsGoodHere-MenuBot/1.0)',

--- a/supabase/functions/menu-refresh/menu-candidates.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.ts
@@ -431,45 +431,12 @@ export function isKnownMenuIframeHost(hostname: string): boolean {
   return KNOWN_MENU_IFRAME_HOSTS.some(apex => lower === apex || lower.endsWith('.' + apex))
 }
 
-// Block hostnames that fetchRawHtml could otherwise be coaxed into reaching:
-// loopback, RFC1918 private space, link-local (incl. AWS/GCP metadata at
-// 169.254.169.254), and the *.local / *.internal suffixes used by service
-// discovery on private networks. A legitimate restaurant menu iframe never
-// points here.
-//
-// Exported so fetchRawHtml can re-check `response.url` after redirects —
-// a public iframe URL can 302 to an internal one, so per-hop validation
-// is required, not just initial-URL validation.
-export function isBlockedHostname(hostname: string): boolean {
-  // Normalize: strip IPv6 brackets, trailing FQDN dot, lowercase.
-  // Trailing-dot variants ('localhost.', 'service.local.') would otherwise
-  // sneak past the suffix and equality checks — DNS treats them as equivalent.
-  const lower = hostname.toLowerCase().replace(/^\[|\]$/g, '').replace(/\.+$/, '')
-  if (lower === 'localhost' || lower === '0.0.0.0' || lower === '') return true
-  if (lower.endsWith('.localhost') || lower.endsWith('.local') || lower.endsWith('.internal')) return true
-  // IPv4 numeric
-  if (/^(\d{1,3}\.){3}\d{1,3}$/.test(lower)) {
-    const parts = lower.split('.').map(Number)
-    if (parts[0] === 0) return true                                            // 0/8
-    if (parts[0] === 127) return true                                          // 127/8 loopback
-    if (parts[0] === 10) return true                                           // 10/8 private
-    if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true      // 172.16/12 private
-    if (parts[0] === 192 && parts[1] === 168) return true                      // 192.168/16 private
-    if (parts[0] === 169 && parts[1] === 254) return true                      // link-local + cloud metadata
-    return false
-  }
-  // Any IPv6 starting with `::` is unreachable on the public internet: those
-  // are the unspecified/loopback/IPv4-compatible/IPv4-mapped compatibility
-  // forms (::1, ::, ::1.2.3.4, ::ffff:1.2.3.4, parser-normalized variants
-  // like ::7f00:1). Real public IPv6 services live in 2000::/3 — none of
-  // them start with `::`. Block the whole class so we don't have to enumerate
-  // every parser-normalization quirk.
-  if (lower.startsWith('::')) return true
-  // IPv6 unique-local + link-local
-  if (/^fc[0-9a-f]{2}:/i.test(lower) || /^fd[0-9a-f]{2}:/i.test(lower)) return true  // fc00::/7 ULA
-  if (/^fe80:/i.test(lower)) return true                                              // fe80::/10 link-local
-  return false
-}
+// isBlockedHostname (the SSRF host guard) now lives in the shared module so
+// restaurant-scraper and menu-refresh share one implementation. Re-exported here
+// so existing importers (fetchRawHtml, findMenuIframes below, the test suite)
+// keep working unchanged.
+import { isBlockedHostname } from '../_shared/ssrf.ts'
+export { isBlockedHostname }
 
 // Strip content the regex shouldn't peek into: HTML comments, script/style
 // bodies, noscript, and inert text containers (<template>, <textarea>) that

--- a/supabase/functions/restaurant-scraper/index.ts
+++ b/supabase/functions/restaurant-scraper/index.ts
@@ -1,5 +1,6 @@
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { safeFetch } from '../_shared/ssrf.ts'
 
 const ANTHROPIC_API_KEY = Deno.env.get('ANTHROPIC_API_KEY')
 
@@ -71,7 +72,11 @@ async function fetchWebContent(url: string): Promise<string> {
   const timeout = setTimeout(() => controller.abort(), 15000)
 
   try {
-    const response = await fetch(url, {
+    // safeFetch validates the host + every redirect hop (SSRF guard). url comes
+    // from restaurant website_url/facebook_url (manager-settable / request body),
+    // so a blocked or malformed URL throws here and is caught by the caller's
+    // per-URL try/catch (logs + continues to the next URL).
+    const response = await safeFetch(url, {
       signal: controller.signal,
       headers: {
         'User-Agent': 'WhatsGoodHere-EventBot/1.0',


### PR DESCRIPTION
## What was broken
`restaurant-scraper` and `menu-refresh` fetch URLs that a **restaurant manager can set** on their own row (`website_url` / `facebook_url` / `menu_url`) or that are scraped from page HTML. Three fetch sites used default/`follow` redirects with **no host validation**, so a manager-planted or attacker-supplied URL could make the function reach **loopback / private / link-local / cloud-metadata** hosts (e.g. `http://169.254.169.254/…`), directly or via a 30x redirect from a public URL.

| Site | Before |
|---|---|
| `restaurant-scraper` `fetchWebContent` | `fetch(url)`, default redirect-follow, no validation |
| `menu-refresh` `findMenuUrl` (HEAD probe) | `redirect: 'follow'`, no validation |
| `menu-refresh` `downloadImageAsBase64` | default redirect-follow, no validation |
| `menu-refresh` `fetchRawHtml` | already guarded (manual-redirect loop) ✅ |

## What changed
- **New `_shared/ssrf.ts`** — `isBlockedHostname` (re-homed from `menu-candidates.ts`, now the single source of truth) + **`safeFetch`**: validates scheme + hostname **before each request** and **re-validates every redirect hop** (`redirect: 'manual'`, max 5). Blocks loopback / RFC1918 / link-local / `169.254.0.0/16` / `*.local` / `*.internal` / non-`http(s)`, and integer/hex/octal IP literals (normalized by `new URL()` first).
- Routed the **3 unguarded sites** through `safeFetch`.
- `fetchRawHtml` now shares the same `isBlockedHostname` via re-export (one implementation to audit).

## From the Codex security review (high effort)
- **Fixed (High):** inherited IPv6 link-local bug — `fe80::/10` (`fe80`–`febf`) was under-matched as `fe80::/16`, leaking `fe90::` / `fea0::` / `febf::`. Corrected the regex; because the guard is now shared, this also hardens `fetchRawHtml`. Added range tests.
- **Assessed, no change (Medium):** the Browserless render path forwards URLs to a third-party fetcher. Both call sites pass **already-validated** URLs (`fetchRawHtml`-validated `menuUrl` / `isKnownMenuIframeHost` allowlist), and Browserless fetches from **its own** infra — so it can't reach our metadata/internal services, and its internal redirects are unguardable from here. Documented as an accepted residual rather than add a redundant check.
- Codex confirmed clean: `safeFetch` redirect logic, `maxHops` boundary (not off-by-one), method/header/signal preservation, relative-`Location` resolution, the re-home/re-export (no regression).

## What could break
- Sites with **>5 redirects** now fail (matches the existing `MAX_REDIRECT_HOPS`). Rare; the URL is skipped, not crashed — all three call sites already swallow a throw (skip / return null / log + continue). Valid public restaurant URLs are unaffected.
- **No `schema.sql` change:** freezing the URL columns would break legitimate manager edits, and the runtime guard neutralizes a planted internal URL at fetch time regardless.
- **Residual (documented):** hostname-based guards don't defend **DNS rebinding** (no IP-pin hook in Deno `fetch`). Same limitation as the pre-existing guard.

## Tests
- New `_shared/ssrf.test.ts` (vitest — **runs in the existing Node CI job**, no `ci.yml` change): 10 tests incl. the redirect-to-internal-host case, integer-IP literal, bad scheme, malformed URL, too-many-redirects, and the `fe80::/10` range.
- Full suite: **38 files / 655 tests** pass. `menu-candidates` (100 tests) still green via re-export. Hermetic Deno: 33/0. `deno check`: 19 pre-existing errors, **0 new**.

## ⚠️ Deploy note
These are Supabase **Edge Functions** — **merging this PR does not deploy them.** `menu-refresh` and `restaurant-scraper` must be **redeployed** (dashboard Edit UI or CLI) for the guard to take effect. Until then the live functions still have the gap.