### PR TITLE
feat(curator): make how-to-add-dishes obvious (splash copy + filled empty-state CTA)

### DIFF
--- a/src/components/profile/CuratorOnboardingSplash.jsx
+++ b/src/components/profile/CuratorOnboardingSplash.jsx
@@ -1,7 +1,7 @@
 const ONBOARDING_POINTS = [
   {
     title: 'Pick your Top 10',
-    body: 'Add the dishes visitors should order — your personal best-of.',
+    body: 'The dishes visitors should order. Search right here, or tap "Add to Top 10" on any dish page.',
   },
   {
     title: 'Rate before you add',

--- a/src/pages/MyList.jsx
+++ b/src/pages/MyList.jsx
@@ -457,16 +457,21 @@ export function MyList() {
               onClick={function () { setShowSearch(true) }}
               className="w-full rounded-xl"
               style={{
-                padding: '12px',
-                background: 'none',
-                border: '1.5px dashed var(--color-primary)',
-                color: 'var(--color-primary)',
-                fontSize: '14px',
-                fontWeight: 600,
+                // Empty list → prominent filled CTA so a new curator can't miss
+                // how to add. Once they've started, fall back to the quieter
+                // dashed "add another" affordance.
+                padding: items.length === 0 ? '14px' : '12px',
+                background: items.length === 0 ? 'var(--color-primary)' : 'none',
+                border: items.length === 0 ? 'none' : '1.5px dashed var(--color-primary)',
+                color: items.length === 0 ? '#fff' : 'var(--color-primary)',
+                fontSize: items.length === 0 ? '15px' : '14px',
+                fontWeight: 700,
                 cursor: 'pointer',
               }}
             >
-              + Add a dish ({10 - items.length} remaining)
+              {items.length === 0
+                ? 'Search & add your first dish'
+                : '+ Add a dish (' + (10 - items.length) + ' remaining)'}
             </button>
           ) : (
             <div


### PR DESCRIPTION
Follow-up to #306. New curators were struggling to figure out *how* to add dishes to their Top 10 — the in-editor add control was a faint dashed button and the dish-page "Add to Top 10" path was undiscovered.

## Changes
- **Splash copy** — the "Pick your Top 10" point now names both add paths: *"Search right here, or tap 'Add to Top 10' on any dish page."*
- **Editor CTA** — when the list is empty, the add control is a **prominent filled button** ("Search & add your first dish") so a new curator can't miss it; once they've added a dish it reverts to the quieter dashed "+ Add a dish (N remaining)".

Durable fix (the editor CTA keeps working after the one-time splash is gone), no schema change, no emoji.

## Verification
- [x] eslint clean on changed files
- [x] splash component tests pass
- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)