### PR TITLE
fix(menu-xray): Codex review fixes — landing motion/a11y + section-ranking correctness

### DIFF
--- a/src/components/scan/XRayResults.jsx
+++ b/src/components/scan/XRayResults.jsx
@@ -1,4 +1,5 @@
 import { MIN_VOTES_FOR_RANKING } from '../../constants/app'
+import { getVerdict } from '../../utils/verdict'
 import { XRayRow } from './XRayRow'
 
 // Each section is its own mini-leaderboard: rated dishes first (best rating,
@@ -6,20 +7,25 @@ import { XRayRow } from './XRayRow'
 // holding the paper menu — IT owns the canonical order; the X-Ray view's job
 // is judgment. Array.prototype.sort is stable, so unrated dishes keep their
 // menu order at the bottom of the section.
-function rankTier(item) {
-  const votes = item.match?.totalVotes || 0
-  if (votes >= MIN_VOTES_FOR_RANKING) return 2
-  if (votes > 0) return 1
-  return 0
+// Tier comes from getVerdict — the SAME brain the chips render with — so a
+// malformed row (votes but no rating) can never sort rated while displaying
+// "be the first".
+const TIER_WEIGHT = { rated: 2, early: 1, new: 0 }
+
+function safeNumber(value) {
+  const n = Number(value)
+  return Number.isFinite(n) ? n : 0
 }
 
 function rankSectionItems(items) {
   return items.slice().sort((a, b) => {
-    const tierDiff = rankTier(b) - rankTier(a)
+    const va = getVerdict(a.match?.avgRating, a.match?.totalVotes)
+    const vb = getVerdict(b.match?.avgRating, b.match?.totalVotes)
+    const tierDiff = TIER_WEIGHT[vb.tier] - TIER_WEIGHT[va.tier]
     if (tierDiff !== 0) return tierDiff
-    const ratingDiff = (b.match?.avgRating ?? 0) - (a.match?.avgRating ?? 0)
+    const ratingDiff = safeNumber(b.match?.avgRating) - safeNumber(a.match?.avgRating)
     if (ratingDiff !== 0) return ratingDiff
-    return (b.match?.totalVotes ?? 0) - (a.match?.totalVotes ?? 0)
+    return safeNumber(b.match?.totalVotes) - safeNumber(a.match?.totalVotes)
   })
 }
 
@@ -53,7 +59,7 @@ export function XRayResults({ result, photoUrl }) {
           </h2>
           {rankSectionItems(section.items).map((item, i) => (
             <XRayRow
-              key={`${section.name}-${item.name}-${i}`}
+              key={item.match?.dishId || `${section.name}-${item.name}`}
               item={item}
               restaurantId={restaurant.id}
               isBest={best != null && item.match?.dishId === best.dishId}

--- a/src/components/scan/XRayResults.test.jsx
+++ b/src/components/scan/XRayResults.test.jsx
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { XRayResults } from './XRayResults'
+import { MIN_VOTES_FOR_RANKING } from '../../constants/app'
 
 const result = {
   restaurant: { id: 'r1', name: 'The Galley' },
@@ -29,6 +30,26 @@ describe('XRayResults', () => {
     expect(rows[0]).toHaveTextContent('Hot Lobster Roll')
     expect(rows[1]).toHaveTextContent('Fried Clams')
     expect(rows[2]).toHaveTextContent('Crab Cakes')
+  })
+
+  it('rated/early boundary tracks MIN_VOTES_FOR_RANKING; malformed rated rows never outrank real ones', () => {
+    const boundary = {
+      ...result,
+      best: null,
+      sections: [{ name: 'Mains', items: [
+        // votes-but-no-rating (malformed) — getVerdict calls this "new", must sink
+        { name: 'Glitch Dish', price: 10, match: { dishId: 'g1', avgRating: null, totalVotes: 50 }, ingested: false },
+        // exactly threshold-1 votes with a HIGHER rating than the rated dish — still early tier, below rated
+        { name: 'Early Star', price: 12, match: { dishId: 'e1', avgRating: 9.9, totalVotes: MIN_VOTES_FOR_RANKING - 1 }, ingested: false },
+        // exactly threshold votes — rated tier, wins the section
+        { name: 'Rated Solid', price: 14, match: { dishId: 'r1', avgRating: 7.5, totalVotes: MIN_VOTES_FOR_RANKING }, ingested: false },
+      ]}],
+    }
+    render(<MemoryRouter><XRayResults result={boundary} photoUrl={null} /></MemoryRouter>)
+    const rows = screen.getAllByRole('button')
+    expect(rows[0]).toHaveTextContent('Rated Solid')
+    expect(rows[1]).toHaveTextContent('Early Star')
+    expect(rows[2]).toHaveTextContent('Glitch Dish')
   })
 
   it('renders all three verdict tiers', () => {

--- a/src/pages/ScanMenu.jsx
+++ b/src/pages/ScanMenu.jsx
@@ -139,21 +139,28 @@ export function ScanMenu() {
 
         {/* The shutter — visibly locked until a restaurant is confirmed */}
         <div className="flex flex-col items-center gap-2.5">
-          <button
-            onClick={() => fileInputRef.current?.click()}
-            disabled={!restaurant}
-            aria-label="Open the camera and scan the menu"
-            className="w-20 h-20 rounded-full flex items-center justify-center transition-all active:scale-95"
-            style={restaurant
-              ? { background: 'var(--color-primary)', color: '#fff', boxShadow: '0 10px 28px rgba(228,68,10,0.38)', animation: 'shutter-ready 2.6s ease-in-out infinite' }
-              : { background: 'var(--color-surface-elevated)', color: 'var(--color-text-tertiary)', border: '2px dashed var(--color-text-tertiary)' }}
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.6} stroke="currentColor" className="w-9 h-9">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6.827 6.175A2.31 2.31 0 0 1 5.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 0 0-1.134-.175 2.31 2.31 0 0 1-1.64-1.055l-.822-1.316a2.192 2.192 0 0 0-1.736-1.039 48.774 48.774 0 0 0-5.232 0 2.192 2.192 0 0 0-1.736 1.039l-.821 1.316Z" />
-              <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 12.75a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0ZM18.75 10.5h.008v.008h-.008V10.5Z" />
-            </svg>
-          </button>
-          <p className="text-xs font-semibold" style={{ color: restaurant ? 'var(--color-primary)' : 'var(--color-text-tertiary)' }}>
+          <div className="relative">
+            {/* Pulse ring: separate element animating transform/opacity only
+                (compositor-friendly — never animate box-shadow on an infinite
+                loop). Hidden entirely under prefers-reduced-motion. */}
+            {restaurant && <span className="scan-shutter-ring" aria-hidden="true" />}
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              disabled={!restaurant}
+              aria-label={restaurant ? 'Open the camera and scan the menu' : 'Camera locked — pick your restaurant first'}
+              aria-describedby="scan-shutter-hint"
+              className="relative w-20 h-20 rounded-full flex items-center justify-center transition-all active:scale-95"
+              style={restaurant
+                ? { background: 'var(--color-primary)', color: '#fff', boxShadow: '0 10px 28px rgba(228,68,10,0.38)' }
+                : { background: 'var(--color-surface-elevated)', color: 'var(--color-text-tertiary)', border: '2px dashed var(--color-text-tertiary)' }}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.6} stroke="currentColor" className="w-9 h-9">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6.827 6.175A2.31 2.31 0 0 1 5.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 0 0-1.134-.175 2.31 2.31 0 0 1-1.64-1.055l-.822-1.316a2.192 2.192 0 0 0-1.736-1.039 48.774 48.774 0 0 0-5.232 0 2.192 2.192 0 0 0-1.736 1.039l-.821 1.316Z" />
+                <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 12.75a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0ZM18.75 10.5h.008v.008h-.008V10.5Z" />
+              </svg>
+            </button>
+          </div>
+          <p id="scan-shutter-hint" className="text-xs font-semibold" style={{ color: restaurant ? 'var(--color-primary)' : 'var(--color-text-tertiary)' }}>
             {restaurant
               ? (result || error ? 'Try another shot' : 'Snap the menu')
               : 'Pick your spot to unlock the camera'}
@@ -164,12 +171,20 @@ export function ScanMenu() {
       <input ref={fileInputRef} type="file" accept="image/*" capture="environment"
         onChange={handleFileChange} style={{ display: 'none' }} />
       <style>{`
-        @keyframes shutter-ready {
-          0%, 100% { box-shadow: 0 10px 28px rgba(228,68,10,0.38); }
-          50% { box-shadow: 0 10px 36px rgba(228,68,10,0.6), 0 0 0 8px rgba(228,68,10,0.08); }
+        .scan-shutter-ring {
+          position: absolute; inset: 0; border-radius: 9999px;
+          border: 2px solid var(--color-primary);
+          animation: scan-shutter-pulse 2.6s ease-out infinite;
+          pointer-events: none;
+        }
+        @keyframes scan-shutter-pulse {
+          0%   { transform: scale(1);    opacity: 0.55; }
+          70%  { transform: scale(1.35); opacity: 0; }
+          100% { transform: scale(1.35); opacity: 0; }
         }
         @media (prefers-reduced-motion: reduce) {
-          @keyframes shutter-ready { 0%, 100% { box-shadow: 0 10px 28px rgba(228,68,10,0.38); } }
+          .scan-shutter-ring { animation: none; display: none; }
+          .xray-demo-line { animation: none; opacity: 0; }
         }
       `}</style>
     </div>


### PR DESCRIPTION
Sequential Codex passes on the two changes that skipped review in the rush:

**Landing:** pulse moved off infinite box-shadow onto a transform/opacity ring (compositor-friendly); prefers-reduced-motion now actually disables animations (nested-keyframes override only swapped frames); shutter aria-label is state-aware + described by the hint text.

**Section ranking:** tier now comes from getVerdict (same brain as the chips — malformed votes-but-no-rating rows can't sort rated while rendering 'be the first'); NaN-safe comparator; row keys stable across reorders (dishId when matched); boundary tests pinned to MIN_VOTES_FOR_RANKING.

Tests 3/3 scan + 8/8 verdict, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)