### PR TITLE
fix(menu-refresh): recover separate drinks menus (cocktails/coffee)

### DIFF
--- a/docs/superpowers/plans/2026-06-09-drinks-extraction-fix.md
+++ b/docs/superpowers/plans/2026-06-09-drinks-extraction-fix.md
@@ -1,0 +1,691 @@
+# Drinks Extraction Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recover cocktail/coffee menus that live on a separate drinks asset or sub-page, which the food-biased candidate scorer currently never sends to the LLM.
+
+**Architecture:** Add an inverted "drinks" scorer + drinks sub-page finder to `menu-candidates.ts`. In `menu-refresh/index.ts`, after a food extraction succeeds, if it found fewer than 5 cocktail/coffee dishes AND a positive-scored drinks source exists, run ONE extra LLM extraction on the best drinks asset/sub-page with a drinks-only hint and merge the rows. Additive, capped at one extra call, food never changes.
+
+**Tech Stack:** TypeScript, Deno (Supabase Edge Function), Vitest (for the pure `menu-candidates.ts` helpers), Anthropic Sonnet (`claude-sonnet-4-6`).
+
+**Spec:** `docs/superpowers/specs/2026-06-09-drinks-extraction-fix-design.md`
+**Gap map:** `docs/superpowers/specs/2026-06-09-menu-pipeline-gap-map.md` (Gap 6)
+
+---
+
+## File Structure
+
+- **Modify** `supabase/functions/menu-refresh/menu-candidates.ts`
+  - Refactor `scoreCandidate` to delegate to a shared `scoreWith(positive, negative, ...)`.
+  - Add `DRINK_POSITIVE_KEYWORDS`, `DRINK_NEGATIVE_KEYWORDS`, `scoreDrinkCandidate`, `discoverDrinkCandidates`.
+  - Add drink sub-page patterns + `findDrinkSubPages`.
+- **Modify** `supabase/functions/menu-refresh/menu-candidates.test.ts` (Vitest) — tests for all of the above.
+- **Modify** `supabase/functions/menu-refresh/index.ts`
+  - `DRINK_RECOVERY_THRESHOLD`, `DRINK_RECOVERY_HINT` constants.
+  - Optional `extractionHint` param on `extractMenuWithClaude`, `extractMenuFromImagesWithClaude`, `extractMenuFromPdfsWithClaude`.
+  - `runDrinkRecovery(...)` helper.
+  - Call sites: Branch A (after BentoBox group backfill, before `upsertDishes`) + Branch B (direct-PDF success branch).
+  - Bump `CURRENT_EXTRACTOR_FINGERPRINT` (append `|drinks-pass-v1`).
+
+Run all Vitest steps from repo root: `npx vitest run supabase/functions/menu-refresh/menu-candidates.test.ts`.
+
+---
+
+## Task 1: Shared scorer + drinks keyword model
+
+**Files:**
+- Modify: `supabase/functions/menu-refresh/menu-candidates.ts`
+- Test: `supabase/functions/menu-refresh/menu-candidates.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `menu-candidates.test.ts`:
+
+```ts
+import { scoreDrinkCandidate } from './menu-candidates.ts' // add to existing import line
+
+describe('scoreDrinkCandidate', () => {
+  it('positive: cocktails in URL', () => {
+    expect(scoreDrinkCandidate('https://x.com/cocktails.pdf').score).toBeGreaterThan(0)
+  })
+  it('positive: drinks menu image', () => {
+    expect(scoreDrinkCandidate('https://x.com/Drinks-Menu.png').score).toBeGreaterThan(0)
+  })
+  it('positive: coffee menu', () => {
+    expect(scoreDrinkCandidate('https://x.com/coffee-menu.pdf').score).toBeGreaterThan(0)
+  })
+  it('negative: a FOOD menu scores negative under the drink model', () => {
+    expect(scoreDrinkCandidate('https://x.com/dinner-menu.pdf').score).toBeLessThan(0)
+  })
+  it('negative: logo rejected', () => {
+    expect(scoreDrinkCandidate('https://x.com/logo.png').score).toBeLessThan(0)
+  })
+  it('negative: gift card rejected', () => {
+    expect(scoreDrinkCandidate('https://x.com/gift-cards.pdf').score).toBeLessThan(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run supabase/functions/menu-refresh/menu-candidates.test.ts -t scoreDrinkCandidate`
+Expected: FAIL — `scoreDrinkCandidate is not exported` / not a function.
+
+- [ ] **Step 3: Implement**
+
+In `menu-candidates.ts`, add the drink keyword arrays after `NEGATIVE_KEYWORDS`:
+
+```ts
+// Drinks scorer — inverted from the food model. Used by the drinks-recovery
+// pass to surface a SEPARATE cocktail/coffee menu (food assets score these
+// terms strongly negative, so they never reach the LLM otherwise). Food terms
+// are negative here so a food menu can't win the drink track. Noise negatives
+// are intentionally duplicated (not shared) so this never perturbs the food
+// scorer above.
+const DRINK_POSITIVE_KEYWORDS: KeywordWeight[] = [
+  { pattern: /\bcocktails?\b/i, weight: 5 },
+  { pattern: /\bdrinks?\b/i, weight: 5 },
+  { pattern: /\bbeverages?\b/i, weight: 4 },
+  { pattern: /\bcoffee\b/i, weight: 4 },
+  { pattern: /\bespresso\b/i, weight: 3 },
+  { pattern: /\bbar[\s-]?menu\b/i, weight: 4 },
+  { pattern: /\bbar\b/i, weight: 2 },
+  { pattern: /\bcaf[eé]\b/i, weight: 2 },
+  { pattern: /\bwines?\b/i, weight: 2 },
+  { pattern: /\bhappy[\s-]?hour\b/i, weight: 2 },
+]
+
+const DRINK_NEGATIVE_KEYWORDS: KeywordWeight[] = [
+  // Food suppressors — a food menu must not win the drink track.
+  { pattern: /\bfood\b/i, weight: -4 },
+  { pattern: /\bdinner\b/i, weight: -4 },
+  { pattern: /\blunch\b/i, weight: -4 },
+  { pattern: /\bbreakfast\b/i, weight: -4 },
+  { pattern: /\bbrunch\b/i, weight: -4 },
+  { pattern: /\bentrees?\b/i, weight: -2 },
+  // Noise (duplicated from the food NEGATIVE_KEYWORDS on purpose).
+  { pattern: /\ballergens?\b/i, weight: -8 },
+  { pattern: /\bnutrition(al)?\b/i, weight: -6 },
+  { pattern: /\bgift[\s-]?cards?\b/i, weight: -8 },
+  { pattern: /\bgiftcards?\b/i, weight: -8 },
+  { pattern: /\bcatering\b/i, weight: -4 },
+  { pattern: /\bprivate[\s-]?events?\b/i, weight: -6 },
+  { pattern: /\bterms\b/i, weight: -10 },
+  { pattern: /\bprivacy\b/i, weight: -10 },
+  { pattern: /\bpolicy\b/i, weight: -8 },
+  { pattern: /\bapplication\b/i, weight: -8 },
+  { pattern: /\bemployment\b/i, weight: -10 },
+  { pattern: /\bjob\b/i, weight: -8 },
+  { pattern: /\bcontract\b/i, weight: -8 },
+  { pattern: /\bwaiver\b/i, weight: -10 },
+  { pattern: /\brules\b/i, weight: -6 },
+  { pattern: /\blogo\b/i, weight: -10 },
+  { pattern: /\bfavicon\b/i, weight: -10 },
+  { pattern: /\bicon\b/i, weight: -8 },
+  { pattern: /\bheader\b/i, weight: -8 },
+  { pattern: /\bbanner\b/i, weight: -8 },
+  { pattern: /\bhero\b/i, weight: -8 },
+  { pattern: /\bavatar\b/i, weight: -8 },
+  { pattern: /\bthumbnail\b/i, weight: -6 },
+  { pattern: /\bgallery\b/i, weight: -6 },
+]
+```
+
+Refactor `scoreCandidate` to delegate to a shared scorer (behavior unchanged), then add `scoreDrinkCandidate`. Replace the existing `export function scoreCandidate(...)` body with:
+
+```ts
+function scoreWith(
+  positive: KeywordWeight[],
+  negative: KeywordWeight[],
+  url: string,
+  context: string,
+): { score: number; evidence: string; hasNegative: boolean } {
+  const decoded = `${normalize(url)} ${normalize(context)}`
+  let score = 0
+  let hasNegative = false
+  const hits: string[] = []
+  for (const { pattern, weight } of positive) {
+    if (pattern.test(decoded)) { score += weight; hits.push(`+${weight}:${pattern.source}`) }
+  }
+  for (const { pattern, weight } of negative) {
+    if (pattern.test(decoded)) { score += weight; hasNegative = true; hits.push(`${weight}:${pattern.source}`) }
+  }
+  return { score, evidence: hits.join(' '), hasNegative }
+}
+
+export function scoreCandidate(url: string, context: string = ''): { score: number; evidence: string; hasNegative: boolean } {
+  return scoreWith(POSITIVE_KEYWORDS, NEGATIVE_KEYWORDS, url, context)
+}
+
+export function scoreDrinkCandidate(url: string, context: string = ''): { score: number; evidence: string; hasNegative: boolean } {
+  return scoreWith(DRINK_POSITIVE_KEYWORDS, DRINK_NEGATIVE_KEYWORDS, url, context)
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass (new + existing scorer tests)**
+
+Run: `npx vitest run supabase/functions/menu-refresh/menu-candidates.test.ts -t scoreDrinkCandidate`
+Expected: PASS.
+Run: `npx vitest run supabase/functions/menu-refresh/menu-candidates.test.ts -t scoreCandidate`
+Expected: PASS (refactor preserved food behavior).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/functions/menu-refresh/menu-candidates.ts supabase/functions/menu-refresh/menu-candidates.test.ts
+git commit -m "feat(menu-refresh): add drinks-biased candidate scorer"
+```
+
+---
+
+## Task 2: discoverDrinkCandidates
+
+**Files:**
+- Modify: `supabase/functions/menu-refresh/menu-candidates.ts`
+- Test: `supabase/functions/menu-refresh/menu-candidates.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { discoverDrinkCandidates } from './menu-candidates.ts' // add to import line
+
+describe('discoverDrinkCandidates', () => {
+  const base = 'https://r.com/menu'
+  it('surfaces a cocktail PDF that the food scorer would reject', () => {
+    const html = `<a href="/files/Cocktail-Menu.pdf">Cocktails</a>`
+    const out = discoverDrinkCandidates(html, base)
+    expect(out.length).toBe(1)
+    expect(out[0].url).toContain('Cocktail-Menu.pdf')
+  })
+  it('does NOT surface a plain food dinner PDF', () => {
+    const html = `<a href="/files/Dinner-Menu.pdf">Dinner</a>`
+    expect(discoverDrinkCandidates(html, base).length).toBe(0)
+  })
+  it('rejects a neutral opaque PDF (positive gate, not >=0)', () => {
+    const html = `<a href="/files/upload-83fa.pdf">x</a>`
+    expect(discoverDrinkCandidates(html, base).length).toBe(0)
+  })
+  it('sorts by score descending', () => {
+    const html = `<a href="/wine.pdf">w</a><a href="/cocktail-drinks.pdf">c</a>`
+    const out = discoverDrinkCandidates(html, base)
+    expect(out[0].url).toContain('cocktail-drinks.pdf')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run supabase/functions/menu-refresh/menu-candidates.test.ts -t discoverDrinkCandidates`
+Expected: FAIL — `discoverDrinkCandidates is not a function`.
+
+- [ ] **Step 3: Implement**
+
+Add to `menu-candidates.ts` (near `discoverMenuCandidates`):
+
+```ts
+/**
+ * Discover drinks-menu candidates (separate cocktail/coffee assets) on a page,
+ * scored with the inverted drink model and a SYMMETRIC positive gate
+ * (pdf > 0, image > 0). The food path passes PDFs at >= 0 because a restaurant
+ * PDF is usually a menu — that prior does NOT hold for drinks, so a neutral
+ * opaque PDF must not become the "best drinks asset" and burn the extra call.
+ * No neutral-image fallback. Sorted by score desc.
+ */
+export function discoverDrinkCandidates(html: string, baseUrl: string): MenuCandidate[] {
+  const raw = extractRawMatches(html, baseUrl)
+  const out: MenuCandidate[] = []
+  for (const r of raw) {
+    const type = classifyType(r.url)
+    if (!type) continue
+    const { score, evidence } = scoreDrinkCandidate(r.url, r.context)
+    if (score > 0) out.push({ url: r.url, type, score, source: r.source, evidence })
+  }
+  out.sort((a, b) => b.score - a.score)
+  return out
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `npx vitest run supabase/functions/menu-refresh/menu-candidates.test.ts -t discoverDrinkCandidates`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/functions/menu-refresh/menu-candidates.ts supabase/functions/menu-refresh/menu-candidates.test.ts
+git commit -m "feat(menu-refresh): discoverDrinkCandidates with positive-only gate"
+```
+
+---
+
+## Task 3: findDrinkSubPages
+
+**Files:**
+- Modify: `supabase/functions/menu-refresh/menu-candidates.ts`
+- Test: `supabase/functions/menu-refresh/menu-candidates.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { findDrinkSubPages } from './menu-candidates.ts' // add to import line
+
+describe('findDrinkSubPages', () => {
+  const base = 'https://r.com/menu'
+  it('finds a /cocktails sub-page', () => {
+    const html = `<a href="/cocktails">Cocktails</a>`
+    expect(findDrinkSubPages(html, base)).toEqual(['https://r.com/cocktails'])
+  })
+  it('finds /bar-menu via anchor text', () => {
+    const html = `<a href="/bar-menu">Bar Menu</a>`
+    expect(findDrinkSubPages(html, base)).toEqual(['https://r.com/bar-menu'])
+  })
+  it('ignores food sub-pages', () => {
+    const html = `<a href="/dinner">Dinner</a>`
+    expect(findDrinkSubPages(html, base)).toEqual([])
+  })
+  it('ignores cross-origin links', () => {
+    const html = `<a href="https://other.com/cocktails">Cocktails</a>`
+    expect(findDrinkSubPages(html, base)).toEqual([])
+  })
+  it('caps at max', () => {
+    const html = `<a href="/cocktails">c</a><a href="/drinks">d</a><a href="/bar">b</a>`
+    expect(findDrinkSubPages(html, base, 1).length).toBe(1)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run supabase/functions/menu-refresh/menu-candidates.test.ts -t findDrinkSubPages`
+Expected: FAIL — `findDrinkSubPages is not a function`.
+
+- [ ] **Step 3: Implement**
+
+Add to `menu-candidates.ts` (after `findSubMenuPages`):
+
+```ts
+const DRINK_SUB_PAGE_PATH_PATTERNS = [
+  /\/(?:[\w-]*-)?cocktails?(?:-menu)?\/?$/i,
+  /\/(?:[\w-]*-)?drinks?(?:-menu)?\/?$/i,
+  /\/(?:[\w-]*-)?bar(?:-menu)?\/?$/i,
+  /\/(?:[\w-]*-)?beverages?(?:-menu)?\/?$/i,
+]
+const DRINK_SUB_PAGE_ANCHOR_PATTERNS = [
+  /\bcocktails?\b/i,
+  /\bdrinks?\b/i,
+  /\bbar[\s-]?menu\b/i,
+  /\bbeverages?\b/i,
+]
+const DRINK_SUB_PAGE_NEGATIVE_TEXT = [
+  /\bfood\b/i, /\bdinner\b/i, /\blunch\b/i, /\bbrunch\b/i, /\bbreakfast\b/i,
+  /\bgift[\s-]?cards?\b/i, /\bcatering\b/i, /\bprivate\b/i, /\bevents?\b/i,
+]
+
+/**
+ * Find drinks/cocktail/bar sub-pages on a parent menu page. Mirror of
+ * findSubMenuPages but inverted: food anchors are disqualified, drink anchors
+ * qualify. Same-origin only; assets skipped; capped at `max` (default 1 —
+ * the drinks-recovery pass tries at most one source).
+ */
+export function findDrinkSubPages(html: string, baseUrl: string, max = 1): string[] {
+  const base = new URL(baseUrl)
+  const baseKey = base.origin + base.pathname + base.search
+  const found = new Set<string>([baseKey])
+  const out: string[] = []
+  const anchorRegex = /<a\b[^>]*\shref=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi
+  let m
+  while ((m = anchorRegex.exec(html)) !== null) {
+    let absolute: URL
+    try { absolute = new URL(m[1], base) } catch { continue }
+    if (absolute.origin !== base.origin) continue
+    if (PDF_EXT.test(absolute.href) || IMAGE_EXT.test(absolute.href)) continue
+    const innerText = stripTags(m[2]).replace(/&amp;/gi, '&').replace(/&#38;/g, '&').slice(0, 100)
+    if (DRINK_SUB_PAGE_NEGATIVE_TEXT.some(p => p.test(innerText))) continue
+    const pathMatches = DRINK_SUB_PAGE_PATH_PATTERNS.some(p => p.test(absolute.pathname))
+    const textMatches = DRINK_SUB_PAGE_ANCHOR_PATTERNS.some(p => p.test(innerText))
+    if (!pathMatches && !textMatches) continue
+    const target = absolute.origin + absolute.pathname + absolute.search
+    if (found.has(target)) continue
+    found.add(target)
+    out.push(target)
+    if (out.length >= max) break
+  }
+  return out
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `npx vitest run supabase/functions/menu-refresh/menu-candidates.test.ts -t findDrinkSubPages`
+Expected: PASS.
+
+- [ ] **Step 5: Run the FULL menu-candidates suite (no regressions)**
+
+Run: `npx vitest run supabase/functions/menu-refresh/menu-candidates.test.ts`
+Expected: PASS (all existing + new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/functions/menu-refresh/menu-candidates.ts supabase/functions/menu-refresh/menu-candidates.test.ts
+git commit -m "feat(menu-refresh): findDrinkSubPages for /cocktails and /bar sub-pages"
+```
+
+---
+
+## Task 4: index.ts — constants + extractionHint param
+
+**Files:**
+- Modify: `supabase/functions/menu-refresh/index.ts`
+
+No Vitest (Deno file). Verify with `deno check` if Deno is installed; otherwise rely on Task 1–3 unit tests + the live run in Task 7.
+
+- [ ] **Step 1: Add the import**
+
+In the existing `menu-candidates.ts` import line in `index.ts`, add `discoverDrinkCandidates`, `findDrinkSubPages`:
+
+```ts
+import { discoverMenuCandidates, findMenuIframes, findSubMenuPages, isBlockedHostname, isKnownMenuIframeHost, safeFetch, discoverDrinkCandidates, findDrinkSubPages, type MenuCandidate } from './menu-candidates.ts'
+```
+
+- [ ] **Step 2: Add constants**
+
+Near `THIN_EXTRACTION_THRESHOLD` / `PRICE_COVERAGE_FLOOR`:
+
+```ts
+// Drinks recovery (Gap 6): if a food extraction found FEWER than this many
+// cocktail/coffee dishes AND a dedicated drinks asset/sub-page exists, run one
+// extra LLM pass on the best drinks source. Low (not zero) because the food
+// prompt already extracts inline drinks — one brunch bloody mary must not
+// suppress recovery of a separate 20-item cocktail list.
+const DRINK_RECOVERY_THRESHOLD = 5
+
+const DRINK_RECOVERY_HINT = 'This is the restaurant\'s DRINKS menu. Extract ONLY alcoholic cocktails (category "cocktails") and coffee drinks (category "coffee"), following the cocktail and coffee rules in your instructions. Do not extract wine, beer, or non-alcoholic beverages.'
+```
+
+- [ ] **Step 3: Thread `extractionHint` into the three extractors**
+
+For `extractMenuWithClaude`, change the signature and the user message:
+
+```ts
+async function extractMenuWithClaude(content: string, restaurantName: string, extractionHint?: string): Promise<MenuExtractionResult> {
+  // ...
+  messages: [
+    {
+      role: 'user',
+      content: `Extract the full menu from "${restaurantName}":\n\n${content}${extractionHint ? `\n\n${extractionHint}` : ''}`,
+    },
+  ],
+```
+
+For `extractMenuFromImagesWithClaude`, add `extractionHint?: string` as the last param and append it to the pushed text block:
+
+```ts
+content.push({
+  type: 'text',
+  text: `Extract the full menu from "${restaurantName}" from the ${successful.length === 1 ? 'attached image' : `${successful.length} attached images`}. The images are page-ordered. If different images represent different services (breakfast, lunch, dinner), preserve those as menu sections.${extractionHint ? `\n\n${extractionHint}` : ''}`,
+})
+```
+
+For `extractMenuFromPdfsWithClaude`, add `extractionHint?: string` as the last param and append it to the pushed text block:
+
+```ts
+content.push({
+  type: 'text',
+  text: `Extract the full menu from "${restaurantName}" from the ${httpsUrls.length === 1 ? 'attached PDF' : `${httpsUrls.length} attached PDFs`}. Combine all dishes into a single output. If different PDFs represent different meal services (breakfast, lunch, dinner), preserve those as menu sections.${extractionHint ? `\n\n${extractionHint}` : ''}`,
+})
+```
+
+- [ ] **Step 4: Type-check (best effort)**
+
+Run: `deno check supabase/functions/menu-refresh/index.ts` (if Deno installed)
+Expected: no errors. If Deno is not installed, skip and rely on the live run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/functions/menu-refresh/index.ts
+git commit -m "feat(menu-refresh): drinks-recovery constants + extractionHint param"
+```
+
+---
+
+## Task 5: index.ts — runDrinkRecovery helper
+
+**Files:**
+- Modify: `supabase/functions/menu-refresh/index.ts`
+
+- [ ] **Step 1: Add the helper** (above `serve(...)`, near the other extraction helpers)
+
+```ts
+/**
+ * Drinks recovery (Gap 6). When the food extraction found few cocktail/coffee
+ * dishes, try ONE extra LLM pass on the best dedicated drinks source and return
+ * the additive drink dishes + any new sections. Caller merges. Bounded to one
+ * Sonnet call. `html` should be the BEST html available (rendered if we
+ * rendered, else raw) so JS-injected drink assets are visible.
+ */
+async function runDrinkRecovery(
+  extracted: MenuExtractionResult,
+  opts: {
+    html: string
+    menuUrl: string
+    restaurantName: string
+    triedUrls: Set<string>
+  },
+): Promise<{ dishes: ExtractedDish[]; sections: string[]; telemetry: Record<string, unknown> }> {
+  const drinkCountBefore = extracted.dishes.filter(
+    d => d.category === 'cocktails' || d.category === 'coffee',
+  ).length
+  const telemetry: Record<string, unknown> = {
+    triggered: false, drink_count_before: drinkCountBefore, source: null, url: null, dishes_found: 0,
+  }
+  if (drinkCountBefore >= DRINK_RECOVERY_THRESHOLD) {
+    return { dishes: [], sections: [], telemetry }
+  }
+
+  // Prefer a drink ASSET. Allow the single best drink-scored asset even if it
+  // was already tried by the food pass — re-asking a mixed "Food & Drinks.pdf"
+  // with the drink-only hint is the whole point.
+  const drinkAssets = discoverDrinkCandidates(opts.html, opts.menuUrl)
+  let result: MenuExtractionResult | null = null
+  let source: string | null = null
+  let usedUrl: string | null = null
+
+  if (drinkAssets.length > 0) {
+    const best = drinkAssets[0]
+    usedUrl = best.url
+    source = best.type // 'image' | 'pdf'
+    opts.triedUrls.add(best.url)
+    try {
+      result = best.type === 'image'
+        ? await extractMenuFromImagesWithClaude([best.url], opts.restaurantName, DRINK_RECOVERY_HINT)
+        : await extractMenuFromPdfsWithClaude([best.url], opts.restaurantName, DRINK_RECOVERY_HINT)
+    } catch (err) {
+      console.error(`${opts.restaurantName}: drink asset extraction failed:`, err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  // No asset (or asset yielded nothing) → try ONE drinks sub-page (text).
+  if (!result || result.dishes.length === 0) {
+    const subPages = findDrinkSubPages(opts.html, opts.menuUrl, 1)
+    if (subPages.length > 0) {
+      const subUrl = subPages[0]
+      try {
+        const subFetch = await fetchRawHtml(subUrl)
+        if (subFetch.type === 'pdf') {
+          result = await extractMenuFromPdfsWithClaude([subFetch.pdfUrl], opts.restaurantName, DRINK_RECOVERY_HINT)
+          source = 'pdf'; usedUrl = subUrl
+        } else {
+          const subText = extractMenuTextFromHtml(subFetch.html)
+          if (subText.length >= 50) {
+            result = await extractMenuWithClaude(subText, opts.restaurantName, DRINK_RECOVERY_HINT)
+            source = 'sub-page'; usedUrl = subUrl
+          }
+        }
+      } catch (err) {
+        console.error(`${opts.restaurantName}: drink sub-page failed:`, err instanceof Error ? err.message : String(err))
+      }
+    }
+  }
+
+  if (!result || result.dishes.length === 0) {
+    return { dishes: [], sections: [], telemetry }
+  }
+
+  // Keep only valid drink rows (the hint + system prompt already constrain to
+  // cocktails/coffee, but enforce here so a mis-tagged row can't sneak in).
+  const drinkDishes = result.dishes
+    .filter(d => d.category === 'cocktails' || d.category === 'coffee')
+    .map(d => ({ ...d, menu_group: null as string | null }))
+
+  telemetry.triggered = true
+  telemetry.source = source
+  telemetry.url = usedUrl
+  telemetry.dishes_found = drinkDishes.length
+  return { dishes: drinkDishes, sections: result.menu_section_order, telemetry }
+}
+```
+
+- [ ] **Step 2: Add a merge helper call at Branch A** (main path, AFTER the BentoBox group backfill block that ends near `index.ts:2117`, BEFORE `const stats = await upsertDishes(...)`):
+
+```ts
+// --- Drinks recovery (Gap 6) ---
+const drinkHtml = renderSucceeded ? extractionContent : rawText // best html we have
+let drinkPass: Record<string, unknown> = { triggered: false }
+{
+  const rec = await runDrinkRecovery(extracted, {
+    html: rawHtml, // raw HTML for asset/anchor discovery (rendered text isn't HTML)
+    menuUrl,
+    restaurantName: restaurant.name,
+    triedUrls,
+  })
+  drinkPass = rec.telemetry
+  if (rec.dishes.length > 0) {
+    const existingKeys = new Set(
+      extracted.dishes.map(d => `${d.name.toLowerCase()}|${(d.menu_section || '').toLowerCase()}`),
+    )
+    for (const d of rec.dishes) {
+      const k = `${d.name.toLowerCase()}|${(d.menu_section || '').toLowerCase()}`
+      if (!existingKeys.has(k)) { extracted.dishes.push(d); existingKeys.add(k) }
+    }
+    for (const sec of rec.sections) {
+      if (!extracted.menu_section_order.includes(sec)) extracted.menu_section_order.push(sec)
+    }
+  }
+}
+```
+
+> NOTE on `html`: discovery needs HTML markup (anchors/img tags), so pass `rawHtml`. The rendered *text* (`extractionContent`) is stripped of tags and can't be scanned for assets. If a render produced new HTML, the main pipeline already merged those candidates into `candidates`; a follow-up improvement can pass rendered HTML here, but rawHtml is correct and safe for v1. Remove the unused `drinkHtml` line if your linter flags it.
+
+Then add `drink_pass: drinkPass` to the success-path `error_context` object on the `menu_import_jobs` update (the object that already includes `winning_strategy`, `attempts`, etc.).
+
+- [ ] **Step 3: Add the same recovery at Branch B** (direct-PDF success branch, after `pdfExtracted` upsert is computed but BEFORE its `upsertDishes` — or immediately after `extractMenuFromPdfsWithClaude` returns dishes and before `upsertDishes(supabase, restaurant.id, pdfExtracted)`):
+
+```ts
+// Drinks recovery for direct-PDF menus: the food PDF won't contain the
+// cocktail list. Use the restaurant website HTML if we can fetch it.
+{
+  let html = ''
+  try {
+    const site = restaurant.website_url || restaurant.menu_url
+    if (site) {
+      const f = await fetchRawHtml(site)
+      if (f.type === 'html') html = f.html
+    }
+  } catch { /* no-op: best effort */ }
+  if (html) {
+    const rec = await runDrinkRecovery(pdfExtracted, {
+      html, menuUrl: restaurant.website_url || menuUrl, restaurantName: restaurant.name, triedUrls: new Set(),
+    })
+    if (rec.dishes.length > 0) {
+      const existingKeys = new Set(pdfExtracted.dishes.map(d => `${d.name.toLowerCase()}|${(d.menu_section || '').toLowerCase()}`))
+      for (const d of rec.dishes) {
+        const k = `${d.name.toLowerCase()}|${(d.menu_section || '').toLowerCase()}`
+        if (!existingKeys.has(k)) { pdfExtracted.dishes.push(d); existingKeys.add(k) }
+      }
+    }
+  }
+}
+```
+
+> `restaurant` in Branch B is selected with `menu_url, website_url` already (see the queue `select` at the top of the job loop), so both fields are available.
+
+- [ ] **Step 4: Type-check (best effort)**
+
+Run: `deno check supabase/functions/menu-refresh/index.ts` (if Deno installed)
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/functions/menu-refresh/index.ts
+git commit -m "feat(menu-refresh): wire drinks-recovery into main + direct-PDF paths"
+```
+
+---
+
+## Task 6: Bump extractor fingerprint
+
+**Files:**
+- Modify: `supabase/functions/menu-refresh/index.ts`
+
+- [ ] **Step 1: Append the segment**
+
+Change `CURRENT_EXTRACTOR_FINGERPRINT` by appending `|drinks-pass-v1`:
+
+```ts
+const CURRENT_EXTRACTOR_FINGERPRINT = 'sonnet-4-6|prompt-v6|pipeline-v2|desc150+dietary-v2|cocktails-v1|thin-fallback-v1|bentobox-jsonld-v1|conservas-skip-v1|menu-groups-v2|drinks-pass-v1'
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add supabase/functions/menu-refresh/index.ts
+git commit -m "chore(menu-refresh): bump extractor fingerprint for drinks-pass-v1"
+```
+
+---
+
+## Task 7: Deploy + live verification + targeted backfill
+
+**Manual steps — coordinate with Dan. Do NOT skip the credit check.**
+
+- [ ] **Step 1: Confirm Anthropic credit balance** (per `feedback_anthropic_credit_balance`) — the fingerprint bump triggers gradual re-extraction.
+
+- [ ] **Step 2: Deploy the edge function** to the live project (`vpioftosgdkyiwvhxewy`) via the Supabase dashboard "Edit" UI (Dan has access) or CLI redeploy from repo. The deployed `menu-candidates.ts` inlines the SSRF guard (known drift) — preserve that inline block when pasting; only add the new exports.
+
+- [ ] **Step 3: Live single-restaurant verification.** Pick a real MV restaurant that has a SEPARATE cocktail menu and currently shows no cocktails in the app. Enqueue a single job (POST `{ "restaurant_id": "<uuid>" }` to menu-refresh, or via the queue), wait for the cron, and confirm in the app:
+  - cocktails/coffee now appear with correct categories,
+  - food dishes are unchanged (count + sections),
+  - `menu_import_jobs.error_context.drink_pass` shows `triggered: true` and `dishes_found > 0`.
+
+- [ ] **Step 4: Targeted backfill (cheaper than force_all).** Enqueue refresh jobs ONLY for restaurants this fix can change — open, with a menu_url, and with fewer than `DRINK_RECOVERY_THRESHOLD` cocktail/coffee dishes:
+
+```sql
+-- Run in Supabase SQL Editor (live project). Idempotent: skips restaurants with an active job.
+INSERT INTO menu_import_jobs (restaurant_id, job_type, priority)
+SELECT r.id, 'refresh', 0
+FROM restaurants r
+WHERE r.is_open = true
+  AND r.menu_url IS NOT NULL
+  AND (SELECT count(*) FROM dishes d
+       WHERE d.restaurant_id = r.id
+         AND d.category IN ('cocktails','coffee')) < 5
+  AND NOT EXISTS (
+    SELECT 1 FROM menu_import_jobs mij
+    WHERE mij.restaurant_id = r.id AND mij.status IN ('pending','processing')
+  );
+```
+
+- [ ] **Step 5: Monitor** the first batch via `menu_import_jobs` (`drink_pass` telemetry, error rates) before letting the nightly cron carry the rest.
+
+---
+
+## Self-Review (completed during planning)
+
+- **Spec coverage:** §1 scorer → Task 1; §2 sub-page finder → Task 3; §1 discover → Task 2; §3 hint → Task 4; §4 integration (both branches, after-bento ordering, triedUrls relaxation, separate telemetry, no-run-on-failure) → Task 5; §5 fingerprint + targeted backfill → Tasks 6–7; cross-category collision regression → see note below.
+- **Cross-category collision (Codex nice-to-have):** `upsertDishes` lives in the Deno `index.ts` and isn't Vitest-reachable, so a true unit test isn't feasible here. Mitigated structurally: `runDrinkRecovery` only emits `cocktails`/`coffee` rows, and Branch A dedup keys on name+section before merge. Verified behaviorally in Task 7 Step 3 (food dishes unchanged). Flagged for a future Deno-level upsert test.
+- **Placeholder scan:** none.
+- **Type consistency:** `runDrinkRecovery` returns `{ dishes: ExtractedDish[]; sections: string[]; telemetry }`; callers use `rec.dishes` / `rec.sections` / `rec.telemetry`. Extractor hint param is optional+last on all three functions. `MenuCandidate` reused unchanged.

--- a/docs/superpowers/specs/2026-06-09-drinks-extraction-fix-design.md
+++ b/docs/superpowers/specs/2026-06-09-drinks-extraction-fix-design.md
@@ -1,0 +1,200 @@
+# Drinks Extraction Fix — Design Spec
+
+**Date:** 2026-06-09
+**Gap:** #6 in `2026-06-09-menu-pipeline-gap-map.md`
+**Scope:** `supabase/functions/menu-refresh/` only (edge function). No frontend, no schema.
+
+## Problem
+
+The candidate discovery layer is food-only by design. In `menu-candidates.ts`:
+- `NEGATIVE_KEYWORDS` scores `drinks -6, beverages -6, cocktails -6, wines -5, beers -5, spirits -5`.
+- Gate: PDFs pass at `score >= 0`, images at `score > 0`.
+- So a separate `Cocktails.pdf` / `Drinks-Menu.png` scores negative and is **never sent to Sonnet.**
+- `findSubMenuPages` `SUB_MENU_NEGATIVE_TEXT` also skips `/drinks`, `/cocktails`, `/bar`, `/wine`.
+
+Result: `cocktails` and `coffee` (both valid categories the prompt wants) are only
+extracted when inline with the food menu. Most restaurants split them onto a separate
+menu → drinks silently missing.
+
+## Goal
+
+When the food extraction yields **zero** drink dishes (no `cocktails` and no `coffee`),
+attempt one additional extraction on the single best drinks asset or drinks sub-page,
+and merge the result. Food extraction is never demoted or changed.
+
+## Decision (Dan, 2026-06-09 — revised after Codex review)
+
+**Gate the drinks pass on a low-coverage heuristic, not strict zero.** Codex flagged
+that the food prompt already extracts `coffee`/`cocktails` inline (`index.ts:218,220`),
+so a single inline drink (one brunch bloody mary, one drip coffee) would make
+`drinkCount > 0` and suppress the recovery pass even when a separate 20-item cocktail
+list exists — the exact case we're fixing.
+
+**Trigger:** run the drinks pass when BOTH
+- the primary extraction produced **fewer than `DRINK_RECOVERY_THRESHOLD` (= 5)** dishes
+  with category `cocktails` or `coffee`, AND
+- a **dedicated drinks asset or sub-page exists** (positive drink score; see §1/§2).
+
+Still capped at **one** extra Sonnet call, so cost stays near-zero. The asset-exists
+half of the gate means restaurants with one combined menu (no separate drinks source)
+never trigger it regardless of count.
+
+## Design
+
+### 1. Drinks scorer (`menu-candidates.ts`)
+
+Add an inverted keyword model and a discovery function that mirrors the food one:
+
+- `DRINK_POSITIVE_KEYWORDS`: `cocktails +5`, `drinks +5`, `beverages +4`, `bar +3`,
+  `coffee +4`, `espresso +3`, `cafe +2`, `wine +2` (a "wine & cocktails" sheet still
+  carries cocktails), `happy[\s-]?hour +2`.
+- `DRINK_NEGATIVE_KEYWORDS`: reuse the food-noise negatives (`logo/favicon/icon/header/
+  banner/hero/avatar/thumbnail/gallery -8..-10`, `allergen/nutrition/giftcard/terms/
+  privacy/policy/application/employment/job/contract/waiver/rules` negatives) PLUS
+  `food -4, dinner -3, lunch -3, breakfast -3, brunch -3, entrees -2` so a food menu
+  doesn't win the drink track.
+- `scoreDrinkCandidate(url, context)` — same structure as `scoreCandidate`, drink weights.
+- `discoverDrinkCandidates(html, baseUrl): MenuCandidate[]` — same extraction as
+  `discoverMenuCandidates` (reuse `extractRawMatches`), scored with the drink model,
+  **a symmetric positive gate (PDF `> 0`, image `> 0`)**, sorted desc. NOTE the
+  difference from the food path: food PDFs pass at `>= 0` because a restaurant PDF is
+  usually a menu, but that prior does NOT transfer to drinks (Codex finding) — a neutral
+  opaque PDF could become the "best drinks asset" and burn the call on the wrong source.
+  Require real positive drink evidence. No neutral-image fallback (don't burn vision on
+  unsignaled images).
+
+Tag is implicit (the function it came from); no schema change to `MenuCandidate`.
+
+### 2. Drinks sub-page finder (`menu-candidates.ts`)
+
+`findDrinkSubPages(html, baseUrl, max = 1): string[]`
+- Anchor-text/path patterns: `/cocktails`, `/drinks`, `/bar`, `/beverages`,
+  `/drink-menu`, `/bar-menu`, `/cocktail-menu`, and anchor text matching
+  `\bcocktails?\b | \bdrinks?\b | \bbar menu\b | \bbeverages?\b`.
+- Exclude food anchors (`food/dinner/lunch/brunch/breakfast`) and the standard noise
+  (`gift card/catering/private/events`).
+- Same-origin only; skip PDF/image hrefs (those are asset candidates); dedup; cap at `max`.
+
+### 3. Extraction hint (`menu-refresh/index.ts`)
+
+Add an optional `extractionHint?: string` parameter to `extractMenuWithClaude`,
+`extractMenuFromImagesWithClaude`, and `extractMenuFromPdfsWithClaude`, appended to the
+user text block (system prompt unchanged). Drinks hint:
+
+> "This is the restaurant's DRINKS menu. Extract ONLY alcoholic cocktails (category
+> `cocktails`) and coffee drinks (category `coffee`), following the cocktail and coffee
+> rules in your instructions. Do not extract wine, beer, or non-alcoholic beverages."
+
+The system prompt's existing wine/beer/mocktail/RTD exclusions still apply, so the drinks
+pass yields only valid `cocktails`/`coffee` rows.
+
+### 4. Integration points (`menu-refresh/index.ts`, queue mode) — pinned to real branches
+
+Codex correctly flagged that "after the gate, before upsert" is NOT one clean spot.
+There are two distinct success branches and several early returns. Pin it explicitly:
+
+**Shared helper.** Factor the recovery into one function so both branches call it:
+
+```
+// runDrinkRecovery(extracted, { rawHtml, renderedHtml, menuUrl, restaurantName,
+//                              candidates, triedUrls }) → { dishes, sections, telemetry }
+//   drinkCount = extracted.dishes.filter(d => d.category==='cocktails' || d.category==='coffee').length
+//   if (drinkCount >= DRINK_RECOVERY_THRESHOLD) return no-op
+//   // 1. drink ASSETS: discoverDrinkCandidates over the BEST html we have
+//   //    (renderedHtml if renderSucceeded, else rawHtml) so JS-injected drink
+//   //    PDFs/images surfaced by Browserless are included (Codex finding).
+//   //    Allow the single best drink-scored asset EVEN IF triedUrls has it
+//   //    (re-ask a mixed "Food & Drinks.pdf" with the drink-only hint).
+//   // 2. else drink SUB-PAGE: findDrinkSubPages(html, menuUrl, 1) → fetch → text.
+//   // 3. if no drink source found → no-op (this is the 'asset exists' half of the gate).
+//   // 4. extract with the drinks hint (§3); merge additive; return telemetry.
+```
+
+**Branch A — main HTML/asset path.** Call `runDrinkRecovery` **after** the BentoBox
+group backfill (`index.ts:2117`) and **before** `upsertDishes`. Running after the Bento
+backfill is required (Codex finding): the backfill mutates `extracted.dishes` to assign
+`menu_group` from `bentoSectionGroups` by section name, so merging drink rows earlier
+risks a section-name collision stamping a Bento group onto a drink row. Drink rows are
+appended with `menu_group = null` after the backfill has already run.
+
+**Branch B — direct-PDF shortcut.** The direct-PDF branch (`index.ts:1502-1582`) upserts
+and returns early, so Branch A never runs for food-PDF menus. Add a `runDrinkRecovery`
+call there too (a food-PDF restaurant very commonly has a separate drinks PDF/page on
+the site). Here `candidates`/rendered HTML don't exist, so recovery uses the homepage/
+website HTML if available; if not, it no-ops (acceptable — Branch B is already a
+narrow shortcut).
+
+**Where it does NOT run (explicit):**
+- **Total extraction failure** (`no_dishes`, `index.ts:2033`) exits before the gate and
+  does NOT trigger drink recovery. Rationale: a restaurant with zero food dishes is a
+  blank-page problem owned by the photo fallback (Gaps 2/4/5), not the drinks fix. We do
+  not want to half-populate a restaurant with only its cocktail list.
+- **Gated / closed / hash-unchanged** early returns are unaffected (no upsert happens).
+
+- Reuse the existing `dishKey` merge/dedup pattern (name+section, lowercase); drinks additive.
+- Append any new drink `menu_section`s to `menu_section_order` (after existing entries).
+- Telemetry: a **separate** `drink_pass` block in `error_context`
+  (`{ triggered, drink_count_before, source: 'image'|'pdf'|'sub-page'|null, url, dishes_found }`).
+  Do NOT overload the closed `ExtractionAttempt.strategy` union (`index.ts:689`) or the
+  `winningStrategy` computed at `index.ts:2063` (Codex finding).
+- Bounded: at most ONE extra Sonnet call, only when `drinkCount < DRINK_RECOVERY_THRESHOLD`
+  AND a positive-scored drink source exists.
+
+### 5. Fingerprint bump
+
+The drinks pass changes stored output, so bump `CURRENT_EXTRACTOR_FINGERPRINT`: append
+`|drinks-pass-v1`. Per the 2-step pattern, this invalidates the hash short-circuit so
+restaurants re-extract on their next cron pass and pick up drinks.
+
+**Cost note:** a fingerprint bump makes the nightly stale-refresh cron re-run every open
+restaurant over time (bounded by 14-day staleness + 3 jobs/min throughput, so it rolls
+gradually, not all at once). **Confirm Anthropic credit balance before deploy** (per
+`feedback_anthropic_credit_balance`).
+
+**Cheaper accelerated rollout (Codex finding):** this fix can ONLY change restaurants
+that currently have no `cocktails` and no `coffee` dishes (and few — under the
+threshold). Instead of a blunt `force_all` backfill, enqueue a targeted one-shot batch
+of exactly those restaurants (`is_open = true`, `menu_url IS NOT NULL`, and no/few
+cocktail/coffee dishes). Far fewer Sonnet calls than re-running the whole inventory.
+Gradual nightly rollout is also safe if we don't need drinks immediately.
+
+## Safety / non-regression
+
+- One combined menu → no separate drink asset/sub-page → `drinkCount` may be >0 anyway,
+  or no candidate found → **zero behavior change.**
+- "Drinks" asset that's actually wine-only → prompt returns ~0 dishes → one bounded
+  wasted call, no bad rows.
+- Drinks pass is purely additive — cannot trip the confidence gate (runs after it) and
+  cannot remove food dishes.
+- SSRF: drink asset/sub-page fetches go through the same `safeFetch` / `fetchRawHtml` +
+  `isBlockedHostname` guards as every other fetch. No new external-fetch surface beyond
+  same-origin sub-pages and same-page assets.
+
+## Testing
+
+- `menu-candidates.test.ts`: `scoreDrinkCandidate` (cocktail PDF positive, food PDF
+  negative under drink model, logo/giftcard rejected), `discoverDrinkCandidates`
+  (gate behavior), `findDrinkSubPages` (matches `/cocktails`, rejects `/dinner`,
+  same-origin only, cap).
+- `extractors.test.ts`: hint param is appended and doesn't break category sanitization.
+- **Cross-category name collision regression (Codex finding):** `upsertDishes` matches
+  existing rows by exact lowercase name first (`index.ts:1071,1188`), so a new drink row
+  could overwrite an existing non-drink row of the same name (e.g. `Affogato` dessert vs
+  coffee). Add a test asserting a same-name, different-category drink row does not clobber
+  the food row's category/section.
+- Manual verification: pick a real MV restaurant with a separate cocktail menu, run a
+  single-restaurant extraction, confirm cocktails/coffee land with correct categories
+  and food is unchanged. (index.ts integration isn't unit-testable under Vitest due to
+  Deno URL imports — candidate-level tests + one live run is the coverage.)
+
+## Deploy
+
+Edge function deploy. Repo `_shared/ssrf.ts` is inlined in the deployed
+`menu-candidates.ts` (known drift). Edit repo files, then deploy via the Supabase
+dashboard "Edit" UI (Dan has access) or CLI redeploy from repo. Bump fingerprint in the
+same deploy.
+
+## Out of scope (separate specs)
+
+Reachability (Gap 7), verification pass, never-blank UX (Gap 5), photo fallback
+(Gaps 2/4/5), reliable enqueue + transient retry (Gaps 1/3).

--- a/docs/superpowers/specs/2026-06-09-menu-pipeline-gap-map.md
+++ b/docs/superpowers/specs/2026-06-09-menu-pipeline-gap-map.md
@@ -1,0 +1,110 @@
+# Menu Pipeline Gap Map — "Works Every Time"
+
+**Date:** 2026-06-09
+**Goal:** When a user (or curator) adds a restaurant, the restaurant page reliably
+populates with the correct menu — dishes, drinks, descriptions, and the right
+sections — *or* presents a clear path to a correct menu. Never a silent blank.
+Currently succeeds ~50% of the time.
+
+**Honest framing:** 100% *auto-extraction from a URL* is impossible — some menus
+exist only as an Instagram photo, a Toast page that 403s scrapers, or a JS app we
+can't read. The achievable goal is **100% coverage**: auto when we can, a graceful
+"building your menu" state while we try, and a **photo-snap fallback** (any logged-in
+user) that always works because a human can photograph a paper menu. Plus quality
+fixes so the auto path is right more often.
+
+---
+
+## The flow (as built)
+
+1. `AddRestaurantModal` → `restaurantsApi.create()` inserts the `restaurants` row.
+2. Fire-and-forget `menuImportApi.createJob(id, 'initial')` → RPC `enqueue_menu_import`
+   inserts a `menu_import_jobs` row (priority 10, idempotent: one active job/restaurant).
+3. pg_cron `process-menu-import-queue` runs every 60s → POSTs `{"mode":"queue"}` to the
+   `menu-refresh` edge function with the `cron_secret`.
+4. `menu-refresh` claims up to 3 jobs (`claim_menu_import_jobs`, priority DESC so
+   `initial` jumps ahead of nightly `refresh`), discovers menu URL/assets, runs the
+   multi-strategy extractor (PDF / JSON-LD / image vision / HTML text / sub-pages /
+   iframes / Browserless render), confidence-gates, and upserts dishes.
+5. Nightly cron `create-menu-refresh-jobs` (3 AM) re-enqueues `refresh` jobs for stale
+   menus (`menu_last_checked` NULL or >14d), **but only where `menu_url IS NOT NULL`**
+   and **not if a `dead` job exists in the last 30 days**.
+
+---
+
+## Permanent-blank black holes (created, but a menu NEVER appears)
+
+### Gap 1 — Enqueue is fire-and-forget and swallowed
+`AddRestaurantModal.jsx:204` & `:331`:
+`menuImportApi.createJob(...).catch(err => logger.warn(...))`. If that RPC call fails
+(network, RLS, transient), the restaurant exists with **no job and nothing retries.**
+- **Root fix:** enqueue from a DB trigger on `restaurants` INSERT, so a restaurant
+  structurally cannot exist without a job. Frontend call becomes belt-and-suspenders.
+
+### Gap 2 — No menu URL → dead → excluded forever
+Manual adds (or Google returns no website) → extractor hits `no_menu_url` → 3 attempts
+→ `dead`. The nightly re-enqueue cron requires `menu_url IS NOT NULL`
+(`add-menu-import-queue.sql:172`), so these restaurants are **never reconsidered**.
+- **Root fix:** the photo fallback (Gap 5) covers no-URL restaurants; also allow the
+  nightly cron / a recovery path to revisit `needs_manual_menu` / no-URL restaurants.
+
+### Gap 3 — Dead jobs frozen for 30 days, even on transient failures
+3 failures → `dead`, even when the cause was transient (Browserless down, Anthropic
+429, DNS blip). Nightly cron skips any restaurant with a dead job <30 days old
+(`add-menu-import-queue.sql:179-184`). One bad night = a month of blank.
+- **Root fix:** distinguish transient vs. terminal `error_code`s; auto-retry transient
+  deaths sooner (hours, not 30 days). Terminal causes route to the photo fallback.
+
+### Gap 4 — Confidence-gate "completed but empty"
+The gate marks the job `completed`, writes 0 dishes, and stamps the current
+hash+fingerprint (`index.ts` low-confidence branch). Nightly staleness won't refire
+(fresh timestamp); even at 14 days the hash+fingerprint short-circuit returns
+"unchanged." **Only a manual fingerprint bump ever retries it.** Permanent blank.
+- **Root fix:** a gated restaurant should set `needs_manual_menu = true` (it does) AND
+  surface the photo fallback to users, instead of silently completing.
+
+### Gap 5 — No escape hatch for the user
+Every failure above is invisible. No "menu loading," no "add a photo." The
+`useMenuImportStatus` hook exists and is tested but is **not wired into the restaurant
+page**, so even the job status we already track isn't shown.
+- **Root fix:** never-blank UX (poll job status → "building your menu") + the
+  photo-snap fallback (any logged-in user) as the universal closer.
+
+---
+
+## Quality leaks (a menu appears, but it's wrong)
+
+### Gap 6 — Drinks systematically dropped
+`menu-candidates.ts` scores `drinks/beverages/cocktails/wine/beer/spirits` strongly
+negative, and the candidate gate (PDF `score >= 0`, image `score > 0`) means a separate
+`Cocktails.pdf` / `Drinks-Menu.png` is **never sent to Sonnet**. `findSubMenuPages`
+likewise skips `/drinks`, `/cocktails`, `/bar`. So cocktails/coffee only get extracted
+when inline with food — most restaurants split them onto a separate menu.
+- **Fix (FIRST code target):** a dedicated drinks-candidate track + drinks sub-page
+  finder; try the best food asset AND the best drinks asset (with a prompt hint), merge.
+  See the drinks-fix design doc.
+
+### Gap 7 — Wrong menu URL → homepage shell
+`findMenuUrl` probes a fixed path list; on a miss it falls back to the homepage, which
+is a nav shell → thin/wrong/hallucinated extraction.
+- **Fix:** follow on-page "Menu" anchor links (and Google Places menu URL) before
+  falling back to the homepage.
+
+### Gap 8 — Descriptions missing
+Rule 13 nulls "marketing copy"; the image/PDF path loses description text more often;
+no recovery pass. Result: dishes with blank descriptions.
+- **Fix:** revisit the description rule + consider a targeted re-ask when coverage is low.
+
+---
+
+## Build order
+
+1. **Drinks fix (Gap 6)** — most concrete, self-contained edge-function win. *(started)*
+2. **Reachability (Gap 7)** — better menu-URL discovery.
+3. **Verification pass** — gate quality before writing (covers Gaps 7/8 sneaking through).
+4. **Never-blank UX (Gap 5)** — wire `useMenuImportStatus` into the restaurant page.
+5. **Photo-snap fallback (Gaps 2/4/5)** — any logged-in user; reuses
+   `extractMenuFromImagesWithClaude`. The universal closer for 100% coverage.
+6. **Reliable enqueue + retry (Gaps 1/3)** — DB-trigger enqueue; transient-death retry.
+
+Each gets its own design → plan → implementation cycle.

--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -1308,6 +1308,78 @@ async function upsertDishes(
   }
 }
 
+/**
+ * Drinks recovery (Gap 6). When the food extraction found few cocktail/coffee
+ * dishes, try ONE extra LLM pass on the best dedicated drinks source and return
+ * the additive drink dishes + any new sections. Caller merges. Bounded to one
+ * Sonnet call.
+ */
+async function runDrinkRecovery(
+  extracted: MenuExtractionResult,
+  opts: { html: string; menuUrl: string; restaurantName: string; triedUrls: Set<string> },
+): Promise<{ dishes: ExtractedDish[]; sections: string[]; telemetry: Record<string, unknown> }> {
+  const drinkCountBefore = extracted.dishes.filter(
+    d => d.category === 'cocktails' || d.category === 'coffee',
+  ).length
+  const telemetry: Record<string, unknown> = {
+    triggered: false, drink_count_before: drinkCountBefore, source: null, url: null, dishes_found: 0,
+  }
+  if (drinkCountBefore >= DRINK_RECOVERY_THRESHOLD) return { dishes: [], sections: [], telemetry }
+
+  const drinkAssets = discoverDrinkCandidates(opts.html, opts.menuUrl)
+  let result: MenuExtractionResult | null = null
+  let source: string | null = null
+  let usedUrl: string | null = null
+
+  if (drinkAssets.length > 0) {
+    const best = drinkAssets[0]
+    usedUrl = best.url
+    source = best.type
+    opts.triedUrls.add(best.url)
+    try {
+      result = best.type === 'image'
+        ? await extractMenuFromImagesWithClaude([best.url], opts.restaurantName, DRINK_RECOVERY_HINT)
+        : await extractMenuFromPdfsWithClaude([best.url], opts.restaurantName, DRINK_RECOVERY_HINT)
+    } catch (err) {
+      console.error(`${opts.restaurantName}: drink asset extraction failed:`, err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  if (!result || result.dishes.length === 0) {
+    const subPages = findDrinkSubPages(opts.html, opts.menuUrl, 1)
+    if (subPages.length > 0) {
+      const subUrl = subPages[0]
+      try {
+        const subFetch = await fetchRawHtml(subUrl)
+        if (subFetch.type === 'pdf') {
+          result = await extractMenuFromPdfsWithClaude([subFetch.pdfUrl], opts.restaurantName, DRINK_RECOVERY_HINT)
+          source = 'pdf'; usedUrl = subUrl
+        } else {
+          const subText = extractMenuTextFromHtml(subFetch.html)
+          if (subText.length >= 50) {
+            result = await extractMenuWithClaude(subText, opts.restaurantName, DRINK_RECOVERY_HINT)
+            source = 'sub-page'; usedUrl = subUrl
+          }
+        }
+      } catch (err) {
+        console.error(`${opts.restaurantName}: drink sub-page failed:`, err instanceof Error ? err.message : String(err))
+      }
+    }
+  }
+
+  if (!result || result.dishes.length === 0) return { dishes: [], sections: [], telemetry }
+
+  const drinkDishes = result.dishes
+    .filter(d => d.category === 'cocktails' || d.category === 'coffee')
+    .map(d => ({ ...d, menu_group: null as string | null }))
+
+  telemetry.triggered = true
+  telemetry.source = source
+  telemetry.url = usedUrl
+  telemetry.dishes_found = drinkDishes.length
+  return { dishes: drinkDishes, sections: result.menu_section_order, telemetry }
+}
+
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders })
@@ -1528,6 +1600,29 @@ serve(async (req) => {
             }
 
             if (pdfExtracted.dishes.length > 0) {
+              // Drinks recovery for direct-PDF menus: the food PDF won't carry the cocktail list.
+              {
+                let html = ''
+                try {
+                  const site = restaurant.website_url || restaurant.menu_url
+                  if (site) {
+                    const f = await fetchRawHtml(site)
+                    if (f.type === 'html') html = f.html
+                  }
+                } catch { /* best effort */ }
+                if (html) {
+                  const rec = await runDrinkRecovery(pdfExtracted, {
+                    html, menuUrl: restaurant.website_url || menuUrl, restaurantName: restaurant.name, triedUrls: new Set(),
+                  })
+                  if (rec.dishes.length > 0) {
+                    const existingKeys = new Set(pdfExtracted.dishes.map(d => `${d.name.toLowerCase()}|${(d.menu_section || '').toLowerCase()}`))
+                    for (const d of rec.dishes) {
+                      const k = `${d.name.toLowerCase()}|${(d.menu_section || '').toLowerCase()}`
+                      if (!existingKeys.has(k)) { pdfExtracted.dishes.push(d); existingKeys.add(k) }
+                    }
+                  }
+                }
+              }
               const stats = await upsertDishes(supabase, restaurant.id, pdfExtracted)
               // Note: we deliberately do not store menu_content_hash here —
               // PDFs route through a different fetch path with no equivalent
@@ -2139,6 +2234,30 @@ serve(async (req) => {
             }
           }
 
+          // --- Drinks recovery (Gap 6) ---
+          let drinkPass: Record<string, unknown> = { triggered: false }
+          {
+            const rec = await runDrinkRecovery(extracted, {
+              html: rawHtml,            // raw HTML markup for asset/anchor discovery
+              menuUrl,
+              restaurantName: restaurant.name,
+              triedUrls,
+            })
+            drinkPass = rec.telemetry
+            if (rec.dishes.length > 0) {
+              const existingKeys = new Set(
+                extracted.dishes.map(d => `${d.name.toLowerCase()}|${(d.menu_section || '').toLowerCase()}`),
+              )
+              for (const d of rec.dishes) {
+                const k = `${d.name.toLowerCase()}|${(d.menu_section || '').toLowerCase()}`
+                if (!existingKeys.has(k)) { extracted.dishes.push(d); existingKeys.add(k) }
+              }
+              for (const sec of rec.sections) {
+                if (!extracted.menu_section_order.includes(sec)) extracted.menu_section_order.push(sec)
+              }
+            }
+          }
+
           // Success path: upsert dishes, store raw hash + render telemetry
           // Note: we hash the raw text (rawHash), not the rendered text. Next run can skip
           // cheaply when the raw HTML shell is unchanged. Mild staleness on JS sites is
@@ -2189,6 +2308,7 @@ serve(async (req) => {
               batch_dedup_skipped: stats.batchDedupSkipped,
               cross_category_skipped: stats.crossCategorySkipped,
               price_gate_rejected: stats.priceGateRejected,
+              drink_pass: drinkPass,
               ...(mergeTelemetry ?? {}),
             },
             lock_expires_at: null,

--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -350,7 +350,7 @@ const STALE_DAYS = 14
 //   - features      : output-schema features (e.g. desc+dietary tags from PR #229)
 // Format is intentionally human-readable so the stored value alone tells you
 // which extractor produced a row — easier to debug than a bare integer.
-const CURRENT_EXTRACTOR_FINGERPRINT = 'sonnet-4-6|prompt-v6|pipeline-v2|desc150+dietary-v2|cocktails-v1|thin-fallback-v1|bentobox-jsonld-v1|conservas-skip-v1|menu-groups-v2'
+const CURRENT_EXTRACTOR_FINGERPRINT = 'sonnet-4-6|prompt-v6|pipeline-v2|desc150+dietary-v2|cocktails-v1|thin-fallback-v1|bentobox-jsonld-v1|conservas-skip-v1|menu-groups-v2|drinks-pass-v1'
 
 // Signals that a restaurant is closed (check before wasting Claude API call)
 const CLOSED_SIGNALS = [

--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -3,7 +3,7 @@ import { encode as encodeBase64 } from 'https://deno.land/std@0.177.0/encoding/b
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { detectCms, cmsRequiresRender } from './cms-detect.ts'
 import { fetchRenderedHtml, BrowserlessError } from './browserless.ts'
-import { discoverMenuCandidates, findMenuIframes, findSubMenuPages, isBlockedHostname, isKnownMenuIframeHost, type MenuCandidate } from './menu-candidates.ts'
+import { discoverMenuCandidates, discoverDrinkCandidates, findMenuIframes, findSubMenuPages, findDrinkSubPages, isBlockedHostname, isKnownMenuIframeHost, type MenuCandidate } from './menu-candidates.ts'
 import { safeFetch } from '../_shared/ssrf.ts'
 import { detectBentoBox, buildBentoBoxMenuText, parseSchemaOrgMenuItems } from './bentobox.ts'
 
@@ -721,6 +721,15 @@ const SPARSE_TEXT_THRESHOLD = 2000
 // worst case of a false positive is "waits for a human" rather than "garbage".
 const PRICE_COVERAGE_FLOOR = 0.2
 
+// Drinks recovery (Gap 6): if a food extraction found FEWER than this many
+// cocktail/coffee dishes AND a dedicated drinks asset/sub-page exists, run one
+// extra LLM pass on the best drinks source. Low (not zero) because the food
+// prompt already extracts inline drinks — one brunch bloody mary must not
+// suppress recovery of a separate 20-item cocktail list.
+const DRINK_RECOVERY_THRESHOLD = 5
+
+const DRINK_RECOVERY_HINT = 'This is the restaurant\'s DRINKS menu. Extract ONLY alcoholic cocktails (category "cocktails") and coffee drinks (category "coffee"), following the cocktail and coffee rules in your instructions. Do not extract wine, beer, or non-alcoholic beverages.'
+
 // Merge two candidate lists by URL (last-write-wins on score), then re-sort.
 // Used when Browserless renders surface JS-injected assets that weren't in the raw HTML.
 function mergeCandidates(a: MenuCandidate[], b: MenuCandidate[]): MenuCandidate[] {
@@ -764,7 +773,7 @@ function toHttpsUrls(urls: string[]): string[] {
 /**
  * Extract dishes from menu text using Claude
  */
-async function extractMenuWithClaude(content: string, restaurantName: string): Promise<MenuExtractionResult> {
+async function extractMenuWithClaude(content: string, restaurantName: string, extractionHint?: string): Promise<MenuExtractionResult> {
   const response = await fetch('https://api.anthropic.com/v1/messages', {
     method: 'POST',
     headers: {
@@ -782,7 +791,7 @@ async function extractMenuWithClaude(content: string, restaurantName: string): P
       messages: [
         {
           role: 'user',
-          content: `Extract the full menu from "${restaurantName}":\n\n${content}`,
+          content: `Extract the full menu from "${restaurantName}":\n\n${content}${extractionHint ? '\n\n' + extractionHint : ''}`,
         },
       ],
       system: MENU_EXTRACTION_PROMPT,
@@ -884,7 +893,8 @@ async function downloadImageAsBase64(
  */
 async function extractMenuFromImagesWithClaude(
   imageUrls: string[],
-  restaurantName: string
+  restaurantName: string,
+  extractionHint?: string
 ): Promise<MenuExtractionResult> {
   const httpsUrls = toHttpsUrls(imageUrls)
   if (httpsUrls.length === 0) return { dishes: [], menu_section_order: [] }
@@ -916,7 +926,7 @@ async function extractMenuFromImagesWithClaude(
 
   content.push({
     type: 'text',
-    text: `Extract the full menu from "${restaurantName}" from the ${successful.length === 1 ? 'attached image' : `${successful.length} attached images`}. The images are page-ordered. If different images represent different services (breakfast, lunch, dinner), preserve those as menu sections.`,
+    text: `Extract the full menu from "${restaurantName}" from the ${successful.length === 1 ? 'attached image' : `${successful.length} attached images`}. The images are page-ordered. If different images represent different services (breakfast, lunch, dinner), preserve those as menu sections.${extractionHint ? '\n\n' + extractionHint : ''}`,
   })
 
   const response = await fetch('https://api.anthropic.com/v1/messages', {
@@ -969,7 +979,8 @@ async function extractMenuFromImagesWithClaude(
  */
 async function extractMenuFromPdfsWithClaude(
   pdfUrls: string[],
-  restaurantName: string
+  restaurantName: string,
+  extractionHint?: string
 ): Promise<MenuExtractionResult> {
   const httpsUrls = toHttpsUrls(pdfUrls)
   if (httpsUrls.length === 0) return { dishes: [], menu_section_order: [] }
@@ -986,7 +997,7 @@ async function extractMenuFromPdfsWithClaude(
 
   content.push({
     type: 'text',
-    text: `Extract the full menu from "${restaurantName}" from the ${httpsUrls.length === 1 ? 'attached PDF' : `${httpsUrls.length} attached PDFs`}. Combine all dishes into a single output. If different PDFs represent different meal services (breakfast, lunch, dinner), preserve those as menu sections.`,
+    text: `Extract the full menu from "${restaurantName}" from the ${httpsUrls.length === 1 ? 'attached PDF' : `${httpsUrls.length} attached PDFs`}. Combine all dishes into a single output. If different PDFs represent different meal services (breakfast, lunch, dinner), preserve those as menu sections.${extractionHint ? '\n\n' + extractionHint : ''}`,
   })
 
   const response = await fetch('https://api.anthropic.com/v1/messages', {

--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -1318,6 +1318,9 @@ async function runDrinkRecovery(
   extracted: MenuExtractionResult,
   opts: { html: string; menuUrl: string; restaurantName: string; triedUrls: Set<string> },
 ): Promise<{ dishes: ExtractedDish[]; sections: string[]; telemetry: Record<string, unknown> }> {
+  const keepDrinks = (r: MenuExtractionResult | null): ExtractedDish[] =>
+    (r?.dishes ?? []).filter(d => d.category === 'cocktails' || d.category === 'coffee')
+
   const drinkCountBefore = extracted.dishes.filter(
     d => d.category === 'cocktails' || d.category === 'coffee',
   ).length
@@ -1345,7 +1348,9 @@ async function runDrinkRecovery(
     }
   }
 
-  if (!result || result.dishes.length === 0) {
+  let kept = keepDrinks(result)
+
+  if (kept.length === 0) {
     const subPages = findDrinkSubPages(opts.html, opts.menuUrl, 1)
     if (subPages.length > 0) {
       const subUrl = subPages[0]
@@ -1361,23 +1366,22 @@ async function runDrinkRecovery(
             source = 'sub-page'; usedUrl = subUrl
           }
         }
+        kept = keepDrinks(result)
       } catch (err) {
         console.error(`${opts.restaurantName}: drink sub-page failed:`, err instanceof Error ? err.message : String(err))
       }
     }
   }
 
-  if (!result || result.dishes.length === 0) return { dishes: [], sections: [], telemetry }
+  if (kept.length === 0) return { dishes: [], sections: [], telemetry }
 
-  const drinkDishes = result.dishes
-    .filter(d => d.category === 'cocktails' || d.category === 'coffee')
-    .map(d => ({ ...d, menu_group: null as string | null }))
+  const drinkDishes = kept.map(d => ({ ...d, menu_group: null as string | null }))
 
   telemetry.triggered = true
   telemetry.source = source
   telemetry.url = usedUrl
   telemetry.dishes_found = drinkDishes.length
-  return { dishes: drinkDishes, sections: result.menu_section_order, telemetry }
+  return { dishes: drinkDishes, sections: result!.menu_section_order, telemetry }
 }
 
 serve(async (req) => {
@@ -1601,10 +1605,11 @@ serve(async (req) => {
 
             if (pdfExtracted.dishes.length > 0) {
               // Drinks recovery for direct-PDF menus: the food PDF won't carry the cocktail list.
+              let pdfDrinkPass: Record<string, unknown> = { triggered: false }
               {
                 let html = ''
                 try {
-                  const site = restaurant.website_url || restaurant.menu_url
+                  const site = websiteUrl || menuUrl
                   if (site) {
                     const f = await fetchRawHtml(site)
                     if (f.type === 'html') html = f.html
@@ -1612,13 +1617,17 @@ serve(async (req) => {
                 } catch { /* best effort */ }
                 if (html) {
                   const rec = await runDrinkRecovery(pdfExtracted, {
-                    html, menuUrl: restaurant.website_url || menuUrl, restaurantName: restaurant.name, triedUrls: new Set(),
+                    html, menuUrl: websiteUrl || menuUrl, restaurantName: restaurant.name, triedUrls: new Set(),
                   })
+                  pdfDrinkPass = rec.telemetry
                   if (rec.dishes.length > 0) {
                     const existingKeys = new Set(pdfExtracted.dishes.map(d => `${d.name.toLowerCase()}|${(d.menu_section || '').toLowerCase()}`))
                     for (const d of rec.dishes) {
                       const k = `${d.name.toLowerCase()}|${(d.menu_section || '').toLowerCase()}`
                       if (!existingKeys.has(k)) { pdfExtracted.dishes.push(d); existingKeys.add(k) }
+                    }
+                    for (const sec of rec.sections) {
+                      if (!pdfExtracted.menu_section_order.includes(sec)) pdfExtracted.menu_section_order.push(sec)
                     }
                   }
                 }
@@ -1649,6 +1658,7 @@ serve(async (req) => {
                   batch_dedup_skipped: stats.batchDedupSkipped,
                   cross_category_skipped: stats.crossCategorySkipped,
                   price_gate_rejected: stats.priceGateRejected,
+                  drink_pass: pdfDrinkPass,
                 },
                 lock_expires_at: null,
                 updated_at: new Date().toISOString(),

--- a/supabase/functions/menu-refresh/menu-candidates.test.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { discoverMenuCandidates, findMenuIframes, findSubMenuPages, isBlockedHostname, isKnownMenuIframeHost, scoreCandidate } from './menu-candidates.ts'
+import { discoverMenuCandidates, findMenuIframes, findSubMenuPages, isBlockedHostname, isKnownMenuIframeHost, scoreCandidate, scoreDrinkCandidate } from './menu-candidates.ts'
 
 describe('scoreCandidate', () => {
   it('positive: menu in URL', () => {
@@ -41,6 +41,27 @@ describe('scoreCandidate', () => {
 
   it('alt-text "drinks menu" stays negative', () => {
     expect(scoreCandidate('https://x.com/x.png', 'drinks menu').score).toBeLessThan(0)
+  })
+})
+
+describe('scoreDrinkCandidate', () => {
+  it('positive: cocktails in URL', () => {
+    expect(scoreDrinkCandidate('https://x.com/cocktails.pdf').score).toBeGreaterThan(0)
+  })
+  it('positive: drinks menu image', () => {
+    expect(scoreDrinkCandidate('https://x.com/Drinks-Menu.png').score).toBeGreaterThan(0)
+  })
+  it('positive: coffee menu', () => {
+    expect(scoreDrinkCandidate('https://x.com/coffee-menu.pdf').score).toBeGreaterThan(0)
+  })
+  it('negative: a FOOD menu scores negative under the drink model', () => {
+    expect(scoreDrinkCandidate('https://x.com/dinner-menu.pdf').score).toBeLessThan(0)
+  })
+  it('negative: logo rejected', () => {
+    expect(scoreDrinkCandidate('https://x.com/logo.png').score).toBeLessThan(0)
+  })
+  it('negative: gift card rejected', () => {
+    expect(scoreDrinkCandidate('https://x.com/gift-cards.pdf').score).toBeLessThan(0)
   })
 })
 

--- a/supabase/functions/menu-refresh/menu-candidates.test.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { discoverMenuCandidates, findMenuIframes, findSubMenuPages, isBlockedHostname, isKnownMenuIframeHost, scoreCandidate, scoreDrinkCandidate } from './menu-candidates.ts'
+import { discoverDrinkCandidates, discoverMenuCandidates, findMenuIframes, findSubMenuPages, isBlockedHostname, isKnownMenuIframeHost, scoreCandidate, scoreDrinkCandidate } from './menu-candidates.ts'
 
 describe('scoreCandidate', () => {
   it('positive: menu in URL', () => {
@@ -62,6 +62,29 @@ describe('scoreDrinkCandidate', () => {
   })
   it('negative: gift card rejected', () => {
     expect(scoreDrinkCandidate('https://x.com/gift-cards.pdf').score).toBeLessThan(0)
+  })
+})
+
+describe('discoverDrinkCandidates', () => {
+  const base = 'https://r.com/menu'
+  it('surfaces a cocktail PDF that the food scorer would reject', () => {
+    const html = `<a href="/files/Cocktail-Menu.pdf">Cocktails</a>`
+    const out = discoverDrinkCandidates(html, base)
+    expect(out.length).toBe(1)
+    expect(out[0].url).toContain('Cocktail-Menu.pdf')
+  })
+  it('does NOT surface a plain food dinner PDF', () => {
+    const html = `<a href="/files/Dinner-Menu.pdf">Dinner</a>`
+    expect(discoverDrinkCandidates(html, base).length).toBe(0)
+  })
+  it('rejects a neutral opaque PDF (positive gate, not >=0)', () => {
+    const html = `<a href="/files/upload-83fa.pdf">x</a>`
+    expect(discoverDrinkCandidates(html, base).length).toBe(0)
+  })
+  it('sorts by score descending', () => {
+    const html = `<a href="/wine.pdf">w</a><a href="/cocktail-drinks.pdf">c</a>`
+    const out = discoverDrinkCandidates(html, base)
+    expect(out[0].url).toContain('cocktail-drinks.pdf')
   })
 })
 

--- a/supabase/functions/menu-refresh/menu-candidates.test.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { discoverDrinkCandidates, discoverMenuCandidates, findMenuIframes, findSubMenuPages, isBlockedHostname, isKnownMenuIframeHost, scoreCandidate, scoreDrinkCandidate } from './menu-candidates.ts'
+import { discoverDrinkCandidates, discoverMenuCandidates, findDrinkSubPages, findMenuIframes, findSubMenuPages, isBlockedHostname, isKnownMenuIframeHost, scoreCandidate, scoreDrinkCandidate } from './menu-candidates.ts'
 
 describe('scoreCandidate', () => {
   it('positive: menu in URL', () => {
@@ -481,6 +481,66 @@ describe('findSubMenuPages', () => {
     const html = '<a href="/our-menu/">Our Menu</a>'
     const out = findSubMenuPages(html, 'https://x.com/')
     expect(out).toEqual(['https://x.com/our-menu/'])
+  })
+})
+
+describe('findDrinkSubPages', () => {
+  const base = 'https://r.com/menu'
+  it('finds a /cocktails sub-page', () => {
+    const html = `<a href="/cocktails">Cocktails</a>`
+    expect(findDrinkSubPages(html, base)).toEqual(['https://r.com/cocktails'])
+  })
+  it('finds /bar-menu via anchor text', () => {
+    const html = `<a href="/bar-menu">Bar Menu</a>`
+    expect(findDrinkSubPages(html, base)).toEqual(['https://r.com/bar-menu'])
+  })
+  it('ignores food sub-pages', () => {
+    const html = `<a href="/dinner">Dinner</a>`
+    expect(findDrinkSubPages(html, base)).toEqual([])
+  })
+  it('ignores cross-origin links', () => {
+    const html = `<a href="https://other.com/cocktails">Cocktails</a>`
+    expect(findDrinkSubPages(html, base)).toEqual([])
+  })
+  it('caps at max', () => {
+    const html = `<a href="/cocktails">c</a><a href="/drinks">d</a><a href="/bar">b</a>`
+    expect(findDrinkSubPages(html, base, 1).length).toBe(1)
+  })
+  it('finds /drinks with various URL patterns', () => {
+    const html = `<a href="/drinks">Drinks</a><a href="/our-drinks">Our Drinks</a><a href="/drinks-menu">Drinks Menu</a>`
+    const out = findDrinkSubPages(html, base, 5)
+    expect(out.length).toBe(3)
+    expect(out).toContain('https://r.com/drinks')
+    expect(out).toContain('https://r.com/our-drinks')
+    expect(out).toContain('https://r.com/drinks-menu')
+  })
+  it('finds /bar via anchor text when path does not match', () => {
+    const html = `<a href="/Default.aspx?p=bar">Bar</a>`
+    expect(findDrinkSubPages(html, base)).toContain('https://r.com/Default.aspx?p=bar')
+  })
+  it('skips food negatives like "Lunch Menu" even on /bar paths', () => {
+    const html = `<a href="/bar">Lunch Menu</a>`
+    expect(findDrinkSubPages(html, base)).toEqual([])
+  })
+  it('dedupes URLs found by both path and text match', () => {
+    const html = `<a href="/cocktails">Cocktails</a><a href="/cocktails">Bar Cocktails</a>`
+    expect(findDrinkSubPages(html, base).length).toBe(1)
+  })
+  it('skips PDFs and images (asset links, not sub-pages)', () => {
+    const html = `<a href="/cocktails-menu.pdf">Cocktails</a><a href="/bar.png">Bar</a>`
+    expect(findDrinkSubPages(html, base)).toEqual([])
+  })
+  it('ignores self-links (already on a drinks page)', () => {
+    const html = `<a href="/cocktails">Cocktails</a><a href="/bar">Bar</a>`
+    expect(findDrinkSubPages(html, 'https://r.com/cocktails')).toEqual(['https://r.com/bar'])
+  })
+  it('finds /beverages sub-pages', () => {
+    const html = `<a href="/beverages">Beverages</a>`
+    expect(findDrinkSubPages(html, base)).toEqual(['https://r.com/beverages'])
+  })
+  it('matches anchor text "Happy Hour Menu"', () => {
+    const html = `<a href="/Default.aspx?type=happy">Happy Hour Menu</a>`
+    expect(findDrinkSubPages(html, base)).toEqual(['https://r.com/Default.aspx?type=happy'])
   })
 })
 

--- a/supabase/functions/menu-refresh/menu-candidates.test.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.test.ts
@@ -502,6 +502,14 @@ describe('findDrinkSubPages', () => {
     const html = `<a href="https://other.com/cocktails">Cocktails</a>`
     expect(findDrinkSubPages(html, base)).toEqual([])
   })
+  it('ignores a Raw Bar page (seafood, not drinks) even on a /raw-bar path', () => {
+    const html = `<a href="/raw-bar">Raw Bar</a>`
+    expect(findDrinkSubPages(html, base)).toEqual([])
+  })
+  it('ignores an Oyster Bar page', () => {
+    const html = `<a href="/oyster-bar">Oyster Bar</a>`
+    expect(findDrinkSubPages(html, base)).toEqual([])
+  })
   it('caps at max', () => {
     const html = `<a href="/cocktails">c</a><a href="/drinks">d</a><a href="/bar">b</a>`
     expect(findDrinkSubPages(html, base, 1).length).toBe(1)

--- a/supabase/functions/menu-refresh/menu-candidates.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.ts
@@ -338,6 +338,10 @@ const DRINK_SUB_PAGE_ANCHOR_PATTERNS = [
 const DRINK_SUB_PAGE_NEGATIVE_TEXT = [
   /\bfood\b/i, /\bdinner\b/i, /\blunch\b/i, /\bbrunch\b/i, /\bbreakfast\b/i,
   /\bgift[\s-]?cards?\b/i, /\bcatering\b/i, /\bprivate\b/i, /\bevents?\b/i,
+  // "Raw Bar" / "Oyster Bar" are seafood (food) pages, not drink menus — the
+  // bare `bar` path/anchor patterns above would otherwise surface them. Common
+  // on Martha's Vineyard. Must precede the bar match (negative check runs first).
+  /\braw[\s-]?bar\b/i, /\boyster[\s-]?bar\b/i,
 ]
 
 /**

--- a/supabase/functions/menu-refresh/menu-candidates.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.ts
@@ -83,6 +83,60 @@ const NEGATIVE_KEYWORDS: KeywordWeight[] = [
   { pattern: /\bpress\b/i, weight: -4 },
 ]
 
+// Drinks scorer — inverted from the food model. Used by the drinks-recovery
+// pass to surface a SEPARATE cocktail/coffee menu (food assets score these
+// terms strongly negative, so they never reach the LLM otherwise). Food terms
+// are negative here so a food menu can't win the drink track. Noise negatives
+// are intentionally duplicated (not shared) so this never perturbs the food
+// scorer above.
+const DRINK_POSITIVE_KEYWORDS: KeywordWeight[] = [
+  { pattern: /\bcocktails?\b/i, weight: 5 },
+  { pattern: /\bdrinks?\b/i, weight: 5 },
+  { pattern: /\bbeverages?\b/i, weight: 4 },
+  { pattern: /\bcoffee\b/i, weight: 4 },
+  { pattern: /\bespresso\b/i, weight: 3 },
+  { pattern: /\bbar[\s-]?menu\b/i, weight: 4 },
+  { pattern: /\bbar\b/i, weight: 2 },
+  { pattern: /\bcaf[eé]\b/i, weight: 2 },
+  { pattern: /\bwines?\b/i, weight: 2 },
+  { pattern: /\bhappy[\s-]?hour\b/i, weight: 2 },
+]
+
+const DRINK_NEGATIVE_KEYWORDS: KeywordWeight[] = [
+  // Food suppressors — a food menu must not win the drink track.
+  { pattern: /\bfood\b/i, weight: -4 },
+  { pattern: /\bdinner\b/i, weight: -4 },
+  { pattern: /\blunch\b/i, weight: -4 },
+  { pattern: /\bbreakfast\b/i, weight: -4 },
+  { pattern: /\bbrunch\b/i, weight: -4 },
+  { pattern: /\bentrees?\b/i, weight: -2 },
+  // Noise (duplicated from the food NEGATIVE_KEYWORDS on purpose).
+  { pattern: /\ballergens?\b/i, weight: -8 },
+  { pattern: /\bnutrition(al)?\b/i, weight: -6 },
+  { pattern: /\bgift[\s-]?cards?\b/i, weight: -8 },
+  { pattern: /\bgiftcards?\b/i, weight: -8 },
+  { pattern: /\bcatering\b/i, weight: -4 },
+  { pattern: /\bprivate[\s-]?events?\b/i, weight: -6 },
+  { pattern: /\bterms\b/i, weight: -10 },
+  { pattern: /\bprivacy\b/i, weight: -10 },
+  { pattern: /\bpolicy\b/i, weight: -8 },
+  { pattern: /\bapplication\b/i, weight: -8 },
+  { pattern: /\bemployment\b/i, weight: -10 },
+  { pattern: /\bjob\b/i, weight: -8 },
+  { pattern: /\bcontract\b/i, weight: -8 },
+  { pattern: /\bwaiver\b/i, weight: -10 },
+  { pattern: /\brules\b/i, weight: -6 },
+  { pattern: /\blogo\b/i, weight: -10 },
+  { pattern: /\bfavicon\b/i, weight: -10 },
+  { pattern: /\bicon\b/i, weight: -8 },
+  { pattern: /\bheader\b/i, weight: -8 },
+  { pattern: /\bbanner\b/i, weight: -8 },
+  { pattern: /\bhero\b/i, weight: -8 },
+  { pattern: /\bavatar\b/i, weight: -8 },
+  { pattern: /\bthumbnail\b/i, weight: -6 },
+  { pattern: /\bgallery\b/i, weight: -6 },
+]
+
 const PDF_EXT = /\.pdf(\?|#|$)/i
 const IMAGE_EXT = /\.(png|jpe?g|webp)(\?|#|$)/i
 
@@ -107,18 +161,23 @@ function normalize(s: string): string {
   return safeDecode(s).replace(/_/g, ' ')
 }
 
-export function scoreCandidate(url: string, context: string = ''): { score: number; evidence: string; hasNegative: boolean } {
+function scoreWith(
+  positive: KeywordWeight[],
+  negative: KeywordWeight[],
+  url: string,
+  context: string,
+): { score: number; evidence: string; hasNegative: boolean } {
   const decoded = `${normalize(url)} ${normalize(context)}`
   let score = 0
   let hasNegative = false
   const hits: string[] = []
-  for (const { pattern, weight } of POSITIVE_KEYWORDS) {
+  for (const { pattern, weight } of positive) {
     if (pattern.test(decoded)) {
       score += weight
       hits.push(`+${weight}:${pattern.source}`)
     }
   }
-  for (const { pattern, weight } of NEGATIVE_KEYWORDS) {
+  for (const { pattern, weight } of negative) {
     if (pattern.test(decoded)) {
       score += weight
       hasNegative = true
@@ -126,6 +185,14 @@ export function scoreCandidate(url: string, context: string = ''): { score: numb
     }
   }
   return { score, evidence: hits.join(' '), hasNegative }
+}
+
+export function scoreCandidate(url: string, context: string = ''): { score: number; evidence: string; hasNegative: boolean } {
+  return scoreWith(POSITIVE_KEYWORDS, NEGATIVE_KEYWORDS, url, context)
+}
+
+export function scoreDrinkCandidate(url: string, context: string = ''): { score: number; evidence: string; hasNegative: boolean } {
+  return scoreWith(DRINK_POSITIVE_KEYWORDS, DRINK_NEGATIVE_KEYWORDS, url, context)
 }
 
 interface RawMatch {

--- a/supabase/functions/menu-refresh/menu-candidates.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.ts
@@ -320,6 +320,26 @@ const SUB_MENU_NEGATIVE_TEXT = [
   /\bprivate\b/i,
 ]
 
+const DRINK_SUB_PAGE_PATH_PATTERNS = [
+  /\/(?:[\w-]*-)?cocktails?(?:-menu)?\/?$/i,
+  /\/(?:[\w-]*-)?drinks?(?:-menu)?\/?$/i,
+  /\/(?:[\w-]*-)?bar(?:-menu)?\/?$/i,
+  /\/(?:[\w-]*-)?beverages?(?:-menu)?\/?$/i,
+]
+
+const DRINK_SUB_PAGE_ANCHOR_PATTERNS = [
+  /\bcocktails?\b/i,
+  /\bdrinks?\b/i,
+  /\bbar\b/i,
+  /\bbeverages?\b/i,
+  /\bhappy[\s-]?hour(?:[\s-]?menu)?\b/i,
+]
+
+const DRINK_SUB_PAGE_NEGATIVE_TEXT = [
+  /\bfood\b/i, /\bdinner\b/i, /\blunch\b/i, /\bbrunch\b/i, /\bbreakfast\b/i,
+  /\bgift[\s-]?cards?\b/i, /\bcatering\b/i, /\bprivate\b/i, /\bevents?\b/i,
+]
+
 /**
  * Find sub-menu page URLs on a parent menu page. Used as Pattern 1 fallback
  * when the menu page itself yielded no dishes — many restaurants split their
@@ -376,6 +396,38 @@ export function findSubMenuPages(html: string, baseUrl: string, max = 4): string
       target = absolute.origin + absolute.pathname + absolute.search
     }
 
+    if (found.has(target)) continue
+    found.add(target)
+    out.push(target)
+    if (out.length >= max) break
+  }
+  return out
+}
+
+/**
+ * Find drinks/cocktail/bar sub-pages on a parent menu page. Mirror of
+ * findSubMenuPages but inverted: food anchors are disqualified, drink anchors
+ * qualify. Same-origin only; assets skipped; capped at `max` (default 1 —
+ * the drinks-recovery pass tries at most one source).
+ */
+export function findDrinkSubPages(html: string, baseUrl: string, max = 1): string[] {
+  const base = new URL(baseUrl)
+  const baseKey = base.origin + base.pathname + base.search
+  const found = new Set<string>([baseKey])
+  const out: string[] = []
+  const anchorRegex = /<a\b[^>]*\shref=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi
+  let m
+  while ((m = anchorRegex.exec(html)) !== null) {
+    let absolute: URL
+    try { absolute = new URL(m[1], base) } catch { continue }
+    if (absolute.origin !== base.origin) continue
+    if (PDF_EXT.test(absolute.href) || IMAGE_EXT.test(absolute.href)) continue
+    const innerText = stripTags(m[2]).replace(/&amp;/gi, '&').replace(/&#38;/g, '&').slice(0, 100)
+    if (DRINK_SUB_PAGE_NEGATIVE_TEXT.some(p => p.test(innerText))) continue
+    const pathMatches = DRINK_SUB_PAGE_PATH_PATTERNS.some(p => p.test(absolute.pathname))
+    const textMatches = DRINK_SUB_PAGE_ANCHOR_PATTERNS.some(p => p.test(innerText))
+    if (!pathMatches && !textMatches) continue
+    const target = absolute.origin + absolute.pathname + absolute.search
     if (found.has(target)) continue
     found.add(target)
     out.push(target)

--- a/supabase/functions/menu-refresh/menu-candidates.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.ts
@@ -385,6 +385,27 @@ export function findSubMenuPages(html: string, baseUrl: string, max = 4): string
 }
 
 /**
+ * Discover drinks-menu candidates (separate cocktail/coffee assets) on a page,
+ * scored with the inverted drink model and a SYMMETRIC positive gate
+ * (pdf > 0, image > 0). The food path passes PDFs at >= 0 because a restaurant
+ * PDF is usually a menu — that prior does NOT hold for drinks, so a neutral
+ * opaque PDF must not become the "best drinks asset" and burn the extra call.
+ * No neutral-image fallback. Sorted by score desc.
+ */
+export function discoverDrinkCandidates(html: string, baseUrl: string): MenuCandidate[] {
+  const raw = extractRawMatches(html, baseUrl)
+  const out: MenuCandidate[] = []
+  for (const r of raw) {
+    const type = classifyType(r.url)
+    if (!type) continue
+    const { score, evidence } = scoreDrinkCandidate(r.url, r.context)
+    if (score > 0) out.push({ url: r.url, type, score, source: r.source, evidence })
+  }
+  out.sort((a, b) => b.score - a.score)
+  return out
+}
+
+/**
  * Discover and score every menu candidate on the page, sorted by descending score.
  *
  * Threshold is asymmetric by type:


### PR DESCRIPTION
## Problem (Gap 6 of the menu-pipeline gap map)

The candidate scorer in `menu-candidates.ts` scores drink terms (`drinks/cocktails/wine/beer/spirits`) strongly negative so a wine list never outranks the food menu. Side effect: a **separate** `Cocktails.pdf` / `Drinks-Menu.png` / `/cocktails` sub-page is never sent to the LLM, so cocktails & coffee go missing whenever they're on a separate menu — which is most restaurants. This is a major contributor to the "drinks are wrong/missing" half of the ~50% menu-population failure rate.

## Fix — a parallel, additive "drinks recovery" pass

When a food extraction finds **fewer than 5** cocktail/coffee dishes **and** a dedicated drinks source exists, run **one** extra LLM extraction on the best drinks asset/sub-page with a drinks-only hint, filter to `cocktails`/`coffee`, and merge additively (dedup by name+section). Food extraction is never demoted or changed. Wired into both the main HTML path (after the BentoBox group backfill, before upsert) and the early-return direct-PDF branch.

- `scoreDrinkCandidate` + shared `scoreWith` (food scorer behavior provably unchanged)
- `discoverDrinkCandidates` — inverted scorer, **positive-only gate** (no wasted call on a blank PDF)
- `findDrinkSubPages` — `/cocktails`, `/drinks`, `/bar`, `/beverages`; excludes food **and** raw/oyster-bar (seafood) pages
- `runDrinkRecovery` helper; `extractionHint` param threaded into all 3 extractors
- Extractor fingerprint bumped `…|drinks-pass-v1` so existing restaurants pick it up

Spec: `docs/superpowers/specs/2026-06-09-drinks-extraction-fix-design.md`
Gap map: `docs/superpowers/specs/2026-06-09-menu-pipeline-gap-map.md`

## Test plan

- `npx vitest run supabase/functions/menu-refresh/menu-candidates.test.ts` → **125/125 pass** (new: scorer, discover, sub-page finder, raw-bar guard)
- `deno check` on `index.ts`: new code type-clean (only pre-existing `SupabaseClient` inference errors remain, present on main)
- Reviewed by 2 independent reviewers + 2 Codex (gpt-5.4 high) passes; all should-fixes applied

## Deploy checklist (manual — required before this helps users)

- [ ] Confirm Anthropic credit balance (fingerprint bump → gradual re-extraction)
- [ ] Deploy edge function to live project via Supabase dashboard (preserve the inlined SSRF guard)
- [ ] Live-verify on one real restaurant with a separate cocktail menu (cocktails/coffee appear, food unchanged, `error_context.drink_pass.triggered = true`)
- [ ] Targeted backfill SQL (only restaurants with <5 cocktail/coffee dishes) — see plan Task 7

## Known follow-ups (not in this PR, on purpose)

- Pre-existing same-name cross-category upsert clobber (e.g. coffee "Affogato" vs dessert) — shared upsert logic, needs its own test
- v2: rendered-HTML drink discovery for JS-CMS sites (Wix/Square)

🤖 Generated with [Claude Code](https://claude.com/claude-code)