### PR TITLE
feat(home): slim wordmark header + settings/notifications

### DIFF
--- a/src/components/NotificationBell.jsx
+++ b/src/components/NotificationBell.jsx
@@ -8,7 +8,7 @@ import { logger } from '../utils/logger'
 /**
  * Notification bell icon with dropdown
  */
-export function NotificationBell() {
+export function NotificationBell({ color = 'var(--color-surface)' } = {}) {
   const navigate = useNavigate()
   const location = useLocation()
   const { user } = useAuth()
@@ -125,7 +125,7 @@ export function NotificationBell() {
       <button
         onClick={handleBellClick}
         className="relative p-2 rounded-full transition-all duration-150 active:scale-95 active:opacity-80"
-        style={{ color: 'var(--color-surface)' }}
+        style={{ color }}
         aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ''}`}
         aria-expanded={showDropdown}
         aria-haspopup="true"

--- a/src/components/SettingsDropdown.jsx
+++ b/src/components/SettingsDropdown.jsx
@@ -11,7 +11,7 @@ import { logger } from '../utils/logger'
 /**
  * Settings gear icon with dropdown — mirrors NotificationBell pattern
  */
-export function SettingsDropdown() {
+export function SettingsDropdown({ color = 'var(--color-surface)' } = {}) {
   const navigate = useNavigate()
   const location = useLocation()
   const { user, signOut } = useAuth()
@@ -75,7 +75,7 @@ export function SettingsDropdown() {
         ref={gearButtonRef}
         onClick={() => setShowDropdown(!showDropdown)}
         className="relative p-2 rounded-full transition-all duration-150 active:scale-95 active:opacity-80"
-        style={{ color: 'var(--color-surface)' }}
+        style={{ color }}
         aria-label="Settings"
         aria-expanded={showDropdown}
         aria-haspopup="true"

--- a/src/components/home/HomeListMode.jsx
+++ b/src/components/home/HomeListMode.jsx
@@ -7,6 +7,8 @@ import { DietButton } from '../DietButton'
 import { EmptyState } from '../EmptyState'
 import { DataLoadError } from '../DataLoadError'
 import { LocationBanner } from '../LocationBanner'
+import { SettingsDropdown } from '../SettingsDropdown'
+import { NotificationBell } from '../NotificationBell'
 import { LocalsPicksBanner, Top10Carousel } from './'
 export const HomeListMode = memo(function HomeListMode({
   listScrollRef,
@@ -64,34 +66,30 @@ export const HomeListMode = memo(function HomeListMode({
     >
       {/* Fixed header: brand + search + chips */}
       <div style={{ flexShrink: 0, background: 'var(--color-bg)', zIndex: 10, paddingTop: 'env(safe-area-inset-top, 0px)' }}>
-        {/* Brand header — the iOS app icon used as the homepage mark.
-            Rounded corners (22% radius matches Apple's icon mask) and a
-            soft shadow make it read as "icon," not bare PNG. Map page
-            already has an <h1 className="sr-only">What's Good Here</h1>
-            so this img carries the screen-reader label as alt text. */}
-        <div className="text-center pt-4 pb-1">
-          <img
-            src="/wgh-icon.png"
-            alt="What's Good Here"
-            style={{
-              display: 'block',
-              margin: '0 auto',
-              width: '120px',
-              height: '120px',
-              borderRadius: '26px',
-              boxShadow: '0 6px 16px rgba(26, 26, 26, 0.12)',
-            }}
-          />
-          <p style={{
-            fontSize: '10px',
-            fontWeight: 600,
-            color: '#999',
-            letterSpacing: '0.15em',
-            textTransform: 'uppercase',
-            margin: '8px 0 0',
+        {/* Brand header — slim left-aligned Amatic SC wordmark. Replaced the
+            large centered app-icon + tagline (which pushed all rankings below
+            the fold and wasted the space on either side) so the list sits
+            higher and the header reads as an app, not a splash screen. Map page
+            already has an <h1 className="sr-only">What's Good Here</h1> for the
+            screen-reader label, so this is aria-hidden decorative text. */}
+        <div className="px-5 pt-3 pb-1" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <span aria-hidden="true" style={{
+            fontFamily: "'Amatic SC', cursive",
+            fontWeight: 700,
+            fontSize: '36px',
+            lineHeight: 1,
+            letterSpacing: '0.5px',
+            color: 'var(--color-primary)',
           }}>
-            Top-rated dishes near you
-          </p>
+            What's <span style={{ color: 'var(--color-accent-gold)' }}>Good</span> Here
+          </span>
+          {/* Settings + notifications — reuse the shared TopBar controls, tinted
+              dark for the stone header (they default to near-white for the
+              orange bar). NotificationBell self-hides when logged out. */}
+          <div className="flex items-center" style={{ marginRight: '-8px' }}>
+            <SettingsDropdown color="var(--color-text-secondary)" />
+            <NotificationBell color="var(--color-text-secondary)" />
+          </div>
         </div>
         {/* Search bar */}
         <div className="px-5 pt-2 pb-1">


### PR DESCRIPTION
## Why
The homepage led with a large **centered app-icon** + "Top-rated dishes near you" tagline — a splash-screen layout that pushed every ranking below the fold and left dead space on both sides. A first-time user (real feedback: a friend found it "confusing") saw branding, not the product.

## What
- **Header:** big centered icon + tagline → **slim left-aligned Amatic SC "What's `Good` Here" wordmark** (Good in gold, per brand pattern). Everything below climbs ~⅓ of a screen.
- **Right side:** added the shared **`SettingsDropdown` + `NotificationBell`** (the exact controls `TopBar` uses elsewhere). Both gained an optional `color` prop **defaulting to `var(--color-surface)`** so TopBar's white-on-orange is unchanged; the homepage tints them `var(--color-text-secondary)` for the stone bg. Both already self-hide when logged out.
- **Everything else below the header (chalkboards, Locals' Picks, carousel, ranked list) is untouched** — explicitly kept per design direction.

## Scope / rollout
Frontend-only. **Web: live on merge.** iOS: needs a Capacitor build to reach the app.

## Test plan
- `npm run build` ✅, eslint ✅ (one pre-existing NotificationBell warning, unrelated)
- Rendered the real component at phone size: wordmark + gear/bell render correctly; logged-out correctly hides the controls.
- Backward compat self-verified: TopBar (no props) → unchanged white-on-orange.
- ⚠️ Codex review was blocked by a concurrent codex run in another worktree (they hang when run in parallel); will run a solo Codex pass as follow-up. Change is small + low-risk (color prop with safe default + markup swap).

## Follow-ups (deliberately deferred)
- Tighten the gap between the gear + bell icons.
- Bigger first-run questions (chalkboards-vs-rankings hierarchy, rating spread) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)