### PR TITLE
feat(profile): split header stats into content + social tiers

### DIFF
--- a/src/components/profile/HeroIdentityCard.jsx
+++ b/src/components/profile/HeroIdentityCard.jsx
@@ -222,38 +222,41 @@ export function HeroIdentityCard({
             </button>
           )}
 
-          {/* Stats row — dishes · restaurants · followers */}
-          <div className="flex items-center gap-2 mt-1.5 flex-wrap" style={{ fontSize: '13px' }}>
-            {stats.totalVotes > 0 && (
-              <>
-                <span style={{ color: 'var(--color-text-secondary)' }}>
-                  <span className="font-bold" style={{ color: 'var(--color-text-primary)' }}>{stats.totalVotes}</span> dishes
-                </span>
-                {stats.uniqueRestaurants > 0 && (
-                  <>
-                    <span style={{ color: 'var(--color-text-tertiary)' }}>&middot;</span>
-                    <span style={{ color: 'var(--color-text-secondary)' }}>
-                      <span className="font-bold" style={{ color: 'var(--color-text-primary)' }}>{stats.uniqueRestaurants}</span> spots
-                    </span>
-                  </>
-                )}
-              </>
-            )}
+          {/* Stats — two tiers: content identity (dishes · spots) reads as the
+              primary line; social (followers · following) sits quieter beneath
+              so the header isn't one flat wall of numbers. */}
+          {stats.totalVotes > 0 && (
+            <div className="flex items-center gap-2 mt-1.5 flex-wrap" style={{ fontSize: '13px' }}>
+              <span style={{ color: 'var(--color-text-secondary)' }}>
+                <span className="font-bold" style={{ color: 'var(--color-text-primary)' }}>{stats.totalVotes}</span> dishes
+              </span>
+              {stats.uniqueRestaurants > 0 && (
+                <>
+                  <span style={{ color: 'var(--color-text-tertiary)' }}>&middot;</span>
+                  <span style={{ color: 'var(--color-text-secondary)' }}>
+                    <span className="font-bold" style={{ color: 'var(--color-text-primary)' }}>{stats.uniqueRestaurants}</span> spots
+                  </span>
+                </>
+              )}
+            </div>
+          )}
+          <div className="flex items-center gap-2 mt-1 flex-wrap" style={{ fontSize: '12px' }}>
             <button
               onClick={() => setFollowListModal('followers')}
               className="hover:underline transition-colors"
-              style={{ color: 'var(--color-text-secondary)' }}
+              style={{ color: 'var(--color-text-tertiary)' }}
             >
-              <span className="font-bold" style={{ color: 'var(--color-text-primary)' }}>
+              <span className="font-semibold" style={{ color: 'var(--color-text-secondary)' }}>
                 {followCounts.followers}
               </span> followers
             </button>
+            <span style={{ color: 'var(--color-text-tertiary)' }}>&middot;</span>
             <button
               onClick={() => setFollowListModal('following')}
               className="hover:underline transition-colors"
-              style={{ color: 'var(--color-text-secondary)' }}
+              style={{ color: 'var(--color-text-tertiary)' }}
             >
-              <span className="font-bold" style={{ color: 'var(--color-text-primary)' }}>
+              <span className="font-semibold" style={{ color: 'var(--color-text-secondary)' }}>
                 {followCounts.following}
               </span> following
             </button>


### PR DESCRIPTION
## What

The profile header stat row was a single 4-item line — **dishes · spots · followers · following** — that wrapped 3-then-1 and read like a data dashboard. Now it's two tiers:

- **Line 1 (content identity, 13px):** `30 dishes · 16 spots`
- **Line 2 (social, 12px, tertiary color):** `6 followers · 29 following` — both still tappable into the follow modal

## Why

Dan flagged it: the four numbered stats looked weird, made worse on native iOS where the jitter "Building" badge is hidden (PR #294 / `jitterTrust.js`), leaving the header sparse. Giving the numbers hierarchy (content over social) fits the editorial-not-dashboard direction. Design call confirmed with Dan (two-tier over drop-following / editorial-phrase).

## How

- Split the one flex row into two. Content line is fully gated on `stats.totalVotes > 0`, so a no-votes profile shows only the social line — never an empty container.
- Social line uses `var(--color-text-tertiary)` labels with semibold `var(--color-text-secondary)` numbers; followers/following remain real `<button>`s wired to `setFollowListModal`.

## Test plan

- `npm run build` ✅
- `npx eslint src/components/profile/HeroIdentityCard.jsx` ✅ clean
- Codex review (medium): no findings — buttons wired, 0-votes edge handled, no a11y/layout regression, no Tailwind color classes (all `var(--color-*)`).
- Manual: `/profile` shows two-tier stats; tap followers/following opens the modal; profile with 0 dishes shows only the social line.

Scope note: this is the owner profile (`HeroIdentityCard`). Public `UserProfile` has its own header and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)