### PR TITLE
feat: rate-first gate for lists + always-visible review bar (ports Denis #183)

### DIFF
--- a/src/components/ReviewFlow.jsx
+++ b/src/components/ReviewFlow.jsx
@@ -57,7 +57,6 @@ export function ReviewFlow({
   // Form state.
   // sliderValue = null means "unrated" — submit button stays disabled.
   const [sliderValue, setSliderValue] = useState(null)
-  const [reviewExpanded, setReviewExpanded] = useState(false)
   const [reviewText, setReviewText] = useState('')
   const [reviewError, setReviewError] = useState(null)
 
@@ -98,7 +97,6 @@ export function ReviewFlow({
           if (vote.rating_10 != null) setSliderValue(vote.rating_10)
           if (vote.review_text) {
             setReviewText(vote.review_text)
-            setReviewExpanded(true)
           }
         }
       } catch (error) {
@@ -117,9 +115,9 @@ export function ReviewFlow({
     }
   }, [dishId])
 
-  // Attach JitterBox to textarea when expanded.
+  // Attach JitterBox to the (always-visible) review textarea on mount.
   useEffect(() => {
-    if (reviewExpanded && reviewTextareaRef.current && !jitterBoxRef.current) {
+    if (reviewTextareaRef.current && !jitterBoxRef.current) {
       jitterBoxRef.current = JitterBox.attach(reviewTextareaRef.current)
     }
     return () => {
@@ -128,7 +126,7 @@ export function ReviewFlow({
         jitterBoxRef.current = null
       }
     }
-  }, [reviewExpanded])
+  }, [])
 
   // Cancel pending photo-nudge timer on unmount so it doesn't fire into
   // a torn-down component.
@@ -288,56 +286,46 @@ export function ReviewFlow({
         </p>
       )}
 
-      {/* Review — collapsed by default */}
-      {!reviewExpanded ? (
-        <button
-          type="button"
-          onClick={() => setReviewExpanded(true)}
-          className="w-full py-3 text-sm rounded-xl transition-colors"
-          style={{ color: 'var(--color-text-secondary)', border: '1px dashed var(--color-divider)' }}
-        >
-          + Add a review (optional)
-        </button>
-      ) : (
-        <div className="relative">
-          <label htmlFor="review-text" className="sr-only">Your review</label>
-          <textarea
-            ref={combinedTextareaRef}
-            id="review-text"
-            value={reviewText}
-            onChange={(e) => {
-              setReviewText(e.target.value)
-              if (reviewError) setReviewError(null)
-            }}
-            placeholder="What stood out?"
-            aria-label="Write your review"
-            aria-describedby={reviewError ? 'review-error' : 'review-char-count'}
-            aria-invalid={!!reviewError}
-            maxLength={MAX_REVIEW_LENGTH + 50}
-            rows={3}
-            className="w-full p-4 rounded-xl text-sm resize-none focus:outline-none focus-ring"
-            style={{
-              background: 'var(--color-surface-elevated)',
-              border: reviewError ? '2px solid var(--color-primary)' : '1px solid var(--color-divider)',
-              color: 'var(--color-text-primary)',
-            }}
-          />
-          {reviewText.length > 0 && (
-            <div
-              id="review-char-count"
-              className="absolute bottom-2 right-3 text-xs"
-              style={{ color: reviewText.length > MAX_REVIEW_LENGTH ? 'var(--color-primary)' : 'var(--color-text-tertiary)' }}
-            >
-              {reviewText.length}/{MAX_REVIEW_LENGTH}
-            </div>
-          )}
-          {reviewError && (
-            <p id="review-error" role="alert" className="text-sm text-center mt-1" style={{ color: 'var(--color-primary)' }}>
-              {reviewError}
-            </p>
-          )}
-        </div>
-      )}
+      {/* Review — always visible, optional. Rating is the required signal; words are a bonus. */}
+      <div className="relative">
+        <label htmlFor="review-text" className="block text-sm mb-1.5" style={{ color: 'var(--color-text-secondary)' }}>
+          Add a review <span style={{ color: 'var(--color-text-tertiary)' }}>(optional)</span>
+        </label>
+        <textarea
+          ref={combinedTextareaRef}
+          id="review-text"
+          value={reviewText}
+          onChange={(e) => {
+            setReviewText(e.target.value)
+            if (reviewError) setReviewError(null)
+          }}
+          placeholder="What stood out?"
+          aria-describedby={reviewError ? 'review-error' : 'review-char-count'}
+          aria-invalid={!!reviewError}
+          maxLength={MAX_REVIEW_LENGTH + 50}
+          rows={3}
+          className="w-full p-4 rounded-xl text-sm resize-none focus:outline-none focus-ring"
+          style={{
+            background: 'var(--color-surface-elevated)',
+            border: reviewError ? '2px solid var(--color-primary)' : '1px solid var(--color-divider)',
+            color: 'var(--color-text-primary)',
+          }}
+        />
+        {reviewText.length > 0 && (
+          <div
+            id="review-char-count"
+            className="absolute bottom-2 right-3 text-xs"
+            style={{ color: reviewText.length > MAX_REVIEW_LENGTH ? 'var(--color-primary)' : 'var(--color-text-tertiary)' }}
+          >
+            {reviewText.length}/{MAX_REVIEW_LENGTH}
+          </div>
+        )}
+        {reviewError && (
+          <p id="review-error" role="alert" className="text-sm text-center mt-1" style={{ color: 'var(--color-primary)' }}>
+            {reviewError}
+          </p>
+        )}
+      </div>
 
       {/* Photo — collapsed by default; if user had a prior photo, show thumbnail + keep/replace/remove. */}
       {existingPhoto && !photoAdded ? (

--- a/src/pages/Dish.jsx
+++ b/src/pages/Dish.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { capture } from '../lib/analytics'
@@ -47,10 +47,15 @@ export function Dish() {
   const [loginModalOpen, setLoginModalOpen] = useState(false)
   const [playlistSheetOpen, setPlaylistSheetOpen] = useState(false)
   const [showReportDish, setShowReportDish] = useState(false)
-  const [showRateFlow, setShowRateFlow] = useState(false)
-  const [pendingAction, setPendingAction] = useState(null) // 'rate' | null
+  // When the user taps "+" / "Add to Top 10" on a dish with no rating yet, we
+  // nudge them to the (always-visible) slider, then auto-complete the queued
+  // add once a number is in. Single value so the two paths are mutually
+  // exclusive — tapping one supersedes the other instead of both replaying.
+  // null | 'playlist' | 'top10'
+  const [pendingListAdd, setPendingListAdd] = useState(null)
   const [priorVote, setPriorVote] = useState(null)
   const [existingPhoto, setExistingPhoto] = useState(null)
+  const rateFlowRef = useRef(null)
   const { profile } = useProfile(user?.id)
   const { dishes: myListDishes, addDish, adding: addingToMyList, loading: myListLoading } = useMyLocalList()
   const isCurator = !!profile?.is_local_curator
@@ -80,6 +85,9 @@ export function Dish() {
   // Fetch prior vote + prior photo in parallel so the CTA label and the
   // ReviewFlow photo thumbnail both reflect current state.
   useEffect(() => {
+    // Drop any queued list-add from a previously-viewed dish so it can't
+    // replay on this one (React Router reuses this component across :dishId).
+    setPendingListAdd(null)
     if (!user || !dishId) {
       setPriorVote(null)
       setExistingPhoto(null)
@@ -107,32 +115,18 @@ export function Dish() {
     return () => { cancelled = true }
   }, [dishId, user])
 
-  // Auth-gate intent preservation: once the user finishes logging in,
-  // resume straight into the rate flow.
-  useEffect(() => {
-    if (user && pendingAction === 'rate') {
-      setPendingAction(null)
-      setShowRateFlow(true)
-    }
-  }, [user, pendingAction])
-
   const handleLoginRequired = () => setLoginModalOpen(true)
 
-  const handleRateClick = () => {
-    if (showRateFlow) {
-      setShowRateFlow(false)
-      return
-    }
-    if (!user) {
-      setPendingAction('rate')
-      setLoginModalOpen(true)
-      return
-    }
-    setShowRateFlow(true)
-  }
-
   const handleVoteSubmitted = () => {
-    setShowRateFlow(false)
+    // If the rating was triggered by a "+ add to list" tap, finish the job:
+    // the dish now has a number, so complete the queued add.
+    if (pendingListAdd === 'playlist') {
+      setPendingListAdd(null)
+      setPlaylistSheetOpen(true)
+    } else if (pendingListAdd === 'top10') {
+      setPendingListAdd(null)
+      handleAddToTop10()
+    }
     // Refresh prior-vote and prior-photo so CTA label and thumbnail stay current.
     // allSettled so a photo-fetch failure doesn't discard the vote result.
     if (user && dishId) {
@@ -285,6 +279,13 @@ export function Dish() {
           <button
             onClick={() => {
               if (!user) { setLoginModalOpen(true); return }
+              // Gate: a dish needs a number before it can go on a list.
+              if (priorVote?.rating_10 == null) {
+                setPendingListAdd('playlist')
+                toast('Rate it first to add it to a list', { duration: 2500 })
+                rateFlowRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                return
+              }
               setPlaylistSheetOpen(true)
             }}
             aria-label="Add to playlist"
@@ -356,45 +357,32 @@ export function Dish() {
               the page layout is unchanged for dishes without tags. */}
           <DishDescription dietaryTags={dish.dietary_tags} />
 
-          {/* LAYER 2: THE ACTION — Rate CTA + inline rate flow */}
+          {/* LAYER 2: THE ACTION — rate flow, always visible (no button to tap) */}
           <div className="p-4 space-y-3">
-            <button
-              type="button"
-              onClick={handleRateClick}
-              aria-expanded={showRateFlow}
-              aria-controls="rate-flow-panel"
-              className="w-full py-4 px-6 rounded-xl font-semibold shadow-lg transition-all duration-200 ease-out focus-ring active:scale-98 hover:shadow-xl"
-              style={{ background: 'var(--color-primary)', color: 'var(--color-text-on-primary)' }}
+            <div
+              id="rate-flow-panel"
+              ref={rateFlowRef}
+              className="p-4 rounded-xl"
+              style={{
+                background: 'var(--color-surface-elevated)',
+                border: '1px solid var(--color-divider)',
+              }}
             >
-              {showRateFlow
-                ? 'Close'
-                : priorVote ? 'Update your rating' : 'Rate this dish'}
-            </button>
-            {showRateFlow && (
-              <div
-                id="rate-flow-panel"
-                className="p-4 rounded-xl"
-                style={{
-                  background: 'var(--color-surface-elevated)',
-                  border: '1px solid var(--color-divider)',
-                }}
-              >
-                <ReviewFlow
-                  dishId={dish.dish_id}
-                  dishName={dish.dish_name}
-                  restaurantId={dish.restaurant_id}
-                  restaurantName={dish.restaurant_name}
-                  category={dish.category}
-                  price={dish.price}
-                  totalVotes={dish.total_votes}
-                  isRanked={isRanked}
-                  existingPhoto={existingPhoto}
-                  onVote={handleVoteSubmitted}
-                  onLoginRequired={handleLoginRequired}
-                  onPhotoUploaded={handlePhotoUploaded}
-                />
-              </div>
-            )}
+              <ReviewFlow
+                dishId={dish.dish_id}
+                dishName={dish.dish_name}
+                restaurantId={dish.restaurant_id}
+                restaurantName={dish.restaurant_name}
+                category={dish.category}
+                price={dish.price}
+                totalVotes={dish.total_votes}
+                isRanked={isRanked}
+                existingPhoto={existingPhoto}
+                onVote={handleVoteSubmitted}
+                onLoginRequired={handleLoginRequired}
+                onPhotoUploaded={handlePhotoUploaded}
+              />
+            </div>
             {myListReady && (
               isOnMyList ? (
                 <button
@@ -425,7 +413,16 @@ export function Dish() {
               ) : (
                 <button
                   type="button"
-                  onClick={handleAddToTop10}
+                  onClick={() => {
+                    // Gate: a curator must rate a dish before it can go on their Top 10.
+                    if (priorVote?.rating_10 == null) {
+                      setPendingListAdd('top10')
+                      toast('Rate it first to add it to your Top 10', { duration: 2500 })
+                      rateFlowRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                      return
+                    }
+                    handleAddToTop10()
+                  }}
                   disabled={addingToMyList}
                   className="w-full py-3 px-4 rounded-xl font-semibold transition-all active:scale-98 disabled:opacity-60"
                   style={{

--- a/src/pages/MyList.jsx
+++ b/src/pages/MyList.jsx
@@ -1,9 +1,12 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
+import { useAuth } from '../context/AuthContext'
 import { useMyLocalList } from '../hooks/useMyLocalList'
 import { useDishSearch } from '../hooks/useDishSearch'
+import { useUserVotes } from '../hooks/useUserVotes'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { getCategoryEmoji } from '../constants/categories'
+import { ReviewFlow } from '../components/ReviewFlow'
 import { logger } from '../utils/logger'
 
 function snapshot(tagline, items) {
@@ -22,7 +25,16 @@ export function MyList() {
   useDocumentTitle('Your top 10')
   var navigate = useNavigate()
   var location = useLocation()
+  var { user } = useAuth()
   var { listMeta, dishes, loading, error, saveList, saving } = useMyLocalList()
+
+  // Rated-dish lookup — a curator can only put dishes they've given a number to
+  // on their Top 10. Tapping an unrated dish opens an inline rate sheet first.
+  var { votes, refetch: refetchVotes } = useUserVotes(user && user.id)
+  var ratedSet = {}
+  votes.forEach(function (v) {
+    if (v.rating_10 != null && v.dishes) ratedSet[v.dishes.id] = true
+  })
 
   var [tagline, setTagline] = useState('')
   var [items, setItems] = useState([])
@@ -32,6 +44,7 @@ export function MyList() {
   var [hydrated, setHydrated] = useState(false)
   var [serverSnapshot, setServerSnapshot] = useState('')
   var [welcomeDismissed, setWelcomeDismissed] = useState(false)
+  var [pendingRateDish, setPendingRateDish] = useState(null)
 
   var { results: searchResults } = useDishSearch(searchQuery, 20)
 
@@ -126,12 +139,11 @@ export function MyList() {
     )
   }
 
-  function handleAddDish(dish) {
-    if (items.length >= 10) return
+  function addToItems(dish) {
     var dishId = dish.dish_id || dish.id
-    if (items.some(function (item) { return item.dish_id === dishId })) return
-
     setItems(function (prev) {
+      if (prev.length >= 10) return prev
+      if (prev.some(function (item) { return item.dish_id === dishId })) return prev
       return prev.concat([{
         dish_id: dishId,
         dish_name: dish.dish_name || dish.name,
@@ -142,6 +154,26 @@ export function MyList() {
     })
     setSearchQuery('')
     setShowSearch(false)
+  }
+
+  function handleAddDish(dish) {
+    if (items.length >= 10) return
+    var dishId = dish.dish_id || dish.id
+    if (items.some(function (item) { return item.dish_id === dishId })) return
+
+    // Gate: must have rated the dish first. Open the inline rate sheet and add
+    // it automatically once a number is in.
+    if (!ratedSet[dishId]) {
+      setPendingRateDish(dish)
+      return
+    }
+    addToItems(dish)
+  }
+
+  function handleRated() {
+    if (pendingRateDish) addToItems(pendingRateDish)
+    setPendingRateDish(null)
+    if (refetchVotes) refetchVotes()
   }
 
   function handleRemoveDish(dishId) {
@@ -595,6 +627,43 @@ export function MyList() {
         </button>
       </div>
 
+      {/* Rate-first sheet — a curator must give a dish a number before it can
+          go on their Top 10. Once rated, it's added automatically. */}
+      {pendingRateDish && (
+        <div
+          className="fixed inset-0 z-50 flex items-end"
+          style={{ background: 'rgba(0,0,0,0.5)' }}
+          onClick={function (e) { if (e.target === e.currentTarget) setPendingRateDish(null) }}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Rate this dish to add it"
+            className="w-full rounded-t-2xl"
+            style={{
+              background: 'var(--color-surface)',
+              padding: '8px 16px 24px',
+              maxHeight: '85vh',
+              overflowY: 'auto',
+            }}
+          >
+            <div style={{ width: 40, height: 4, background: 'var(--color-divider)', borderRadius: 2, margin: '8px auto 16px' }} />
+            <div style={{ marginBottom: '4px', fontSize: '18px', fontWeight: 800, color: 'var(--color-text-primary)' }}>
+              Rate it to add it
+            </div>
+            <div style={{ marginBottom: '16px', fontSize: '13px', color: 'var(--color-text-tertiary)' }}>
+              {(pendingRateDish.dish_name || pendingRateDish.name)} &middot; {pendingRateDish.restaurant_name}
+            </div>
+            <ReviewFlow
+              dishId={pendingRateDish.dish_id || pendingRateDish.id}
+              dishName={pendingRateDish.dish_name || pendingRateDish.name}
+              category={pendingRateDish.category}
+              onVote={handleRated}
+              onLoginRequired={function () { navigate('/login') }}
+            />
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Ports Denis's #183 (Denisgingras75/WGH PR #7) into the canonical repo, and extends the gate to our curator **Add to Top 10** path that Denis's base didn't have.

## What changed
A dish must have a rating before it can go on **any** list — closing the gap where local Top 10s and playlists were filling up with unrated dishes (no vote signal).

- **`ReviewFlow.jsx`** — review textarea is always visible under the slider (no `+ Add a review` tap-to-reveal). Rating stays the only required input; JitterBox attaches on mount.
- **`Dish.jsx`** — rate flow renders inline / always-visible (removed the `Rate this dish` toggle + `showRateFlow`/`pendingAction`/`handleRateClick`). Rate-first gate on:
  - the playlist `+` button
  - the curator **Add to your Top 10** button *(our path — not in Denis's base)*
- **`MyList.jsx`** — curator search-add opens an inline rate sheet for unrated dishes; once rated, it's auto-added.

Pattern everywhere: **rate first → auto-add**, no dead-end error.

## Review notes
- Codex (gpt-5.4) caught 2 real bugs in `Dish.jsx`, both fixed: the two add-paths could both replay after one vote, and the queued add could leak across dishes on navigation. Resolved with a single mutually-exclusive `pendingListAdd` enum (`null|'playlist'|'top10'`) that resets on `dishId` change.
- `ReviewFlow` reviewed clean; `MyList` reviewed manually (hooks order, stale closure, sheet scroll, a11y) — no blocking issues.

## ⚠️ Known limitation
This is a **client-side UX gate, not server-enforced** — a raw `add_dish_to_playlist` RPC call could still bypass it. Follow-up: add a vote-exists check inside the RPC for true integrity.

## Product note (from Denis)
Lists are now "dishes I've actually rated," not a "want to try later" wishlist. Confirmed desired behavior — the unrated-dish problem is exactly what this fixes.

## Test plan
- [x] `npm run lint` (source clean; 0 errors in changed files)
- [x] `npm run build` passes
- [x] `npm run test` passes
- [ ] Manual: tap `+` / Add-to-Top-10 on an unrated dish → nudged to rate → auto-adds after rating
- [ ] Manual: curator search-add of an unrated dish opens rate sheet → auto-adds

🤖 Generated with [Claude Code](https://claude.com/claude-code)