### PR TITLE
feat: Share to Instagram for playlists + locals lists (+ Create-your-own CTA)

### DIFF
--- a/docs/superpowers/plans/2026-06-01-share-to-instagram.md
+++ b/docs/superpowers/plans/2026-06-01-share-to-instagram.md
@@ -1,0 +1,603 @@
+# Share to Instagram Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users post an on-brand 1080×1080 image of a playlist or their locals list to Instagram via the native share sheet, flag-gated and reversible.
+
+**Architecture:** A zero-dependency `<canvas>` renderer (isolated behind one module so it can be swapped for a DOM-snapshot impl) produces a PNG `File`; a new `shareImage()` in the existing Capacitor-aware share util hands it to the OS (web Web-Share-with-files now; native Capacitor Filesystem+Share in Phase 2); a shared `ShareToInstagramButton` pre-generates the image on mount (iOS gesture requirement) and orchestrates fallbacks. No new RPC/migration/server — card data already lives in the React tree.
+
+**Tech Stack:** React 19, Vite, Capacitor (`@capacitor/share`, + `@capacitor/filesystem` in Phase 2), `sonner` toasts, PostHog `capture`, vitest.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/constants/features.js` (modify) | Add `IG_SHARE_ENABLED` master kill flag |
+| `src/components/share/renderShareCardToFile.js` (create) | **Reversibility boundary.** Canvas → PNG `File`. v1 impl; swappable |
+| `src/components/share/ShareToInstagramButton.jsx` (create) | Button + pre-generate-on-mount + share orchestration + fallback toast |
+| `src/components/share/index.js` (create) | Barrel export |
+| `src/utils/share.js` (modify) | Add `shareImage({file,blob,url,text})` — mirrors existing `shareOrCopy` ladder |
+| `src/utils/share.test.js` (create) | Critical-path test: `shareImage` fallback chain |
+| `src/components/share/ShareToInstagramButton.test.jsx` (create) | Flag-gating + render |
+| `src/pages/Playlist.jsx` (modify) | Mount IG button (commit 1) + "Create your own" CTA (commit 2) |
+| `src/pages/Profile.jsx` (modify) | Mount IG button beside `SharePicksButton` |
+| `package.json` (modify, Phase 2) | Add `@capacitor/filesystem` |
+
+> **Note on canvas + jsdom:** `getContext('2d')`/`toBlob` are not implemented in jsdom, and mocking them tests the mock, not behavior (and "mocks lie"). So the **renderer is verified manually in a browser / on-device** (it's visual output anyway). Automated tests cover the genuinely testable logic: the `shareImage` fallback ladder and the button's flag-gating.
+
+---
+
+## Phase 1 — Web image-share (ships + tests today)
+
+### Task 1: Feature flag
+
+**Files:** Modify `src/constants/features.js`
+
+- [ ] **Step 1: Add the flag** (default-on, env-killable — matches `APPLE_SIGNIN_ENABLED`)
+
+```js
+  // Share-to-Instagram (image → native share sheet). Default-on;
+  // set VITE_FEATURES_IG_SHARE=false to kill instantly without a deploy.
+  IG_SHARE_ENABLED: import.meta.env.VITE_FEATURES_IG_SHARE !== 'false',
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/constants/features.js
+git commit -m "feat(share): add IG_SHARE_ENABLED feature flag"
+```
+
+---
+
+### Task 2: Canvas renderer (the reversibility boundary)
+
+**Files:** Create `src/components/share/renderShareCardToFile.js`
+
+- [ ] **Step 1: Implement the renderer** — complete, working code:
+
+```js
+import { logger } from '../../utils/logger'
+
+const SIZE = 1080
+
+// Brand colors read from CSS vars so the card stays theme-driven (rebrand = one file).
+function token(name, fallback) {
+  try {
+    const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+    return v || fallback
+  } catch {
+    return fallback
+  }
+}
+
+async function ensureFonts() {
+  if (typeof document === 'undefined' || !document.fonts || !document.fonts.load) return
+  try {
+    await Promise.all([
+      document.fonts.load("700 72px 'Amatic SC'"),
+      document.fonts.load("800 72px 'Outfit'"),
+    ])
+    await document.fonts.ready
+  } catch (err) {
+    logger.warn('Share card font load failed; using fallback fonts:', err)
+  }
+}
+
+function roundRect(ctx, x, y, w, h, r) {
+  ctx.beginPath()
+  ctx.moveTo(x + r, y)
+  ctx.arcTo(x + w, y, x + w, y + h, r)
+  ctx.arcTo(x + w, y + h, x, y + h, r)
+  ctx.arcTo(x, y + h, x, y, r)
+  ctx.arcTo(x, y, x + w, y, r)
+  ctx.closePath()
+}
+
+function fillTruncated(ctx, text, x, y, maxWidth) {
+  let t = String(text == null ? '' : text)
+  if (ctx.measureText(t).width <= maxWidth) { ctx.fillText(t, x, y); return }
+  while (t.length > 1 && ctx.measureText(t + '…').width > maxWidth) t = t.slice(0, -1)
+  ctx.fillText(t + '…', x, y)
+}
+
+/**
+ * Render a 1080x1080 share card to a PNG File. Pure visual output — verified
+ * manually in-browser / on-device (canvas is not implemented in jsdom).
+ * @param {{title:string, byline:string, emojis?:string[], topItems?:string[], footerUrl?:string}} data
+ * @returns {Promise<{file:File, blob:Blob}>}
+ */
+export async function renderShareCardToFile({ title, byline, emojis = [], topItems = [], footerUrl = 'wghapp.com' }) {
+  await ensureFonts()
+
+  const canvas = document.createElement('canvas')
+  canvas.width = SIZE
+  canvas.height = SIZE
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('Canvas 2D context unavailable')
+
+  const bg = token('--color-bg', '#F0ECE8')
+  const gold = token('--color-accent-gold', '#C48A12')
+  const textPrimary = token('--color-text-primary', '#1A1A1A')
+  const textSecondary = token('--color-text-secondary', '#555555')
+  const tileColors = ['#C48A12', '#E4440A', '#B07340', '#16A34A']
+
+  ctx.fillStyle = bg
+  ctx.fillRect(0, 0, SIZE, SIZE)
+
+  // Wordmark: WHAT'S GOOD HERE (GOOD in gold)
+  ctx.textBaseline = 'alphabetic'
+  ctx.textAlign = 'left'
+  ctx.font = "700 56px 'Amatic SC', cursive"
+  ctx.fillStyle = textSecondary
+  ctx.fillText("WHAT'S ", 80, 120)
+  const w1 = ctx.measureText("WHAT'S ").width
+  ctx.fillStyle = gold
+  ctx.fillText('GOOD', 80 + w1, 120)
+  const w2 = ctx.measureText('GOOD').width
+  ctx.fillStyle = textSecondary
+  ctx.fillText(' HERE', 80 + w1 + w2, 120)
+
+  // 2x2 emoji tiles
+  const tile = 150, gap = 16, ox = 80, oy = 180
+  for (let i = 0; i < 4; i++) {
+    const x = ox + (i % 2) * (tile + gap)
+    const y = oy + Math.floor(i / 2) * (tile + gap)
+    ctx.fillStyle = tileColors[i]
+    roundRect(ctx, x, y, tile, tile, 18)
+    ctx.fill()
+    ctx.font = '88px serif'
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    ctx.fillText(emojis[i] || '🍽️', x + tile / 2, y + tile / 2 + 4)
+  }
+  ctx.textAlign = 'left'
+  ctx.textBaseline = 'alphabetic'
+
+  // Title
+  const titleY = oy + 2 * tile + gap + 96
+  ctx.fillStyle = textPrimary
+  ctx.font = "800 72px 'Outfit', sans-serif"
+  fillTruncated(ctx, title, 80, titleY, SIZE - 160)
+
+  // Byline
+  ctx.fillStyle = textSecondary
+  ctx.font = "500 34px 'Outfit', sans-serif"
+  fillTruncated(ctx, byline, 80, titleY + 52, SIZE - 160)
+
+  // Top 3 items
+  ctx.fillStyle = textPrimary
+  ctx.font = "600 38px 'Outfit', sans-serif"
+  let ly = titleY + 132
+  for (let i = 0; i < Math.min(3, topItems.length); i++) {
+    fillTruncated(ctx, '▸ ' + topItems[i], 80, ly, SIZE - 160)
+    ly += 58
+  }
+
+  // Footer
+  ctx.fillStyle = gold
+  ctx.font = "700 32px 'Outfit', sans-serif"
+  ctx.fillText(footerUrl, 80, SIZE - 72)
+
+  const blob = await new Promise((resolve, reject) => {
+    canvas.toBlob((b) => (b ? resolve(b) : reject(new Error('toBlob returned null'))), 'image/png', 0.95)
+  })
+  const file = new File([blob], 'wgh-share.png', { type: 'image/png' })
+  return { file, blob }
+}
+```
+
+- [ ] **Step 2: Commit** (with Task 3–4; this module alone isn't runnable)
+
+---
+
+### Task 3: `shareImage()` in the share util
+
+**Files:** Modify `src/utils/share.js`
+
+- [ ] **Step 1: Write the failing test** — `src/utils/share.test.js`
+
+```js
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { shareImage } from './share'
+
+describe('shareImage', () => {
+  const file = new File(['x'], 'wgh-share.png', { type: 'image/png' })
+  const blob = new Blob(['x'], { type: 'image/png' })
+
+  beforeEach(() => {
+    // jsdom has no canShare/share by default
+    delete navigator.canShare
+    delete navigator.share
+    navigator.clipboard = { writeText: vi.fn().mockResolvedValue(undefined) }
+    // stub anchor download
+    vi.spyOn(document.body, 'appendChild').mockImplementation((n) => n)
+    vi.spyOn(document.body, 'removeChild').mockImplementation((n) => n)
+    globalThis.URL.createObjectURL = vi.fn(() => 'blob:x')
+    globalThis.URL.revokeObjectURL = vi.fn()
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('falls back to download + copy-link when file share is unsupported', async () => {
+    const result = await shareImage({ file, blob, url: 'https://wghapp.com/playlist/1', text: 'hi' })
+    expect(result.method).toBe('download_copy')
+    expect(result.success).toBe(true)
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('https://wghapp.com/playlist/1')
+  })
+
+  it('uses web file share when supported', async () => {
+    navigator.canShare = vi.fn(() => true)
+    navigator.share = vi.fn().mockResolvedValue(undefined)
+    const result = await shareImage({ file, blob, url: 'u', text: 'hi' })
+    expect(navigator.share).toHaveBeenCalled()
+    expect(result).toEqual({ method: 'web_share_file', success: true })
+  })
+})
+```
+
+- [ ] **Step 2: Run, expect FAIL** — `npm run test -- src/utils/share.test.js --run` → "shareImage is not a function"
+
+- [ ] **Step 3: Implement** — append to `src/utils/share.js` (note: `Capacitor`/`Share` already imported at top; Phase 2 adds the native branch):
+
+```js
+/**
+ * Share an image File via the platform share sheet, with graceful fallback.
+ * Ladder: (Phase 2: Capacitor native file-share) → Web Share w/ files → download + copy-link.
+ * Never throws.
+ * @param {{ file: File, blob: Blob, url: string, text?: string, dialogTitle?: string }} options
+ * @returns {Promise<{ method: string, success: boolean }>}
+ */
+export async function shareImage({ file, blob, url, text, dialogTitle }) {
+  // 1. Web Share API with files (mobile browsers)
+  if (navigator.canShare && navigator.canShare({ files: [file] })) {
+    try {
+      const data = { files: [file] }
+      if (text) data.text = text
+      await navigator.share(data)
+      return { method: 'web_share_file', success: true }
+    } catch (err) {
+      if (err && err.name === 'AbortError') return { method: 'web_share_file', success: false }
+      logger.warn('Web file share failed, falling back:', err)
+    }
+  }
+
+  // 2. Fallback: download the image, then copy/share the link
+  try {
+    const a = document.createElement('a')
+    a.href = URL.createObjectURL(blob || file)
+    a.download = file.name || 'wgh-share.png'
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(a.href)
+  } catch (err) {
+    logger.warn('Image download fallback failed:', err)
+  }
+  const link = await shareOrCopy({ url, text })
+  return { method: 'download_copy', success: link.success }
+}
+```
+
+- [ ] **Step 4: Run, expect PASS** — `npm run test -- src/utils/share.test.js --run`
+
+---
+
+### Task 4: `ShareToInstagramButton` + barrel
+
+**Files:** Create `src/components/share/ShareToInstagramButton.jsx`, `src/components/share/index.js`, `src/components/share/ShareToInstagramButton.test.jsx`
+
+- [ ] **Step 1: Implement the button**
+
+```jsx
+import { useState, useEffect, useRef } from 'react'
+import { renderShareCardToFile } from './renderShareCardToFile'
+import { shareImage } from '../../utils/share'
+import { FEATURES } from '../../constants/features'
+import { capture } from '../../lib/analytics'
+import { logger } from '../../utils/logger'
+import { toast } from 'sonner'
+
+/**
+ * Share an on-brand card image of a playlist / locals list to Instagram.
+ * Pre-generates the image on mount: iOS Safari/WKWebView invalidate share()
+ * if you await after the tap, so the File must be ready before the gesture.
+ *
+ * Props: { surface: 'playlist'|'locals_list', id, url, cardData, shareText? }
+ *   cardData = { title, byline, emojis[], topItems[], footerUrl }
+ */
+export function ShareToInstagramButton({ surface, id, url, cardData, shareText }) {
+  const [busy, setBusy] = useState(false)
+  const assetRef = useRef(null)
+
+  useEffect(() => {
+    if (!FEATURES.IG_SHARE_ENABLED) return undefined
+    let cancelled = false
+    renderShareCardToFile(cardData)
+      .then((asset) => { if (!cancelled) assetRef.current = asset })
+      .catch((err) => logger.warn('Share card pre-render failed:', err))
+    return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id])
+
+  if (!FEATURES.IG_SHARE_ENABLED) return null
+
+  async function handleShare() {
+    setBusy(true)
+    try {
+      let asset = assetRef.current
+      if (!asset) asset = await renderShareCardToFile(cardData) // safety net (rare)
+      const result = await shareImage({ file: asset.file, blob: asset.blob, url, text: shareText })
+      capture('share_to_instagram', { surface, id, method: result.method, success: result.success })
+      if (result.success && result.method === 'download_copy') {
+        toast.success('Image saved — open Instagram to post', { duration: 2500 })
+      }
+    } catch (err) {
+      logger.warn('Share to Instagram failed:', err)
+      toast.error('Could not prepare the image. Please try again.', { duration: 2500 })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <button
+      onClick={handleShare}
+      disabled={busy}
+      className="px-5 py-2 rounded-full font-semibold transition-all hover:opacity-90 active:scale-[0.97] disabled:opacity-60"
+      style={{ background: 'var(--color-primary)', color: 'var(--color-text-on-primary)', fontSize: '13px' }}
+    >
+      {busy ? 'Preparing…' : 'Share to Instagram'}
+    </button>
+  )
+}
+```
+
+- [ ] **Step 2: Barrel** — `src/components/share/index.js`
+
+```js
+export { ShareToInstagramButton } from './ShareToInstagramButton'
+export { renderShareCardToFile } from './renderShareCardToFile'
+```
+
+- [ ] **Step 3: Test** — `src/components/share/ShareToInstagramButton.test.jsx` (flag-gating; renderer mocked so canvas never runs)
+
+```jsx
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('./renderShareCardToFile', () => ({
+  renderShareCardToFile: vi.fn().mockResolvedValue({ file: {}, blob: {} }),
+}))
+vi.mock('../../constants/features', () => ({ FEATURES: { IG_SHARE_ENABLED: false } }))
+
+import { ShareToInstagramButton } from './ShareToInstagramButton'
+
+const data = { title: 'Best Bites', byline: 'by Denis · 12 dishes', emojis: [], topItems: [], footerUrl: 'wghapp.com' }
+
+describe('ShareToInstagramButton', () => {
+  it('renders nothing when the flag is off', () => {
+    const { container } = render(<ShareToInstagramButton surface="playlist" id="1" url="u" cardData={data} />)
+    expect(container.firstChild).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 4: Run** — `npm run test -- src/components/share src/utils/share.test.js --run` → PASS
+
+- [ ] **Step 5: Commit (feature core)**
+
+```bash
+git add src/constants/features.js src/components/share src/utils/share.js src/utils/share.test.js
+git commit -m "feat(share): Instagram share-card renderer, shareImage(), and button"
+```
+
+---
+
+### Task 5: Wire into Playlist detail (`/playlist/:id`)
+
+**Files:** Modify `src/pages/Playlist.jsx` (existing `handleShare` ~line 97; existing Share button ~line 169)
+
+- [ ] **Step 1:** Import + build cardData from the loaded `playlist`/`items`, and render the button next to the existing "Share":
+
+```jsx
+import { ShareToInstagramButton } from '../components/share'
+import { categoryEmojiFor } from '../constants/categories' // already imported in this file
+// ...
+const igCardData = useMemo(() => ({
+  title: playlist?.title || 'Playlist',
+  byline: `by ${playlist?.owner_display_name || 'a local'} · ${items.length} dish${items.length === 1 ? '' : 'es'}`,
+  emojis: items.slice(0, 4).map((i) => categoryEmojiFor(i.category)),
+  topItems: items.slice(0, 3).map((i) => i.dish_name),
+  footerUrl: 'wghapp.com',
+}), [playlist?.title, playlist?.owner_display_name, items])
+```
+
+Render beside the Share button:
+
+```jsx
+<ShareToInstagramButton
+  surface="playlist"
+  id={id}
+  url={canonicalShareUrl('/playlist/' + id)}
+  cardData={igCardData}
+  shareText={`${igCardData.title} on What's Good Here`}
+/>
+```
+
+> **Verify on implement:** confirm `playlist.owner_display_name` exists on `usePlaylistDetail`'s shape (it's returned by `get_playlist_detail`). If the field name differs, use the actual one. Keep the `useMemo` ABOVE any early `return` (Rules of Hooks — there's prior art: commit `31fe155` hoisted a playlist `useMemo` for exactly this).
+
+- [ ] **Step 2:** `npm run build` → passes. Manual browser check: button appears, desktop tap downloads PNG + copies link + toast.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/Playlist.jsx
+git commit -m "feat(share): Share to Instagram on playlist detail"
+```
+
+---
+
+### Task 6: Wire into locals list (owner's `/profile`)
+
+**Files:** Modify `src/pages/Profile.jsx` (near `SharePicksButton` ~line 177; locals data via `useLocalListDetail`/existing profile state)
+
+- [ ] **Step 1:** Build cardData from the owner's locals list items + profile name; render beside `SharePicksButton`. Only render when the list has items.
+
+```jsx
+import { ShareToInstagramButton } from '../components/share'
+import { categoryEmojiFor } from '../constants/categories'
+// localList items already available on Profile (or via useLocalListDetail(user.id))
+const localItems = localList?.items || []
+const igListData = useMemo(() => ({
+  title: localItems[0]?.title || 'My Local Picks',
+  byline: `by ${profile?.display_name || 'me'} · ${localItems.length} dish${localItems.length === 1 ? '' : 'es'}`,
+  emojis: localItems.slice(0, 4).map((i) => categoryEmojiFor(i.category)),
+  topItems: localItems.slice(0, 3).map((i) => i.dish_name),
+  footerUrl: 'wghapp.com',
+}), [localItems, profile?.display_name])
+// ...
+{localItems.length > 0 && (
+  <ShareToInstagramButton
+    surface="locals_list"
+    id={user.id}
+    url={canonicalShareUrl('/user/' + user.id)}
+    cardData={igListData}
+    shareText={`${igListData.title} on What's Good Here`}
+  />
+)}
+```
+
+> **Verify on implement:** confirm how Profile.jsx currently loads the locals list (hook name + item field names: `title`, `dish_name`, `category`) and the profile display-name field. `canonicalShareUrl` is already used in this file's neighbors — import from `../utils/share` if not present.
+
+- [ ] **Step 2:** `npm run build` → passes. Manual check on `/profile`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/Profile.jsx
+git commit -m "feat(share): Share to Instagram for locals list on profile"
+```
+
+---
+
+## Phase 2 — Native iOS image-share (separable; gated on real-device test)
+
+### Task 7: Capacitor Filesystem native branch
+
+**Files:** Modify `package.json`, `src/utils/share.js`; run `npx cap sync ios`
+
+- [ ] **Step 1: Add the plugin (match Capacitor 8.x)**
+
+```bash
+npm install @capacitor/filesystem@^8
+```
+
+- [ ] **Step 2:** Add a native branch at the TOP of `shareImage` (before the Web Share block). Add imports near the existing `@capacitor/*` imports:
+
+```js
+import { Filesystem, Directory } from '@capacitor/filesystem'
+
+function blobToBase64(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onloadend = () => resolve(String(reader.result).split(',')[1] || '')
+    reader.onerror = reject
+    reader.readAsDataURL(blob)
+  })
+}
+```
+
+Native branch (insert as step 1 of `shareImage`, before Web Share):
+
+```js
+  // 0. Capacitor native: write to cache, share the file URI
+  if (Capacitor?.isNativePlatform?.()) {
+    try {
+      const base64 = await blobToBase64(blob || file)
+      const written = await Filesystem.writeFile({
+        path: 'wgh-share.png', data: base64, directory: Directory.Cache,
+      })
+      await Share.share({ files: [written.uri], url, dialogTitle: dialogTitle || 'Share to Instagram' })
+      return { method: 'native_capacitor_file', success: true }
+    } catch (err) {
+      if (err && (err.message || '').toLowerCase().includes('cancel')) {
+        return { method: 'native_capacitor_file', success: false }
+      }
+      logger.warn('Capacitor file share failed, falling back:', err)
+    }
+  }
+```
+
+- [ ] **Step 3:** `npx cap sync ios` (registers the plugin in the iOS project).
+
+- [ ] **Step 4:** `npm run test -- src/utils/share.test.js --run` (web tests still pass — native branch is gated by `isNativePlatform`, false in jsdom) and `npm run build`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json package-lock.json src/utils/share.js ios
+git commit -m "feat(share): native iOS image-share via Capacitor Filesystem"
+```
+
+- [ ] **Step 6: REAL-DEVICE GATE (manual, not automatable):** Rebuild the iOS app in Xcode, deploy to a physical iPhone, open a playlist → Share to Instagram → confirm Instagram appears in the sheet and the image posts to a Story/feed cleanly. Coordinate with Dan on the iOS build if needed. Until verified, the flag can stay off in the iOS env (`VITE_FEATURES_IG_SHARE=false`).
+
+---
+
+## Commit 2 (separate logical change) — "Create your own playlist" CTA
+
+### Task 8: Create-playlist CTA on playlist detail
+
+**Files:** Modify `src/pages/Playlist.jsx`
+
+- [ ] **Step 1:** Import `CreatePlaylistModal`, add `createOpen` state, render a subtle "Create your own" CTA (only for non-owners, or always — confirm with the page's `is_owner`), opening the existing modal. Reuse the exact pattern from `Profile.jsx:392`.
+
+```jsx
+import { CreatePlaylistModal } from '../components/playlists/CreatePlaylistModal'
+const [createOpen, setCreateOpen] = useState(false)
+// ... near the playlist header / footer:
+{!playlist.is_owner && (
+  <button onClick={() => setCreateOpen(true)} className="..." style={{ color: 'var(--color-accent-gold)', /* text-button */ }}>
+    + Create your own playlist
+  </button>
+)}
+<CreatePlaylistModal isOpen={createOpen} onClose={() => setCreateOpen(false)} onCreated={(pl) => navigate('/playlist/' + pl.id)} />
+```
+
+- [ ] **Step 2:** `npm run build` → passes. Manual: CTA opens modal; created playlist navigates to its page.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/Playlist.jsx
+git commit -m "feat(playlist): 'Create your own' CTA on playlist detail"
+```
+
+---
+
+## Final verification + handoff
+
+### Task 9: Verify, push, PR, notify Dan
+
+- [ ] `npm run lint` and `npm run build` clean; `npm run test -- src/utils/share.test.js src/components/share --run` green.
+- [ ] Grep guards: no `console.*` in new files; no `toSorted`/`Array.at`/ES2023+; `className` layout-only / `style` for color.
+- [ ] Rebase onto latest `upstream/main` (`git fetch upstream main && git rebase upstream/main`) — Denis wants currency with Dan's.
+- [ ] Push `feat/share-to-instagram` to `origin`; open PR to `upstream` (Dan's main) with the spec + this plan linked, screenshots of the generated card, and a checklist noting Phase 2's real-device gate.
+- [ ] Post a review request to the **wgh-phone** repo (`Denisgingras75/wgh-phone` issues) for Dan, linking the PR and calling out the two things needing his eyes: (1) card visual/brand, (2) the iOS native rebuild for Phase 2.
+
+---
+
+## Self-Review (against spec)
+
+- **Spec §3 mechanic/format/renderer/flag** → Tasks 1, 2, 4. ✅
+- **Spec §5.1 renderer isolated** → Task 2 (single module, swappable). ✅
+- **Spec §5.2 shareImage ladder** → Task 3 (web + fallback) + Task 7 (native). ✅
+- **Spec §5.3 pre-generate-on-mount + capture + flag-hide** → Task 4. ✅
+- **Spec §6 card content (both surfaces)** → Tasks 5, 6. ✅
+- **Spec §7 no new data layer** → reuses loaded data (Tasks 5, 6). ✅
+- **Spec §8 phased native** → Phase 1 (Tasks 1–6) / Phase 2 (Task 7). ✅
+- **Spec §9 reversibility** → flag (Task 1), isolated renderer (Task 2), additive buttons (Tasks 5, 6). ✅
+- **Spec §10 create-CTA separate commit** → Task 8. ✅
+- **Spec §12 testing (critical paths; renderer manual)** → Tasks 3, 4 + manual gates. ✅
+- **Type consistency:** `renderShareCardToFile → {file, blob}` consumed identically in Task 4 & 3; `shareImage({file,blob,url,text})` signature matches call site; `cardData` shape `{title,byline,emojis,topItems,footerUrl}` consistent across Tasks 2/4/5/6. ✅

--- a/docs/superpowers/specs/2026-06-01-share-to-instagram-design.md
+++ b/docs/superpowers/specs/2026-06-01-share-to-instagram-design.md
@@ -1,0 +1,164 @@
+# Share to Instagram — playlists & locals lists
+
+- **Date:** 2026-06-01
+- **Status:** Design — awaiting Denis review
+- **Branch:** `feat/share-to-instagram` (off `upstream/main` / Dan's main)
+- **Surfaces:** Playlist detail (`/playlist/:id`), locals list (via owner's `/profile`)
+
+---
+
+## 1. Goal
+
+Add a **"Share to Instagram"** affordance that lets a user post an on-brand image of a
+playlist (or their locals list) to their Instagram Story/feed in one tap from the native
+share sheet.
+
+## 2. The Instagram reality (why this is image-first)
+
+Instagram has **no API to post on a user's behalf**, and it strips links from posts. Every
+real "share to Instagram" reduces to: **generate a share-worthy image → hand it to the OS
+share sheet**, where the user taps Instagram and posts it themselves. So this feature is
+fundamentally an *image generator + a file-share*, not a link button. (Locked with Denis.)
+
+## 3. Decisions locked
+
+| Decision | Choice | Notes |
+|---|---|---|
+| Mechanic | Branded image → native share sheet | Not Stories deep-link, not link-only |
+| Image format | **Square 1080×1080** | Safe in feed, DMs, and centered in a Story |
+| Renderer | **Zero-dep `<canvas>`** (v1) | Most robust in the iOS WKWebView; A1 DOM-snapshot is a documented drop-in alternative behind the same interface |
+| Kill switch | `FEATURES.IG_SHARE_ENABLED` | Default-on, env-killable — instant rollback |
+| Create-CTA | Separate commit, same branch | "Create your own playlist" on `/playlist/:id` (see §10) |
+
+### Why canvas, not a DOM-snapshot library (recommendation changed on new evidence)
+Initial lean was a DOM-snapshot lib (`modern-screenshot`) for design ergonomics. Re-grounding
+on Dan's main revealed WGH now ships as a **native iOS app (Capacitor)** — the primary surface
+is a WKWebView, where `foreignObject`-based snapshot libs are the flakier path and canvas 2D is
+rock-solid. The card design is locked and simple, so canvas's iteration cost is low. Zero deps
+also best serves "make change cheap" + easy rollback. **A1 remains documented as a swap-in** if
+we later want richer, photo-bearing cards.
+
+## 4. Re-grounding deltas (read before building)
+
+Local `main` was **240 commits behind** `upstream/main`. Verified on Dan's main:
+- **Capacitor iOS app** — `@capacitor/share` present; `shareOrCopy()` already does native Share →
+  web Share → clipboard → execCommand, with `canonicalShareUrl()` returning `https://wghapp.com`
+  on native.
+- **`@capacitor/filesystem` is NOT installed.** Capacitor's native `Share.share({ files })` needs
+  a **file URI**, so native image-share requires adding Filesystem + `cap sync ios` + a native
+  rebuild (see §8, Phase 2).
+- Domain is **wghapp.com** (use `canonicalShareUrl()`, never a hardcoded origin).
+- No prior Instagram/image-share work exists — safe to build.
+
+## 5. Architecture — one shared unit, two surfaces
+
+```
+src/components/share/
+  ShareCard.jsx            # (optional, A1 only) presentational card — props in, DOM out
+  renderShareCardToFile.js # ISOLATED renderer — the reversibility boundary
+  ShareToInstagramButton.jsx # button + pre-generate + share orchestration + fallbacks
+src/utils/share.js         # + shareImage()  (extends existing 4-tier shareOrCopy)
+src/constants/features.js  # + IG_SHARE_ENABLED
+```
+
+### 5.1 `renderShareCardToFile({ title, byline, emojis, topItems, footerUrl }) → Promise<{ file: File, blob: Blob }>`
+The single swappable unit. **v1 = canvas:** draw a 1080×1080 card, `canvas.toBlob('image/png')`,
+wrap in a `File`. Reads brand colors via
+`getComputedStyle(document.documentElement).getPropertyValue('--color-*')` so the card stays
+theme-driven (rebrand = one file, honored even in canvas). Loads Amatic SC via
+`document.fonts.load(...)` before drawing. No remote images → no canvas tainting.
+**A1 alternative:** same signature, renders `<ShareCard>` off-screen and snapshots it.
+
+### 5.2 `shareImage({ file, url, text, dialogTitle }) → Promise<{ method, success }>`
+Mirrors the existing `shareOrCopy` ladder, but for an image file:
+1. **Capacitor native:** write the PNG to `Directory.Cache` via `@capacitor/filesystem`, then
+   `Share.share({ files: [uri], url, dialogTitle })`. *(Phase 2 — needs the new plugin.)*
+2. **Web Share w/ files:** `navigator.canShare({ files }) && navigator.share({ files: [file], text })`.
+3. **Fallback:** trigger a PNG download + `shareOrCopy({ url })`, toast
+   *"Image saved — open Instagram to post."*
+Never throws; returns `{ method, success }` for analytics + toasts.
+
+### 5.3 `ShareToInstagramButton`
+Props: `{ surface: 'playlist' | 'locals_list', id, cardData }`.
+- **Pre-generates the File on mount** (idle/effect), holds it in a ref. *This is the
+  make-or-break iOS detail:* Safari/WKWebView invalidate `share()` if you `await` after the tap,
+  so the File must be ready **before** the gesture. Button shows a brief spinner until ready.
+- On tap → `shareImage(...)` synchronously with the ready File.
+- `capture('share_to_instagram', { surface, id, method, success })`.
+- Hidden entirely when `!FEATURES.IG_SHARE_ENABLED`.
+
+## 6. Card content (1080×1080)
+
+| Element | Playlist | Locals list |
+|---|---|---|
+| Wordmark | "WHAT'S **GOOD** HERE" (Amatic SC, GOOD in `--color-accent-gold`) | same |
+| Emoji tiles (2×2) | `playlist.cover_categories` | `categoryEmojiFor()` of top item categories |
+| Title | `playlist.title` | `items[0].title` |
+| Byline | `by {owner} · {item_count} dishes` | `by {owner} · {n} dishes` |
+| Top 3 (▸) | first 3 item `dish_name`s | first 3 `dish_name`s |
+| Footer | `wghapp.com` | `wghapp.com` |
+
+Truncate long titles. Background = `--color-bg` warm stone (per approved mockup).
+
+## 7. Data — nothing new
+
+Reuse data already loaded in the React tree: `usePlaylistDetail(id)` on `Playlist.jsx`,
+`useLocalListDetail(userId)` behind the profile. **No new RPC, no migration, no serverless fn.**
+Owner display name comes from the page's existing profile data.
+
+## 8. Platform scope — two phases (Phase 2 separable)
+
+- **Phase 1 — Web image-share.** Card renderer + `shareImage` web/fallback paths +
+  `ShareToInstagramButton` on both surfaces, flag-gated. **Testable in a browser today.** In the
+  native app (until Phase 2) the button degrades to link-share via the existing ladder — not
+  broken, just no image.
+- **Phase 2 — Native iOS image-share.** Add `@capacitor/filesystem`, the native branch of
+  `shareImage`, `npx cap sync ios`, native rebuild, **real-device verification** (share sheet →
+  Instagram → image posts). Rides with the already-pending iOS real-device testing; may need Dan
+  coordination on the iOS build.
+
+> **Cost flag:** Phase 2 touches the native build (new Capacitor plugin + `cap sync` + Xcode
+> rebuild + real-device test). Phase 1 is pure JS and ships/tests immediately. The flag lets
+> Phase 1 ship without waiting on Phase 2.
+
+## 9. Reversibility — three escape hatches
+
+1. **Flag off** — `VITE_FEATURES_IG_SHARE=false` hides it instantly, no deploy.
+2. **Swap renderer** — canvas → A1 (or vice-versa) is a one-file change to
+   `renderShareCardToFile.js`; zero call-site edits.
+3. **Remove button** — purely additive UI; delete one import per surface.
+
+## 10. Companion change (separate commit) — "Create your own playlist" CTA
+
+On `/playlist/:id`, add a "Create your own" CTA opening the existing `CreatePlaylistModal`. This
+closes the funnel the IG share opens (stranger lands from Instagram → becomes a creator).
+Profile already has create; UserProfile is intentionally skipped (low intent). **Ships as its own
+commit** so it reverts independently of the share work.
+
+## 11. Constraints honored
+
+- No `toSorted`/`Array.at`/ES2023+ — `slice().sort()`, `arr[arr.length-1]`.
+- `className` = layout/spacing only; `style={{}}` = color/bg/border via `var(--color-*)`.
+- `logger`, never `console.*`.
+- Off-screen card (A1) must be laid out (not `display:none`) for snapshot.
+
+## 12. Testing
+
+- **Unit (vitest, `--run`):** `renderShareCardToFile` returns a non-empty PNG `File` for sample
+  playlist + locals data; `shareImage` fallback chain doesn't throw when `navigator.share`/
+  `canShare` are absent (mocked).
+- **Critical path:** button renders only when flag on; pre-generated File is ready before tap.
+- **Manual / real-device (the real gate):** iOS app → Share to Instagram → image lands in the IG
+  composer and posts cleanly. Desktop → download + copy-link fallback fires with toast.
+
+## 13. Out of scope (YAGNI v1)
+
+Instagram Stories deep-link; 9:16 variant; dish-photo collages; visitor-shares-someone-else's-list
+(trivial follow-on — same component on `UserProfile`); any server-side render.
+
+## 14. Open redlines for Denis
+
+1. **Native scope** — build Phase 2 now, or ship Phase 1 (web) and fast-follow native? (Recommend:
+   build both; flag covers the verification lag.)
+2. **Renderer** — confirm zero-dep canvas as v1 (recommendation changed from A1 after the
+   native-iOS finding). A1 stays documented + swappable.

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.3.1"),
         .package(name: "CapacitorApp", path: "../../../node_modules/@capacitor/app"),
         .package(name: "CapacitorBrowser", path: "../../../node_modules/@capacitor/browser"),
+        .package(name: "CapacitorFilesystem", path: "../../../node_modules/@capacitor/filesystem"),
         .package(name: "CapacitorGeolocation", path: "../../../node_modules/@capacitor/geolocation"),
         .package(name: "CapacitorShare", path: "../../../node_modules/@capacitor/share"),
         .package(name: "CapgoCapacitorSocialLogin", path: "../../../node_modules/@capgo/capacitor-social-login")
@@ -26,6 +27,7 @@ let package = Package(
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
                 .product(name: "CapacitorApp", package: "CapacitorApp"),
                 .product(name: "CapacitorBrowser", package: "CapacitorBrowser"),
+                .product(name: "CapacitorFilesystem", package: "CapacitorFilesystem"),
                 .product(name: "CapacitorGeolocation", package: "CapacitorGeolocation"),
                 .product(name: "CapacitorShare", package: "CapacitorShare"),
                 .product(name: "CapgoCapacitorSocialLogin", package: "CapgoCapacitorSocialLogin")

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@capacitor/browser": "^8.0.3",
         "@capacitor/cli": "^8.3.1",
         "@capacitor/core": "^8.3.1",
+        "@capacitor/filesystem": "^8.1.2",
         "@capacitor/geolocation": "^8.2.0",
         "@capacitor/ios": "^8.3.1",
         "@capacitor/share": "^8.0.1",
@@ -138,7 +139,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1770,9 +1770,20 @@
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.3.1.tgz",
       "integrity": "sha512-UF8ItlHguU1Z6GXfPTeT2gakf+ctNI8pAS1kwSBQlsJMlfD4OPoto/SmKnOxKCQvnF4WRcdWeg6C0zREUNaAQg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/filesystem": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/filesystem/-/filesystem-8.1.2.tgz",
+      "integrity": "sha512-doaaMfGoFR2hWU6aV6u83I+5ZsGyJVq+Gz4r9lMpJzUKMm1eMu0hLnFdV1aXZlU9FlK/RndFrVD8oRZfNOqWgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@capacitor/synapse": "^1.0.4"
+      },
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/geolocation": {
@@ -1911,7 +1922,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1935,7 +1945,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3376,7 +3385,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4491,7 +4499,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4582,7 +4591,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4593,7 +4601,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5646,7 +5653,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6151,7 +6157,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6897,7 +6902,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.3.1",
@@ -7261,7 +7267,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8921,7 +8926,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -8952,7 +8956,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -9107,8 +9110,7 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -9247,6 +9249,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -10149,7 +10152,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10353,6 +10355,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10368,6 +10371,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10380,7 +10384,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pretty-ms": {
       "version": "7.0.1",
@@ -10671,7 +10676,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10681,7 +10685,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11091,7 +11094,6 @@
       "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -12061,7 +12063,6 @@
       "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -12600,7 +12601,6 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -14142,7 +14142,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -14210,7 +14209,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -14595,7 +14593,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@capacitor/browser": "^8.0.3",
     "@capacitor/cli": "^8.3.1",
     "@capacitor/core": "^8.3.1",
+    "@capacitor/filesystem": "^8.1.2",
     "@capacitor/geolocation": "^8.2.0",
     "@capacitor/ios": "^8.3.1",
     "@capacitor/share": "^8.0.1",

--- a/src/components/share/ShareToInstagramButton.jsx
+++ b/src/components/share/ShareToInstagramButton.jsx
@@ -1,0 +1,70 @@
+import { useState, useEffect, useRef } from 'react'
+import { renderShareCardToFile } from './renderShareCardToFile'
+import { shareImage } from '../../utils/share'
+import { FEATURES } from '../../constants/features'
+import { capture } from '../../lib/analytics'
+import { logger } from '../../utils/logger'
+import { toast } from 'sonner'
+
+/**
+ * Share an on-brand card image of a playlist / locals list to Instagram.
+ *
+ * Pre-generates the image on mount: iOS Safari/WKWebView invalidate share()
+ * if you await after the tap, so the File must be ready BEFORE the gesture.
+ *
+ * Props:
+ *   surface   - 'playlist' | 'locals_list' (analytics)
+ *   id        - playlist id or user id (analytics + key)
+ *   url       - canonical share URL (rides along as link)
+ *   cardData  - { title, byline, emojis[], topItems[], footerUrl }
+ *   shareText - optional text for the share payload
+ */
+export function ShareToInstagramButton({ surface, id, url, cardData, shareText }) {
+  const [busy, setBusy] = useState(false)
+  const assetRef = useRef(null)
+
+  useEffect(() => {
+    if (!FEATURES.IG_SHARE_ENABLED) return undefined
+    let cancelled = false
+    renderShareCardToFile(cardData)
+      .then((asset) => { if (!cancelled) assetRef.current = asset })
+      .catch((err) => logger.warn('Share card pre-render failed:', err))
+    return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id])
+
+  if (!FEATURES.IG_SHARE_ENABLED) return null
+
+  async function handleShare() {
+    setBusy(true)
+    try {
+      let asset = assetRef.current
+      if (!asset) asset = await renderShareCardToFile(cardData) // safety net (rare)
+      const result = await shareImage({ file: asset.file, blob: asset.blob, url, text: shareText })
+      capture('share_to_instagram', { surface, id, method: result.method, success: result.success })
+      if (result.success && result.method === 'download_copy') {
+        toast.success('Image saved — open Instagram to post', { duration: 2500 })
+      }
+    } catch (err) {
+      logger.warn('Share to Instagram failed:', err)
+      toast.error('Could not prepare the image. Please try again.', { duration: 2500 })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <button
+      onClick={handleShare}
+      disabled={busy}
+      className="px-5 py-2 rounded-full font-semibold transition-all hover:opacity-90 active:scale-[0.97] disabled:opacity-60"
+      style={{
+        background: 'var(--color-primary)',
+        color: 'var(--color-text-on-primary)',
+        fontSize: '13px',
+      }}
+    >
+      {busy ? 'Preparing…' : 'Share to Instagram'}
+    </button>
+  )
+}

--- a/src/components/share/ShareToInstagramButton.test.jsx
+++ b/src/components/share/ShareToInstagramButton.test.jsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+// Flip the flag per-test via a hoisted holder the mock getter reads.
+const h = vi.hoisted(() => ({ flag: false }))
+vi.mock('../../constants/features', () => ({
+  FEATURES: { get IG_SHARE_ENABLED() { return h.flag } },
+}))
+// Keep canvas out of jsdom — the renderer is verified manually.
+vi.mock('./renderShareCardToFile', () => ({
+  renderShareCardToFile: vi.fn().mockResolvedValue({ file: {}, blob: {} }),
+}))
+
+import { ShareToInstagramButton } from './ShareToInstagramButton'
+
+const data = { title: 'Best Bites', byline: 'by Denis · 12 dishes', emojis: [], topItems: [], footerUrl: 'wghapp.com' }
+
+describe('ShareToInstagramButton', () => {
+  beforeEach(() => { h.flag = false })
+
+  it('renders nothing when the flag is off', () => {
+    const { container } = render(<ShareToInstagramButton surface="playlist" id="1" url="u" cardData={data} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the button when the flag is on', () => {
+    h.flag = true
+    render(<ShareToInstagramButton surface="playlist" id="1" url="u" cardData={data} />)
+    expect(screen.getByRole('button', { name: /share to instagram/i })).toBeTruthy()
+  })
+})

--- a/src/components/share/index.js
+++ b/src/components/share/index.js
@@ -1,0 +1,2 @@
+export { ShareToInstagramButton } from './ShareToInstagramButton'
+export { renderShareCardToFile } from './renderShareCardToFile'

--- a/src/components/share/renderShareCardToFile.js
+++ b/src/components/share/renderShareCardToFile.js
@@ -1,0 +1,144 @@
+import { logger } from '../../utils/logger'
+
+// Reversibility boundary: the ONLY image renderer. Swap this module's body
+// (e.g. to a DOM-snapshot impl) without touching any call site. v1 = canvas,
+// chosen for robustness inside the iOS WKWebView and zero dependencies.
+
+const SIZE = 1080
+
+// Brand colors read from CSS vars so the card stays theme-driven (rebrand = one file).
+function token(name, fallback) {
+  try {
+    const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+    return v || fallback
+  } catch {
+    return fallback
+  }
+}
+
+async function ensureFonts() {
+  if (typeof document === 'undefined' || !document.fonts || !document.fonts.load) return
+  try {
+    await Promise.all([
+      document.fonts.load("700 72px 'Amatic SC'"),
+      document.fonts.load("800 72px 'Outfit'"),
+    ])
+    await document.fonts.ready
+  } catch (err) {
+    logger.warn('Share card font load failed; using fallback fonts:', err)
+  }
+}
+
+function roundRect(ctx, x, y, w, h, r) {
+  ctx.beginPath()
+  ctx.moveTo(x + r, y)
+  ctx.arcTo(x + w, y, x + w, y + h, r)
+  ctx.arcTo(x + w, y + h, x, y + h, r)
+  ctx.arcTo(x, y + h, x, y, r)
+  ctx.arcTo(x, y, x + w, y, r)
+  ctx.closePath()
+}
+
+function fillTruncated(ctx, text, x, y, maxWidth) {
+  let t = String(text == null ? '' : text)
+  if (ctx.measureText(t).width <= maxWidth) {
+    ctx.fillText(t, x, y)
+    return
+  }
+  while (t.length > 1 && ctx.measureText(t + '…').width > maxWidth) t = t.slice(0, -1)
+  ctx.fillText(t + '…', x, y)
+}
+
+/**
+ * Render a 1080x1080 share card to a PNG File. Pure visual output — verified
+ * manually in-browser / on-device (canvas is not implemented in jsdom).
+ * @param {{title:string, byline:string, emojis?:string[], topItems?:string[], footerUrl?:string}} data
+ * @returns {Promise<{file:File, blob:Blob}>}
+ */
+export async function renderShareCardToFile({ title, byline, emojis = [], topItems = [], footerUrl = 'wghapp.com' }) {
+  await ensureFonts()
+
+  const canvas = document.createElement('canvas')
+  canvas.width = SIZE
+  canvas.height = SIZE
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('Canvas 2D context unavailable')
+
+  const bg = token('--color-bg', '#F0ECE8')
+  const gold = token('--color-accent-gold', '#C48A12')
+  const textPrimary = token('--color-text-primary', '#1A1A1A')
+  const textSecondary = token('--color-text-secondary', '#555555')
+  // Emoji-tile fills read from brand tokens (hex = off-DOM fallback only).
+  const tileColors = [
+    token('--color-accent-gold', '#C48A12'),
+    token('--color-primary', '#E4440A'),
+    token('--color-medal-bronze', '#B07340'),
+    token('--color-rating', '#16A34A'),
+  ]
+
+  ctx.fillStyle = bg
+  ctx.fillRect(0, 0, SIZE, SIZE)
+
+  // Wordmark: WHAT'S GOOD HERE (GOOD in gold)
+  ctx.textBaseline = 'alphabetic'
+  ctx.textAlign = 'left'
+  ctx.font = "700 56px 'Amatic SC', cursive"
+  ctx.fillStyle = textSecondary
+  ctx.fillText("WHAT'S ", 80, 120)
+  const w1 = ctx.measureText("WHAT'S ").width
+  ctx.fillStyle = gold
+  ctx.fillText('GOOD', 80 + w1, 120)
+  const w2 = ctx.measureText('GOOD').width
+  ctx.fillStyle = textSecondary
+  ctx.fillText(' HERE', 80 + w1 + w2, 120)
+
+  // 2x2 emoji tiles
+  const tile = 150
+  const gap = 16
+  const ox = 80
+  const oy = 180
+  for (let i = 0; i < 4; i++) {
+    const x = ox + (i % 2) * (tile + gap)
+    const y = oy + Math.floor(i / 2) * (tile + gap)
+    ctx.fillStyle = tileColors[i]
+    roundRect(ctx, x, y, tile, tile, 18)
+    ctx.fill()
+    ctx.font = '88px serif'
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    ctx.fillText(emojis[i] || '🍽️', x + tile / 2, y + tile / 2 + 4)
+  }
+  ctx.textAlign = 'left'
+  ctx.textBaseline = 'alphabetic'
+
+  // Title
+  const titleY = oy + 2 * tile + gap + 96
+  ctx.fillStyle = textPrimary
+  ctx.font = "800 72px 'Outfit', sans-serif"
+  fillTruncated(ctx, title, 80, titleY, SIZE - 160)
+
+  // Byline
+  ctx.fillStyle = textSecondary
+  ctx.font = "500 34px 'Outfit', sans-serif"
+  fillTruncated(ctx, byline, 80, titleY + 52, SIZE - 160)
+
+  // Top 3 items
+  ctx.fillStyle = textPrimary
+  ctx.font = "600 38px 'Outfit', sans-serif"
+  let ly = titleY + 132
+  for (let i = 0; i < Math.min(3, topItems.length); i++) {
+    fillTruncated(ctx, '▸ ' + topItems[i], 80, ly, SIZE - 160)
+    ly += 58
+  }
+
+  // Footer
+  ctx.fillStyle = gold
+  ctx.font = "700 32px 'Outfit', sans-serif"
+  ctx.fillText(footerUrl, 80, SIZE - 72)
+
+  const blob = await new Promise((resolve, reject) => {
+    canvas.toBlob((b) => (b ? resolve(b) : reject(new Error('toBlob returned null'))), 'image/png', 0.95)
+  })
+  const file = new File([blob], 'wgh-share.png', { type: 'image/png' })
+  return { file, blob }
+}

--- a/src/constants/features.js
+++ b/src/constants/features.js
@@ -7,4 +7,7 @@ export const FEATURES = {
   // App Store rejection. Default-on; set VITE_FEATURES_APPLE_SIGNIN=false in
   // a local .env.local (or via a Vercel env var) to disable for debugging.
   APPLE_SIGNIN_ENABLED: import.meta.env.VITE_FEATURES_APPLE_SIGNIN !== 'false',
+  // Share-to-Instagram (image → native share sheet). Default-on; set
+  // VITE_FEATURES_IG_SHARE=false to kill instantly without a deploy.
+  IG_SHARE_ENABLED: import.meta.env.VITE_FEATURES_IG_SHARE !== 'false',
 }

--- a/src/pages/MyList.jsx
+++ b/src/pages/MyList.jsx
@@ -5,6 +5,9 @@ import { useDishSearch } from '../hooks/useDishSearch'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { getCategoryEmoji } from '../constants/categories'
 import { logger } from '../utils/logger'
+import { useAuth } from '../context/AuthContext'
+import { canonicalShareUrl } from '../utils/share'
+import { ShareToInstagramButton } from '../components/share'
 
 function snapshot(tagline, items) {
   return JSON.stringify({
@@ -22,6 +25,7 @@ export function MyList() {
   useDocumentTitle('Your top 10')
   var navigate = useNavigate()
   var location = useLocation()
+  var { user } = useAuth()
   var { listMeta, dishes, loading, error, saveList, saving } = useMyLocalList()
 
   var [tagline, setTagline] = useState('')
@@ -59,6 +63,17 @@ export function MyList() {
   var currentSnapshot = useMemo(function () {
     return snapshot(tagline, items)
   }, [tagline, items])
+
+  // Share-card data — must stay above the early returns (Rules of Hooks).
+  var igListData = useMemo(function () {
+    return {
+      title: (listMeta && listMeta.title ? listMeta.title : '').trim() || 'My Top 10',
+      byline: (tagline || '').trim() || (items.length + ' dish' + (items.length === 1 ? '' : 'es')),
+      emojis: items.slice(0, 4).map(function (i) { return getCategoryEmoji(i.category) || '🍽️' }),
+      topItems: items.slice(0, 3).map(function (i) { return i.dish_name }),
+      footerUrl: 'wghapp.com',
+    }
+  }, [listMeta, tagline, items])
   var isDirty = hydrated && currentSnapshot !== serverSnapshot
 
   // beforeunload — only while dirty. Removed on cleanup or when clean.
@@ -239,6 +254,19 @@ export function MyList() {
           Pick up to 10 dishes visitors should try
         </p>
       </div>
+
+      {/* Share the published list to Instagram (owner only, non-empty) */}
+      {items.length > 0 && user && user.id && (
+        <div className="px-4 pb-1">
+          <ShareToInstagramButton
+            surface="locals_list"
+            id={user.id}
+            url={canonicalShareUrl('/user/' + user.id)}
+            cardData={igListData}
+            shareText={igListData.title + " on What's Good Here"}
+          />
+        </div>
+      )}
 
       {/* Welcome banner (just-accepted curator) */}
       {showWelcome && (

--- a/src/pages/Playlist.jsx
+++ b/src/pages/Playlist.jsx
@@ -8,6 +8,7 @@ import { PlaylistCover } from '../components/playlists/PlaylistCover'
 import { PlaylistOwnerMenu } from '../components/playlists/PlaylistOwnerMenu'
 import { getCategoryNeonImage, categoryEmojiFor } from '../constants/categories'
 import { AddDishSearchSheet } from '../components/playlists/AddDishSearchSheet'
+import { CreatePlaylistModal } from '../components/playlists/CreatePlaylistModal'
 import { capture } from '../lib/analytics'
 import { shareOrCopy, canonicalShareUrl } from '../utils/share'
 import { ShareToInstagramButton } from '../components/share'
@@ -21,6 +22,7 @@ export function Playlist() {
   const { playlist, loading, error } = usePlaylistDetail(id)
   const { follow, unfollow, removeDish } = usePlaylistMutations()
   const [searchSheetOpen, setSearchSheetOpen] = useState(false)
+  const [createOpen, setCreateOpen] = useState(false)
 
   useDocumentTitle(playlist?.playlist_name || null)
 
@@ -307,6 +309,32 @@ export function Playlist() {
           })}
         </ol>
       )}
+
+      {/* Funnel: turn a viewer (often arriving from a shared image) into a creator */}
+      {!playlist.is_owner && (
+        <div style={{ padding: '24px 20px 8px', textAlign: 'center' }}>
+          <button
+            onClick={function () {
+              if (!user) {
+                var nextParam = encodeURIComponent(location.pathname + location.search + location.hash)
+                navigate('/login?next=' + nextParam)
+                return
+              }
+              capture('create_playlist_cta_clicked', { from: 'playlist_detail', playlist_id: id })
+              setCreateOpen(true)
+            }}
+            style={{ color: 'var(--color-accent-gold)', background: 'none', border: 'none', fontWeight: 700, fontSize: 14 }}
+          >
+            + Create your own playlist
+          </button>
+        </div>
+      )}
+
+      <CreatePlaylistModal
+        isOpen={createOpen}
+        onClose={function () { setCreateOpen(false) }}
+        onCreated={function (pl) { if (pl && pl.id) navigate('/playlist/' + pl.id) }}
+      />
 
       <AddDishSearchSheet
         isOpen={searchSheetOpen}

--- a/src/pages/Playlist.jsx
+++ b/src/pages/Playlist.jsx
@@ -10,6 +10,7 @@ import { getCategoryNeonImage, categoryEmojiFor } from '../constants/categories'
 import { AddDishSearchSheet } from '../components/playlists/AddDishSearchSheet'
 import { capture } from '../lib/analytics'
 import { shareOrCopy, canonicalShareUrl } from '../utils/share'
+import { ShareToInstagramButton } from '../components/share'
 import { toast } from 'sonner'
 
 export function Playlist() {
@@ -26,6 +27,15 @@ export function Playlist() {
 
   const items = playlist?.items || []
   const existingDishIds = useMemo(() => items.map((i) => i.dish_id), [items])
+
+  // Share-card data — must stay above the early returns (Rules of Hooks).
+  const igCardData = useMemo(() => ({
+    title: playlist?.title || 'Playlist',
+    byline: `by ${playlist?.owner_display_name || 'a local'} · ${items.length} dish${items.length === 1 ? '' : 'es'}`,
+    emojis: items.slice(0, 4).map((i) => categoryEmojiFor(i.category)),
+    topItems: items.slice(0, 3).map((i) => i.dish_name),
+    footerUrl: 'wghapp.com',
+  }), [playlist?.title, playlist?.owner_display_name, items])
 
   useEffect(() => {
     if (playlist) {
@@ -147,7 +157,7 @@ export function Playlist() {
           {' · '}{playlist.item_count} {playlist.item_count === 1 ? 'dish' : 'dishes'}
           {playlist.follower_count > 0 && ` · ${playlist.follower_count} followers`}
         </div>
-        <div className="flex justify-center gap-3" style={{ marginTop: 16 }}>
+        <div className="flex justify-center gap-3 flex-wrap" style={{ marginTop: 16 }}>
           {!playlist.is_owner && (
             <button
               onClick={toggleFollow}
@@ -179,6 +189,13 @@ export function Playlist() {
           >
             Share
           </button>
+          <ShareToInstagramButton
+            surface="playlist"
+            id={id}
+            url={canonicalShareUrl('/playlist/' + id)}
+            cardData={igCardData}
+            shareText={playlist.title + " on What's Good Here"}
+          />
           {playlist.is_owner && <PlaylistOwnerMenu playlist={playlist} />}
         </div>
       </div>

--- a/src/utils/share.js
+++ b/src/utils/share.js
@@ -128,3 +128,42 @@ export function buildRestaurantShareData(restaurant) {
     text: `Check out ${restaurant.name}${restaurant.town ? ` in ${restaurant.town}` : ''} on What's Good Here!`,
   }
 }
+
+/**
+ * Share an image File via the platform share sheet, with graceful fallback.
+ * Ladder: Web Share API w/ files → download the image + copy/share the link.
+ * (Native Capacitor file-share is added in Phase 2 — needs @capacitor/filesystem.)
+ * Never throws. Returns { method, success } so callers can toast accordingly.
+ *
+ * @param {{ file: File, blob: Blob, url: string, text?: string, dialogTitle?: string }} options
+ * @returns {Promise<{ method: string, success: boolean }>}
+ */
+export async function shareImage({ file, blob, url, text }) {
+  // 1. Web Share API with files (mobile browsers)
+  if (navigator.canShare && navigator.canShare({ files: [file] })) {
+    try {
+      const data = { files: [file] }
+      if (text) data.text = text
+      await navigator.share(data)
+      return { method: 'web_share_file', success: true }
+    } catch (err) {
+      if (err && err.name === 'AbortError') return { method: 'web_share_file', success: false }
+      logger.warn('Web file share failed, falling back:', err)
+    }
+  }
+
+  // 2. Fallback: download the image, then copy/share the link
+  try {
+    const a = document.createElement('a')
+    a.href = URL.createObjectURL(blob || file)
+    a.download = (file && file.name) || 'wgh-share.png'
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(a.href)
+  } catch (err) {
+    logger.warn('Image download fallback failed:', err)
+  }
+  const link = await shareOrCopy({ url, text })
+  return { method: 'download_copy', success: link.success }
+}

--- a/src/utils/share.js
+++ b/src/utils/share.js
@@ -1,5 +1,6 @@
 import { Capacitor } from '@capacitor/core'
 import { Share } from '@capacitor/share'
+import { Filesystem, Directory } from '@capacitor/filesystem'
 import { logger } from './logger'
 
 // Canonical public origin for share/invite URLs. Inside the iOS Capacitor
@@ -129,16 +130,43 @@ export function buildRestaurantShareData(restaurant) {
   }
 }
 
+function blobToBase64(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onloadend = () => resolve(String(reader.result).split(',')[1] || '')
+    reader.onerror = reject
+    reader.readAsDataURL(blob)
+  })
+}
+
 /**
  * Share an image File via the platform share sheet, with graceful fallback.
- * Ladder: Web Share API w/ files → download the image + copy/share the link.
- * (Native Capacitor file-share is added in Phase 2 — needs @capacitor/filesystem.)
- * Never throws. Returns { method, success } so callers can toast accordingly.
+ * Ladder: Capacitor native file-share → Web Share API w/ files → download the
+ * image + copy/share the link. Never throws; returns { method, success }.
  *
  * @param {{ file: File, blob: Blob, url: string, text?: string, dialogTitle?: string }} options
  * @returns {Promise<{ method: string, success: boolean }>}
  */
-export async function shareImage({ file, blob, url, text }) {
+export async function shareImage({ file, blob, url, text, dialogTitle }) {
+  // 0. Capacitor native (iOS/Android): write the PNG to cache, share the file URI
+  if (Capacitor?.isNativePlatform?.()) {
+    try {
+      const base64 = await blobToBase64(blob || file)
+      const written = await Filesystem.writeFile({
+        path: 'wgh-share.png',
+        data: base64,
+        directory: Directory.Cache,
+      })
+      await Share.share({ files: [written.uri], url, dialogTitle: dialogTitle || 'Share to Instagram' })
+      return { method: 'native_capacitor_file', success: true }
+    } catch (err) {
+      if (err && (err.message || '').toLowerCase().includes('cancel')) {
+        return { method: 'native_capacitor_file', success: false }
+      }
+      logger.warn('Capacitor file share failed, falling back:', err)
+    }
+  }
+
   // 1. Web Share API with files (mobile browsers)
   if (navigator.canShare && navigator.canShare({ files: [file] })) {
     try {

--- a/src/utils/share.test.js
+++ b/src/utils/share.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 vi.mock('@capacitor/core', () => ({ Capacitor: { isNativePlatform: () => false } }))
 vi.mock('@capacitor/share', () => ({ Share: { share: vi.fn() } }))
+vi.mock('@capacitor/filesystem', () => ({ Filesystem: { writeFile: vi.fn() }, Directory: { Cache: 'CACHE' } }))
 
 import { shareImage } from './share'
 

--- a/src/utils/share.test.js
+++ b/src/utils/share.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('@capacitor/core', () => ({ Capacitor: { isNativePlatform: () => false } }))
+vi.mock('@capacitor/share', () => ({ Share: { share: vi.fn() } }))
+
+import { shareImage } from './share'
+
+function setNav(prop, value) {
+  Object.defineProperty(navigator, prop, { value, configurable: true, writable: true })
+}
+
+describe('shareImage', () => {
+  const file = new File(['x'], 'wgh-share.png', { type: 'image/png' })
+  const blob = new Blob(['x'], { type: 'image/png' })
+  let clickSpy
+
+  beforeEach(() => {
+    setNav('share', undefined)
+    setNav('canShare', undefined)
+    setNav('clipboard', { writeText: vi.fn().mockResolvedValue(undefined) })
+    globalThis.URL.createObjectURL = vi.fn(() => 'blob:x')
+    globalThis.URL.revokeObjectURL = vi.fn()
+    clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('falls back to download + copy-link when file share is unsupported', async () => {
+    const result = await shareImage({ file, blob, url: 'https://wghapp.com/playlist/1', text: 'hi' })
+    expect(clickSpy).toHaveBeenCalled()
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('https://wghapp.com/playlist/1')
+    expect(result).toEqual({ method: 'download_copy', success: true })
+  })
+
+  it('uses web file share when supported', async () => {
+    setNav('canShare', vi.fn(() => true))
+    setNav('share', vi.fn().mockResolvedValue(undefined))
+    const result = await shareImage({ file, blob, url: 'u', text: 'hi' })
+    expect(navigator.share).toHaveBeenCalled()
+    expect(result).toEqual({ method: 'web_share_file', success: true })
+  })
+})


### PR DESCRIPTION
## What

A **"Share to Instagram"** button on playlist detail and the curator's My List page. It generates an on-brand 1080×1080 card image and hands it to the native share sheet, where Instagram shows up as a target. Plus a separate **"Create your own playlist"** CTA on playlist detail.

> **Why image, not a link:** Instagram has no API to post on a user's behalf and strips links from posts. Every real "share to IG" = generate a share-worthy image → OS share sheet → user posts it. So this is an image generator + file-share, not a link button.

## Commits (each reviewable independently)
- `26863c4` Phase 1 — web image-share (flag, canvas renderer, `shareImage()`, button, both surfaces)
- `6d72859` Phase 2 — native iOS file-share (`@capacitor/filesystem` + SPM registration)
- `13aa1c6` "Create your own playlist" CTA (separate logical change)
- `83fc688` / `9755ec7` — design spec + implementation plan under `docs/superpowers/`

## How it works
- **Renderer** (`src/components/share/renderShareCardToFile.js`) — zero-dep `<canvas>`, reads `--color-*` tokens so it stays theme-driven. Isolated behind one module so the impl can be swapped without touching call sites.
- **`shareImage()`** (`src/utils/share.js`) — ladder: Capacitor native file-share → Web Share API w/ files → download image + copy link. Extends the existing Capacitor-aware `shareOrCopy`.
- **Button** pre-generates the image on mount — iOS Safari/WKWebView invalidate `share()` if you `await` after the tap, so the file must be ready before the gesture.
- **Flag-gated** `FEATURES.IG_SHARE_ENABLED` (default-on; `VITE_FEATURES_IG_SHARE=false` kills it without a deploy).

## Reversibility
Flag-off (instant) · swap renderer (one file) · remove button (additive). The renderer recommendation moved from a DOM-snapshot lib → canvas precisely because the native iOS WKWebView is the primary surface.

## 🔴 Needs your eyes, Dan
1. **Card visual / brand** — the 1080×1080 layout (wordmark, emoji tiles, title, top-3 dishes, footer URL). It's one canvas file, easy to restyle. No screenshot here — canvas only renders in a real browser, not jsdom; please eyeball it on `npm run dev`.
2. **iOS native rebuild** — Phase 2 added `@capacitor/filesystem` and ran `cap sync ios` (Package.swift registered). Needs an **Xcode rebuild + real-device test**: open a playlist → Share to Instagram → confirm IG appears in the sheet and the image posts cleanly. Until verified, safe to ship with `VITE_FEATURES_IG_SHARE=false` on the iOS build.

## Notes
- Locals-list share landed on **MyList.jsx** (the dedicated curator page), not Profile as the plan tentatively suggested — better grounded, since the list lives there.
- `npm install` was required (local was 240 commits behind main; `@capacitor/geolocation` wasn't installed). Phase 1's lockfile was kept byte-identical to main; only Phase 2 touches it, for the new dep.
- Pre-existing ESLint warnings (`items`/`useMemo`, `useEffect` deps) left as-is to avoid folding a refactor into feature commits.

## Verification
`npm run build` ✓ · `npm run test --run` → **672/672 ✓** · `npm run lint` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
