### PR TITLE
refactor: shared link builders + move getUserVoteForDish to votesApi

### DIFF
--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -761,34 +761,4 @@ export const authApi = {
       logger.error('signOutNative failed', err)
     }
   },
-
-  /**
-   * Get current user's vote for a dish
-   * @param {string} dishId - Dish ID
-   * @param {string} userId - User ID
-   * @returns {Promise<Object|null>} Vote data or null
-   */
-  async getUserVoteForDish(dishId, userId) {
-    try {
-      if (!userId) {
-        return null
-      }
-
-      const { data, error } = await supabase
-        .from('votes')
-        .select('rating_10, review_text, review_created_at')
-        .eq('dish_id', dishId)
-        .eq('user_id', userId)
-        .maybeSingle()
-
-      if (error) {
-        throw createClassifiedError(error)
-      }
-
-      return data
-    } catch (error) {
-      logger.error('Error fetching user vote:', error)
-      throw error.type ? error : createClassifiedError(error)
-    }
-  },
 }

--- a/src/api/authApi.test.js
+++ b/src/api/authApi.test.js
@@ -242,44 +242,6 @@ describe('Auth API', () => {
     })
   })
 
-  describe('getUserVoteForDish', () => {
-    it('should return null if no user ID', async () => {
-      const result = await authApi.getUserVoteForDish('dish-1', null)
-      expect(result).toBeNull()
-    })
-
-    it('should fetch user vote successfully', async () => {
-      const mockVote = { rating_10: 8, review_text: null, review_created_at: null }
-      const selectFn = vi.fn((fields) => {
-        // Ensure binary vote field is not projected any more.
-        expect(fields).not.toMatch(/would_order_again/)
-        return {
-          eq: vi.fn(function() { return this }),
-          maybeSingle: vi.fn().mockResolvedValueOnce({ data: mockVote, error: null }),
-        }
-      })
-
-      supabase.from.mockReturnValueOnce({ select: selectFn })
-
-      const result = await authApi.getUserVoteForDish('dish-1', 'user-1')
-
-      expect(result).toEqual(mockVote)
-    })
-
-    it('should return null if vote not found', async () => {
-      const selectFn = vi.fn(() => ({
-        eq: vi.fn(function() { return this }),
-        maybeSingle: vi.fn().mockResolvedValueOnce({ data: null, error: null }),
-      }))
-
-      supabase.from.mockReturnValueOnce({ select: selectFn })
-
-      const result = await authApi.getUserVoteForDish('dish-1', 'user-1')
-
-      expect(result).toBeNull()
-    })
-  })
-
   describe('persistAppleRefreshToken (Flow K)', () => {
     beforeEach(() => {
       vi.useFakeTimers()

--- a/src/api/votesApi.js
+++ b/src/api/votesApi.js
@@ -659,4 +659,34 @@ export const votesApi = {
       throw error.type ? error : createClassifiedError(error)
     }
   },
+
+  /**
+   * Get the current user's vote for a dish (rating + review fields), or null.
+   * @param {string} dishId
+   * @param {string} userId
+   * @returns {Promise<Object|null>}
+   */
+  async getUserVoteForDish(dishId, userId) {
+    try {
+      if (!userId) {
+        return null
+      }
+
+      const { data, error } = await supabase
+        .from('votes')
+        .select('rating_10, review_text, review_created_at')
+        .eq('dish_id', dishId)
+        .eq('user_id', userId)
+        .maybeSingle()
+
+      if (error) {
+        throw createClassifiedError(error)
+      }
+
+      return data
+    } catch (error) {
+      logger.error('Error fetching user vote:', error)
+      throw error.type ? error : createClassifiedError(error)
+    }
+  },
 }

--- a/src/api/votesApi.test.js
+++ b/src/api/votesApi.test.js
@@ -654,4 +654,42 @@ describe('votesApi', () => {
       await expect(votesApi.getReviewsForUser('user-1')).rejects.toThrow()
     })
   })
+
+  describe('getUserVoteForDish', () => {
+    it('should return null if no user ID', async () => {
+      const result = await votesApi.getUserVoteForDish('dish-1', null)
+      expect(result).toBeNull()
+    })
+
+    it('should fetch user vote successfully', async () => {
+      const mockVote = { rating_10: 8, review_text: null, review_created_at: null }
+      const selectFn = vi.fn((fields) => {
+        // Ensure binary vote field is not projected any more.
+        expect(fields).not.toMatch(/would_order_again/)
+        return {
+          eq: vi.fn(function() { return this }),
+          maybeSingle: vi.fn().mockResolvedValueOnce({ data: mockVote, error: null }),
+        }
+      })
+
+      supabase.from.mockReturnValueOnce({ select: selectFn })
+
+      const result = await votesApi.getUserVoteForDish('dish-1', 'user-1')
+
+      expect(result).toEqual(mockVote)
+    })
+
+    it('should return null if vote not found', async () => {
+      const selectFn = vi.fn(() => ({
+        eq: vi.fn(function() { return this }),
+        maybeSingle: vi.fn().mockResolvedValueOnce({ data: null, error: null }),
+      }))
+
+      supabase.from.mockReturnValueOnce({ select: selectFn })
+
+      const result = await votesApi.getUserVoteForDish('dish-1', 'user-1')
+
+      expect(result).toBeNull()
+    })
+  })
 })

