### PR TITLE
fix(votes): remove 3-day vote gate + fix dish-name CHECK blocking votes

### DIFF
--- a/supabase/migrations/2026-06-01-dish-name-filter-insert-only.sql
+++ b/supabase/migrations/2026-06-01-dish-name-filter-insert-only.sql
@@ -1,0 +1,45 @@
+-- 2026-06-01 — Convert dishes.name content filter from a hard CHECK to an
+-- INSERT/UPDATE-OF-name trigger.
+--
+-- ROOT CAUSE: dishes_name_content_filter_check = CHECK (NOT is_offensive(name))
+-- (added NOT VALID on 2026-04-24) re-validates the ENTIRE row on every UPDATE,
+-- not just on name changes. So the vote trigger's `UPDATE dishes SET total_votes…`
+-- re-checks the name and rolls back for any dish whose name trips is_offensive
+-- — meaning users silently CANNOT vote on such dishes (e.g. the real product
+-- "Smack My Ass Hot Sauce"), and the vote-count backfill fails on them too.
+--
+-- FIX: drop the CHECK; enforce the same is_offensive() guard via a BEFORE
+-- INSERT OR UPDATE OF name trigger. New dishes and name edits are still blocked
+-- if offensive, but updates that don't touch `name` (vote counts, ratings,
+-- value scores) no longer re-validate it. Input-time filtering in the app
+-- (validateUserContent, per content-safety rule) remains the first line.
+--
+-- NOTE: the same CHECK-on-UPDATE flaw exists on restaurants.name,
+-- profiles.display_name, and votes.review_text. Not changed here (dishes is the
+-- acute path — the vote trigger writes dishes on every vote). Flagged to Denis.
+
+CREATE OR REPLACE FUNCTION public.check_dish_name_offensive()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF public.is_offensive(NEW.name) THEN
+    RAISE EXCEPTION 'Dish name contains inappropriate content'
+      USING ERRCODE = 'check_violation';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SET search_path = public;
+
+DROP TRIGGER IF EXISTS dishes_name_content_filter_trigger ON public.dishes;
+CREATE TRIGGER dishes_name_content_filter_trigger
+  BEFORE INSERT OR UPDATE OF name ON public.dishes
+  FOR EACH ROW EXECUTE FUNCTION public.check_dish_name_offensive();
+
+ALTER TABLE public.dishes DROP CONSTRAINT IF EXISTS dishes_name_content_filter_check;
+
+-- ROLLBACK:
+-- DROP TRIGGER IF EXISTS dishes_name_content_filter_trigger ON public.dishes;
+-- DROP FUNCTION IF EXISTS public.check_dish_name_offensive();
+-- ALTER TABLE public.dishes DROP CONSTRAINT IF EXISTS dishes_name_content_filter_check;
+-- ALTER TABLE public.dishes
+--   ADD CONSTRAINT dishes_name_content_filter_check CHECK (NOT public.is_offensive(name)) NOT VALID;
+-- (Note: re-adding the CHECK restores the bug where votes on offensive-named dishes fail.)

