### PR TITLE
refactor(profile): one canonical Food Story stats module (kill the rating-style/standout dup)

### DIFF
--- a/src/hooks/useUserVotes.js
+++ b/src/hooks/useUserVotes.js
@@ -2,6 +2,7 @@ import { useEffect, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { votesApi } from '../api/votesApi'
 import { logger } from '../utils/logger'
+import { computeRatingStyle, computeStandoutPicks } from '../utils/foodStats'
 
 /**
  * Transform raw vote data to dish format
@@ -24,86 +25,24 @@ function transformVote(vote) {
 }
 
 /**
- * Compute rating style from avgRating and ratingVariance
+ * Map raw votes to the normalized rated-item shape computeStandoutPicks expects.
+ * Skips unrated votes; carries the fields the Food Story render reads. The
+ * Best Find / Hottest Take math itself lives in utils/foodStats.js.
  */
-function computeRatingStyle(avgRating, ratingVariance) {
-  if (avgRating === null) return null
-
-  // Level based on average rating
-  let level, emoji
-  if (avgRating < 6.0) {
-    level = 'tough'
-    emoji = '\uD83E\uDDD0' // monocle face
-  } else if (avgRating < 7.5) {
-    level = 'fair'
-    emoji = '\u2696\uFE0F' // balance scale
-  } else if (avgRating < 8.5) {
-    level = 'generous'
-    emoji = '\uD83D\uDE0A' // smiling face
-  } else {
-    level = 'easy'
-    emoji = '\uD83E\uDD70' // smiling face with hearts
-  }
-
-  // Consistency based on variance
-  const consistency = ratingVariance < 1.5 ? 'consistent' : 'varied'
-
-  // Compose label
-  const levelLabels = {
-    tough: 'Tough Critic',
-    fair: 'Fair Judge',
-    generous: 'Generous Rater',
-    easy: 'Easy to Please',
-  }
-  const label = levelLabels[level]
-
-  return { level, consistency, label, emoji }
-}
-
-/**
- * Compute standout picks by comparing user ratings to community averages
- */
-function computeStandoutPicks(data, communityAvgs) {
-  const MIN_COMMUNITY_VOTES = 3
-  const picks = {}
-
-  // ratedVotes: every rated dish — feeds Best Find (just the user's top rating).
-  // comparisons: subset with community baseline — feeds Hottest Take (you-vs-crowd diff).
-  const ratedVotes = []
-  const comparisons = []
-  for (const vote of data) {
+function votesToRatedItems(votes) {
+  const items = []
+  for (const vote of votes) {
     if (vote.rating_10 == null) continue
-    const dishId = vote.dishes.id
-    const item = {
-      dish_id: dishId,
+    items.push({
+      dish_id: vote.dishes.id,
       dish_name: vote.dishes.name,
       category: vote.dishes.category,
       restaurant_id: vote.dishes.restaurants?.id,
       restaurant_name: vote.dishes.restaurants?.name,
       userRating: vote.rating_10,
-    }
-    ratedVotes.push(item)
-
-    const community = communityAvgs[dishId]
-    if (!community || community.count < MIN_COMMUNITY_VOTES) continue
-    comparisons.push({
-      ...item,
-      communityAvg: community.avg,
-      diff: vote.rating_10 - community.avg,
     })
   }
-
-  if (ratedVotes.length > 0) {
-    const best = ratedVotes.slice().sort((a, b) => b.userRating - a.userRating)
-    picks.bestFind = best[0]
-  }
-
-  if (comparisons.length > 0) {
-    const harsh = comparisons.slice().sort((a, b) => a.diff - b.diff)
-    if (harsh[0].diff <= -1.0) picks.harshestTake = harsh[0]
-  }
-
-  return picks
+  return items
 }
 
 /**
@@ -341,7 +280,7 @@ export function useUserVotes(userId) {
       ? computeCategoryComparison(votes, communityAvgs)
       : {}
     const standoutPicks = communityAvgs
-      ? computeStandoutPicks(votes, communityAvgs)
+      ? computeStandoutPicks(votesToRatedItems(votes), communityAvgs)
       : {}
 
     return {

--- a/src/pages/UserProfile.jsx
+++ b/src/pages/UserProfile.jsx
@@ -4,6 +4,7 @@ import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useAuth } from '../context/AuthContext'
 import { logger } from '../utils/logger'
 import { getCompatColor } from '../utils/formatters'
+import { computeRatingStyle, computeStandoutPicks } from '../utils/foodStats'
 import { followsApi } from '../api/followsApi'
 import { useFollowUser } from '../hooks/useFollowUser'
 import { votesApi } from '../api/votesApi'
@@ -39,29 +40,8 @@ function formatLocationName(slug) {
 // with the binary vote (Apr 2026). The shelf filter UI is no longer rendered;
 // kept only for search-history compatibility.
 
-/**
- * Compute rating style from average rating and variance
- */
-function computeRatingStyle(avgRating, ratingVariance) {
-  if (avgRating === null) return null
-
-  let level, label
-  if (avgRating < 6.0) {
-    level = 'tough'
-    label = 'Tough Critic'
-  } else if (avgRating < 7.5) {
-    level = 'fair'
-    label = 'Fair Judge'
-  } else if (avgRating < 8.5) {
-    level = 'generous'
-    label = 'Generous Rater'
-  } else {
-    level = 'easy'
-    label = 'Easy to Please'
-  }
-
-  return { level, label }
-}
+// Rating-style + standout-picks math is shared via utils/foodStats.js so this
+// page and the owner Profile (useUserVotes) can't drift.
 
 /**
  * Public User Profile Page
@@ -254,12 +234,10 @@ export function UserProfile() {
       if (results[0].status === 'fulfilled') {
         try {
           const communityAvgs = results[0].value
-          const MIN_COMMUNITY = 3
-          const picks = {}
-
-          // Best Find = the user's highest-rated dish, no community gate (matches
-          // user expectation: "my favorite," not "consensus favorite").
-          const allRated = ratedVotes
+          // Normalize this page's recent_votes shape into the shared item shape;
+          // the Best Find / Hottest Take math lives in utils/foodStats.js so this
+          // page and the owner Profile (useUserVotes) can't drift.
+          const items = ratedVotes
             .filter(v => v.dish?.id)
             .map(v => ({
               dish_id: v.dish.id,
@@ -268,30 +246,7 @@ export function UserProfile() {
               restaurant_name: v.dish.restaurant_name,
               userRating: v.rating,
             }))
-
-          if (allRated.length > 0) {
-            const best = allRated.slice().sort((a, b) => b.userRating - a.userRating)
-            picks.bestFind = best[0]
-          }
-
-          // Hottest Take still needs community comparison to be meaningful.
-          const comparisons = ratedVotes
-            .filter(v => v.dish?.id && communityAvgs[v.dish.id]?.count >= MIN_COMMUNITY)
-            .map(v => ({
-              dish_id: v.dish.id,
-              dish_name: v.dish.name,
-              restaurant_id: v.dish.restaurant_id,
-              restaurant_name: v.dish.restaurant_name,
-              userRating: v.rating,
-              communityAvg: communityAvgs[v.dish.id].avg,
-              diff: v.rating - communityAvgs[v.dish.id].avg,
-            }))
-
-          if (comparisons.length > 0) {
-            const harsh = comparisons.slice().sort((a, b) => a.diff - b.diff)
-            if (harsh[0].diff <= -1.0) picks.harshestTake = harsh[0]
-          }
-
+          const picks = computeStandoutPicks(items, communityAvgs)
           if (picks.bestFind || picks.harshestTake) setStandoutPicks(picks)
         } catch (err) {
           logger.error('Failed to compute standout picks:', err)

--- a/src/utils/foodStats.js
+++ b/src/utils/foodStats.js
@@ -1,0 +1,92 @@
+// Canonical "Food Story" stat helpers — the single source of truth for the
+// rating-style label and the standout-picks (Best Find / Hottest Take) shown on
+// both the owner Profile (via useUserVotes) and the public UserProfile page.
+//
+// These two pages historically each carried their own copy of this logic and
+// drifted (e.g. one returned an emoji, the other didn't). Keep all rating-style
+// thresholds, labels, and the standout-pick rules HERE so the two pages cannot
+// diverge again. Each page adapts its own vote shape into the normalized inputs
+// below; the math lives only in this file.
+
+export const RATING_STYLE_LABELS = {
+  tough: 'Tough Critic',
+  fair: 'Fair Judge',
+  generous: 'Generous Rater',
+  easy: 'Easy to Please',
+}
+
+// Standout-pick rules.
+export const MIN_COMMUNITY_VOTES_FOR_STANDOUT = 3   // community baseline needed for a Hottest Take
+export const HOTTEST_TAKE_DIFF_THRESHOLD = -1.0      // you must be ≥1.0 below the crowd to qualify
+
+/**
+ * Rating style from a user's average rating + variance.
+ * @param {number|null} avgRating
+ * @param {number} ratingVariance — std-dev of ratings
+ * @returns {{ level: string, consistency: string, label: string, emoji: string } | null}
+ */
+export function computeRatingStyle(avgRating, ratingVariance) {
+  if (avgRating === null) return null
+
+  // Level based on average rating
+  let level, emoji
+  if (avgRating < 6.0) {
+    level = 'tough'
+    emoji = '🧐' // monocle face
+  } else if (avgRating < 7.5) {
+    level = 'fair'
+    emoji = '⚖️' // balance scale
+  } else if (avgRating < 8.5) {
+    level = 'generous'
+    emoji = '😊' // smiling face
+  } else {
+    level = 'easy'
+    emoji = '🥰' // smiling face with hearts
+  }
+
+  // Consistency based on variance
+  const consistency = ratingVariance < 1.5 ? 'consistent' : 'varied'
+
+  return { level, consistency, label: RATING_STYLE_LABELS[level], emoji }
+}
+
+/**
+ * Standout picks from a user's rated dishes vs community averages.
+ *
+ * @param {Array<{ dish_id: string, userRating: number, [k:string]: any }>} ratedItems
+ *   Normalized, already-rated items. Whatever extra fields each caller includes
+ *   (dish_name, restaurant_name, category, …) are passed through onto the picks.
+ * @param {Object<string, { avg: number, count: number }>} communityAvgs — keyed by dish_id
+ * @returns {{ bestFind?: object, harshestTake?: object }}
+ *
+ * - bestFind: the user's highest-rated dish (no community gate — "my favorite").
+ * - harshestTake: the dish where the user is furthest below the crowd, but only
+ *   if that gap is at least HOTTEST_TAKE_DIFF_THRESHOLD and the dish has a
+ *   community baseline of MIN_COMMUNITY_VOTES_FOR_STANDOUT votes.
+ */
+export function computeStandoutPicks(ratedItems, communityAvgs) {
+  const picks = {}
+
+  if (ratedItems.length > 0) {
+    const best = ratedItems.slice().sort((a, b) => b.userRating - a.userRating)
+    picks.bestFind = best[0]
+  }
+
+  const comparisons = []
+  for (const item of ratedItems) {
+    const community = communityAvgs?.[item.dish_id]
+    if (!community || community.count < MIN_COMMUNITY_VOTES_FOR_STANDOUT) continue
+    comparisons.push({
+      ...item,
+      communityAvg: community.avg,
+      diff: item.userRating - community.avg,
+    })
+  }
+
+  if (comparisons.length > 0) {
+    const harsh = comparisons.slice().sort((a, b) => a.diff - b.diff)
+    if (harsh[0].diff <= HOTTEST_TAKE_DIFF_THRESHOLD) picks.harshestTake = harsh[0]
+  }
+
+  return picks
+}

--- a/src/utils/foodStats.test.js
+++ b/src/utils/foodStats.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeRatingStyle,
+  computeStandoutPicks,
+  RATING_STYLE_LABELS,
+  MIN_COMMUNITY_VOTES_FOR_STANDOUT,
+  HOTTEST_TAKE_DIFF_THRESHOLD,
+} from './foodStats'
+
+describe('computeRatingStyle', () => {
+  it('returns null when avgRating is null', () => {
+    expect(computeRatingStyle(null, 0)).toBe(null)
+  })
+
+  it('maps each average-rating band to the right level + label', () => {
+    expect(computeRatingStyle(5.9, 0)).toMatchObject({ level: 'tough', label: 'Tough Critic' })
+    expect(computeRatingStyle(7.4, 0)).toMatchObject({ level: 'fair', label: 'Fair Judge' })
+    expect(computeRatingStyle(8.4, 0)).toMatchObject({ level: 'generous', label: 'Generous Rater' })
+    expect(computeRatingStyle(9.0, 0)).toMatchObject({ level: 'easy', label: 'Easy to Please' })
+  })
+
+  it('uses the exact band boundaries (<6.0, <7.5, <8.5)', () => {
+    expect(computeRatingStyle(6.0, 0).level).toBe('fair')     // 6.0 is NOT tough
+    expect(computeRatingStyle(7.5, 0).level).toBe('generous') // 7.5 is NOT fair
+    expect(computeRatingStyle(8.5, 0).level).toBe('easy')     // 8.5 is NOT generous
+  })
+
+  it('preserves the exact emoji per level (locks the literal == the old \\uXXXX escapes)', () => {
+    expect(computeRatingStyle(5.0, 0).emoji).toBe('🧐') // monocle
+    expect(computeRatingStyle(7.0, 0).emoji).toBe('⚖️') // balance scale
+    expect(computeRatingStyle(8.0, 0).emoji).toBe('😊') // smiling face
+    expect(computeRatingStyle(9.0, 0).emoji).toBe('🥰') // smiling face w/ hearts
+  })
+
+  it('derives consistency from variance with a 1.5 boundary (<1.5 consistent)', () => {
+    expect(computeRatingStyle(7.0, 1.49).consistency).toBe('consistent')
+    expect(computeRatingStyle(7.0, 1.5).consistency).toBe('varied') // 1.5 is NOT < 1.5
+    expect(computeRatingStyle(7.0, 2.0).consistency).toBe('varied')
+  })
+
+  it('labels map matches the public constant', () => {
+    expect(RATING_STYLE_LABELS).toEqual({
+      tough: 'Tough Critic', fair: 'Fair Judge', generous: 'Generous Rater', easy: 'Easy to Please',
+    })
+  })
+})
+
+describe('computeStandoutPicks', () => {
+  const item = (dish_id, userRating, extra = {}) => ({ dish_id, dish_name: `dish-${dish_id}`, userRating, ...extra })
+
+  it('returns {} for no rated items', () => {
+    expect(computeStandoutPicks([], {})).toEqual({})
+  })
+
+  it('bestFind is the highest-rated dish, with no community gate', () => {
+    const items = [item('a', 7), item('b', 9), item('c', 8)]
+    const picks = computeStandoutPicks(items, {}) // no community data at all
+    expect(picks.bestFind.dish_id).toBe('b')
+    expect(picks.harshestTake).toBeUndefined()
+  })
+
+  it('passes the caller item fields through onto bestFind', () => {
+    const picks = computeStandoutPicks([item('a', 9, { restaurant_name: 'Nancy\'s', category: 'lobster' })], {})
+    expect(picks.bestFind).toMatchObject({ dish_id: 'a', dish_name: 'dish-a', userRating: 9, restaurant_name: 'Nancy\'s', category: 'lobster' })
+  })
+
+  it('harshestTake requires the community baseline (MIN_COMMUNITY_VOTES_FOR_STANDOUT) and a diff <= threshold', () => {
+    const items = [item('a', 4), item('b', 9)]
+    const community = {
+      a: { avg: 8, count: MIN_COMMUNITY_VOTES_FOR_STANDOUT }, // diff -4 → qualifies
+      b: { avg: 8, count: MIN_COMMUNITY_VOTES_FOR_STANDOUT }, // diff +1 → no
+    }
+    const picks = computeStandoutPicks(items, community)
+    expect(picks.harshestTake.dish_id).toBe('a')
+    expect(picks.harshestTake.communityAvg).toBe(8)
+    expect(picks.harshestTake.diff).toBe(-4)
+  })
+
+  it('excludes dishes below the community vote threshold from harshestTake', () => {
+    const items = [item('a', 4)]
+    const community = { a: { avg: 8, count: MIN_COMMUNITY_VOTES_FOR_STANDOUT - 1 } } // only 2 votes
+    const picks = computeStandoutPicks(items, community)
+    expect(picks.harshestTake).toBeUndefined()
+    expect(picks.bestFind.dish_id).toBe('a') // bestFind still set (no gate)
+  })
+
+  it('respects the exact diff threshold boundary (<= -1.0 qualifies, -0.9 does not)', () => {
+    const community = { a: { avg: 8, count: 5 } }
+    expect(computeStandoutPicks([item('a', 7.0)], community).harshestTake?.dish_id).toBe('a')   // diff -1.0
+    expect(computeStandoutPicks([item('a', 7.1)], community).harshestTake).toBeUndefined()       // diff -0.9
+    expect(HOTTEST_TAKE_DIFF_THRESHOLD).toBe(-1.0)
+  })
+
+  it('picks the single most-negative diff as harshestTake', () => {
+    const items = [item('a', 6), item('b', 3), item('c', 7)]
+    const community = { a: { avg: 8, count: 5 }, b: { avg: 8, count: 5 }, c: { avg: 8, count: 5 } }
+    expect(computeStandoutPicks(items, community).harshestTake.dish_id).toBe('b') // diff -5
+  })
+})


### PR DESCRIPTION
## Problem
The Food Story logic — rating-style label + standout picks (Best Find / Hottest Take) — was implemented **twice**, in `hooks/useUserVotes.js` (owner Profile) and `pages/UserProfile.jsx` (public profile), and had **already drifted**: useUserVotes returned `{level, consistency, label, emoji}`, UserProfile returned `{level, label}`. Exactly the kind of split that produces "why does my profile say X but theirs say Y" bugs.

## Fix
Extract the canonical math into **`src/utils/foodStats.js`** (`computeRatingStyle` + `computeStandoutPicks`) and point both callers at it. Each page keeps a thin adapter for its own vote shape:
- `useUserVotes` → `votesToRatedItems(votes)` (raw `v.dishes.id` / `v.rating_10`)
- `UserProfile` → inline map of `recent_votes` (`v.dish.id` / `v.rating`)

Net: **−125 lines** of duplicated logic; the rules now live in one file the two pages can't diverge from.

## Behavior-preserving (hard requirement)
- **`computeRatingStyle`**: thresholds (`<6.0`/`<7.5`/`<8.5`), labels, `consistency` (`<1.5`) match both originals. The emoji literals (🧐 ⚖️ 😊 🥰) are **byte-identical** to the old `\uXXXX` escapes (verified by codepoint). UserProfile's render reads only `.label`, so the now-present `emoji`/`consistency` fields are invisible there; the Profile page shows the same emoji as before.
- **`computeStandoutPicks`**: identical output — `bestFind` = highest `userRating` (no community gate); `hottestTake` = most-negative diff, gated by community `count ≥ 3` **and** `diff ≤ −1.0`. Per-caller item fields preserved; stable sort preserves tie-breaks.
- **Favorite-restaurant logic left UN-unified, on purpose.** It genuinely differs (useUserVotes counts *all* votes with *no* minimum; UserProfile counts *rated-only* with a *≥2* threshold). Unifying it would change one page's displayed output — that's a product decision, explicitly out of scope here. Flagging it rather than silently picking a winner.

## Tests
New **`src/utils/foodStats.test.js`** (13 cases) locks the thresholds, exact band boundaries, emoji equivalence, the `1.5` consistency boundary, and every standout gate (community count, the `−1.0` diff boundary, most-negative selection, empty input).
- Full suite: **39 files / 668 tests pass** · build clean · **0 lint errors**.

## Review note
Codex CLI was stalling today (two runs, zero output, killed), so this was reviewed **inline**: a line-by-line comparison against both originals plus the new tests that lock the invariants. Happy to gate on a Codex pass once it's behaving if preferred.