### PR TITLE
fix(menu-refresh): capture JS-shell (SPA) menus + residential-proxy block escalation

### DIFF
--- a/docs/superpowers/specs/2026-06-09-spa-render-capture-design.md
+++ b/docs/superpowers/specs/2026-06-09-spa-render-capture-design.md
@@ -36,17 +36,25 @@ if (extractionContent.length < 50) {
 
 CMS detection stays only as a **timeout hint** — keep the existing `waitForTimeoutMs: 12000` (Wix needs the longest hydrate; it's a safe upper bound for generic SPAs too). `rendererAttempted = true` is still set so render fallback #2 doesn't double-render. Bounded: one extra Browserless render only for pages that previously bailed at `page_too_short` (near-certain shells), never for content-rich pages.
 
+**Asset-only render hole (Codex):** candidate rediscovery currently lives *inside* the `renderedText.length >= 50` block (`index.ts:~1702-1707`). A render that surfaces a JS-injected menu **image/PDF** but little body text would still bail at the `page_too_short` guard (`1715`) without ever trying those candidates. Two coupled changes:
+1. After a successful render, **always** re-run `candidates = mergeCandidates(candidates, discoverMenuCandidates(renderedHtml, menuUrl))` regardless of `renderedText` length (move it out of the `>=50` block, gated only on a non-empty `renderedHtml`).
+2. Soften the `page_too_short` guard at `1715` to `if (extractionContent.length < 50 && candidates.length === 0)` — only bail when there's neither text nor any asset candidate to try. (Asset extraction at `~1807` already runs before the HTML-text path, so surviving the guard with candidates present means they get tried.)
+
 ### Step 2 — Escalate to the residential `/unblock` proxy on a block
 
 `browserless.ts` already implements `fetchRenderedHtml(url, { useUnblock: true })` (residential proxy + `/unblock` pipeline) and throws `BrowserlessError` with `code: 'TARGET_ERROR'` when the target returns 4xx (e.g. Cloudflare/scraper 403). It is never invoked. Add a thin wrapper used by the menu-page render sites:
 
 ```ts
+// Block-like target statuses worth a residential-proxy retry. NOT all 4xx —
+// BrowserlessError code 'TARGET_ERROR' fires for any target >= 400 (browserless.ts),
+// so escalating on 404/410/500 would just waste residential units (Codex).
+const UNBLOCK_RETRY_STATUSES = new Set([401, 403, 429, 503])
+
 async function renderWithUnblockFallback(url, opts): Promise<string> {
   try {
     return await fetchRenderedHtml(url, opts)
   } catch (err) {
-    // Retry once via residential proxy only for target-side blocks (403/Cloudflare).
-    if (err instanceof BrowserlessError && (err.code === 'TARGET_ERROR' || err.status === 403)) {
+    if (err instanceof BrowserlessError && UNBLOCK_RETRY_STATUSES.has(err.status)) {
       return await fetchRenderedHtml(url, { ...opts, useUnblock: true })
     }
     throw err
@@ -56,7 +64,11 @@ async function renderWithUnblockFallback(url, opts): Promise<string> {
 
 Use `renderWithUnblockFallback` in place of the direct `fetchRenderedHtml` calls in render fallback #1 (`~1694`) and render fallback #2 (`~1986`). (Leave the iframe-host render path as-is for now — those are already gated to known menu hosts.)
 
-**Initial-fetch 403 recovery:** in the fetch catch (`index.ts:1485-1498`), today a `403` from `fetchRawHtml` writes `fetch_failed` and retries/dies. Before failing, if the classified error is a 4xx block (`classified.code === 'fetch_error'` and `context.http_status` ∈ {`401`,`403`,`429`}), attempt `renderWithUnblockFallback(menuUrl, { useUnblock: true, gotoTimeout: 45000, waitForTimeoutMs: 12000 })`; if it returns ≥50 chars of extractable text, synthesize `fetchResult = { type: 'html', html }`, set `rendererAttempted = true`, and continue the normal pipeline instead of failing. If the unblock render also fails/empty, fall through to today's `fetch_failed` behavior.
+**Initial-fetch 403 recovery:** in the fetch catch (`index.ts:1485-1498`), today a `403` from `fetchRawHtml` writes `fetch_failed` and retries/dies. Before failing, if the classified error is a block (`classified.code === 'fetch_error'` and `String(classified.context.http_status)` ∈ {`'401'`,`'403'`,`'429'`,`'503'`} — note `http_status` is stored as a **string** by `classifyError`, `index.ts:500`), attempt `renderWithUnblockFallback(menuUrl, { useUnblock: true, gotoTimeout: 45000, waitForTimeoutMs: 12000 })`; if it returns ≥50 chars of extractable text, synthesize `fetchResult = { type: 'html', html }` and continue the normal pipeline instead of failing.
+
+**State-ordering caveat (Codex):** the render-state vars (`rendererAttempted`, `renderSucceeded`, `renderError`, `renderedTextLen`) are declared at `index.ts:~1591`, *after* the fetch catch. So the catch cannot set `rendererAttempted = true` directly. Declare a `let prefetchRendered = false` **before** the `try`, set it `true` in the catch on a successful unblock recovery, and initialize `let rendererAttempted = prefetchRendered` at the existing declaration site. This prevents render fallback #2 (`~1984`, gated on `!rendererAttempted`) from double-rendering and keeps Step 3 telemetry correct. If the unblock render also fails/empty, fall through to today's `fetch_failed` behavior.
+
+**Caveat:** on this recovery path `rawHash` (`~1621`) hashes the *rendered* HTML, not the raw fetch — acceptable (the raw fetch was a 403 with no usable body). And a Cloudflare/access-denied block that returns a **verbose non-2xx HTML body** won't enter the fetch catch at all (`fetchRawHtml` tolerates long non-2xx HTML, `index.ts:~609-624`), so this recovery only helps *thrown* `HTTP 401/403/429/503`. Detecting verbose block pages is out of scope here.
 
 ### Step 3 — Never silent-dead (small, included)
 
@@ -66,7 +78,7 @@ When we still end at `page_too_short` *after* a render attempt (`index.ts:1715` 
 
 - Step 1 adds one render to jobs that previously bailed at `page_too_short` (shells only) — not to content-rich pages. Render fallback #2's existing sparse-text trigger already renders many of these on the 0-dishes path; Step 1 just moves the capture earlier for the empty-text case.
 - Step 2 adds at most ONE extra render (the `/unblock` retry), and only on a 403/Cloudflare block. Residential `/unblock` units cost more (per `browserless.ts` pricing notes) but fire rarely.
-- Each `fetchRenderedHtml` is ≤60s wall-clock; the queue processes 3 jobs/run with a 2s gap and a ~150s edge idle-timeout. Worst case a single job now does fetch + 1-2 renders + extraction — within budget, and the existing stalled-job recovery handles any timeout. **No change to per-run job count.**
+- Each `fetchRenderedHtml` is ≤60s wall-clock. **Queue mode** (the user-add path) claims **3** jobs/run (`claim_menu_import_jobs` p_limit:3); **batch fallback mode** processes up to `MAX_RESTAURANTS_PER_RUN = 10` (`index.ts:337`). A single slow job doing fetch + 1-2 renders + extraction can consume most of the ~150s edge idle-timeout (`index.ts:~2321`). This is **timeout-recoverable**, not comfortably-within-budget: the batch pre-stamp + stalled-job recovery (5-min lock reset) re-queue any job killed mid-render, so a timeout costs a retry, not a stuck row. **No change to per-run job count.**
 - `BROWSERLESS_API_KEY` must be set on the deployed function (it already is — render fallbacks #1/#2 use it today).
 
 ## Safety / non-regression

--- a/docs/superpowers/specs/2026-06-09-spa-render-capture-design.md
+++ b/docs/superpowers/specs/2026-06-09-spa-render-capture-design.md
@@ -1,0 +1,92 @@
+# SPA Render Capture + Block Escalation — Design Spec
+
+**Date:** 2026-06-09
+**Gap:** reachability (Gap 7 family) — the "blank on JS-shell sites" failure (e.g. Aalia's).
+**Scope:** `supabase/functions/menu-refresh/` only. No frontend, no schema.
+
+## Problem (diagnosed live on Aalia's)
+
+Aalia's enqueue returned `error_code: page_too_short`, `drink_pass: null`. Root cause in `index.ts`:
+
+```ts
+// Render fallback #1  (index.ts:1692)
+if (extractionContent.length < 50 && cmsRequiresRender(cms)) { ...render... }
+```
+
+`cmsRequiresRender` (`cms-detect.ts`) returns true ONLY for `wix`/`square`/`weebly`. Aalia's is a custom React/Next SPA — not a recognized CMS — so the render is skipped, and the code bails at the `page_too_short` gate (`index.ts:1715`) → `dead`. **The browser-render tool that would capture it is gated on recognizing the brand of shell.** Any custom SPA whose raw HTML is an empty shell dies the same way.
+
+(Note: render fallback #2 at `index.ts:1984` *does* fire on `rawTextLen < SPARSE_TEXT_THRESHOLD` regardless of CMS — but it's on the **0-dishes** path, which a `<50`-char page never reaches because `page_too_short` exits first.)
+
+## Goal
+
+Capture JS-shell sites (custom SPAs, not just known CMSs) by rendering whenever the raw page is empty, and recover 403/Cloudflare-blocked sites via the residential `/unblock` proxy that already exists in `browserless.ts` but is never called. Never silent-dead: a page we still can't read gets flagged for manual import, not buried.
+
+## Design
+
+### Step 1 — Render on *thinness*, not CMS brand (the Aalia's killer)
+
+Change render fallback #1 (`index.ts:1692`) to fire whenever the extracted text is empty, regardless of detected CMS — an empty text body *is* a JS shell by definition:
+
+```ts
+// before:
+if (extractionContent.length < 50 && cmsRequiresRender(cms)) {
+// after:
+if (extractionContent.length < 50) {
+```
+
+CMS detection stays only as a **timeout hint** — keep the existing `waitForTimeoutMs: 12000` (Wix needs the longest hydrate; it's a safe upper bound for generic SPAs too). `rendererAttempted = true` is still set so render fallback #2 doesn't double-render. Bounded: one extra Browserless render only for pages that previously bailed at `page_too_short` (near-certain shells), never for content-rich pages.
+
+### Step 2 — Escalate to the residential `/unblock` proxy on a block
+
+`browserless.ts` already implements `fetchRenderedHtml(url, { useUnblock: true })` (residential proxy + `/unblock` pipeline) and throws `BrowserlessError` with `code: 'TARGET_ERROR'` when the target returns 4xx (e.g. Cloudflare/scraper 403). It is never invoked. Add a thin wrapper used by the menu-page render sites:
+
+```ts
+async function renderWithUnblockFallback(url, opts): Promise<string> {
+  try {
+    return await fetchRenderedHtml(url, opts)
+  } catch (err) {
+    // Retry once via residential proxy only for target-side blocks (403/Cloudflare).
+    if (err instanceof BrowserlessError && (err.code === 'TARGET_ERROR' || err.status === 403)) {
+      return await fetchRenderedHtml(url, { ...opts, useUnblock: true })
+    }
+    throw err
+  }
+}
+```
+
+Use `renderWithUnblockFallback` in place of the direct `fetchRenderedHtml` calls in render fallback #1 (`~1694`) and render fallback #2 (`~1986`). (Leave the iframe-host render path as-is for now — those are already gated to known menu hosts.)
+
+**Initial-fetch 403 recovery:** in the fetch catch (`index.ts:1485-1498`), today a `403` from `fetchRawHtml` writes `fetch_failed` and retries/dies. Before failing, if the classified error is a 4xx block (`classified.code === 'fetch_error'` and `context.http_status` ∈ {`401`,`403`,`429`}), attempt `renderWithUnblockFallback(menuUrl, { useUnblock: true, gotoTimeout: 45000, waitForTimeoutMs: 12000 })`; if it returns ≥50 chars of extractable text, synthesize `fetchResult = { type: 'html', html }`, set `rendererAttempted = true`, and continue the normal pipeline instead of failing. If the unblock render also fails/empty, fall through to today's `fetch_failed` behavior.
+
+### Step 3 — Never silent-dead (small, included)
+
+When we still end at `page_too_short` *after* a render attempt (`index.ts:1715` branch, with `rendererAttempted === true`), also set `needs_manual_menu = true` on the restaurant before the job update, so an unreadable site surfaces in the manual-import queue (and the future photo-OCR path) instead of dying invisibly. Pure-additive flag; doesn't change retry/dead logic.
+
+## Cost / timeout
+
+- Step 1 adds one render to jobs that previously bailed at `page_too_short` (shells only) — not to content-rich pages. Render fallback #2's existing sparse-text trigger already renders many of these on the 0-dishes path; Step 1 just moves the capture earlier for the empty-text case.
+- Step 2 adds at most ONE extra render (the `/unblock` retry), and only on a 403/Cloudflare block. Residential `/unblock` units cost more (per `browserless.ts` pricing notes) but fire rarely.
+- Each `fetchRenderedHtml` is ≤60s wall-clock; the queue processes 3 jobs/run with a 2s gap and a ~150s edge idle-timeout. Worst case a single job now does fetch + 1-2 renders + extraction — within budget, and the existing stalled-job recovery handles any timeout. **No change to per-run job count.**
+- `BROWSERLESS_API_KEY` must be set on the deployed function (it already is — render fallbacks #1/#2 use it today).
+
+## Safety / non-regression
+
+- Step 1 only loosens a gate in the **content < 50** branch — content-rich pages are unaffected.
+- `renderWithUnblockFallback` is a strict superset of `fetchRenderedHtml`: same behavior unless the error is a target-side block, in which case it retries once. Non-block errors propagate unchanged.
+- Initial-403 recovery only triggers on 401/403/429 and only *adds* a recovery attempt before the existing failure path — it can't make a currently-succeeding fetch worse.
+- No fingerprint bump (extractor output schema unchanged). Restaurants stuck at `page_too_short`/`fetch_failed` will be re-attempted on their next cron/backoff; a targeted re-enqueue of `error_code IN ('page_too_short','fetch_error')` rows accelerates it.
+- SSRF: `/unblock` fetches the same restaurant-controlled `menuUrl` already validated/used by the normal render path; no new target surface (Browserless fetches it server-side either way).
+
+## Testing
+
+- `cms-detect.test.ts` (Vitest) already covers detection; no change there.
+- The render-gating + escalation live in the Deno `index.ts` (not Vitest-reachable). Verify with `deno check` (new code type-clean; only pre-existing `SupabaseClient` errors remain) + a **live run on Aalia's**: re-enqueue → expect the render to fire (no longer `page_too_short`) and either dishes extracted or, if still unreadable, `needs_manual_menu = true` instead of a bare dead job.
+- If `renderWithUnblockFallback` is extracted into a tiny pure helper, add a Vitest/Deno unit test asserting it retries with `useUnblock` only on `TARGET_ERROR`/403 and rethrows other errors. (Optional — the branch logic is small; live run is the primary check.)
+
+## Deploy
+
+Edge-function deploy via Supabase dashboard (same reconciliation as the drinks fix — SSRF inlined into `menu-candidates.ts`, no `_shared/` import). Confirm `BROWSERLESS_API_KEY` env is set on the function. Optional targeted re-enqueue of `page_too_short`/`fetch_error` restaurants after deploy.
+
+## Out of scope
+
+Menu-URL discovery (the separate `2026-06-09-menu-url-reachability-fix-design.md`), and the photo-OCR human fallback (the only fix for sites with no machine-readable menu anywhere — the real 100% closer).

--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -1297,6 +1297,26 @@ async function upsertDishes(
   }
 }
 
+// Block-like target statuses worth a residential-proxy retry. NOT all 4xx —
+// BrowserlessError 'TARGET_ERROR' fires for any target >= 400, so escalating on
+// 404/410/500 would waste residential units.
+const UNBLOCK_RETRY_STATUSES = new Set([401, 403, 429, 503])
+
+/**
+ * fetchRenderedHtml wrapper: on a target-side BLOCK (401/403/429/503), retry
+ * once through the residential /unblock proxy. Non-block errors propagate.
+ */
+async function renderWithUnblockFallback(url: string, opts: Parameters<typeof fetchRenderedHtml>[1] = {}): Promise<string> {
+  try {
+    return await fetchRenderedHtml(url, opts)
+  } catch (err) {
+    if (err instanceof BrowserlessError && UNBLOCK_RETRY_STATUSES.has(err.status)) {
+      return await fetchRenderedHtml(url, { ...opts, useUnblock: true })
+    }
+    throw err
+  }
+}
+
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders })
@@ -1479,24 +1499,51 @@ serve(async (req) => {
           }
 
           // --- Fetch + extract (with render fallback for JS-rendered sites) ---
-          let fetchResult: MenuFetchResult
+          // eslint-disable-next-line prefer-const
+          let fetchResult: MenuFetchResult = null!
+          let prefetchRendered = false
           try {
             fetchResult = await fetchRawHtml(menuUrl)
           } catch (fetchErr) {
             const classified = classifyError(fetchErr)
-            const newAttemptCount = job.attempt_count + 1
-            await supabase.from('menu_import_jobs').update({
-              status: newAttemptCount >= job.max_attempts ? 'dead' : 'pending',
-              attempt_count: newAttemptCount,
-              run_after: newAttemptCount >= job.max_attempts ? undefined : calculateBackoff(newAttemptCount).toISOString(),
-              error_code: classified.code,
-              error_message: classified.message,
-              error_context: { ...classified.context, menu_url: menuUrl },
-              lock_expires_at: null,
-              updated_at: new Date().toISOString(),
-            }).eq('id', job.id)
-            results.push({ job_id: job.id, status: 'fetch_failed', restaurant: restaurant.name, error: classified.code })
-            continue
+            // Recovery: if the raw fetch was blocked (401/403/429/503), attempt
+            // a residential-proxy render before declaring fetch_failed. On
+            // success, synthesize an html fetchResult and fall through to normal
+            // processing; on failure, keep today's fetch_failed behaviour.
+            let recovered = false
+            if (
+              classified.code === 'fetch_error' &&
+              ['401', '403', '429', '503'].includes(String(classified.context?.http_status))
+            ) {
+              try {
+                const html = await renderWithUnblockFallback(menuUrl, { useUnblock: true, gotoTimeout: 45000, waitForTimeoutMs: 12000 })
+                const recoveredText = extractMenuTextFromHtml(html)
+                if (recoveredText.length >= 50) {
+                  fetchResult = { type: 'html', html }
+                  prefetchRendered = true
+                  recovered = true
+                } else {
+                  throw new Error('unblock recovery empty')
+                }
+              } catch {
+                // fall through to fetch_failed below
+              }
+            }
+            if (!recovered) {
+              const newAttemptCount = job.attempt_count + 1
+              await supabase.from('menu_import_jobs').update({
+                status: newAttemptCount >= job.max_attempts ? 'dead' : 'pending',
+                attempt_count: newAttemptCount,
+                run_after: newAttemptCount >= job.max_attempts ? undefined : calculateBackoff(newAttemptCount).toISOString(),
+                error_code: classified.code,
+                error_message: classified.message,
+                error_context: { ...classified.context, menu_url: menuUrl },
+                lock_expires_at: null,
+                updated_at: new Date().toISOString(),
+              }).eq('id', job.id)
+              results.push({ job_id: job.id, status: 'fetch_failed', restaurant: restaurant.name, error: classified.code })
+              continue
+            }
           }
 
           // Direct-PDF shortcut: menu_url served `application/pdf` (Squarespace
@@ -1588,7 +1635,7 @@ serve(async (req) => {
           const rawText = extractMenuTextFromHtml(rawHtml)
           const rawTextLen = rawText.length
           let extractionContent = rawText
-          let rendererAttempted = false
+          let rendererAttempted = prefetchRendered
           let renderSucceeded = false
           let renderError: string | null = null
           let renderedTextLen: number | null = null
@@ -1688,12 +1735,13 @@ serve(async (req) => {
             }
           }
 
-          // Render fallback #1: content too short AND CMS requires rendering
-          if (extractionContent.length < 50 && cmsRequiresRender(cms)) {
-            console.log(`${restaurant.name}: content too short + ${cms} CMS, attempting render fallback`)
+          // Render fallback #1: content too short — fire for ANY JS shell,
+          // not just known CMSs. An empty text body is a JS shell by definition.
+          if (extractionContent.length < 50) {
+            console.log(`${restaurant.name}: content too short (cms: ${cms}), attempting render fallback`)
             rendererAttempted = true  // mark ATTEMPTED regardless of outcome
             try {
-              const renderedHtml = await fetchRenderedHtml(menuUrl, {
+              const renderedHtml = await renderWithUnblockFallback(menuUrl, {
                 gotoTimeout: 45000,
                 waitForTimeoutMs: 12000,  // Wix needs time to hydrate menu API data
               })
@@ -1702,8 +1750,11 @@ serve(async (req) => {
               if (renderedText.length >= 50) {
                 extractionContent = renderedText
                 renderSucceeded = true
-                // Re-discover candidates from the rendered HTML — JS-injected menu
-                // PDFs/images are invisible in raw HTML.
+              }
+              // Always re-discover candidates from the rendered HTML, even when
+              // renderedText is short — a JS-injected menu image/PDF link is
+              // useful even with near-zero body text.
+              if (renderedHtml.length > 0) {
                 candidates = mergeCandidates(candidates, discoverMenuCandidates(renderedHtml, menuUrl))
               }
             } catch (renderErr) {
@@ -1712,7 +1763,16 @@ serve(async (req) => {
             }
           }
 
-          if (extractionContent.length < 50) {
+          // Only bail here when there is neither usable text NOR any asset
+          // candidate to try — a render may have surfaced PDF/image candidates
+          // even when body text is thin, and asset extraction at ~1807 will
+          // try those candidates when we survive this guard.
+          if (extractionContent.length < 50 && candidates.length === 0) {
+            // If we already attempted a render and still can't read the page,
+            // flag it for manual import so it surfaces in the queue.
+            if (rendererAttempted) {
+              await supabase.from('restaurants').update({ needs_manual_menu: true }).eq('id', restaurant.id)
+            }
             const classified = classifyError(null, 'page_too_short')
             const newAttemptCount = job.attempt_count + 1
             await supabase.from('menu_import_jobs').update({
@@ -1985,7 +2045,7 @@ serve(async (req) => {
             console.log(`${restaurant.name}: Sonnet found 0 dishes in ${cms} site, attempting render fallback`)
             rendererAttempted = true  // mark ATTEMPTED regardless of outcome
             try {
-              const renderedHtml = await fetchRenderedHtml(menuUrl, {
+              const renderedHtml = await renderWithUnblockFallback(menuUrl, {
                 gotoTimeout: 45000,
                 waitForTimeoutMs: 12000,  // Wix needs time to hydrate menu API data
               })


### PR DESCRIPTION
## Problem (diagnosed live on Aalia's)

Aalia's — a custom React/Next SPA — died with `error_code: page_too_short`. Root cause: render fallback #1 was gated on `cmsRequiresRender(cms)`, which only matches **wix/square/weebly**. Any custom SPA whose raw HTML is an empty shell skips the render entirely and bails to `page_too_short` → `dead`. The browser-render tool that would capture it was gated on recognizing the *brand* of shell.

## Fix — render escalation ladder

1. **Render on thinness, not CMS brand** — render fallback #1 now fires whenever the extracted text is `< 50` chars (an empty body *is* a JS shell). CMS detection stays only as a hydrate-timeout hint. **This is the Aalia's killer.**
2. **Residential `/unblock` escalation** — `browserless.ts` already had `useUnblock` (residential proxy) but it was never called. New `renderWithUnblockFallback` retries once via `/unblock` on a target-side block (401/403/429/503), used by render fallbacks #1/#2; and a thrown 403/Cloudflare on the *initial* fetch now attempts an unblock-render recovery before failing.
3. **Asset rediscovery on render** — candidate rediscovery moved out of the `renderedText ≥ 50` block, and the `page_too_short` guard softened to `< 50 && candidates.length === 0`, so a render that surfaces a JS-injected menu *image/PDF* (but little text) still gets extracted.
4. **Never silent-dead** — when a rendered page is still unreadable, set `needs_manual_menu = true` so it surfaces for manual/photo import instead of dying invisibly.

Spec: `docs/superpowers/specs/2026-06-09-spa-render-capture-design.md`

## ⚠️ Stacking note

This branch is cut from `main` and does **NOT** include the drinks fix (PR #317), which also edits `index.ts`. To deploy both together: merge #317 first, then rebase this branch — or use a combined deploy bundle. Do not deploy this branch's `index.ts` alone over a live function that already has the drinks fix (it would revert drinks). `menu-candidates.ts` is unchanged by this PR.

## Test plan

- `deno check` on `index.ts`: new code type-clean (only pre-existing `SupabaseClient` errors, present on main).
- Reviewed by an independent reviewer + Codex (gpt-5.4 high) — both APPROVED, no must-fix.
- Live verification: re-enqueue Aalia's → expect the render to fire (no longer `page_too_short`); either dishes extracted, or `needs_manual_menu = true` instead of a bare dead job.

## Bounded cost

Render-on-thin only fires on pages that previously bailed at `page_too_short` (shells); `/unblock` retry fires only on block statuses. Per-run job count unchanged; timeouts remain recoverable via the existing pre-stamp + stalled-job recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)