--- a/supabase/migrations/2026-06-01-remove-3day-vote-gate.sql
+++ b/supabase/migrations/2026-06-01-remove-3day-vote-gate.sql
@@ -1,0 +1,116 @@
+-- 2026-06-01 — Remove the undocumented 3-day account-age gate from vote counting.
+--
+-- ROOT CAUSE: the LIVE update_dish_avg_rating() trigger function counted a user's
+-- vote toward dishes.total_votes / avg_rating / weighted_vote_count ONLY if that
+-- user's account was >= 3 days old. This gate:
+--   1. was applied directly to prod and never committed (not in schema.sql or any
+--      migration) — silent source-of-truth drift;
+--   2. is inconsistent with get_ranked_dishes (the ranked list counts ALL votes),
+--      so the list and the dish-detail page disagreed (list 5 / detail 1);
+--   3. is architecturally stale: the gate is time-based but only recomputed on a
+--      vote write, so a vote from a <3-day account is never re-counted when the
+--      account ages — it stays excluded indefinitely;
+--   4. hides the majority of real votes on a launching app (most accounts are new)
+--      and drops new-user-only dishes out of rankings (get_ranked_dishes filters on
+--      dishes.total_votes > 0).
+--
+-- FIX: count every rating-bearing vote (with the existing 0.5x ai_estimated source
+-- weighting), making total_votes a single, real, time-INDEPENDENT number that is
+-- correct by construction and consistent with get_ranked_dishes. Anti-sybil, if
+-- still wanted, belongs as a ranking-time weight — not by hiding the vote count.
+--
+-- This restores the function to the (ungated) definition already in schema.sql, so
+-- no schema.sql change is required. Then backfills every dish to clear the drift.
+
+-- 1. Replace the function body (trigger already points at it by name — no trigger
+--    drop/recreate needed).
+CREATE OR REPLACE FUNCTION update_dish_avg_rating()
+RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE dishes
+  SET avg_rating = sub.avg_r,
+      total_votes = sub.raw_count,
+      weighted_vote_count = sub.weighted_count
+  FROM (
+    SELECT
+      ROUND(
+        (SUM(v.rating_10 * CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END) /
+         NULLIF(SUM(CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END), 0)
+        )::NUMERIC, 1
+      ) AS avg_r,
+      COUNT(*)::INT AS raw_count,
+      COALESCE(SUM(CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END), 0)::NUMERIC AS weighted_count
+    FROM votes v
+    WHERE v.dish_id = COALESCE(NEW.dish_id, OLD.dish_id)
+      AND v.rating_10 IS NOT NULL
+  ) sub
+  WHERE dishes.id = COALESCE(NEW.dish_id, OLD.dish_id);
+  RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- 2. One-time backfill: recompute every dish from the real votes using the exact
+--    same formula as the trigger. LEFT JOIN + COALESCE so dishes with zero
+--    rating-bearing votes correctly reset to total_votes=0, avg_rating=NULL,
+--    weighted_vote_count=0. Idempotent — safe to re-run.
+UPDATE dishes d
+SET total_votes        = COALESCE(s.raw_count, 0),
+    avg_rating         = s.avg_r,
+    weighted_vote_count = COALESCE(s.weighted_count, 0)
+FROM (
+  SELECT dd.id,
+    ROUND(
+      (SUM(v.rating_10 * CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END) /
+       NULLIF(SUM(CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END), 0)
+      )::NUMERIC, 1) AS avg_r,
+    COUNT(v.id)::INT AS raw_count,
+    SUM(CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END)::NUMERIC AS weighted_count
+  FROM dishes dd
+  LEFT JOIN votes v ON v.dish_id = dd.id AND v.rating_10 IS NOT NULL
+  GROUP BY dd.id
+) s
+WHERE d.id = s.id;
+
+-- ROLLBACK (restores the prior gated behavior — note this re-introduces the bug):
+-- CREATE OR REPLACE FUNCTION update_dish_avg_rating()
+-- RETURNS TRIGGER AS $$
+-- BEGIN
+--   UPDATE dishes
+--   SET avg_rating = sub.avg_r, total_votes = sub.raw_count, weighted_vote_count = sub.weighted_count
+--   FROM (
+--     SELECT
+--       ROUND((SUM(v.rating_10 * CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END) /
+--              NULLIF(SUM(CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END), 0))::NUMERIC, 1) AS avg_r,
+--       COUNT(*)::INT AS raw_count,
+--       COALESCE(SUM(CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END), 0)::NUMERIC AS weighted_count
+--     FROM votes v
+--     WHERE v.dish_id = COALESCE(NEW.dish_id, OLD.dish_id)
+--       AND v.rating_10 IS NOT NULL
+--       AND (v.source = 'ai_estimated' OR EXISTS (
+--         SELECT 1 FROM auth.users u WHERE u.id = v.user_id AND u.created_at <= NOW() - INTERVAL '3 days'))
+--   ) sub
+--   WHERE dishes.id = COALESCE(NEW.dish_id, OLD.dish_id);
+--   RETURN COALESCE(NEW, OLD);
+-- END;
+-- $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+-- NOTE: replacing the function above only restores GATED behavior for FUTURE
+-- writes. Existing dish aggregates stay at their (correct, ungated) values until
+-- each dish is next touched — which is the desired end state, since the gate is
+-- the bug. For a literal full restore of the prior gated numbers, also re-run a
+-- gated backfill:
+-- UPDATE dishes d
+-- SET total_votes = COALESCE(s.raw_count, 0), avg_rating = s.avg_r, weighted_vote_count = COALESCE(s.weighted_count, 0)
+-- FROM (
+--   SELECT dd.id,
+--     ROUND((SUM(v.rating_10 * CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END) /
+--            NULLIF(SUM(CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END), 0))::NUMERIC, 1) AS avg_r,
+--     COUNT(v.id)::INT AS raw_count,
+--     SUM(CASE WHEN v.source = 'ai_estimated' THEN 0.5 ELSE 1.0 END)::NUMERIC AS weighted_count
+--   FROM dishes dd
+--   LEFT JOIN votes v ON v.dish_id = dd.id AND v.rating_10 IS NOT NULL
+--     AND (v.source = 'ai_estimated' OR EXISTS (
+--       SELECT 1 FROM auth.users u WHERE u.id = v.user_id AND u.created_at <= NOW() - INTERVAL '3 days'))
+--   GROUP BY dd.id
+-- ) s WHERE d.id = s.id;
+-- The forward backfill itself recomputes from source-of-truth votes, so recovery
+-- from a bad forward run is simply re-running the (ungated) backfill UPDATE above.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1002,10 +1002,28 @@ ALTER TABLE public.votes
   ADD CONSTRAINT votes_review_text_content_filter_check
   CHECK (NOT public.is_offensive(review_text)) NOT VALID;
 
