### PR TITLE
fix(auth): preserve next destination through cross-device PKCE flow

### DIFF
--- a/CURRENT_FOCUS.md
+++ b/CURRENT_FOCUS.md
@@ -2,11 +2,13 @@
 
 *Dan (or any Claude session starting work) updates this file at session start. Every other Claude session reads it first to avoid collisions.*
 
-**Last updated:** 2026-06-10
+**Last updated:** 2026-07-16
 
 ---
 
 ## Active handoff
+
+**#184 cross-device redirect fix (Dan, 2026-07-16, branch `fix/cross-device-next-redirect`).** Fixing the mint-link signup redirect bug: cross-device PKCE branch drops `safeNext`. **Claimed surfaces:** `src/pages/AuthCallback.jsx`, `src/pages/CrossDevicePkce.jsx` (+ new tests for both). Does NOT touch `authApi.js` (redirect param already exists) or the #156 verifyOtp surface.
 
 **Menu X-Ray session (Dan, 2026-06-10, branch `feat/menu-xray`) — BUILT, PR #323 OPEN.** Migration run in SQL Editor ✅, `menu-xray` function deployed via dashboard (Verify-JWT off) ✅, live smoke passed (Lookout 27/27 matched) ✅. Remaining: Dan's logged-in field test at a real table, then merge; homepage camera icon is a follow-up PR after a few days of field use (T43). Original scope note: scan a physical menu → Claude vision extracts → pg_trgm match → rating chips → quiet menu ingest. Spec: `docs/superpowers/specs/2026-06-10-menu-xray-design.md` · Plan: `docs/superpowers/plans/2026-06-10-menu-xray.md`. Validation spike PASSED 7/7 on real menu photos. **Claimed surfaces:** `supabase/functions/menu-xray/` (new), `src/components/scan/` (new), `src/pages/ScanMenu.jsx` (new), `src/utils/verdict.js`, `src/api/menuScanApi.js`, `src/hooks/useMenuScan.js`, `src/App.jsx` (/scan route), `src/pages/RestaurantDetail.jsx` (header button), `supabase/schema.sql` (appending menu_scans table + 4 RPCs). Reads menu-refresh code but NEVER edits it.
 

