### PR TITLE
feat(menu-xray): rank dishes within each menu section

### DIFF
--- a/src/components/scan/XRayResults.jsx
+++ b/src/components/scan/XRayResults.jsx
@@ -1,6 +1,28 @@
 import { MIN_VOTES_FOR_RANKING } from '../../constants/app'
 import { XRayRow } from './XRayRow'
 
+// Each section is its own mini-leaderboard: rated dishes first (best rating,
+// then most votes), early-signal dishes next, never-rated last. The user is
+// holding the paper menu — IT owns the canonical order; the X-Ray view's job
+// is judgment. Array.prototype.sort is stable, so unrated dishes keep their
+// menu order at the bottom of the section.
+function rankTier(item) {
+  const votes = item.match?.totalVotes || 0
+  if (votes >= MIN_VOTES_FOR_RANKING) return 2
+  if (votes > 0) return 1
+  return 0
+}
+
+function rankSectionItems(items) {
+  return items.slice().sort((a, b) => {
+    const tierDiff = rankTier(b) - rankTier(a)
+    if (tierDiff !== 0) return tierDiff
+    const ratingDiff = (b.match?.avgRating ?? 0) - (a.match?.avgRating ?? 0)
+    if (ratingDiff !== 0) return ratingDiff
+    return (b.match?.totalVotes ?? 0) - (a.match?.totalVotes ?? 0)
+  })
+}
+
 export function XRayResults({ result, photoUrl }) {
   const { restaurant, sections, best, summary } = result
   const favorites = sections
@@ -29,7 +51,7 @@ export function XRayResults({ result, photoUrl }) {
           <h2 className="text-xl border-b pb-0.5 mb-1" style={{ fontFamily: "'Amatic SC', cursive", fontWeight: 700, color: 'var(--color-accent-gold)', borderColor: 'var(--color-category-strip)' }}>
             {section.name}
           </h2>
-          {section.items.map((item, i) => (
+          {rankSectionItems(section.items).map((item, i) => (
             <XRayRow
               key={`${section.name}-${item.name}-${i}`}
               item={item}

--- a/src/components/scan/XRayResults.test.jsx
+++ b/src/components/scan/XRayResults.test.jsx
@@ -15,6 +15,22 @@ const result = {
 }
 
 describe('XRayResults', () => {
+  it('ranks each section: rated by rating first, early next, unrated last', () => {
+    const shuffled = {
+      ...result,
+      sections: [{ name: 'Mains', items: [
+        { name: 'Crab Cakes', price: 24, match: null, ingested: true },
+        { name: 'Fried Clams', price: 22, match: { dishId: 'd2', avgRating: 9.1, totalVotes: 2 }, ingested: false },
+        { name: 'Hot Lobster Roll', price: 34, match: { dishId: 'd1', avgRating: 9.4, totalVotes: 12 }, ingested: false },
+      ]}],
+    }
+    render(<MemoryRouter><XRayResults result={shuffled} photoUrl={null} /></MemoryRouter>)
+    const rows = screen.getAllByRole('button')
+    expect(rows[0]).toHaveTextContent('Hot Lobster Roll')
+    expect(rows[1]).toHaveTextContent('Fried Clams')
+    expect(rows[2]).toHaveTextContent('Crab Cakes')
+  })
+
   it('renders all three verdict tiers', () => {
     render(<MemoryRouter><XRayResults result={result} photoUrl={null} /></MemoryRouter>)
     expect(screen.getByText('9.4')).toBeInTheDocument()


### PR DESCRIPTION
Per Dan: each scanned section orders by ranking, not menu order — rated (rating desc, votes desc) → early → unrated (stable, keeps menu order). Test added asserting the order. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)