### PR TITLE
feat(profile): match two-tier header stats on public UserProfile

### DIFF
--- a/src/api/followsApi.js
+++ b/src/api/followsApi.js
@@ -530,7 +530,11 @@ export const followsApi = {
         `)
         .eq('user_id', userId)
         .order('created_at', { ascending: false })
-        .limit(50),
+        // 500 to match the owner profile's stat accuracy (useUserVotes →
+        // getDetailedVotesForUser also caps at 500). The header dish/spot
+        // counts are derived from this list, so the cap defines how high
+        // those counts can read — 50 would understate any prolific user.
+        .limit(500),
       // 5. Get badges
       supabase.rpc('get_user_badges', { p_user_id: userId, p_public_only: false }),
     ])

--- a/src/pages/UserProfile.jsx
+++ b/src/pages/UserProfile.jsx
@@ -314,19 +314,23 @@ export function UserProfile() {
 
   // Handle share profile
   // Compute stats from recent votes — single "My Ratings" shelf, sorted by recency.
-  const { totalVotes, ratingStyle, favoriteRestaurant, favoriteRestaurantCount, favoriteRestaurantId } = useMemo(() => {
+  const { totalVotes, uniqueRestaurants, ratingStyle, favoriteRestaurant, favoriteRestaurantCount, favoriteRestaurantId } = useMemo(() => {
     if (!profile?.recent_votes?.length) {
-      return { totalVotes: 0, ratingStyle: null, favoriteRestaurant: null, favoriteRestaurantCount: 0, favoriteRestaurantId: null }
+      return { totalVotes: 0, uniqueRestaurants: 0, ratingStyle: null, favoriteRestaurant: null, favoriteRestaurantCount: 0, favoriteRestaurantId: null }
     }
     const restaurantCounts = {}
     const restaurantIdByName = {}
+    const allRestaurants = new Set()
     const ratings = []
     profile.recent_votes.forEach(vote => {
       const isRated = vote.rating != null
       const restName = vote.dish?.restaurant_name
       const restId = vote.dish?.restaurant_id
-      // Most loyal counts only rated votes — photo-only / saved-only
-      // entries shouldn't read as loyalty.
+      // "Spots" counts every distinct restaurant the user has an entry at,
+      // matching the owner profile's uniqueRestaurants (all votes, not just
+      // rated). "Most loyal" below stays rated-only — photo/saved entries
+      // shouldn't read as loyalty.
+      if (restName) allRestaurants.add(restName)
       if (restName && isRated) {
         restaurantCounts[restName] = (restaurantCounts[restName] || 0) + 1
         if (restId && !restaurantIdByName[restName]) restaurantIdByName[restName] = restId
@@ -364,6 +368,7 @@ export function UserProfile() {
 
     return {
       totalVotes: profile.recent_votes.length,
+      uniqueRestaurants: allRestaurants.size,
       ratingStyle: style,
       favoriteRestaurant: favRest,
       favoriteRestaurantCount: favCount,
@@ -573,14 +578,31 @@ export function UserProfile() {
               {jitterBadgeType && <TrustBadge type={jitterBadgeType} size="md" />}
             </div>
 
-            {/* Follow Stats */}
-            <div className="flex items-center gap-2 mt-1.5" style={{ fontSize: '13px' }}>
+            {/* Stats — two tiers, matching the owner profile (HeroIdentityCard):
+                content identity (dishes · spots) reads primary; social
+                (followers · following) sits quieter beneath. */}
+            {totalVotes > 0 && (
+              <div className="flex items-center gap-2 mt-1.5 flex-wrap" style={{ fontSize: '13px' }}>
+                <span style={{ color: 'var(--color-text-secondary)' }}>
+                  <span className="font-bold" style={{ color: 'var(--color-text-primary)' }}>{totalVotes}</span> dishes
+                </span>
+                {uniqueRestaurants > 0 && (
+                  <>
+                    <span style={{ color: 'var(--color-text-tertiary)' }}>&middot;</span>
+                    <span style={{ color: 'var(--color-text-secondary)' }}>
+                      <span className="font-bold" style={{ color: 'var(--color-text-primary)' }}>{uniqueRestaurants}</span> spots
+                    </span>
+                  </>
+                )}
+              </div>
+            )}
+            <div className="flex items-center gap-2 mt-1 flex-wrap" style={{ fontSize: '12px' }}>
               <button
                 onClick={() => setFollowListModal('followers')}
                 className="hover:underline transition-colors"
-                style={{ color: 'var(--color-text-secondary)' }}
+                style={{ color: 'var(--color-text-tertiary)' }}
               >
-                <span className="font-bold" style={{ color: 'var(--color-text-primary)' }}>
+                <span className="font-semibold" style={{ color: 'var(--color-text-secondary)' }}>
                   {profile.follower_count || 0}
                 </span> followers
               </button>
@@ -588,9 +610,9 @@ export function UserProfile() {
               <button
                 onClick={() => setFollowListModal('following')}
                 className="hover:underline transition-colors"
-                style={{ color: 'var(--color-text-secondary)' }}
+                style={{ color: 'var(--color-text-tertiary)' }}
               >
-                <span className="font-bold" style={{ color: 'var(--color-text-primary)' }}>
+                <span className="font-semibold" style={{ color: 'var(--color-text-secondary)' }}>
                   {profile.following_count || 0}
                 </span> following
               </button>


### PR DESCRIPTION
## What

Brings the **public** `UserProfile` header in line with the owner profile's new two-tier stats:

- **Line 1 (content, 13px):** `47 dishes · 22 spots`
- **Line 2 (social, 12px, tertiary):** `6 followers · 29 following` (still tappable)

Previously public profiles showed only a lone `followers · following` line.

## Why

Follows the owner-profile cleanup (#310). Dan asked to "match" so other people's profiles feel as complete as your own.

## How

- **`followsApi.getUserProfile`**: raised the vote fetch `50 → 500` so derived dish/spot counts don't understate prolific users — matches the owner profile's source (`getDetailedVotesForUser` also caps at 500).
- **`UserProfile` stats memo**: now also returns `uniqueRestaurants` (distinct `restaurant_name` across *all* `recent_votes`, including unrated) — identical semantics to the owner profile's `uniqueRestaurants` in `useUserVotes`.
- Header renders two tiers; the content line is gated on `totalVotes > 0`, so a no-votes profile shows only the social line.

### RLS note
Counts are derived from the **same `recent_votes`** that already power this page's Food Story — no new cross-user vote read is introduced. (Votes RLS has conflicting policies across migrations; this change is intentionally agnostic to which is live, so it can't regress visibility.)

## Test plan

- `npm run build` ✅
- `npx eslint` ✅ (only 2 pre-existing unused-var warnings, unrelated)
- Codex review (medium): no findings — `uniqueRestaurants` wired in both return paths, semantics match owner, colors via `var(--color-*)`, no a11y/layout regression.
- Manual: view another user → header shows `N dishes · N spots` over `followers · following`; tap follow counts → modal opens; a brand-new user (0 votes) shows only the social line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)