--- a/src/pages/AuthCallback.jsx
+++ b/src/pages/AuthCallback.jsx
@@ -48,7 +48,7 @@ export function AuthCallback() {
         if (error) {
           const msg = String(error.message || '').toLowerCase()
           if (msg.includes('code verifier') || msg.includes('verifier not found')) {
-            navigate('/auth/cross-device', { replace: true, state: { type } })
+            navigate('/auth/cross-device', { replace: true, state: { type, next: safeNext } })
             return
           }
           navigate('/login', { replace: true, state: { authError: 'link_expired' } })
@@ -61,7 +61,7 @@ export function AuthCallback() {
         logger.warn('AuthCallback exchangeCodeForSession failed', error)
         const msg = String(error?.message || '').toLowerCase()
         if (msg.includes('code verifier') || msg.includes('verifier not found')) {
-          navigate('/auth/cross-device', { replace: true, state: { type } })
+          navigate('/auth/cross-device', { replace: true, state: { type, next: safeNext } })
           return
         }
         navigate('/login', { replace: true, state: { authError: 'link_expired' } })

--- a/src/pages/AuthCallback.test.jsx
+++ b/src/pages/AuthCallback.test.jsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, cleanup, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { AuthCallback } from './AuthCallback'
+import { authApi } from '../api/authApi'
+
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+vi.mock('../api/authApi', () => ({
+  authApi: { exchangeCodeForSession: vi.fn() },
+}))
+
+function renderCallback(search) {
+  return render(
+    <MemoryRouter initialEntries={[`/auth/callback${search}`]}>
+      <AuthCallback />
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(cleanup)
+
+describe('AuthCallback', () => {
+  it('navigates to next on successful exchange', async () => {
+    authApi.exchangeCodeForSession.mockResolvedValue({ error: null })
+    renderCallback('?code=abc&type=signup&next=%2Flocals%2Fxyz')
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/locals/xyz', { replace: true })
+    })
+  })
+
+  it('carries next into cross-device state when the verifier is missing (returned error)', async () => {
+    authApi.exchangeCodeForSession.mockResolvedValue({
+      error: { message: 'code verifier not found' },
+    })
+    renderCallback('?code=abc&type=signup&next=%2Flocals%2Fxyz')
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/auth/cross-device', {
+        replace: true,
+        state: { type: 'signup', next: '/locals/xyz' },
+      })
+    })
+  })
+
+  it('carries next into cross-device state when the verifier is missing (thrown error)', async () => {
+    authApi.exchangeCodeForSession.mockRejectedValue(new Error('code verifier not found'))
+    renderCallback('?code=abc&type=signup&next=%2Flocals%2Fxyz')
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/auth/cross-device', {
+        replace: true,
+        state: { type: 'signup', next: '/locals/xyz' },
+      })
+    })
+  })
+
+  it('passes null next to cross-device when no next param is present', async () => {
+    authApi.exchangeCodeForSession.mockResolvedValue({
+      error: { message: 'code verifier not found' },
+    })
+    renderCallback('?code=abc&type=signup')
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/auth/cross-device', {
+        replace: true,
+        state: { type: 'signup', next: null },
+      })
+    })
+  })
+
+  it('preserves query and hash in next', async () => {
+    authApi.exchangeCodeForSession.mockResolvedValue({
+      error: { message: 'code verifier not found' },
+    })
+    renderCallback(`?code=abc&type=signup&next=${encodeURIComponent('/dish/123?q=foo#bar')}`)
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/auth/cross-device', {
+        replace: true,
+        state: { type: 'signup', next: '/dish/123?q=foo#bar' },
+      })
+    })
+  })
+
+  it('rejects a protocol-relative next and passes null to cross-device', async () => {
+    authApi.exchangeCodeForSession.mockResolvedValue({
+      error: { message: 'code verifier not found' },
+    })
+    renderCallback(`?code=abc&type=signup&next=${encodeURIComponent('//evil.example.com/path')}`)
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/auth/cross-device', {
+        replace: true,
+        state: { type: 'signup', next: null },
+      })
+    })
+  })
+
+  it('rejects a next pointing back at /auth/callback (loop prevention)', async () => {
+    authApi.exchangeCodeForSession.mockResolvedValue({
+      error: { message: 'code verifier not found' },
+    })
+    renderCallback(`?code=abc&type=signup&next=${encodeURIComponent('/auth/callback?type=signup')}`)
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/auth/cross-device', {
+        replace: true,
+        state: { type: 'signup', next: null },
+      })
+    })
+  })
+
+  it('rejects a cross-origin next and passes null to cross-device', async () => {
+    authApi.exchangeCodeForSession.mockResolvedValue({
+      error: { message: 'code verifier not found' },
+    })
+    renderCallback(`?code=abc&type=signup&next=${encodeURIComponent('https://evil.example.com/phish')}`)
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/auth/cross-device', {
+        replace: true,
+        state: { type: 'signup', next: null },
+      })
+    })
+  })
+})

