### PR TITLE
feat(menu-xray): camera entry on homepage header

### DIFF
--- a/src/components/home/HomeListMode.jsx
+++ b/src/components/home/HomeListMode.jsx
@@ -87,6 +87,19 @@ export const HomeListMode = memo(function HomeListMode({
               dark for the stone header (they default to near-white for the
               orange bar). NotificationBell self-hides when logged out. */}
           <div className="flex items-center" style={{ marginRight: '-8px' }}>
+            {/* Menu X-Ray entry — coral so the new hero feature is findable.
+                Routes to /scan; restaurant gets confirmed there (GPS + chip). */}
+            <button
+              onClick={() => navigate('/scan')}
+              aria-label="Scan a menu"
+              className="w-10 h-10 rounded-full flex items-center justify-center transition-all active:scale-95"
+              style={{ color: 'var(--color-primary)' }}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.8} stroke="currentColor" className="w-6 h-6">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6.827 6.175A2.31 2.31 0 0 1 5.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 0 0-1.134-.175 2.31 2.31 0 0 1-1.64-1.055l-.822-1.316a2.192 2.192 0 0 0-1.736-1.039 48.774 48.774 0 0 0-5.232 0 2.192 2.192 0 0 0-1.736 1.039l-.821 1.316Z" />
+                <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 12.75a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0ZM18.75 10.5h.008v.008h-.008V10.5Z" />
+              </svg>
+            </button>
             <SettingsDropdown color="var(--color-text-secondary)" />
             <NotificationBell color="var(--color-text-secondary)" />
           </div>


### PR DESCRIPTION
One button: the Menu X-Ray camera in the homepage header (coral, next to settings). Routes to /scan; restaurant confirmation happens there. Closes the T43 'homepage entry' follow-up — Dan's call: the iOS-binary economics flip the rollout-valve logic, and the scan page's confirm chip already protects data quality. Tests/lint/build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)