### PR TITLE
fix(jitter): hide dead-end "Building" trust state on iOS

### DIFF
--- a/src/api/jitterApi.js
+++ b/src/api/jitterApi.js
@@ -1,6 +1,7 @@
 import { supabase } from '../lib/supabase'
 import { createClassifiedError } from '../utils/errorHandler'
 import { logger } from '../utils/logger'
+import { jitterTrustVisible } from '../utils/jitterTrust'
 
 export const jitterApi = {
   /**
@@ -109,7 +110,9 @@ export const jitterApi = {
       return 'human_verified'
     }
     if (jitterProfile.review_count > 0) {
-      return 'building'
+      // The "building" state is a dead-end on iOS (rhythm can't be captured on
+      // the soft keyboard), so we don't surface it there. See jitterTrust.js.
+      return jitterTrustVisible() ? 'building' : null
     }
     return null
   },

--- a/src/components/jitter/ProfileJitterCard.jsx
+++ b/src/components/jitter/ProfileJitterCard.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { jitterTrustVisible } from '../../utils/jitterTrust'
 
 /**
  * Your Review Fingerprint — personal typing identity card.
@@ -13,6 +14,9 @@ export function ProfileJitterCard({ profile, user, userProfile, displayName, isP
   const data = profile.profile_data || {}
   const hasPrivateData = !isPublic && Object.keys(data).length > 0
   const tierInfo = getTierInfo(profile.confidence_level, profile.consistency_score)
+  // The "Building" state is a dead-end on iOS — the soft keyboard can't feed
+  // the typing-rhythm signal, so it never advances. Hide it there. See jitterTrust.js.
+  if (tierInfo.label === 'Building' && !jitterTrustVisible()) return null
   const nextTier = isPublic ? null : getNextTier(profile.confidence_level, profile.review_count, profile.consistency_score)
   const name = displayName || userProfile?.display_name || ''
   const initial = name?.charAt(0).toUpperCase() || user?.email?.charAt(0).toUpperCase() || '?'

--- a/src/components/profile/HeroIdentityCard.jsx
+++ b/src/components/profile/HeroIdentityCard.jsx
@@ -2,6 +2,7 @@ import { useState, useRef } from 'react'
 import { toast } from 'sonner'
 import { profileApi } from '../../api/profileApi'
 import { logger } from '../../utils/logger'
+import { jitterTrustVisible } from '../../utils/jitterTrust'
 
 /**
  * Hero Identity Card for the Profile page
@@ -61,6 +62,13 @@ export function HeroIdentityCard({
   }
   const jitterData = jitterProfile?.profile_data || {}
   const hasJitterDetail = !!(jitterProfile && Object.keys(jitterData).length > 0)
+  // On iOS the soft keyboard can't feed the typing-rhythm signal, so the
+  // "Building" tier never advances — hide that dead-end state (chip + expanded
+  // panel) there. Verified/Trusted still show. See jitterTrust.js.
+  const jitterTier = jitterProfile
+    ? getTierInfo(jitterProfile.confidence_level, jitterProfile.consistency_score)
+    : null
+  const hideJitter = !!jitterTier && jitterTier.label === 'Building' && !jitterTrustVisible()
 
   return (
     <div
@@ -253,8 +261,8 @@ export function HeroIdentityCard({
         </div>
 
         {/* Compact Jitter Fingerprint — tap to expand */}
-        {jitterProfile && (() => {
-          const tier = getTierInfo(jitterProfile.confidence_level, jitterProfile.consistency_score)
+        {jitterProfile && !hideJitter && (() => {
+          const tier = jitterTier
           return (
             <button
               onClick={hasJitterDetail ? () => setJitterExpanded(!jitterExpanded) : undefined}
@@ -297,7 +305,7 @@ export function HeroIdentityCard({
       </div>
 
       {/* Expanded Jitter Detail Panel */}
-      {jitterExpanded && hasJitterDetail && (
+      {jitterExpanded && hasJitterDetail && !hideJitter && (
         <div
           className="mx-4 mt-3 rounded-xl overflow-hidden"
           style={{

--- a/src/utils/jitterTrust.js
+++ b/src/utils/jitterTrust.js
@@ -1,0 +1,17 @@
+import { Capacitor } from '@capacitor/core'
+
+// Jitter trust scoring measures per-keystroke typing rhythm, captured from
+// keydown/keyup events. On native iOS (Capacitor WKWebView) the soft keyboard
+// — autocorrect, predictive text, swipe-typing, dictation — does not emit
+// reliable per-character keydown events, so rhythm samples never reach the
+// 10-flight-time floor and the score can never advance past "Building".
+// Showing a "building trust / verify yourself" state there is a promise no
+// mobile user can fulfill, so we suppress the Building state on native.
+//
+// Verified/Trusted states still render (a user who reached them on web keeps
+// the credit when viewing on the app). Only the dead-end Building state is hidden.
+//
+// Background: wgh-phone #180 (root cause) and #174 (strategy).
+export function jitterTrustVisible() {
+  return !Capacitor.isNativePlatform()
+}


### PR DESCRIPTION
## Why
Jitter trust scoring measures per-keystroke typing **rhythm**, captured from `keydown`/`keyup` events. On native iOS (Capacitor WKWebView) the soft keyboard — autocorrect, predictive text, swipe-typing, dictation — does **not** emit reliable per-character keydown events. So rhythm samples never reach the 10-flight-time floor (`jitter-box.js:502`, `usePurityTracker.js:130`) and a user's tier is permanently stuck at **"Building."**

Discovered by debugging Dan's own account: **18 reviews with text, 1 sample landed** (the lone sample was pre-launch, typed on web). Essentially **no iPhone user can ever earn the badge** — so showing a "building trust / verify yourself" state on iOS is an unkeepable promise.

Root cause + strategy: wgh-phone #180 / #174.

## What
Gate the **Building** state off on **native only**. Verified/Trusted still render (web-verified users keep credit on the app). **Web behavior is unchanged.**

- **`src/utils/jitterTrust.js`** (new) — `jitterTrustVisible()` = `!Capacitor.isNativePlatform()`, centralizing the platform check + rationale.
- **`jitterApi.getTrustBadgeType()`** — returns `null` instead of `'building'` on native (review badges, public profiles).
- **`HeroIdentityCard`** — hides the Building "Review Fingerprint" chip *and* its expanded panel (one shared `hideJitter` gate).
- **`ProfileJitterCard`** — returns `null` in the Building state.

`/how-reviews-work` is untouched (hardcoded teaching examples).

## Scope / rollout
Frontend-only → bundled into `dist` → reaches **iOS users on the next Capacitor build**; web on next deploy. No schema/RPC changes.

## Test plan
- `npm run build` ✅
- `eslint` on all four files ✅
- `vitest run src/components/jitter` — 28/28 ✅
- Codex (gpt-5.3-codex, read-only) review ✅ — confirmed complete coverage, no missed surfaces, callers tolerate `null`; flagged one low-risk dangling-panel edge case which is now hardened via the shared gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)