### PR TITLE
feat(menu): reliable enqueue (DB trigger) + transient-dead retry (Gaps 1/3)

### DIFF
--- a/docs/superpowers/specs/2026-06-09-reliable-enqueue-design.md
+++ b/docs/superpowers/specs/2026-06-09-reliable-enqueue-design.md
@@ -1,0 +1,89 @@
+# Reliable Enqueue + Transient Retry — Design Spec
+
+**Date:** 2026-06-09
+**Gaps:** #1 + #3 in `2026-06-09-menu-pipeline-gap-map.md`.
+**Scope:** one SQL migration (DB trigger + cron change). No edge-fn or frontend code changes required (frontend `createJob` stays as-is, belt-and-suspenders).
+
+## Problem
+
+- **Gap 1 — enqueue is fire-and-forget + swallowed.** `AddRestaurantModal.jsx` does `menuImportApi.createJob(...).catch(err => logger.warn(...))`. If that RPC call fails (network/RLS/transient), the restaurant row exists with **no import job and nothing ever retries** → permanent blank.
+- **Gap 3 — dead jobs frozen 30 days, even on transient failures.** After 3 attempts a job → `dead`. The nightly `create-menu-refresh-jobs` cron skips any restaurant with a dead job <30 days old. A transient outage (Browserless down, Anthropic 429, DNS blip) burns all 3 attempts in ~3.5h (backoff 5→30→180 min) → `dead` → blank for a month even after the cause clears.
+
+## Design
+
+### Part A (Gap 1) — DB-trigger enqueue (structural guarantee)
+Add an `AFTER INSERT ON restaurants` trigger that enqueues the initial job, so a restaurant **cannot** exist without a job regardless of whether the client call succeeds:
+
+```sql
+CREATE OR REPLACE FUNCTION trg_enqueue_menu_import_on_restaurant() RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  -- Only user-created restaurants (the Gap 1 fire-and-forget case). Discovery /
+  -- bulk-seed inserts (created_by NULL) are left to the nightly stale-refresh cron
+  -- so a large discovery batch can't flood the queue.
+  IF NEW.created_by IS NOT NULL THEN
+    PERFORM enqueue_menu_import(NEW.id, 'initial', 10);
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS enqueue_menu_import_on_restaurant ON restaurants;
+CREATE TRIGGER enqueue_menu_import_on_restaurant
+  AFTER INSERT ON restaurants
+  FOR EACH ROW EXECUTE FUNCTION trg_enqueue_menu_import_on_restaurant();
+```
+
+- `enqueue_menu_import` is already idempotent (partial-unique index `one_active_per_restaurant` + `ON CONFLICT DO NOTHING`), so the trigger + the frontend's belt-and-suspenders `createJob` call can both fire and only one job is created.
+- SECURITY DEFINER lets the trigger insert into the service-role-only `menu_import_jobs`.
+- The trigger fires inside the insert transaction, so by the time `restaurantsApi.create()` returns, the job exists. The frontend `createJob` stays (it returns `job_id` for status polling and is harmless/idempotent).
+- **Gating on `created_by IS NOT NULL`** scopes this precisely to the user-add case (Gap 1) and avoids enqueuing a job per row on a `discover-restaurants` / backfill batch.
+
+### Part B (Gap 3) — transient-vs-terminal dead retry
+Classify `error_code`s:
+- **TRANSIENT** (self-heals; re-enqueue soon): `fetch_timeout`, `dns_error`, `claude_error`, `unknown_error`.
+- **TERMINAL** (won't change on its own; rely on the photo fallback / longer wait): `no_menu_url`, `no_dishes`, `page_too_short`, `parse_error`, `fetch_error`.
+
+Modify the nightly `create-menu-refresh-jobs` cron's dead-exclusion so a **transient** dead older than 6 hours no longer blocks re-enqueue, while **terminal** deads keep the 30-day exclusion:
+
+```sql
+AND NOT EXISTS (
+  SELECT 1 FROM menu_import_jobs mij
+  WHERE mij.restaurant_id = r.id AND mij.status = 'dead'
+    AND (
+      (mij.error_code NOT IN ('fetch_timeout','dns_error','claude_error','unknown_error')
+         AND mij.created_at > NOW() - INTERVAL '30 days')
+      OR (mij.error_code IN ('fetch_timeout','dns_error','claude_error','unknown_error')
+         AND mij.created_at > NOW() - INTERVAL '6 hours')
+    )
+)
+```
+
+- A restaurant whose only recent deads are transient + >6h old becomes eligible at the next nightly run → self-heals within ~1 day instead of 30.
+- The cron still requires `menu_url IS NOT NULL`, so `no_menu_url` deads (no URL) are not resurrected here — those are the photo-fallback's job (#320). That's the right division.
+- Cadence note: the cron runs daily (3am), so transient recovery is "within a day," not minutes. A dedicated hourly resurrect-transient cron would tighten that; deferred as a v2 (daily is already a 30×improvement).
+
+The edge function's per-job retry (3 attempts, exponential backoff) is unchanged — Part B only changes when a *dead* job gets a fresh job created.
+
+## Migration `2026-06-09-reliable-enqueue.sql`
+1. The trigger function + trigger (Part A).
+2. `cron.unschedule('create-menu-refresh-jobs')` then `cron.schedule(...)` with the new dead-exclusion (Part B). Copy the existing cron body verbatim except the dead-exclusion block. (This cron is a pure SQL INSERT — no `net.http_post`/vault secret, unlike the queue-processor cron.)
+3. `-- ROLLBACK:` block (drop trigger + function; reschedule the cron with the original 30-day-only exclusion).
+
+## Safety / non-regression
+- Trigger is additive + idempotent; worst case a duplicate enqueue attempt that the unique index absorbs. Gated to user-created rows.
+- Cron change only *loosens* the dead-exclusion for transient errors — it can't cause a terminal/no-URL restaurant to be re-tried in a tight loop (those stay excluded 30 days), and active-job + staleness guards are unchanged, so it won't double-enqueue or re-burn Sonnet on fresh rows.
+- No change to the queue processor, the per-job backoff, or the frontend.
+
+## Testing
+- Migrations aren't unit-testable here; verify by:
+  - Insert a restaurant with a `created_by` → confirm a `menu_import_jobs` row appears (trigger). Insert one with `created_by = NULL` → confirm NO job (gating).
+  - Confirm `cron.job` shows the rescheduled `create-menu-refresh-jobs` with the new command (`SELECT jobname, command FROM cron.job WHERE jobname='create-menu-refresh-jobs'`).
+  - Spot: a restaurant with a 7-hour-old `dead` job whose `error_code='claude_error'` is now eligible for the nightly re-enqueue; one with `error_code='no_dishes'` is not.
+- Codex-review the migration before deploy.
+
+## Deploy
+Run the migration in the Supabase SQL editor (it `unschedule`s + reschedules the cron and creates the trigger). Idempotent (`CREATE OR REPLACE`, `DROP ... IF EXISTS`). No edge-fn redeploy, no app build.
+
+## Out of scope
+Gap 2 (no-URL restaurants) — covered by the photo fallback. A faster (hourly) transient-resurrect cron — deferred.

--- a/supabase/migrations/2026-06-09-reliable-enqueue.sql
+++ b/supabase/migrations/2026-06-09-reliable-enqueue.sql
@@ -104,13 +104,13 @@ SELECT cron.schedule(
           (NOT (
              mij.error_code IN ('fetch_timeout','dns_error','claude_error','unknown_error')
              OR (mij.error_code = 'fetch_error'
-                 AND (mij.error_context->>'http_status') ~ '^(408|425|429|5[0-9][0-9])$')
+                 AND COALESCE(mij.error_context->>'http_status', '') ~ '^(408|425|429|5[0-9][0-9])$')
            ) AND mij.created_at > NOW() - INTERVAL '30 days')
           -- TRANSIENT deads: only a 6-hour cooldown, then re-enqueue-eligible
           OR (
              (mij.error_code IN ('fetch_timeout','dns_error','claude_error','unknown_error')
               OR (mij.error_code = 'fetch_error'
-                  AND (mij.error_context->>'http_status') ~ '^(408|425|429|5[0-9][0-9])$'))
+                  AND COALESCE(mij.error_context->>'http_status', '') ~ '^(408|425|429|5[0-9][0-9])$'))
              AND mij.created_at > NOW() - INTERVAL '6 hours')
         )
     )

