### PR TITLE
feat(menu-xray): redesign X-Ray results as a printed menu

### DIFF
--- a/src/components/scan/VerdictChip.jsx
+++ b/src/components/scan/VerdictChip.jsx
@@ -1,34 +1,27 @@
 import { getVerdict } from '../../utils/verdict'
 
+// The rating mark in the menu's right margin. getVerdict maps tier + the
+// site-standard rating color (green/amber/red), so a score reads the same here
+// as on the dish page. Vote counts are intentionally omitted — that detail
+// lives on the dish card. Three states: rated (colored number), a vote or two
+// (muted gray number), none (a soft "+" invitation).
 export function VerdictChip({ avgRating, totalVotes }) {
   const v = getVerdict(avgRating, totalVotes)
+
   if (v.tier === 'new') {
-    return (
-      <span
-        className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-bold whitespace-nowrap"
-        style={{ color: 'var(--color-accent-gold)', border: '1.5px dashed var(--color-accent-gold)', background: 'var(--color-surface)' }}
-      >
-        🆕 be the first
-      </span>
-    )
+    return <span className="text-[17px] font-bold leading-none" style={{ color: 'var(--color-text-tertiary)' }}>+</span>
   }
   if (v.tier === 'early') {
     return (
-      <span
-        className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-bold whitespace-nowrap"
-        style={{ color: 'var(--color-text-tertiary)', background: 'var(--color-surface)' }}
-      >
-        {v.score} · {v.votes} vote{v.votes === 1 ? '' : 's'}
+      <span className="text-[15px] font-bold" style={{ color: 'var(--color-text-secondary)', fontVariantNumeric: 'tabular-nums' }}>
+        {v.score}
       </span>
     )
   }
   return (
-    <span
-      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-sm font-bold whitespace-nowrap"
-      style={{ color: v.color, background: 'var(--color-surface-elevated)', boxShadow: '0 1px 4px rgba(0,0,0,0.08)' }}
-    >
-      <span className="w-2 h-2 rounded-full" style={{ background: v.color }} />
-      {v.score}
+    <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
+      <span className="w-1.5 h-1.5 rounded-full" style={{ background: v.color }} />
+      <span className="text-[16px] font-extrabold leading-none" style={{ color: v.color, fontVariantNumeric: 'tabular-nums' }}>{v.score}</span>
     </span>
   )
 }

--- a/src/components/scan/XRayResults.jsx
+++ b/src/components/scan/XRayResults.jsx
@@ -1,39 +1,16 @@
 import { MIN_VOTES_FOR_RANKING } from '../../constants/app'
-import { getVerdict } from '../../utils/verdict'
 import { XRayRow } from './XRayRow'
 
