### PR TITLE
feat(menu-refresh): anchor-first menu-URL discovery (stop landing on homepage shells)

### DIFF
--- a/docs/superpowers/specs/2026-06-09-menu-url-reachability-fix-design.md
+++ b/docs/superpowers/specs/2026-06-09-menu-url-reachability-fix-design.md
@@ -1,0 +1,117 @@
+# Menu-URL Reachability Fix — Design Spec
+
+**Date:** 2026-06-09
+**Gap:** #7 in `2026-06-09-menu-pipeline-gap-map.md`
+**Scope:** `supabase/functions/menu-refresh/` only. No frontend, no schema.
+
+## Problem
+
+`findMenuUrl(websiteUrl)` (in `index.ts`) probes a fixed `MENU_PATHS` list with **`HEAD`** requests and returns the first that responds `ok`. On a miss, the queue loop falls back to dumping the **homepage** at the extractor. Two real failure modes:
+
+1. **HEAD false-negatives.** Many restaurant hosts (WordPress, Cloudflare, Wix) answer `405`/`403` to `HEAD` but `200` to `GET`. The real `/menu` is missed → homepage fallback.
+2. **Half-working homepage fallback is worse than failing.** If the homepage carries a few featured/special dishes, extraction returns ~5–10 dishes — **not empty, not thin enough** to trigger `findSubMenuPages` — so the real full-menu page is never visited. Result: a partial/wrong menu that *looks* populated. (Matches the "not enough" symptom.)
+
+## Goal
+
+Land on the restaurant's actual menu page far more often, and stop silently extracting a homepage's handful of featured dishes as if they were the whole menu.
+
+## Decision (Dan, 2026-06-09 — revised after Codex review)
+
+**Anchor-discovery FIRST, parallel path-probe as fallback, hash-clear on URL change.** Codex flagged the original GET-probe-first design as unsound: (a) ~25 sequential 5s probes ≈ 100-125s, dangerously near the 150s edge timeout; (b) SPA shells that 200 every route would lock in a fake `/food-menu`; (c) a changed `menu_url` wouldn't force re-extraction because of the `menu_content_hash` short-circuit. The revision below fixes all three.
+
+## Design
+
+### 1. `findBestMenuLink(html, baseUrl): string | null` (new, `menu-candidates.ts`)
+
+Returns the single best **food-menu page** anchor on a homepage, or `null`. Uses a
+**dedicated menu-link scorer** — NOT the asset `scoreCandidate` (which positively scores
+"raw bar"/"seafood" and lacks nav negatives).
+
+- Parse anchors (reuse the anchor regex / `stripTags`). Score `href path + anchor text`.
+- **Positives:** `menu +5`, `food +3`, `dinner/lunch/brunch/breakfast +2`.
+- **Negatives:** `drinks/wine/cocktail/bar -4`, `about/contact/reservations?/order(-online)?/catering/events/gift-?cards?/careers?/jobs/blog/news/gallery/press/private -5`, and the raw/oyster-bar seafood guard from the drinks work.
+- **Eligibility:** skip `PDF_EXT`/`IMAGE_EXT` hrefs (assets handled elsewhere); skip the base page itself; require `score > 0`.
+- **Host scope (precise, no public-suffix list):** let `baseHost` = the base URL's hostname with a leading `www.` stripped. Accept the link's host `h` iff `h === baseHost` **or** `h === 'www.' + baseHost` **or** `h.endsWith('.' + baseHost)` (proper subdomain, e.g. `menu.foo.com`/`order.foo.com` for base `foo.com` or `www.foo.com`). Reject everything else. Still fetched later through `safeFetch` (SSRF-guarded).
+- **Ranking:** prefer an anchor whose text or path contains the `menu` token; tiebreak by score, then shorter path.
+
+Unit-testable (Vitest), mirrors `findDrinkSubPages`.
+
+### 2. `findMenuUrl` restructure (`index.ts`)
+
+```
+async function findMenuUrl(websiteUrl):
+  normalize base
+  // Step A (PRIMARY) — anchor discovery: follow the link the site itself exposes.
+  // One homepage GET; far more accurate than blind probing and avoids the
+  // sequential-probe time bomb. SPA homepages whose links are JS-injected just
+  // yield null here and fall through to Step B.
+  try:
+    home = fetchRawHtml(base)
+    if home.type === 'html':
+      link = findBestMenuLink(home.html, base)
+      if link: return link
+  catch: /* best effort */
+
+  // Step B (FALLBACK) — PARALLEL path probe, bounded wall-time.
+  // Fire all MENU_PATHS probes concurrently (GET, 3s abort each, body cancelled).
+  // Take the highest-priority path (MENU_PATHS order) that passes acceptProbe().
+  results = await Promise.allSettled(MENU_PATHS.map(p => probe(base + p)))
+  return first path (in MENU_PATHS order) whose probe resolved accepted, else null
+
+probe(url): GET via safeFetch, 3s abort, read status + res.url, cancel body,
+            return { accepted: res.ok && acceptProbe(res, url), url }
+```
+
+**`acceptProbe(res, probedUrl)` guard** (hardened soft-404 / SPA defense):
+- Reject if the final `res.url` host differs from the probed host (off-origin bounce).
+- Normalize pathnames (lowercase, strip trailing slash). Reject if the final pathname is root (`''`/`/`) or an index page (`/index.html?`, `/home`) while we probed a non-root path (redirect-to-home soft-404).
+- Reject if the final pathname no longer contains the probed path's last segment (e.g. `/menu` → `/order-online` bounce).
+- This does NOT fully defeat a true SPA that serves a distinct-looking 200 at every route, but anchor-discovery (Step A) is the primary path and SPA shells are handled downstream by the render/BentoBox/confidence-gate machinery. Step B no longer runs first, so it can't pre-empt anchor discovery.
+
+**Timeouts:** each `probe` clears its abort timer in a `finally` (fixes the existing leak where a thrown `HEAD` left its timer alive). Parallel + 3s cap ⇒ Step B wall-time ≈ 3s regardless of path count.
+
+### 3. Widen `MENU_PATHS`
+
+Add `/the-menu`, `/our-food`, `/eats`, `/food-menus`, `/menu/food`. Keep specific-before-generic ordering (it now also defines Step B priority among accepted probes).
+
+### 4. Re-discover stored-homepage rows + force re-extraction on URL change (caller, `index.ts`)
+
+Today the queue loop only calls `findMenuUrl` when `!menuUrl` (`index.ts:~1528`). That means a restaurant already pointed at its **homepage root** (a past homepage-fallback victim) never gets re-discovered — so this fix wouldn't reach exactly the rows it's meant to correct (Codex blocker).
+
+**Change the trigger:** run `findMenuUrl` when `!menuUrl` **OR** when the stored `menuUrl`'s normalized pathname is root (`''`/`/`) i.e. it equals the website root — meaning we only ever had the homepage. Concretely:
+
+```
+const storedIsHomepageRoot = menuUrl && (() => {
+  try { const p = new URL(menuUrl).pathname.replace(/\/+$/, ''); return p === '' } catch { return false }
+})()
+if ((!menuUrl || storedIsHomepageRoot) && (websiteUrl || menuUrl)) {
+  const found = await findMenuUrl(websiteUrl || menuUrl)
+  if (found && found !== menuUrl) {
+    menuUrl = found
+    dbUpdates.menu_url = found
+    dbUpdates.menu_content_hash = null   // force re-extract of the corrected URL
+  }
+}
+```
+
+**Force re-extraction:** whenever `findMenuUrl` yields a URL **different from the stored `restaurant.menu_url`**, also set `dbUpdates.menu_content_hash = null`. This defeats the `menu_content_hash` short-circuit (`index.ts:~1739`) so the corrected URL is re-extracted unconditionally on this run (Codex Critical #1). The direct-PDF and batch-fallback paths are unaffected (they don't hash-short-circuit PDF-backed rows). Adapt to the real variable names/structure of the existing `if (!menuUrl && websiteUrl)` block.
+
+## Safety / non-regression
+
+- Caller still persists the discovered URL and keeps the homepage fallback when `findMenuUrl` returns `null` — unchanged.
+- Worst-case added latency: one homepage GET (Step A) + a single ~3s parallel probe window (Step B) — far below today's potential 100s+ sequential HEAD cost, and well clear of the 150s edge timeout.
+- SSRF: every fetch goes through `safeFetch`/`fetchRawHtml` (host + redirect-hop validation). `findBestMenuLink` only parses HTML; subdomain-of-base acceptance is still validated at fetch time.
+- No fingerprint bump (output schema unchanged). The §4 hash-clear is what guarantees corrected URLs actually re-extract. Targeted re-enqueue: restaurants whose `menu_url` equals their website root (homepage-fallback victims) or is null.
+
+## Testing
+
+- `menu-candidates.test.ts` (Vitest): `findBestMenuLink` — picks `/menu` over `/about`, prefers a "menu"-texted link, rejects cross-origin, rejects PDF/image hrefs, returns null when no menu link, drinks/catering links excluded.
+- `findMenuUrl` is Deno + network (not Vitest-reachable): verify with `deno check` + a live run on a restaurant whose menu sits at a non-standard path or behind a HEAD-405 host. Confirm `restaurants.menu_url` gets persisted to the real menu page.
+
+## Deploy
+
+Edge function deploy (same as the drinks fix — Supabase dashboard, preserve inlined SSRF guard). No fingerprint bump. Optional targeted re-enqueue: restaurants whose `menu_url` equals their website root (homepage-fallback victims) or is null.
+
+## Out of scope
+
+Other gaps (never-blank UX, photo fallback, reliable enqueue, transient-retry) — separate specs.

--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -414,8 +414,19 @@ function acceptProbe(res: Response, probedUrl: string): boolean {
     return false
   }
 
-  // Off-origin bounce
-  if (finalUrl.hostname.toLowerCase() !== probedParsed.hostname.toLowerCase()) return false
+  // Off-origin bounce — allow www↔bare and proper-subdomain redirects (canonical
+  // TLS redirects, e.g. foo.com/menu → www.foo.com/menu) but reject genuinely
+  // off-site finals (foo.com → evil.com).
+  const probedHost = probedParsed.hostname.toLowerCase()
+  const finalHost = finalUrl.hostname.toLowerCase()
+  const stripWww = (h: string) => h.replace(/^www\./, '')
+  const probedStripped = stripWww(probedHost)
+  const finalStripped = stripWww(finalHost)
+  const sameSite =
+    probedStripped === finalStripped ||
+    finalStripped.endsWith('.' + probedStripped) ||
+    probedStripped.endsWith('.' + finalStripped)
+  if (!sameSite) return false
 
   // Normalize pathnames: lowercase, strip trailing slash
   const finalPath = finalUrl.pathname.toLowerCase().replace(/\/+$/, '') || '/'
@@ -1524,14 +1535,23 @@ serve(async (req) => {
 
           // Re-discover the menu URL when:
           //  (a) we have no menu_url at all, OR
-          //  (b) the stored menu_url is the website root (a past homepage-
-          //      fallback victim whose real /menu page was never found).
-          // Condition (b) ensures this fix reaches exactly the restaurants
-          // it's meant to correct — without it, a row already pointing at
-          // the homepage root would never get re-discovered.
-          const storedIsHomepageRoot = menuUrl && (() => {
-            try { return new URL(menuUrl).pathname.replace(/\/+$/, '') === '' } catch { return false }
-          })()
+          //  (b) the stored menu_url is the website root AND shares the same
+          //      host as the restaurant's website (a past homepage-fallback
+          //      victim whose real /menu page was never found).
+          //
+          // Condition (b) is intentionally narrow: a legit menu at a different
+          // host with a root path (e.g. https://menu.example.com/) must NOT
+          // be treated as "stuck on homepage" — that would cause churn by
+          // re-running discovery every refresh for a perfectly valid URL.
+          const sameHostRoot = (mu: string, wu: string): boolean => {
+            try {
+              const m = new URL(mu)
+              const w = new URL(wu)
+              const strip = (h: string) => h.replace(/^www\./, '')
+              return strip(m.hostname) === strip(w.hostname) && m.pathname.replace(/\/+$/, '') === ''
+            } catch { return false }
+          }
+          const storedIsHomepageRoot = !!(menuUrl && websiteUrl && sameHostRoot(menuUrl, websiteUrl))
           if ((!menuUrl || storedIsHomepageRoot) && (websiteUrl || menuUrl)) {
             const found = await findMenuUrl(websiteUrl || menuUrl!)
             if (found && found !== menuUrl) {
@@ -1540,7 +1560,12 @@ serve(async (req) => {
               // Force re-extraction of the corrected URL by clearing the
               // content hash — defeats the hash short-circuit so the real
               // menu page is extracted on this run, not skipped as "unchanged".
+              // Must also null the IN-MEMORY field: the hash short-circuit
+              // reads restaurant.menu_content_hash directly; staging the null
+              // only in dbUpdates leaves the in-memory value intact and the
+              // short-circuit still exits early as 'hash_unchanged'.
               dbUpdates.menu_content_hash = null
+              restaurant.menu_content_hash = null
             } else if (!found) {
               // Ephemeral fallback for THIS run only. Many restaurants link the
               // menu as a PDF or image (e.g. /wp-content/uploads/*.pdf) only from

--- a/supabase/functions/menu-refresh/index.ts
+++ b/supabase/functions/menu-refresh/index.ts
@@ -3,7 +3,7 @@ import { encode as encodeBase64 } from 'https://deno.land/std@0.177.0/encoding/b
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { detectCms, cmsRequiresRender } from './cms-detect.ts'
 import { fetchRenderedHtml, BrowserlessError } from './browserless.ts'
-import { discoverMenuCandidates, findMenuIframes, findSubMenuPages, isBlockedHostname, isKnownMenuIframeHost, type MenuCandidate } from './menu-candidates.ts'
+import { discoverMenuCandidates, findBestMenuLink, findMenuIframes, findSubMenuPages, isBlockedHostname, isKnownMenuIframeHost, type MenuCandidate } from './menu-candidates.ts'
 import { safeFetch } from '../_shared/ssrf.ts'
 import { detectBentoBox, buildBentoBoxMenuText, parseSchemaOrgMenuItems } from './bentobox.ts'
 
@@ -381,40 +381,125 @@ function sleep(ms: number): Promise<void> {
 const GOOGLE_API_KEY = Deno.env.get('GOOGLE_PLACES_API_KEY')
 
 const MENU_PATHS = [
-  // More specific paths first — less likely to hit a wrong page
+  // More specific paths first — less likely to hit a wrong page (also defines
+  // Step B priority among accepted probes: first match in this order wins).
   '/food-menu', '/dinner-menu', '/lunch-menu', '/breakfast-menu', '/brunch-menu',
-  '/our-menu', '/menus', '/food-drink', '/food--drinks',
-  '/menu', '/menu-1', '/menu-2', '/food', '/eat', '/dining',
+  '/our-menu', '/the-menu', '/our-food', '/menus', '/food-drink', '/food--drinks',
+  '/food-menus', '/menu/food',
+  '/menu', '/menu-1', '/menu-2', '/food', '/eats', '/eat', '/dining',
   '/dinner', '/breakfast', '/lunch',
   '/order', '/order-online',
 ]
 
 /**
- * Probe a website for common menu URL paths (HEAD requests)
+ * Reject a probe result if the server bounced us to a different page.
+ *
+ * Soft-404 / SPA defense: some hosts 200 every route (SPA shell) or redirect
+ * all unknown paths back to the homepage. We detect the two most common failure
+ * modes:
+ *  1. Redirect-to-root: the final URL's pathname is empty/root/index while we
+ *     probed a non-root path → homepage soft-404.
+ *  2. Content-swap: the final pathname no longer contains the probed path's
+ *     last segment → the server substituted a different resource (e.g.
+ *     /menu → /order-online bounce).
+ *  3. Off-origin bounce: the final host differs from the probed host.
+ */
+function acceptProbe(res: Response, probedUrl: string): boolean {
+  let finalUrl: URL
+  let probedParsed: URL
+  try {
+    finalUrl = new URL(res.url || probedUrl)
+    probedParsed = new URL(probedUrl)
+  } catch {
+    return false
+  }
+
+  // Off-origin bounce
+  if (finalUrl.hostname.toLowerCase() !== probedParsed.hostname.toLowerCase()) return false
+
+  // Normalize pathnames: lowercase, strip trailing slash
+  const finalPath = finalUrl.pathname.toLowerCase().replace(/\/+$/, '') || '/'
+  const probedPath = probedParsed.pathname.toLowerCase().replace(/\/+$/, '')
+
+  // If we probed a non-root path, reject root/index redirects (soft-404)
+  if (probedPath && probedPath !== '/') {
+    const isRootOrIndex = finalPath === '' || finalPath === '/' ||
+      finalPath === '/index.html' || finalPath === '/index' || finalPath === '/home'
+    if (isRootOrIndex) return false
+  }
+
+  // Reject if the final pathname no longer contains the probed path's last segment
+  // e.g. probed /menu → final /order-online: "menu" ∉ "/order-online"
+  const probedLastSegment = probedPath.split('/').filter(Boolean).pop()
+  if (probedLastSegment && !finalPath.includes(probedLastSegment)) return false
+
+  return true
+}
+
+/**
+ * Find the best menu URL for a restaurant website.
+ *
+ * Step A (PRIMARY): Fetch the homepage and look for a menu nav link using
+ * findBestMenuLink. This is a single GET that reads what the restaurant itself
+ * advertises — far more accurate than blind probing. SPA homepages whose links
+ * are JS-injected yield null here and fall through to Step B.
+ *
+ * Step B (FALLBACK): Fire all MENU_PATHS as concurrent GET probes (3s abort
+ * each, body cancelled). Take the first path (in MENU_PATHS order) whose
+ * probe passes acceptProbe(). Wall-time ≈ 3s regardless of path count.
  */
 async function findMenuUrl(websiteUrl: string): Promise<string | null> {
   if (!websiteUrl) return null
   let base = websiteUrl.replace(/\/+$/, '')
   if (!base.startsWith('http')) base = 'https://' + base
 
-  for (const path of MENU_PATHS) {
-    const candidate = base + path
-    try {
+  // ── Step A: anchor discovery ──────────────────────────────────────────────
+  // Follow the link the site itself exposes. One homepage GET; avoids the
+  // sequential-probe time bomb and SPA-false-positive issues.
+  try {
+    const home = await fetchRawHtml(base)
+    if (home.type === 'html') {
+      const link = findBestMenuLink(home.html, base)
+      if (link) return link
+    }
+  } catch {
+    // Best-effort — fall through to Step B
+  }
+
+  // ── Step B: parallel path probe ───────────────────────────────────────────
+  // Fire all paths concurrently. Each probe: GET, 3s abort, body cancelled.
+  // Take the FIRST path (in MENU_PATHS order) that passes acceptProbe.
+  type ProbeResult = { path: string; accepted: boolean }
+
+  const probeResults = await Promise.allSettled(
+    MENU_PATHS.map(async (path): Promise<ProbeResult> => {
+      const candidate = base + path
       const controller = new AbortController()
-      const timeout = setTimeout(() => controller.abort(), 5000)
-      // safeFetch validates the host + every redirect hop (SSRF guard). A blocked,
-      // malformed, or over-redirecting candidate throws and is skipped by catch.
-      const res = await safeFetch(candidate, {
-        method: 'HEAD',
-        signal: controller.signal,
-        headers: { 'User-Agent': 'Mozilla/5.0 (compatible; WhatsGoodHere-Bot/1.0)' },
-      })
-      clearTimeout(timeout)
-      if (res.ok) return candidate
-    } catch {
-      // skip
+      const timeout = setTimeout(() => controller.abort(), 3000)
+      try {
+        const res = await safeFetch(candidate, {
+          method: 'GET',
+          signal: controller.signal,
+          headers: { 'User-Agent': 'Mozilla/5.0 (compatible; WhatsGoodHere-Bot/1.0)' },
+        })
+        await res.body?.cancel()
+        return { path, accepted: res.ok && acceptProbe(res, candidate) }
+      } catch {
+        return { path, accepted: false }
+      } finally {
+        clearTimeout(timeout)
+      }
+    })
+  )
+
+  // Return the first accepted path in MENU_PATHS order (priority preserved).
+  for (let i = 0; i < MENU_PATHS.length; i++) {
+    const result = probeResults[i]
+    if (result.status === 'fulfilled' && result.value.accepted) {
+      return base + MENU_PATHS[i]
     }
   }
+
   return null
 }
 
@@ -1437,12 +1522,26 @@ serve(async (req) => {
             }
           }
 
-          if (!menuUrl && websiteUrl) {
-            const found = await findMenuUrl(websiteUrl)
-            if (found) {
+          // Re-discover the menu URL when:
+          //  (a) we have no menu_url at all, OR
+          //  (b) the stored menu_url is the website root (a past homepage-
+          //      fallback victim whose real /menu page was never found).
+          // Condition (b) ensures this fix reaches exactly the restaurants
+          // it's meant to correct — without it, a row already pointing at
+          // the homepage root would never get re-discovered.
+          const storedIsHomepageRoot = menuUrl && (() => {
+            try { return new URL(menuUrl).pathname.replace(/\/+$/, '') === '' } catch { return false }
+          })()
+          if ((!menuUrl || storedIsHomepageRoot) && (websiteUrl || menuUrl)) {
+            const found = await findMenuUrl(websiteUrl || menuUrl!)
+            if (found && found !== menuUrl) {
               menuUrl = found
-              dbUpdates.menu_url = menuUrl
-            } else {
+              dbUpdates.menu_url = found
+              // Force re-extraction of the corrected URL by clearing the
+              // content hash — defeats the hash short-circuit so the real
+              // menu page is extracted on this run, not skipped as "unchanged".
+              dbUpdates.menu_content_hash = null
+            } else if (!found) {
               // Ephemeral fallback for THIS run only. Many restaurants link the
               // menu as a PDF or image (e.g. /wp-content/uploads/*.pdf) only from
               // the homepage — paths findMenuUrl's probe list misses. Letting the
@@ -1451,9 +1550,11 @@ serve(async (req) => {
               // HTML. We do NOT persist this to dbUpdates.menu_url — that would
               // lock the restaurant into the homepage forever and prevent
               // future discovery of a real /menu URL.
-              let normalized = websiteUrl.replace(/\/+$/, '')
-              if (!normalized.startsWith('http')) normalized = 'https://' + normalized
-              menuUrl = normalized
+              if (!menuUrl) {
+                let normalized = (websiteUrl || '').replace(/\/+$/, '')
+                if (!normalized.startsWith('http')) normalized = 'https://' + normalized
+                menuUrl = normalized
+              }
             }
           }
 

--- a/supabase/functions/menu-refresh/menu-candidates.test.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.test.ts
@@ -851,6 +851,36 @@ describe('findBestMenuLink', () => {
     expect(result).toBe('https://www.example-restaurant.com/food')
   })
 
+  it('skips www-alias self-link at root (foo.com base, www.foo.com/ link)', () => {
+    // A site whose homepage is foo.com/ emitting a canonical link to www.foo.com/
+    // is a self-link — it must never surface as a menu candidate.
+    const html = `
+      <a href="https://www.example-restaurant.com/">Home</a>
+      <a href="/menu">Menu</a>
+    `
+    const result = findBestMenuLink(html, 'https://example-restaurant.com/')
+    expect(result).toBe('https://example-restaurant.com/menu')
+  })
+
+  it('skips bare-alias self-link at root (www.foo.com base, foo.com/ link)', () => {
+    const html = `
+      <a href="https://example-restaurant.com/">Home</a>
+      <a href="/menu">Menu</a>
+    `
+    const result = findBestMenuLink(html, 'https://www.example-restaurant.com/')
+    expect(result).toBe('https://www.example-restaurant.com/menu')
+  })
+
+  it('does NOT skip menu.<base> root — that is a genuine menu subdomain', () => {
+    // menu.example-restaurant.com/ is a different host from the base;
+    // the www-alias root skip must not fire here.
+    const html = `
+      <a href="https://menu.example-restaurant.com/">View Menu</a>
+    `
+    const result = findBestMenuLink(html, 'https://www.example-restaurant.com/')
+    expect(result).toBe('https://menu.example-restaurant.com/')
+  })
+
   it('tiebreaks by shorter pathname when both have menu token and same score', () => {
     // Both links contain the menu token and score identically (menu +5 in path,
     // same anchor text). Shorter pathname wins.

--- a/supabase/functions/menu-refresh/menu-candidates.test.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { discoverMenuCandidates, findMenuIframes, findSubMenuPages, isBlockedHostname, isKnownMenuIframeHost, scoreCandidate } from './menu-candidates.ts'
+import { discoverMenuCandidates, findBestMenuLink, findMenuIframes, findSubMenuPages, isBlockedHostname, isKnownMenuIframeHost, scoreCandidate } from './menu-candidates.ts'
 
 describe('scoreCandidate', () => {
   it('positive: menu in URL', () => {
@@ -731,5 +731,134 @@ describe('isKnownMenuIframeHost', () => {
   it('normalizes trailing dot (DNS-equivalent FQDN forms)', () => {
     expect(isKnownMenuIframeHost('popmenu.com.')).toBe(true)
     expect(isKnownMenuIframeHost('order.popmenu.com.')).toBe(true)
+  })
+})
+
+describe('findBestMenuLink', () => {
+  const base = 'https://www.example-restaurant.com/'
+
+  it('picks /menu over /about', () => {
+    const html = `
+      <nav>
+        <a href="/menu">Menu</a>
+        <a href="/about">About Us</a>
+        <a href="/contact">Contact</a>
+      </nav>
+    `
+    const result = findBestMenuLink(html, base)
+    expect(result).toBe('https://www.example-restaurant.com/menu')
+  })
+
+  it('prefers a "menu"-texted link over a bare /food link', () => {
+    const html = `
+      <nav>
+        <a href="/food">Our food</a>
+        <a href="/dining">Dining</a>
+        <a href="/explore">See the Menu</a>
+      </nav>
+    `
+    const result = findBestMenuLink(html, base)
+    // /explore has anchor text "See the Menu" — menu token in text wins
+    expect(result).toBe('https://www.example-restaurant.com/explore')
+  })
+
+  it('rejects cross-origin links', () => {
+    const html = `
+      <a href="https://other-site.com/menu">Menu</a>
+    `
+    const result = findBestMenuLink(html, base)
+    expect(result).toBeNull()
+  })
+
+  it('accepts a menu.<base> subdomain as same-site', () => {
+    const html = `
+      <a href="https://menu.example-restaurant.com/">View Menu</a>
+    `
+    const result = findBestMenuLink(html, base)
+    expect(result).toBe('https://menu.example-restaurant.com/')
+  })
+
+  it('accepts www.base when base has no www', () => {
+    const html = `<a href="https://www.example-restaurant.com/food-menu">Food Menu</a>`
+    const result = findBestMenuLink(html, 'https://example-restaurant.com/')
+    expect(result).toBe('https://www.example-restaurant.com/food-menu')
+  })
+
+  it('rejects PDF hrefs', () => {
+    const html = `
+      <a href="/menu.pdf">Menu</a>
+      <a href="/food">Food</a>
+    `
+    const result = findBestMenuLink(html, base)
+    // /food has score +3, /menu.pdf should be skipped; /food has no menu token so score 3 only
+    expect(result).toBe('https://www.example-restaurant.com/food')
+  })
+
+  it('rejects image hrefs', () => {
+    const html = `
+      <a href="/menu.png">Menu Photo</a>
+      <a href="/our-menu">Menu</a>
+    `
+    const result = findBestMenuLink(html, base)
+    expect(result).toBe('https://www.example-restaurant.com/our-menu')
+  })
+
+  it('returns null when no eligible menu link exists', () => {
+    const html = `
+      <a href="/about">About</a>
+      <a href="/contact">Contact</a>
+      <a href="/reservations">Reservations</a>
+    `
+    const result = findBestMenuLink(html, base)
+    expect(result).toBeNull()
+  })
+
+  it('excludes a /drinks link (negative score)', () => {
+    const html = `
+      <a href="/drinks">Drinks</a>
+      <a href="/wine">Wine List</a>
+    `
+    const result = findBestMenuLink(html, base)
+    expect(result).toBeNull()
+  })
+
+  it('excludes a /catering link (negative score)', () => {
+    const html = `
+      <a href="/catering">Catering</a>
+      <a href="/events">Events</a>
+    `
+    const result = findBestMenuLink(html, base)
+    expect(result).toBeNull()
+  })
+
+  it('returns null when all links are below score threshold', () => {
+    // /about scores -5, cocktails scores -4 — all negative
+    const html = `
+      <a href="/about">About</a>
+      <a href="/cocktails">Cocktails</a>
+    `
+    const result = findBestMenuLink(html, base)
+    expect(result).toBeNull()
+  })
+
+  it('skips the base page itself (self-link)', () => {
+    const html = `
+      <a href="/">Home</a>
+      <a href="https://www.example-restaurant.com/">Root</a>
+      <a href="/food">Food</a>
+    `
+    const result = findBestMenuLink(html, base)
+    expect(result).toBe('https://www.example-restaurant.com/food')
+  })
+
+  it('tiebreaks by shorter pathname when both have menu token and same score', () => {
+    // Both links contain the menu token and score identically (menu +5 in path,
+    // same anchor text). Shorter pathname wins.
+    const html = `
+      <a href="/view-our-menu/page">Menu</a>
+      <a href="/menu">Menu</a>
+    `
+    const result = findBestMenuLink(html, base)
+    expect(result).toBe('https://www.example-restaurant.com/menu')
   })
 })

--- a/supabase/functions/menu-refresh/menu-candidates.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.ts
@@ -253,6 +253,159 @@ const SUB_MENU_NEGATIVE_TEXT = [
   /\bprivate\b/i,
 ]
 
+// ─── findBestMenuLink scoring constants ────────────────────────────────────
+// Separate from the asset scoreCandidate above: asset scoring positively weights
+// "raw bar"/"seafood" (food-menu assets) and lacks nav-page negatives. Here we
+// need a DEDICATED scorer that picks the site's actual menu PAGE link from nav
+// anchors — a different job with different signals.
+
+const MENU_LINK_POSITIVES: KeywordWeight[] = [
+  { pattern: /\bmenu\b/i, weight: 5 },
+  { pattern: /\bfood\b/i, weight: 3 },
+  { pattern: /\bdinner\b/i, weight: 2 },
+  { pattern: /\blunch\b/i, weight: 2 },
+  { pattern: /\bbrunch\b/i, weight: 2 },
+  { pattern: /\bbreakfast\b/i, weight: 2 },
+]
+
+const MENU_LINK_NEGATIVES: KeywordWeight[] = [
+  { pattern: /\bdrinks?\b/i, weight: -4 },
+  { pattern: /\bwines?\b/i, weight: -4 },
+  { pattern: /\bcocktails?\b/i, weight: -4 },
+  { pattern: /\bbar\b/i, weight: -4 },
+  { pattern: /\braw[\s-]?bar\b/i, weight: -4 },
+  { pattern: /\boyster[\s-]?bar\b/i, weight: -4 },
+  { pattern: /\babout\b/i, weight: -5 },
+  { pattern: /\bcontact\b/i, weight: -5 },
+  { pattern: /\breservations?\b/i, weight: -5 },
+  { pattern: /\border(?:[\s-]online)?\b/i, weight: -5 },
+  { pattern: /\bcatering\b/i, weight: -5 },
+  { pattern: /\bevents?\b/i, weight: -5 },
+  { pattern: /\bgift[\s-]?cards?\b/i, weight: -5 },
+  { pattern: /\bcareers?\b/i, weight: -5 },
+  { pattern: /\bjobs?\b/i, weight: -5 },
+  { pattern: /\bblog\b/i, weight: -5 },
+  { pattern: /\bnews\b/i, weight: -5 },
+  { pattern: /\bgallery\b/i, weight: -5 },
+  { pattern: /\bpress\b/i, weight: -5 },
+  { pattern: /\bprivate\b/i, weight: -5 },
+]
+
+function scoreMenuLink(path: string, text: string): number {
+  const subject = normalize(path) + ' ' + normalize(text)
+  let score = 0
+  for (const { pattern, weight } of MENU_LINK_POSITIVES) {
+    if (pattern.test(subject)) score += weight
+  }
+  for (const { pattern, weight } of MENU_LINK_NEGATIVES) {
+    if (pattern.test(subject)) score += weight
+  }
+  return score
+}
+
+/**
+ * Find the single best food-menu PAGE link on a homepage.
+ *
+ * Scans anchor tags, scores each href+text combination with a dedicated
+ * menu-link scorer (NOT the asset scoreCandidate), and returns the absolute
+ * URL of the top candidate, or null if none exceed 0.
+ *
+ * Host-scope rule: accepts the link iff its host equals baseHost, or equals
+ * 'www.'+baseHost, or ends with '.'+baseHost (proper subdomain). Rejects all
+ * other cross-origin links. PDF/image hrefs are skipped (asset candidates).
+ * The base page itself is skipped (self-link).
+ *
+ * Ranking: prefer a link whose text OR path contains the 'menu' token;
+ * tiebreak by score desc, then by shorter pathname.
+ */
+export function findBestMenuLink(html: string, baseUrl: string): string | null {
+  let base: URL
+  try {
+    base = new URL(baseUrl)
+  } catch {
+    return null
+  }
+
+  // Compute baseHost with leading www. stripped for host-scope comparison.
+  const baseHost = base.hostname.toLowerCase().replace(/^www\./, '')
+  // Normalize the base pathname for self-link detection.
+  const basePathNorm = base.pathname.toLowerCase().replace(/\/+$/, '')
+
+  const MENU_TOKEN = /\bmenu\b/i
+
+  interface LinkCandidate {
+    href: string
+    score: number
+    hasMenuToken: boolean
+    pathnameLen: number
+  }
+
+  const candidates: LinkCandidate[] = []
+  const seen = new Set<string>()
+
+  const anchorRegex = /<a\b[^>]*\shref=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi
+  let m
+  while ((m = anchorRegex.exec(html)) !== null) {
+    const rawHref = m[1]
+    const innerText = stripTags(m[2]).slice(0, 200)
+
+    // Absolutize
+    let abs: URL
+    try {
+      abs = new URL(rawHref, base)
+    } catch {
+      continue
+    }
+
+    // Protocol must be http/https
+    if (abs.protocol !== 'http:' && abs.protocol !== 'https:') continue
+
+    // Skip PDF/image assets — those are handled by discoverMenuCandidates
+    if (PDF_EXT.test(abs.href) || IMAGE_EXT.test(abs.href)) continue
+
+    // Host-scope check: accept same origin (with or without www), and proper
+    // subdomains (e.g. menu.foo.com when base is foo.com or www.foo.com).
+    const linkHost = abs.hostname.toLowerCase()
+    const linkHostStripped = linkHost.replace(/^www\./, '')
+    const sameOrigin =
+      linkHostStripped === baseHost ||
+      linkHost === 'www.' + baseHost ||
+      linkHostStripped.endsWith('.' + baseHost)
+    if (!sameOrigin) continue
+
+    // Dedup by href (case-insensitive pathname)
+    const dedupKey = abs.hostname.toLowerCase() + abs.pathname.toLowerCase()
+    if (seen.has(dedupKey)) continue
+
+    // Skip the base page itself
+    const linkPathNorm = abs.pathname.toLowerCase().replace(/\/+$/, '')
+    if (linkHost === base.hostname.toLowerCase() && linkPathNorm === basePathNorm) continue
+
+    const score = scoreMenuLink(abs.pathname, innerText)
+    if (score <= 0) continue
+
+    seen.add(dedupKey)
+    const hasMenuToken = MENU_TOKEN.test(abs.pathname) || MENU_TOKEN.test(innerText)
+    candidates.push({
+      href: abs.href,
+      score,
+      hasMenuToken,
+      pathnameLen: abs.pathname.length,
+    })
+  }
+
+  if (candidates.length === 0) return null
+
+  // Sort: menu-token links first, then by score desc, then by shorter pathname.
+  candidates.sort((a, b) => {
+    if (a.hasMenuToken !== b.hasMenuToken) return a.hasMenuToken ? -1 : 1
+    if (b.score !== a.score) return b.score - a.score
+    return a.pathnameLen - b.pathnameLen
+  })
+
+  return candidates[0].href
+}
+
 /**
  * Find sub-menu page URLs on a parent menu page. Used as Pattern 1 fallback
  * when the menu page itself yielded no dishes — many restaurants split their

--- a/supabase/functions/menu-refresh/menu-candidates.ts
+++ b/supabase/functions/menu-refresh/menu-candidates.ts
@@ -377,9 +377,18 @@ export function findBestMenuLink(html: string, baseUrl: string): string | null {
     const dedupKey = abs.hostname.toLowerCase() + abs.pathname.toLowerCase()
     if (seen.has(dedupKey)) continue
 
-    // Skip the base page itself
+    // Skip the base page itself AND its www/bare alias at the root path.
+    // Without the alias check, a site whose homepage is foo.com/ but emits a
+    // self-link to www.foo.com/ (or vice-versa) would slip through as a menu
+    // candidate — a link to the root of the same site is never a menu page.
     const linkPathNorm = abs.pathname.toLowerCase().replace(/\/+$/, '')
-    if (linkHost === base.hostname.toLowerCase() && linkPathNorm === basePathNorm) continue
+    const isBaseHost = linkHost === base.hostname.toLowerCase()
+    const isBaseAliasRoot =
+      linkHostStripped === baseHost &&
+      linkPathNorm === '' &&
+      basePathNorm === ''
+    if (isBaseHost && linkPathNorm === basePathNorm) continue
+    if (isBaseAliasRoot) continue
 
     const score = scoreMenuLink(abs.pathname, innerText)
     if (score <= 0) continue


### PR DESCRIPTION
## Gap 7 — reachability

`findMenuUrl` probed a fixed path list with `HEAD` (often 405s on real hosts → misses the real `/menu`), then fell back to dumping the **homepage** at the extractor. If the homepage carried a few featured dishes, extraction returned ~5–10 — not thin enough to trigger sub-page traversal — so the real full menu was never visited (the "not enough" symptom).

## Fix
- **Anchor-discovery first** — fetch the homepage once, run a dedicated menu-link scorer (`findBestMenuLink`) and follow the link the site itself exposes. Far more accurate than blind probing, and avoids ~25 sequential probes.
- **Parallel path probe as fallback** — `Promise.allSettled` over `MENU_PATHS` (GET, 3s, body-cancelled, abort-timer cleared in `finally`), first accepted by priority order. Bounded to ~one 3s window.
- **Hardened `acceptProbe`** — rejects off-site bounces, redirect-to-root/index soft-404s, and last-segment-mismatch bounces; **allows** www↔bare↔subdomain canonical redirects (same-site).
- **Re-discover homepage-stuck restaurants** — the caller now runs discovery when the stored `menu_url` IS the website root (`sameHostRoot`), not just when it's null; and **clears `menu_content_hash` (in-memory + DB)** so the corrected URL re-extracts on the same run.
- Widened `MENU_PATHS` (`/the-menu`, `/our-food`, `/eats`, …).

## Codex-hardened
Two review rounds (gpt-5.4 high). Fixed: design-level (anchor-first reorder, parallel probe, hash-clear, subdomain rule, guarded timers) **and** implementation-level — incl. a **Critical**: clearing `menu_content_hash` only in `dbUpdates` didn't force *this* run's re-extract (short-circuit reads the in-memory row) → now also nulls in memory. Plus scoped `storedIsHomepageRoot` to avoid churn on legit `menu.<domain>` roots, and same-site `acceptProbe` so canonical www redirects aren't rejected.

## Test plan
- `npx vitest run supabase/functions/menu-refresh/menu-candidates.test.ts` → **116/116** (incl. `findBestMenuLink`: picks /menu over /about, www-alias handling, subdomain scope, asset/cross-origin rejection).
- `deno check` clean on `index.ts` (only pre-existing SupabaseClient noise).

## ⚠️ Stacking + deploy
Branched off main; edits `index.ts` + `menu-candidates.ts` like #317/#319/#320 — merge in order, rebasing. **No migration.** Deploys as part of the combined `menu-refresh` function paste (dashboard, SSRF inlined). No fingerprint bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)