--- a/supabase/migrations/2026-06-09-reliable-enqueue.sql
+++ b/supabase/migrations/2026-06-09-reliable-enqueue.sql
@@ -1,0 +1,139 @@
+-- Reliable enqueue + transient-dead retry (Gaps 1/3)
+-- Spec: docs/superpowers/specs/2026-06-09-reliable-enqueue-design.md
+-- Run in Supabase SQL editor. Idempotent.
+--
+-- Part A: a user-created restaurant ALWAYS gets an import job (DB trigger),
+--   even if the frontend fire-and-forget createJob call fails (Gap 1). Also
+--   re-enqueues when an operator later adds a website/menu URL to a restaurant
+--   that had none.
+-- Part B: a job that died from a TRANSIENT error self-heals within ~a day
+--   instead of being frozen for 30 days (Gap 3).
+
+-- ───────────────────────── Part A: trigger ─────────────────────────
+-- Invoker rights (NOT security definer): the privileged write already lives in
+-- enqueue_menu_import (SECURITY DEFINER; authenticated has EXECUTE). The PERFORM
+-- is wrapped so an enqueue failure can NEVER abort the restaurant insert/update.
+-- enqueue_menu_import is idempotent (one_active_per_restaurant partial unique
+-- index + ON CONFLICT DO NOTHING), so trigger + the frontend's belt-and-suspenders
+-- createJob both firing is safe.
+CREATE OR REPLACE FUNCTION trg_enqueue_menu_import_on_restaurant()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $fn$
+BEGIN
+  -- Only user-created restaurants (the Gap 1 case). Discovery / bulk-seed rows
+  -- (created_by NULL) are left to the nightly stale-refresh cron so a large
+  -- discovery batch can't flood the queue at insert time.
+  IF NEW.created_by IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- On UPDATE, only act when a URL went from absent -> present (operator filled
+  -- in a website/menu later). Any other update is a no-op. This is safe against
+  -- the queue processor's own menu_url/website_url discovery writes: those happen
+  -- while a job is 'processing', so the enqueue below is absorbed by the
+  -- active-job unique index (ON CONFLICT DO NOTHING).
+  IF TG_OP = 'UPDATE' THEN
+    IF NOT (
+      (OLD.website_url IS NULL AND OLD.menu_url IS NULL)
+      AND (NEW.website_url IS NOT NULL OR NEW.menu_url IS NOT NULL)
+    ) THEN
+      RETURN NEW;
+    END IF;
+  END IF;
+
+  BEGIN
+    PERFORM enqueue_menu_import(NEW.id, 'initial', 10);
+  EXCEPTION WHEN OTHERS THEN
+    -- Never let an enqueue hiccup abort the restaurant write (that's the whole
+    -- point of Gap 1 — resilience). Log loudly instead.
+    RAISE WARNING 'trg_enqueue_menu_import_on_restaurant: enqueue failed for restaurant %: %', NEW.id, SQLERRM;
+  END;
+
+  RETURN NEW;
+END;
+$fn$;
+
+DROP TRIGGER IF EXISTS enqueue_menu_import_on_restaurant ON restaurants;
+CREATE TRIGGER enqueue_menu_import_on_restaurant
+  AFTER INSERT OR UPDATE OF website_url, menu_url ON restaurants
+  FOR EACH ROW EXECUTE FUNCTION trg_enqueue_menu_import_on_restaurant();
+
+-- ───────────────────────── Part B: transient-dead retry ─────────────────────────
+-- Rewrites the CURRENT create-menu-refresh-jobs cron (2026-05-20 version, which
+-- added the extractor_fingerprint IS NULL self-requeue + ON CONFLICT guard —
+-- both PRESERVED here). The ONLY change is the dead-job exclusion: a dead job
+-- whose error is TRANSIENT (network/timeout/Claude/unknown, or a 408/425/429/5xx
+-- fetch_error) now only blocks re-enqueue for 6 hours; TERMINAL deads keep the
+-- 30-day cooldown. So a transient outage self-heals at the next nightly tick
+-- instead of staying blank for a month.
+DO $unschedule$
+BEGIN
+  PERFORM cron.unschedule('create-menu-refresh-jobs');
+EXCEPTION WHEN OTHERS THEN
+  RAISE NOTICE 'create-menu-refresh-jobs was not scheduled; skipping unschedule';
+END
+$unschedule$;
+
+SELECT cron.schedule(
+  'create-menu-refresh-jobs',
+  '0 3 * * *',
+  $cron$
+  INSERT INTO menu_import_jobs (restaurant_id, job_type, priority)
+  SELECT r.id, 'refresh', 0
+  FROM restaurants r
+  WHERE r.is_open = true
+    AND r.menu_url IS NOT NULL
+    AND (
+      r.menu_last_checked IS NULL
+      OR r.menu_last_checked < NOW() - INTERVAL '14 days'
+      OR r.extractor_fingerprint IS NULL
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM menu_import_jobs mij
+      WHERE mij.restaurant_id = r.id
+        AND mij.status IN ('pending', 'processing')
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM menu_import_jobs mij
+      WHERE mij.restaurant_id = r.id
+        AND mij.status = 'dead'
+        AND (
+          -- TERMINAL deads: 30-day cooldown
+          (NOT (
+             mij.error_code IN ('fetch_timeout','dns_error','claude_error','unknown_error')
+             OR (mij.error_code = 'fetch_error'
+                 AND (mij.error_context->>'http_status') ~ '^(408|425|429|5[0-9][0-9])$')
+           ) AND mij.created_at > NOW() - INTERVAL '30 days')
+          -- TRANSIENT deads: only a 6-hour cooldown, then re-enqueue-eligible
+          OR (
+             (mij.error_code IN ('fetch_timeout','dns_error','claude_error','unknown_error')
+              OR (mij.error_code = 'fetch_error'
+                  AND (mij.error_context->>'http_status') ~ '^(408|425|429|5[0-9][0-9])$'))
+             AND mij.created_at > NOW() - INTERVAL '6 hours')
+        )
+    )
+  ON CONFLICT (restaurant_id) WHERE status IN ('pending', 'processing') DO NOTHING
+  $cron$
+);
+
+-- Verify:
+--   SELECT jobname, schedule, substring(command,1,200) FROM cron.job WHERE jobname='create-menu-refresh-jobs';
+--   -- trigger present:
+--   SELECT tgname FROM pg_trigger WHERE tgrelid='restaurants'::regclass AND tgname='enqueue_menu_import_on_restaurant';
+
+-- ───────────────────────── ROLLBACK ─────────────────────────
+-- DROP TRIGGER IF EXISTS enqueue_menu_import_on_restaurant ON restaurants;
+-- DROP FUNCTION IF EXISTS trg_enqueue_menu_import_on_restaurant();
+-- -- Restore the pre-this-migration cron (2026-05-20 body: 30-day-only dead exclusion):
+-- DO $rb$ BEGIN PERFORM cron.unschedule('create-menu-refresh-jobs'); EXCEPTION WHEN OTHERS THEN NULL; END $rb$;
+-- SELECT cron.schedule('create-menu-refresh-jobs','0 3 * * *', $cron$
+--   INSERT INTO menu_import_jobs (restaurant_id, job_type, priority)
+--   SELECT r.id, 'refresh', 0 FROM restaurants r
+--   WHERE r.is_open = true AND r.menu_url IS NOT NULL
+--     AND (r.menu_last_checked IS NULL OR r.menu_last_checked < NOW() - INTERVAL '14 days' OR r.extractor_fingerprint IS NULL)
+--     AND NOT EXISTS (SELECT 1 FROM menu_import_jobs mij WHERE mij.restaurant_id=r.id AND mij.status IN ('pending','processing'))
+--     AND NOT EXISTS (SELECT 1 FROM menu_import_jobs mij WHERE mij.restaurant_id=r.id AND mij.status='dead' AND mij.created_at > NOW() - INTERVAL '30 days')
+--   ON CONFLICT (restaurant_id) WHERE status IN ('pending','processing') DO NOTHING
+-- $cron$);


