### PR TITLE
chore(menu): prompt-drift CI tripwire + T44 consolidation scoping

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -664,3 +664,11 @@ Core feature is live: scan a physical menu → rating chips overlay → quiet me
 - **Multi-page menus** — re-scan currently replaces results; merge view is deferred polish.
 - **On-device OCR** — cost optimization, revisit at scan volume. v2 live-AR overlay: dream item, requires text geometry.
 - **`menu_scans` mining** — the audit table accumulates ground-truth photos + extraction results; feeds the self-learning menu refresher idea later.
+
+## T44: Extraction-core consolidation (one prompt, one engine, two commit modes)
+
+**Trigger: whenever PR #320 revives OR the extraction prompt next changes — whichever first.** Not urgent today (all copies verified identical; T44's tripwire `supabase/functions/prompt-drift.deno.test.ts` fails CI on any drift).
+
+The debt: FOUR copies of MENU_EXTRACTION_PROMPT (menu-refresh, menu-xray/lib.ts, #320's extract-menu-from-photo, plus parse-menu's smaller variant) and two photo→menu pipelines (menu-xray instant ingest; #320's staged review flow, HELD undeployed).
+
+The shape (agreed 2026-06-11): `_shared/extraction.ts` carrying prompt + VALID_CATEGORIES + normalizeDishKey + the Claude call; all functions consume it; two commit modes (menu-xray instant-capped; #320 staged human review on menu_photo_extractions); deploy-drift managed per the SSRF-guard precedent (repo imports _shared, deployed copies inline, CLI redeploy reconciles) + the tripwire test until consolidation deletes it. Lanes are not a constraint (Dan's call, 2026-06-11) — Denis gets an FYI, not a veto. Full brainstorm → spec → plan session when triggered.

--- a/scripts/spike-menu-xray.mjs
+++ b/scripts/spike-menu-xray.mjs
@@ -14,7 +14,7 @@ if (!dir || !apiKey) {
 // Pull the production prompt straight out of menu-refresh so the spike tests
 // EXACTLY what will ship. The const is a single template literal.
 const src = fs.readFileSync('supabase/functions/menu-refresh/index.ts', 'utf8')
-const m = src.match(/const MENU_EXTRACTION_PROMPT = `([\s\S]*?)`\n\n/)
+const m = src.match(/const MENU_EXTRACTION_PROMPT = `((?:[^`\\]|\\[\s\S])*)`/) // lexes escaped backticks correctly
 if (!m) { console.error('Could not locate MENU_EXTRACTION_PROMPT in menu-refresh/index.ts'); process.exit(1) }
 const PROMPT = m[1]
 

--- a/supabase/functions/prompt-drift.deno.test.ts
+++ b/supabase/functions/prompt-drift.deno.test.ts
@@ -1,0 +1,59 @@
+// Prompt-drift tripwire. The menu-extraction prompt is deliberately COPIED into
+// each self-contained edge function (dashboard deploys can't follow ../_shared
+// imports). Copies are fine; SILENT drift is not — a prompt improvement in
+// menu-refresh that doesn't reach menu-xray means scans extract differently
+// than the cron. This test fails CI the moment any copy diverges.
+//
+// When the full extraction-core consolidation lands (TASKS.md), this test
+// should be replaced by the shared module. Until then it IS the consolidation's
+// guarantee. When PR #320 (extract-menu-from-photo) merges, add its path below.
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+// Proper template-literal lexing: the prompt CONTAINS escaped backticks
+// (\`V\` → \`vegetarian\`), so a lazy `[\s\S]*?` up to the next backtick
+// silently truncates. Match any run of (non-backtick, non-backslash) chars
+// or escape sequences, then the real closing backtick.
+const PROMPT_RE = /const MENU_EXTRACTION_PROMPT = `((?:[^`\\]|\\[\s\S])*)`/
+// menu-xray deliberately appends one rule the cron prompt doesn't need:
+const XRAY_EXTRA_RULE =
+  'If the image is NOT a menu (a person, a pet, scenery, a receipt), return exactly: {"dishes": [], "not_a_menu": true}'
+
+function readPrompt(path: string): string {
+  const src = Deno.readTextFileSync(path)
+  const m = src.match(PROMPT_RE)
+  assert(m, `Could not locate MENU_EXTRACTION_PROMPT in ${path} — extraction regex needs updating`)
+  return m[1]
+}
+
+Deno.test('menu-xray extraction prompt matches menu-refresh (modulo the deliberate not-a-menu rule)', () => {
+  const refresh = readPrompt('supabase/functions/menu-refresh/index.ts')
+  const xray = readPrompt('supabase/functions/menu-xray/lib.ts')
+
+  assert(
+    xray.includes(XRAY_EXTRA_RULE),
+    'menu-xray lost its not-a-menu rule — scans of non-menu photos will hallucinate dishes',
+  )
+  const xrayNormalized = xray.replace(XRAY_EXTRA_RULE, '').replace(/\n+$/, '')
+  const refreshNormalized = refresh.replace(/\n+$/, '')
+  assertEquals(
+    xrayNormalized,
+    refreshNormalized,
+    'PROMPT DRIFT: menu-xray/lib.ts and menu-refresh/index.ts no longer carry the same ' +
+      'extraction prompt. Whoever changed one must change both (and bump ' +
+      'CURRENT_EXTRACTOR_FINGERPRINT in menu-refresh if extraction output changed). ' +
+      'Or: do the extraction-core consolidation in TASKS.md and delete this test.',
+  )
+})
+
+Deno.test('menu-xray normalizeDishKey matches menu-refresh extractors.ts', () => {
+  const FN_RE = /export function normalizeDishKey[\s\S]*?\n}\n/
+  const a = Deno.readTextFileSync('supabase/functions/menu-refresh/extractors.ts').match(FN_RE)
+  const b = Deno.readTextFileSync('supabase/functions/menu-xray/lib.ts').match(FN_RE)
+  assert(a && b, 'Could not locate normalizeDishKey in one of the copies — regex needs updating')
+  assertEquals(
+    b[0],
+    a[0],
+    'normalizeDishKey drifted between menu-refresh/extractors.ts and menu-xray/lib.ts — ' +
+      'dedupe behavior must stay identical or scans and cron will disagree on duplicates.',
+  )
+})


### PR DESCRIPTION
One-hour insurance instead of a midnight refactor: a hermetic *.deno.test.ts (auto-runs in existing CI) that fails the build if the extraction prompt or normalizeDishKey copies drift between menu-refresh and menu-xray. Caught a real bug in its own first run (escaped-backtick truncation in the extraction regex — also fixed in the spike script). Full extraction-core consolidation is scoped as TASKS.md T44 with explicit triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)