--- a/src/components/DishListItem.jsx
+++ b/src/components/DishListItem.jsx
@@ -6,6 +6,7 @@ import { getCategoryNeonImage, getCategoryEmoji, getDishNameIcon, getMenuSection
 import { RestaurantAvatar } from './RestaurantAvatar'
 import { sanitizeUrl } from '../utils/sanitize'
 import { openExternalLink } from '../utils/openExternalLink'
+import { buildDirectionsUrl, buildToastOrderUrl } from '../utils/restaurantLinks'
 /**
  * DishListItem — the ONE component for showing a dish in any list.
  *
@@ -249,7 +250,7 @@ export const DishListItem = memo(function DishListItem({
           <div className="flex items-center gap-2" style={{ marginTop: '4px' }}>
             {(toastSlug || sanitizeUrl(orderUrl)) && (
               <a
-                href={toastSlug ? 'https://order.toasttab.com/online/' + toastSlug : sanitizeUrl(orderUrl)}
+                href={buildToastOrderUrl(toastSlug, orderUrl)}
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={(e) => { e.stopPropagation(); openExternalLink(e, e.currentTarget.href) }}
@@ -265,7 +266,7 @@ export const DishListItem = memo(function DishListItem({
             )}
             {restaurantLat && restaurantLng && (
               <a
-                href={'https://www.google.com/maps/dir/?api=1&destination=' + restaurantLat + ',' + restaurantLng}
+                href={buildDirectionsUrl({ lat: restaurantLat, lng: restaurantLng })}
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={(e) => { e.stopPropagation(); openExternalLink(e, e.currentTarget.href) }}

--- a/src/components/ReviewFlow.jsx
+++ b/src/components/ReviewFlow.jsx
@@ -5,7 +5,7 @@ import { useVote } from '../hooks/useVote'
 import { usePurityTracker } from '../hooks/usePurityTracker'
 import JitterBox from '../utils/jitter-box'
 import { jitterApi } from '../api/jitterApi'
-import { authApi } from '../api/authApi'
+import { votesApi } from '../api/votesApi'
 import { dishPhotosApi } from '../api/dishPhotosApi'
 import { FoodRatingSlider } from './FoodRatingSlider'
 import { MAX_REVIEW_LENGTH } from '../constants/app'
@@ -90,7 +90,7 @@ export function ReviewFlow({
         return
       }
       try {
-        const vote = await authApi.getUserVoteForDish(dishId, user.id)
+        const vote = await votesApi.getUserVoteForDish(dishId, user.id)
         if (cancelled) return
         if (vote) {
           setPriorRating(vote.rating_10 ?? null)

--- a/src/pages/Dish.jsx
+++ b/src/pages/Dish.jsx
@@ -18,7 +18,8 @@ import { ReportModal } from '../components/ReportModal'
 import { MIN_VOTES_FOR_RANKING } from '../constants/app'
 import { sanitizeUrl } from '../utils/sanitize'
 import { openExternalLink } from '../utils/openExternalLink'
-import { authApi } from '../api/authApi'
+import { buildDirectionsUrl, buildToastOrderUrl } from '../utils/restaurantLinks'
+import { votesApi } from '../api/votesApi'
 import { dishPhotosApi } from '../api/dishPhotosApi'
 import { ErrorTypes, getUserMessage } from '../utils/errorHandler'
 
@@ -89,7 +90,7 @@ export function Dish() {
     // allSettled so a photo-fetch failure doesn't also discard the vote fetch —
     // otherwise the CTA label silently regresses to "Rate this dish" for re-raters.
     Promise.allSettled([
-      authApi.getUserVoteForDish(dishId, user.id),
+      votesApi.getUserVoteForDish(dishId, user.id),
       dishPhotosApi.getUserPhotoForDish(dishId),
     ]).then(([voteResult, photoResult]) => {
       if (cancelled) return
@@ -137,7 +138,7 @@ export function Dish() {
     // allSettled so a photo-fetch failure doesn't discard the vote result.
     if (user && dishId) {
       Promise.allSettled([
-        authApi.getUserVoteForDish(dishId, user.id),
+        votesApi.getUserVoteForDish(dishId, user.id),
         dishPhotosApi.getUserPhotoForDish(dishId),
       ]).then(([voteResult, photoResult]) => {
         if (voteResult.status === 'fulfilled') {
@@ -510,7 +511,7 @@ export function Dish() {
         >
           {(dish.toast_slug || sanitizeUrl(dish.order_url)) ? (
             <a
-              href={dish.toast_slug ? 'https://order.toasttab.com/online/' + dish.toast_slug : sanitizeUrl(dish.order_url)}
+              href={buildToastOrderUrl(dish.toast_slug, dish.order_url)}
               target="_blank"
               rel="noopener noreferrer"
               onClick={(e) => {
@@ -554,10 +555,11 @@ export function Dish() {
           ) : null}
 
           <a
-            href={dish.restaurant_lat && dish.restaurant_lng
-              ? 'https://www.google.com/maps/dir/?api=1&destination=' + dish.restaurant_lat + ',' + dish.restaurant_lng
-              : 'https://www.google.com/maps/dir/?api=1&destination=' + encodeURIComponent((dish.restaurant_address || (dish.restaurant_name + ', ' + (dish.restaurant_town || "Martha's Vineyard") + ', MA')))
-            }
+            href={buildDirectionsUrl({
+              lat: dish.restaurant_lat,
+              lng: dish.restaurant_lng,
+              address: dish.restaurant_address || (dish.restaurant_name + ', ' + (dish.restaurant_town || "Martha's Vineyard") + ', MA'),
+            })}
             target="_blank"
             rel="noopener noreferrer"
             onClick={(e) => openExternalLink(e, e.currentTarget.href)}

--- a/src/pages/RestaurantDetail.jsx
+++ b/src/pages/RestaurantDetail.jsx
@@ -10,6 +10,7 @@ import { getUserMessage } from '../utils/errorHandler'
 import { shareOrCopy, canonicalShareUrl } from '../utils/share'
 import { sanitizeUrl } from '../utils/sanitize'
 import { openExternalLink } from '../utils/openExternalLink'
+import { buildDirectionsUrl, buildToastOrderUrl } from '../utils/restaurantLinks'
 import { restaurantsApi } from '../api/restaurantsApi'
 import { placesApi } from '../api/placesApi'
 import { votesApi } from '../api/votesApi'
@@ -516,10 +517,7 @@ export function RestaurantDetail() {
             <div className="flex items-center gap-3 flex-wrap">
               {restaurant.address && (
                 <a
-                  href={restaurant.lat && restaurant.lng
-                    ? `https://www.google.com/maps/dir/?api=1&destination=${restaurant.lat},${restaurant.lng}`
-                    : `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(restaurant.address)}`
-                  }
+                  href={buildDirectionsUrl({ lat: restaurant.lat, lng: restaurant.lng, address: restaurant.address })}
                   target="_blank"
                   rel="noopener noreferrer"
                   onClick={(e) => openExternalLink(e, e.currentTarget.href)}
@@ -798,7 +796,7 @@ export function RestaurantDetail() {
         <div className="flex gap-2">
           {(restaurant.toast_slug || sanitizeUrl(restaurant.order_url)) && (
             <a
-              href={restaurant.toast_slug ? 'https://order.toasttab.com/online/' + restaurant.toast_slug : sanitizeUrl(restaurant.order_url)}
+              href={buildToastOrderUrl(restaurant.toast_slug, restaurant.order_url)}
               target="_blank"
               rel="noopener noreferrer"
               onClick={(e) => openExternalLink(e, e.currentTarget.href)}

--- a/src/utils/restaurantLinks.js
+++ b/src/utils/restaurantLinks.js
@@ -1,0 +1,32 @@
+// Shared builders for the external "action" links rendered on dish/restaurant
+// surfaces (Dish, RestaurantDetail, DishListItem). Previously each surface
+// hand-rolled these, and the directions fallback had already drifted — keep the
+// URL shapes here so they can't diverge.
+import { sanitizeUrl } from './sanitize'
+
+const MAPS_DIR_BASE = 'https://www.google.com/maps/dir/?api=1&destination='
+
+/**
+ * Google Maps directions URL. Prefers exact coordinates; otherwise falls back
+ * to an encoded address string. Callers pass their own fallback address (Dish
+ * uses name + town, RestaurantDetail uses the raw address, DishListItem only
+ * renders with coords so it passes none).
+ *
+ * @param {{ lat?: number|string, lng?: number|string, address?: string }} args
+ */
+export function buildDirectionsUrl({ lat, lng, address } = {}) {
+  if (lat && lng) return MAPS_DIR_BASE + lat + ',' + lng
+  return MAPS_DIR_BASE + encodeURIComponent(address || '')
+}
+
+/**
+ * Order link for a restaurant: a Toast online-ordering deep link when there's a
+ * toast_slug, otherwise the sanitized fallback order_url (sanitizeUrl returns
+ * null for an invalid/unsafe URL, matching the prior inline behavior).
+ *
+ * @param {string|null|undefined} toastSlug
+ * @param {string|null|undefined} orderUrl
+ */
+export function buildToastOrderUrl(toastSlug, orderUrl) {
+  return toastSlug ? 'https://order.toasttab.com/online/' + toastSlug : sanitizeUrl(orderUrl)
+}

--- a/src/utils/restaurantLinks.test.js
+++ b/src/utils/restaurantLinks.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest'
+import { buildDirectionsUrl, buildToastOrderUrl } from './restaurantLinks'
+
+// sanitizeUrl is exercised for real (it's a pure util); these assertions assume
+// it passes through a valid http(s) URL and rejects junk.
+describe('buildDirectionsUrl', () => {
+  it('uses coordinates when both lat and lng are present', () => {
+    expect(buildDirectionsUrl({ lat: 41.45, lng: -70.55, address: 'ignored' }))
+      .toBe('https://www.google.com/maps/dir/?api=1&destination=41.45,-70.55')
+  })
+
+  it('falls back to the encoded address when coords are missing', () => {
+    expect(buildDirectionsUrl({ address: "Nancy's, Oak Bluffs, MA" }))
+      .toBe('https://www.google.com/maps/dir/?api=1&destination=Nancy\'s%2C%20Oak%20Bluffs%2C%20MA')
+  })
+
+  it('falls back when only one coord is present (matches the && truthiness check)', () => {
+    expect(buildDirectionsUrl({ lat: 41.45, lng: null, address: 'X' }))
+      .toBe('https://www.google.com/maps/dir/?api=1&destination=X')
+  })
+
+  it('handles no address gracefully (DishListItem coord-only case)', () => {
+    expect(buildDirectionsUrl({ lat: 1, lng: 2 }))
+      .toBe('https://www.google.com/maps/dir/?api=1&destination=1,2')
+    expect(buildDirectionsUrl({})).toBe('https://www.google.com/maps/dir/?api=1&destination=')
+  })
+})
+
+describe('buildToastOrderUrl', () => {
+  it('builds a Toast deep link from a slug', () => {
+    expect(buildToastOrderUrl('the-cafe', 'https://example.com/order'))
+      .toBe('https://order.toasttab.com/online/the-cafe')
+  })
+
+  it('falls back to the sanitized order URL when there is no slug', () => {
+    expect(buildToastOrderUrl(null, 'https://example.com/order'))
+      .toBe('https://example.com/order')
+  })
+
+  it('returns the sanitizer result for an unsafe/empty fallback (no slug)', () => {
+    // sanitizeUrl rejects javascript: and the like → null (falsy), preserving the
+    // "no order link" guard behavior at the call sites.
+    expect(buildToastOrderUrl(null, 'javascript:alert(1)')).toBe(null)
+    expect(buildToastOrderUrl(null, null)).toBe(null)
+  })
+})


### PR DESCRIPTION
Two behavior-preserving dedups from the audit's "duplicated logic" list.

## 1. Shared link builders — `src/utils/restaurantLinks.js` (+ 7 tests)
- **`buildToastOrderUrl(toastSlug, orderUrl)`** — was **identical** across `Dish.jsx`, `RestaurantDetail.jsx`, `DishListItem.jsx`.
- **`buildDirectionsUrl({ lat, lng, address })`** — the three copies had **drifted** address fallbacks:
  - `Dish.jsx` → `restaurant_address || name + ', ' + town + ', MA'`
  - `RestaurantDetail.jsx` → `restaurant.address`
  - `DishListItem.jsx` → coord-only (no fallback; it's coord-guarded)
  
  So the shared builder takes a **caller-computed `address`** — each site keeps its **exact** prior output (verified: the lat/lng truthiness check, string concat, and `encodeURIComponent` all preserved).

## 2. `getUserVoteForDish` → `votesApi`
A pure `votes` query that lived in `authApi` for no reason. Moved verbatim to `votesApi`, updated the 3 call sites (`Dish.jsx` ×2, `ReviewFlow.jsx`), and **moved its 3 tests** with it (`authApi.test.js` → `votesApi.test.js`). Both consumers dropped their now-unused `authApi` import. The 30/38-line removals from `authApi` exactly match the additions to `votesApi`.

## Deliberately skipped: clipboard
The audit listed `copyTextToClipboard`, but on inspection it's a **single-file helper** (one real use context in `Admin.jsx`) plus one *intentionally different* gesture-preserving inline block — not genuine cross-file duplication. Hoisting it would be the "abstraction before 2–3 use cases" the audit itself warns against. Left as-is.

## Safety
**0 lint errors, build clean, 40 files / 675 tests pass.** No behavior change. (Codex still down today — reviewed inline + locked by the new builder tests.)