### PR TITLE
chore(schema): sync server-side rate-first gate guards into schema.sql

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -3626,6 +3626,15 @@ BEGIN
     RETURN json_build_object('success', false, 'error', 'Dish not found');
   END IF;
 
+  -- Rate-first gate (server-enforced): a curator can only put a dish they've
+  -- rated on their Top 10. Mirrors the client gate in Dish.jsx / MyList.jsx.
+  IF NOT EXISTS (
+    SELECT 1 FROM votes
+    WHERE votes.dish_id = p_dish_id AND votes.user_id = v_user_id AND votes.rating_10 IS NOT NULL
+  ) THEN
+    RETURN json_build_object('success', false, 'error', 'Rate this dish first to add it to your Top 10');
+  END IF;
+
   SELECT id INTO v_list_id FROM local_lists WHERE user_id = v_user_id FOR UPDATE;
 
   IF v_list_id IS NULL THEN
@@ -4598,6 +4607,14 @@ BEGIN
     RAISE EXCEPTION 'Playlist not found' USING ERRCODE = 'P0002';
   END IF;
   IF p_note IS NOT NULL THEN PERFORM fn_check_content_blocklist(p_note, 'Note'); END IF;
+  -- Rate-first gate (server-enforced): a dish can only go on a list if the
+  -- caller has rated it. Mirrors the client gate in Dish.jsx / MyList.jsx.
+  IF NOT EXISTS (
+    SELECT 1 FROM votes
+    WHERE votes.dish_id = p_dish_id AND votes.user_id = v_user AND votes.rating_10 IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'Rate this dish before adding it to a list' USING ERRCODE = 'P0001';
+  END IF;
   SELECT COALESCE(MAX(position), 0) + 1 INTO v_next_pos
     FROM user_playlist_items WHERE playlist_id = p_playlist_id;
   INSERT INTO user_playlist_items (playlist_id, dish_id, position, note)


### PR DESCRIPTION
Syncs `schema.sql` (source of truth) with the two server-side rate-first guards **already deployed live** to the DB today via the SQL editor. **No deploy impact** — this is documentation catching up to reality.

## What
Vote-exists checks added to the two direct-add RPCs so an unrated dish can't be put on a list even via a raw RPC call (backstop to the client gate from #304):
- `add_dish_to_playlist` — `RAISE` "Rate this dish before adding it to a list"
- `add_dish_to_my_local_list` — returns `{success:false, error:'Rate this dish first…'}`

Guard: `IF NOT EXISTS (SELECT 1 FROM votes WHERE votes.dish_id = … AND votes.user_id = … AND votes.rating_10 IS NOT NULL)`. Live definitions were verified to match the repo before patching (no drift).

## Intentionally NOT gated (deferred to shareable-lists)
- `save_my_local_list` (bulk) — naive enforcement would lock curators out of saving any edit while a pre-gate unrated dish sits on their list
- `clone_local_list_to_playlist` — cloning a curator's picks ≠ claiming you rated them

Related: #304 (client gate + always-visible review bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)