-// Each section is its own mini-leaderboard: rated dishes first (best rating,
-// then most votes), early-signal dishes next, never-rated last. The user is
-// holding the paper menu — IT owns the canonical order; the X-Ray view's job
-// is judgment. Array.prototype.sort is stable, so unrated dishes keep their
-// menu order at the bottom of the section.
-// Tier comes from getVerdict — the SAME brain the chips render with — so a
-// malformed row (votes but no rating) can never sort rated while displaying
-// "be the first".
-const TIER_WEIGHT = { rated: 2, early: 1, new: 0 }
-
-function safeNumber(value) {
-  const n = Number(value)
-  return Number.isFinite(n) ? n : 0
-}
-
-function rankSectionItems(items) {
-  return items.slice().sort((a, b) => {
-    const va = getVerdict(a.match?.avgRating, a.match?.totalVotes)
-    const vb = getVerdict(b.match?.avgRating, b.match?.totalVotes)
-    const tierDiff = TIER_WEIGHT[vb.tier] - TIER_WEIGHT[va.tier]
-    if (tierDiff !== 0) return tierDiff
-    const ratingDiff = safeNumber(b.match?.avgRating) - safeNumber(a.match?.avgRating)
-    if (ratingDiff !== 0) return ratingDiff
-    return safeNumber(b.match?.totalVotes) - safeNumber(a.match?.totalVotes)
-  })
-}
-
+// The X-Ray view reads like the paper menu in your hand: printed-menu order
+// (no reordering, nothing hidden), section headers, dish … price · rating.
+// The crowd's verdict sits in the margin as a site-colored number; the
+// "tell me what to get" button (in ScanMenu) owns the decisive answer.
 export function XRayResults({ result, photoUrl }) {
-  const { restaurant, sections, best, summary } = result
+  const { restaurant, sections, summary } = result
   const favorites = sections
     .flatMap(s => s.items)
-    .filter(i => i.match && i.match.totalVotes >= MIN_VOTES_FOR_RANKING && i.match.avgRating >= 8.0).length
+    .filter(i => i.match && (i.match.totalVotes ?? 0) >= MIN_VOTES_FOR_RANKING && i.match.avgRating >= 8.0).length
+
   return (
     <div className="px-4 pb-28">
       <div className="flex items-start justify-between gap-3 pt-4 pb-2">
@@ -42,7 +19,7 @@ export function XRayResults({ result, photoUrl }) {
             {restaurant.name}
           </h1>
           <p className="text-sm mt-1" style={{ color: 'var(--color-text-secondary)' }}>
-            {favorites > 0 && <strong style={{ color: 'var(--color-rating)' }}>{favorites} crowd favorite{favorites === 1 ? '' : 's'} · </strong>}
+            {favorites > 0 && <strong style={{ color: 'var(--color-primary)' }}>{favorites} crowd favorite{favorites === 1 ? '' : 's'} · </strong>}
             {summary.total} dish{summary.total === 1 ? '' : 'es'}
             {summary.ingested > 0 && ` · ${summary.ingested} new to the map`}
           </p>
@@ -52,22 +29,42 @@ export function XRayResults({ result, photoUrl }) {
             style={{ border: '1px solid var(--color-category-strip)' }} />
         )}
       </div>
-      {sections.map(section => (
-        <section key={section.name} className="mt-3">
-          <h2 className="text-xl border-b pb-0.5 mb-1" style={{ fontFamily: "'Amatic SC', cursive", fontWeight: 700, color: 'var(--color-accent-gold)', borderColor: 'var(--color-category-strip)' }}>
-            {section.name}
-          </h2>
-          {rankSectionItems(section.items).map((item, i) => (
-            <XRayRow
-              key={item.match?.dishId || `${section.name}-${item.name}`}
-              item={item}
-              restaurantId={restaurant.id}
-              isBest={best != null && item.match?.dishId === best.dishId}
-              index={i}
-            />
-          ))}
-        </section>
-      ))}
+
+      {/* The menu card — warm paper, dishes in their printed order. */}
+      <div
+        style={{
+          marginTop: '6px',
+          padding: '18px 18px 22px',
+          borderRadius: '18px',
+          background: 'linear-gradient(170deg, #fffdf8, var(--color-paper-cream-light))',
+          boxShadow: '0 4px 18px rgba(40,30,20,0.08)',
+        }}
+      >
+        {sections.map((section, si) => (
+          <section key={section.name}>
+            <h2
+              className="text-center"
+              style={{
+                fontFamily: "'Amatic SC', cursive",
+                fontWeight: 700,
+                fontSize: '22px',
+                color: 'var(--color-accent-gold)',
+                letterSpacing: '0.5px',
+                margin: si === 0 ? '0 0 4px' : '18px 0 4px',
+              }}
+            >
+              {section.name}
+            </h2>
+            {section.items.map((item, i) => (
+              <XRayRow
+                key={item.match?.dishId || `${section.name}-${item.name}-${i}`}
+                item={item}
+                restaurantId={restaurant.id}
+              />
+            ))}
+          </section>
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/components/scan/XRayResults.test.jsx
+++ b/src/components/scan/XRayResults.test.jsx
@@ -16,48 +16,40 @@ const result = {
 }
 
 describe('XRayResults', () => {
-  it('ranks each section: rated by rating first, early next, unrated last', () => {
-    const shuffled = {
-      ...result,
-      sections: [{ name: 'Mains', items: [
-        { name: 'Crab Cakes', price: 24, match: null, ingested: true },
-        { name: 'Fried Clams', price: 22, match: { dishId: 'd2', avgRating: 9.1, totalVotes: 2 }, ingested: false },
-        { name: 'Hot Lobster Roll', price: 34, match: { dishId: 'd1', avgRating: 9.4, totalVotes: 12 }, ingested: false },
-      ]}],
-    }
-    render(<MemoryRouter><XRayResults result={shuffled} photoUrl={null} /></MemoryRouter>)
+  it('renders dishes in printed-menu order with the three rating states', () => {
+    render(<MemoryRouter><XRayResults result={result} photoUrl={null} /></MemoryRouter>)
     const rows = screen.getAllByRole('button')
+    // menu order preserved — no reordering of winners to the top
     expect(rows[0]).toHaveTextContent('Hot Lobster Roll')
     expect(rows[1]).toHaveTextContent('Fried Clams')
     expect(rows[2]).toHaveTextContent('Crab Cakes')
+    expect(screen.getByText('9.4')).toBeInTheDocument()  // rated: colored number
+    expect(screen.getByText('9.1')).toBeInTheDocument()  // early: muted number, no count
+    expect(screen.queryByText(/vote/i)).not.toBeInTheDocument()  // vote counts dropped
+    expect(screen.getByText('+')).toBeInTheDocument()    // unrated: invitation
+    expect(screen.getByText('The Galley')).toBeInTheDocument()
   })
 
-  it('rated/early boundary tracks MIN_VOTES_FOR_RANKING; malformed rated rows never outrank real ones', () => {
+  it('rated dish shows the site rating color; early dish is muted gray', () => {
+    render(<MemoryRouter><XRayResults result={result} photoUrl={null} /></MemoryRouter>)
+    // rated (12 votes, 9.4) → green-deep, the site's >=8 color
+    expect(screen.getByText('9.4').getAttribute('style')).toContain('--color-green-deep')
+    // early (2 votes) → muted secondary, NOT a rating color
+    expect(screen.getByText('9.1').getAttribute('style')).toContain('--color-text-secondary')
+  })
+
+  it('the rated/early boundary tracks MIN_VOTES_FOR_RANKING', () => {
     const boundary = {
       ...result,
-      best: null,
       sections: [{ name: 'Mains', items: [
-        // votes-but-no-rating (malformed) — getVerdict calls this "new", must sink
-        { name: 'Glitch Dish', price: 10, match: { dishId: 'g1', avgRating: null, totalVotes: 50 }, ingested: false },
-        // exactly threshold-1 votes with a HIGHER rating than the rated dish — still early tier, below rated
-        { name: 'Early Star', price: 12, match: { dishId: 'e1', avgRating: 9.9, totalVotes: MIN_VOTES_FOR_RANKING - 1 }, ingested: false },
-        // exactly threshold votes — rated tier, wins the section
-        { name: 'Rated Solid', price: 14, match: { dishId: 'r1', avgRating: 7.5, totalVotes: MIN_VOTES_FOR_RANKING }, ingested: false },
+        { name: 'Just Rated', price: 10, match: { dishId: 'b1', avgRating: 8.5, totalVotes: MIN_VOTES_FOR_RANKING } },
+        { name: 'Still Early', price: 10, match: { dishId: 'b2', avgRating: 8.5, totalVotes: MIN_VOTES_FOR_RANKING - 1 } },
       ]}],
     }
     render(<MemoryRouter><XRayResults result={boundary} photoUrl={null} /></MemoryRouter>)
-    const rows = screen.getAllByRole('button')
-    expect(rows[0]).toHaveTextContent('Rated Solid')
-    expect(rows[1]).toHaveTextContent('Early Star')
-    expect(rows[2]).toHaveTextContent('Glitch Dish')
-  })
-
-  it('renders all three verdict tiers', () => {
-    render(<MemoryRouter><XRayResults result={result} photoUrl={null} /></MemoryRouter>)
-    expect(screen.getByText('9.4')).toBeInTheDocument()
-    expect(screen.getByText(/9\.1 · 2 votes/)).toBeInTheDocument()
-    expect(screen.getByText(/be the first/)).toBeInTheDocument()
-    expect(screen.getByText(/★/)).toBeInTheDocument()
-    expect(screen.getByText('The Galley')).toBeInTheDocument()
+    const nums = screen.getAllByText('8.5')
+    // first (at threshold) is rated → colored; second (below) is early → gray
+    expect(nums[0].getAttribute('style')).toContain('--color-green-deep')
+    expect(nums[1].getAttribute('style')).toContain('--color-text-secondary')
   })
 })

--- a/src/components/scan/XRayRow.jsx
+++ b/src/components/scan/XRayRow.jsx
@@ -1,31 +1,34 @@
 import { useNavigate } from 'react-router-dom'
+import { MIN_VOTES_FOR_RANKING } from '../../constants/app'
 import { VerdictChip } from './VerdictChip'
 
-export function XRayRow({ item, restaurantId, isBest, index }) {
+// One printed-menu line: dish name … dotted leader … price · rating.
+// Rated dishes get a slightly heavier name; everything stays in menu order.
+export function XRayRow({ item, restaurantId }) {
   const navigate = useNavigate()
+  const rated = item.match != null && (item.match.totalVotes ?? 0) >= MIN_VOTES_FOR_RANKING
   const handleTap = () => {
     if (item.match) navigate(`/dish/${item.match.dishId}`)
     else navigate(`/restaurants/${restaurantId}/rate`)
   }
   return (
-    <button
-      onClick={handleTap}
-      className="w-full flex items-center justify-between gap-3 py-2.5 text-left"
-      style={{ animationDelay: `${index * 60}ms` }}
-    >
-      <span className="min-w-0 flex-1">
-        <span className="block truncate font-semibold text-[15px]" style={{ color: 'var(--color-text-primary)' }}>
-          {isBest && <span style={{ color: 'var(--color-medal-gold)' }}>★ </span>}
-          {item.name}
-        </span>
-        {item.price != null && (
-          <span className="text-xs" style={{ color: 'var(--color-text-tertiary)' }}>${Number(item.price).toFixed(0)}</span>
-        )}
+    <button onClick={handleTap} className="w-full flex items-baseline gap-1.5 py-2 text-left">
+      <span
+        className="truncate"
+        style={{ fontSize: '15px', fontWeight: rated ? 700 : 600, color: 'var(--color-text-primary)', flexShrink: 1, minWidth: 0 }}
+      >
+        {item.name}
       </span>
-      <VerdictChip
-        avgRating={item.match?.avgRating ?? null}
-        totalVotes={item.match?.totalVotes ?? 0}
-      />
+      {/* dotted leader — one-off decorative menu element */}
+      <span className="flex-1" style={{ borderBottom: '1.5px dotted #c9bca3', margin: '0 3px 4px', minWidth: '14px' }} />
+      {item.price != null && (
+        <span className="text-[13px] flex-shrink-0" style={{ color: 'var(--color-text-secondary)', fontVariantNumeric: 'tabular-nums' }}>
+          ${Number(item.price).toFixed(0)}
+        </span>
+      )}
+      <span className="ml-2 flex-shrink-0">
+        <VerdictChip avgRating={item.match?.avgRating ?? null} totalVotes={item.match?.totalVotes ?? 0} />
+      </span>
     </button>
   )
 }

--- a/src/pages/ScanMenu.jsx
+++ b/src/pages/ScanMenu.jsx
@@ -95,7 +95,7 @@ export function ScanMenu() {
           <div className="fixed bottom-6 left-4 right-4 z-30">
             <button onClick={() => { setDecideOpen(true); capture('decide_opened', { restaurant_id: restaurant.id }) }}
               className="w-full py-4 rounded-2xl font-bold text-base"
-              style={{ background: 'var(--color-rating)', color: '#fff', boxShadow: '0 8px 26px rgba(22,163,74,0.45)' }}>
+              style={{ background: 'var(--color-primary)', color: '#fff', boxShadow: '0 8px 26px rgba(228,68,10,0.42)' }}>
               🎯 Just tell me what to get
             </button>
           </div>


### PR DESCRIPTION
The X-Ray results now read like the paper menu in your hand — Dan-approved direction after a few rounds.

- **Reads like the menu:** printed-menu order (per-section ranking removed — nothing jumps to the top or hides), section headers, dish … dotted leader … price · rating.
- **Site-consistent rating colors:** the crowd's verdict is a `getRatingColor` number (green ≥8 / amber ≥6 / red below) — identical to the dish page. No green glow-badges.
- **Vote counts dropped** — that detail lives on the dish card. Three clean states: rated (colored number + dot), a vote or two (muted gray number), unrated (soft +).
- Coral decide button; the "tell me what to get" button owns the decisive answer.

Font: inline `'Amatic SC'` to match current main (a separate terminal is mid-migration to a `--font-display` token app-wide; this commit deliberately doesn't couple to that uncommitted work — it'll be swept up with the rest).

Codex-reviewed (long-name truncation guard + rating-tier boundary tests added). 11 scan tests + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)