### PR TITLE
chore: fix 3 lint errors + refresh stale CLAUDE.md route table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ src/
 ├── context/          # AuthContext, LocationContext
 ├── hooks/            # Custom React hooks (20 hooks)
 ├── lib/              # Infrastructure (supabase, analytics, storage, sounds, rateLimiter, reviewBlocklist)
-├── pages/            # Page components (19 pages, all lazy-loaded)
+├── pages/            # Page components (28 pages, all lazy-loaded)
 ├── utils/            # Pure utilities (errorHandler, ranking, distance, logger, sanitize, etc.)
 └── test/             # Test setup
 
@@ -397,7 +397,8 @@ Defined in `src/index.css`. Light theme only ("Appetite"). Use `var(--color-*)` 
 | `seed-reviews` | AI review generation (dev utility) |
 | `backfill-restaurants` | Data migration tool |
 
-### 4.14 Routes (18 pages, all lazy-loaded via `lazyWithRetry()`)
+### 4.14 Routes (28 page components, all lazy-loaded via `lazyWithRetry()`)
+Source of truth: `src/App.jsx`.
 | Route | Page | Auth |
 |---|---|---|
 | `/` | Map (dual-mode list/map homepage; reads `?category=<id>` and `?q=<query>` to seed filters) | No |
@@ -406,18 +407,29 @@ Defined in `src/index.css`. Light theme only ("Appetite"). Use `var(--color-*)` 
 | `/dish/:dishId` | Dish | No |
 | `/restaurants` | Restaurants | No |
 | `/restaurants/:restaurantId` | RestaurantDetail | No |
+| `/restaurants/:restaurantId/rate` | RateYourMeal | No |
+| `/restaurants/:restaurantId/reviews` | RestaurantReviews | No |
 | `/profile` | Profile (journal feed) | Yes |
 | `/user/:userId` | UserProfile (public) | No |
 | `/login` | Login | No |
+| `/auth/callback` | AuthCallback | No |
 | `/reset-password` | ResetPassword | No |
+| `/auth/cross-device` | CrossDevicePkce | No |
 | `/admin` | Admin | Yes |
 | `/invite/:token` | AcceptInvite | No |
+| `/curator-invite/:token` | AcceptCuratorInvite | No |
+| `/my-list` | MyList | Yes |
 | `/manage` | ManageRestaurant | Yes |
 | `/privacy` | Privacy | No |
 | `/terms` | Terms | No |
+| `/support` | Support | No |
 | `/how-reviews-work` | HowReviewsWork | No |
 | `/for-restaurants` | ForRestaurants | No |
+| `/playlist/:id` | Playlist | No |
 | `/jitter` | JitterLanding | No |
+| `/waitlist` | Waitlist | No |
+| `/locals` | Locals | No |
+| `/locals/:userId` | LocalsCurator | No |
 | `*` | NotFound | No |
 
 ### 4.15 File Organization

--- a/src/api/votesApi.js
+++ b/src/api/votesApi.js
@@ -173,7 +173,7 @@ export const votesApi = {
           })
           submittedDishIds.push(normalizedVotes[i].dishId)
         } catch (error) {
-          var classifiedError = error.type ? error : createClassifiedError(error)
+          const classifiedError = error.type ? error : createClassifiedError(error)
           classifiedError.submittedCount = submittedDishIds.length
           classifiedError.submittedDishIds = submittedDishIds.slice()
           throw classifiedError
@@ -192,7 +192,7 @@ export const votesApi = {
         throw error
       }
 
-      var classifiedError = createClassifiedError(error)
+      const classifiedError = createClassifiedError(error)
       if (error.submittedCount != null) {
         classifiedError.submittedCount = error.submittedCount
         classifiedError.submittedDishIds = error.submittedDishIds

--- a/src/pages/RestaurantDetail.jsx
+++ b/src/pages/RestaurantDetail.jsx
@@ -26,6 +26,10 @@ import { useRestaurantEvents } from '../hooks/useEvents'
 import { SpecialCard } from '../components/SpecialCard'
 import { EventCard } from '../components/EventCard'
 
+// Specials & Events ("Happening Here") are hidden until Launch 2.0 — the scraped
+// data is stale. Flip to true to surface the block.
+const SHOW_SPECIALS_EVENTS = false
+
 export function RestaurantDetail() {
   const { restaurantId } = useParams()
   const navigate = useNavigate()
@@ -746,7 +750,7 @@ export function RestaurantDetail() {
       </div>
 
       {/* Happening Here - Specials & Events (hidden until Launch 2.0 — stale scraped data) */}
-      {false && (specials.length > 0 || events.length > 0) && (
+      {SHOW_SPECIALS_EVENTS && (specials.length > 0 || events.length > 0) && (
         <div className="px-4 py-4">
           <div
             className="mb-3 h-px"


### PR DESCRIPTION
Gets `src/` to **0 lint errors** and corrects the onboarding doc that's been lying about the route map.

## Lint errors (3 → 0)
- **`votesApi.js` — `no-redeclare`:** `submitBatchVotes` had two `var classifiedError` declarations (inner + outer catch) that hoist to the same function scope. Both changed to block-scoped **`const`** — identical runtime behavior, clears the redeclare.
- **`RestaurantDetail.jsx` — `no-constant-binary-expression` ×2:** the `{false && (specials… || events…)}` gate is now a named **`SHOW_SPECIALS_EVENTS = false`** flag. Clearer "hidden until Launch 2.0" intent, **same behavior** (still off). *Note:* this only fixes the lint — the hooks above it still fire each load; actually stopping that is a separate decision, intentionally not done here.

## Docs
- **`CLAUDE.md` §4.14 route table was stale** — claimed 18/19 pages; there are **28**. Rebuilt the table from `src/App.jsx` (30 routes incl. the 2 redirects) and added the 12 missing routes: `RateYourMeal`, `RestaurantReviews`, `AuthCallback`, `CrossDevicePkce`, `AcceptCuratorInvite`, `MyList`, `Support`, `Playlist`, `Waitlist`, `Locals`, `LocalsCurator`. Fixed the `19 pages` count in the structure diagram too.

## Safety
0 lint errors, build clean, **668 tests pass**. No behavior change — `var`→`const` is runtime-identical, the flag is still `false`, the rest is documentation.