--- a/src/pages/CrossDevicePkce.jsx
+++ b/src/pages/CrossDevicePkce.jsx
@@ -6,6 +6,10 @@ import { logger } from '../utils/logger'
 export default function CrossDevicePkce() {
   const { state } = useLocation()
   const type = state?.type ?? 'magiclink'
+  // Destination the user was originally headed to (sanitized same-origin path
+  // from AuthCallback). Threaded through the fresh magic link so a first-time
+  // signup from a shared link still lands on the shared target. See #184.
+  const next = state?.next ?? null
   const [email, setEmail] = useState('')
   const [sent, setSent] = useState(false)
   const [error, setError] = useState(null)
@@ -19,7 +23,10 @@ export default function CrossDevicePkce() {
       if (type === 'recovery') {
         await authApi.resetPassword(email)
       } else {
-        await authApi.signInWithMagicLink(email)
+        const returnPath = next
+          ? `/auth/callback?type=${encodeURIComponent(type)}&next=${encodeURIComponent(next)}`
+          : null
+        await authApi.signInWithMagicLink(email, returnPath)
       }
       setSent(true)
     } catch (err) {

--- a/src/pages/CrossDevicePkce.test.jsx
+++ b/src/pages/CrossDevicePkce.test.jsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import CrossDevicePkce from './CrossDevicePkce'
+import { authApi } from '../api/authApi'
+
+vi.mock('../api/authApi', () => ({
+  authApi: {
+    signInWithMagicLink: vi.fn().mockResolvedValue({ success: true }),
+    resetPassword: vi.fn().mockResolvedValue({ success: true }),
+  },
+}))
+
+function renderWithState(state) {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: '/auth/cross-device', state }]}>
+      <CrossDevicePkce />
+    </MemoryRouter>
+  )
+}
+
+async function submitEmail(email = 'user@example.com') {
+  fireEvent.change(screen.getByPlaceholderText('you@example.com'), {
+    target: { value: email },
+  })
+  fireEvent.click(screen.getByRole('button', { name: /send new link/i }))
+  await waitFor(() => {
+    expect(screen.getByText(/a new link is on the way/i)).toBeInTheDocument()
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  authApi.signInWithMagicLink.mockResolvedValue({ success: true })
+  authApi.resetPassword.mockResolvedValue({ success: true })
+})
+
+afterEach(cleanup)
+
+describe('CrossDevicePkce', () => {
+  it('threads next into the magic link return path', async () => {
+    renderWithState({ type: 'signup', next: '/locals/xyz' })
+    await submitEmail()
+
+    expect(authApi.signInWithMagicLink).toHaveBeenCalledWith(
+      'user@example.com',
+      '/auth/callback?type=signup&next=%2Flocals%2Fxyz'
+    )
+  })
+
+  it('passes null return path when there is no next', async () => {
+    renderWithState({ type: 'signup' })
+    await submitEmail()
+
+    expect(authApi.signInWithMagicLink).toHaveBeenCalledWith('user@example.com', null)
+  })
+
+  it('passes null return path when there is no route state at all', async () => {
+    renderWithState(undefined)
+    await submitEmail()
+
+    expect(authApi.signInWithMagicLink).toHaveBeenCalledWith('user@example.com', null)
+  })
+
+  it('uses resetPassword for recovery links', async () => {
+    renderWithState({ type: 'recovery', next: '/locals/xyz' })
+    fireEvent.change(screen.getByPlaceholderText('you@example.com'), {
+      target: { value: 'user@example.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send new link/i }))
+
+    await waitFor(() => {
+      expect(authApi.resetPassword).toHaveBeenCalledWith('user@example.com')
+    })
+    expect(authApi.signInWithMagicLink).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
Fixes the mint-link signup redirect bug (wgh-phone#184, re #177): a first-time user who signs up from a shared link and opens the verification email in a **different browser** (the normal mobile case — signup in native app/in-app browser, email opens in Safari) lost their destination and landed on the homepage.

Two small changes:
- `AuthCallback.jsx` — when the code verifier is missing and we route to `/auth/cross-device`, carry the sanitized `safeNext` in router state (previously dropped) — both the returned-error and thrown-error branches.
- `CrossDevicePkce.jsx` — read `next` from route state and pass a return path of `/auth/callback?type=<type>&next=<next>` to `signInWithMagicLink`, whose existing (previously unused) `redirectUrl` param builds the same-origin `emailRedirectTo`.

The second email round-trip now lands back on `/auth/callback`, which re-sanitizes `next` (same-origin only, `/auth/callback` self-reference excluded) before navigating — so nothing new is trusted.

PR #265 fixed the same-browser path in May; this completes the cross-device half. Unblocks Denis's two mint-link feature asks (area Top-10 link + "sign up & make your Top 10").

## Test plan
- [x] 12 new unit tests: `AuthCallback` (success nav, verifier-missing carries next, null/cross-origin/protocol-relative/callback-loop rejection, query+hash preservation) and `CrossDevicePkce` (return path threading, no-state fallback, recovery branch untouched)
- [x] Full suite: 764 passed (50 files)
- [x] `npm run build` passes, eslint clean on changed files
- [x] Codex review (gpt-5.5): no blocking findings
- [ ] Live cross-device smoke: sign up from a `/locals/:userId` link in one browser, open the email in another, request fresh link, confirm landing on the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)