### PR DESCRIPTION
## Closes the two "permanent blank" black holes (Gaps 1/3)

A single SQL migration — no edge-fn or frontend changes.

**Gap 1 — enqueue can silently fail.** `AddRestaurantModal` does `createJob(...).catch(logger.warn)`; if that RPC hiccups, the restaurant exists with no job and nothing retries. → **DB trigger** `AFTER INSERT OR UPDATE OF website_url, menu_url ON restaurants` (gated `created_by IS NOT NULL`) enqueues the initial job. A user-created restaurant now *cannot* exist without a job. Idempotent (rides `enqueue_menu_import`'s `ON CONFLICT`), invoker-rights, and the `PERFORM` is exception-wrapped so a failed enqueue can never abort the restaurant write. The UPDATE arm also self-heals a restaurant when an operator later adds a website/menu URL that was previously absent.

**Gap 3 — transient failures froze restaurants for 30 days.** A Browserless/Anthropic/DNS blip burns 3 attempts in ~3.5h → `dead` → the nightly cron skipped it for 30 days. → The `create-menu-refresh-jobs` cron's dead-exclusion now distinguishes **transient** (`fetch_timeout`/`dns_error`/`claude_error`/`unknown_error`, or a `408/425/429/5xx` `fetch_error`) from **terminal**: transient deads are re-enqueue-eligible after **6h** (self-heal at the next nightly tick); terminal deads keep the 30-day cooldown. `no_menu_url` deads stay the photo-fallback's job.

## Codex-hardened (4 findings fixed)
- Rewrote the **current** cron body (preserves `extractor_fingerprint IS NULL` self-requeue + `ON CONFLICT DO NOTHING` — would've regressed if I'd copied the old migration).
- `fetch_error` classified by `error_context->>'http_status'`, not blanket-terminal.
- **`COALESCE(http_status,'')`** so a NULL status resolves to a clean boolean → terminal (no accidental nightly retry loop — the last Codex Medium).
- Guarded `cron.unschedule` (DO/EXCEPTION), invoker-rights trigger, exception-safe enqueue.

## Test plan
- Insert a restaurant with `created_by` → a `menu_import_jobs` row appears; with `created_by=NULL` → none.
- `SELECT jobname, command FROM cron.job WHERE jobname='create-menu-refresh-jobs'` shows the new dead-exclusion.
- A 7h-old `claude_error` dead is re-enqueue-eligible; a `no_dishes` dead is not.
- Reviewed by Codex (gpt-5.4 high) across design + migration; all findings fixed.

## Deploy
Run `supabase/migrations/2026-06-09-reliable-enqueue.sql` in the SQL editor (idempotent — `CREATE OR REPLACE`, `DROP IF EXISTS`, guarded unschedule). No edge-fn redeploy, no app build. ROLLBACK block included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)