+-- dishes.name uses an INSERT/UPDATE-OF-name trigger instead of a CHECK: a CHECK
+-- re-validates the whole row on EVERY update, so the vote trigger's
+-- `UPDATE dishes SET total_votes…` would roll back for any dish whose name trips
+-- is_offensive() — silently blocking votes on it. The trigger fires only on
+-- insert or an actual name change. See migration 2026-06-01-dish-name-filter-insert-only.sql.
 ALTER TABLE public.dishes DROP CONSTRAINT IF EXISTS dishes_name_content_filter_check;
-ALTER TABLE public.dishes
-  ADD CONSTRAINT dishes_name_content_filter_check
-  CHECK (NOT public.is_offensive(name)) NOT VALID;
+
+CREATE OR REPLACE FUNCTION public.check_dish_name_offensive()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF public.is_offensive(NEW.name) THEN
+    RAISE EXCEPTION 'Dish name contains inappropriate content'
+      USING ERRCODE = 'check_violation';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SET search_path = public;
+
+DROP TRIGGER IF EXISTS dishes_name_content_filter_trigger ON public.dishes;
+CREATE TRIGGER dishes_name_content_filter_trigger
+  BEFORE INSERT OR UPDATE OF name ON public.dishes
+  FOR EACH ROW EXECUTE FUNCTION public.check_dish_name_offensive();
 
 ALTER TABLE public.restaurants DROP CONSTRAINT IF EXISTS restaurants_name_content_filter_check;
 ALTER TABLE public.restaurants
@@ -1029,13 +1047,8 @@ BEGIN
     ALTER TABLE public.votes VALIDATE CONSTRAINT votes_review_text_content_filter_check;
   END IF;
 
-  IF NOT EXISTS (
-    SELECT 1
-    FROM public.dishes
-    WHERE public.is_offensive(public.dishes.name) IS TRUE
-  ) THEN
-    ALTER TABLE public.dishes VALIDATE CONSTRAINT dishes_name_content_filter_check;
-  END IF;
+  -- dishes.name is enforced via the dishes_name_content_filter_trigger
+  -- (INSERT/UPDATE OF name) above, not a CHECK — so nothing to VALIDATE here.
 
   IF NOT EXISTS (
     SELECT 1


### PR DESCRIPTION
## What this fixes
Users reported the dish-detail page showing **fewer votes than the home ranked list** (Dirty Banana: list 5 / detail 1; Apple Fritter: list 5 / detail 3). Root-caused to **two coupled, undocumented production issues** — **45 of 138 dishes** had undercounted votes. Both fixes were applied to the live DB today and are committed here to end repo↔live drift.

## Root cause 1 — undocumented 3-day account-age vote gate
The **live** `update_dish_avg_rating()` trigger counted a vote toward `dishes.total_votes`/`avg_rating`/`weighted_vote_count` only if `auth.users.created_at <= NOW() - INTERVAL '3 days'`. This clause existed **only on prod** — not in `schema.sql` or any migration. It was:
- **inconsistent** — `get_ranked_dishes` (the list) counts all votes, no gate;
- **architecturally stale** — gate is time-based but only recomputed on a vote *write*, so a vote from a <3-day account is never re-counted when the account ages;
- **launch-toxic** — most accounts are <3 days old, so the majority of real votes were hidden and new-user-only dishes dropped out of rankings.

**Fix:** remove the gate (keep the 0.5× `ai_estimated` weighting) so `total_votes` is the real, time-independent count, consistent with `get_ranked_dishes`; backfill all dishes. Anti-sybil, if still wanted, belongs as a **ranking-time weight**, not by hiding the count.

## Root cause 2 — dish-name CHECK silently blocking votes
`dishes_name_content_filter_check = CHECK (NOT is_offensive(name))` (added `NOT VALID` 2026-04-24) re-validates the **whole row on every UPDATE**. So the vote trigger's `UPDATE dishes SET total_votes…` rolled back for any dish whose name tripped `is_offensive()` — e.g. the real product **"Smack My Ass Hot Sauce"** — meaning users **could not vote on it at all**, and the backfill failed on it.

**Fix:** replace the CHECK with a `BEFORE INSERT OR UPDATE OF name` trigger — name is validated on insert/rename only, never on unrelated column updates. New offensive names still blocked; input-time `validateUserContent` remains the first line.

## Verification (live)
After running: `still_stale = 0` (was 45), Dirty Banana = 5, Apple Fritter = 5, and the hot-sauce row is updatable/votable again.

## Scope / rollout
**Backend-only.** Live for all users (web + iOS, any binary) immediately — no app build / no 1.9 needed. Both migrations Codex-reviewed (gpt-5.4). Each has a `-- ROLLBACK:` block.

## Not changed (flagged to Denis, #182)
The same CHECK-on-UPDATE pattern exists on `restaurants.name`, `profiles.display_name`, `votes.review_text`. Lower-risk (no high-frequency trigger writes them like votes write dishes), so left for a deliberate call rather than scope-creeping this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)